### PR TITLE
README: Drop the "(pronounced 'Oh Really')" parenthetical

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![tip for next commit](http://tip4commit.com/projects/860.svg)](http://tip4commit.com/projects/860)
 
-This is the repository for the Orly (pronounced "Oh Really") non-relational database. It's meant to be fast and to scale for billions of users.  Orly provides a single path to data and will eliminate our need for memcache due to its speed and high concurrency.
+This is the repository for the Orly non-relational database. It's meant to be fast and to scale for billions of users.  Orly provides a single path to data and will eliminate our need for memcache due to its speed and high concurrency.
 
 ## Orly features:
 


### PR DESCRIPTION
## Summary

Removes the `(pronounced "Oh Really")` parenthetical from the opening line of the README. Reverts the single-line change introduced by d22119a.

## Diff

```diff
-This is the repository for the Orly (pronounced "Oh Really") non-relational database.
+This is the repository for the Orly non-relational database.
```

## Test plan

- [x] README still renders cleanly
- N/A — documentation-only change, no code paths touched