### PR TITLE
Fix mlock/static-init crashes in test suite (178 -> 186 passing)

### DIFF
--- a/base/mlock.cc
+++ b/base/mlock.cc
@@ -16,6 +16,7 @@
 
 #include <base/mlock.h>
 
+#include <cerrno>
 #include <sys/mman.h>
 
 #include <test/is_in_test.h>
@@ -24,8 +25,19 @@
 void Base::MlockRaw(const void *val, uint64_t len) {
   int res = mlock(val, len);
 
-  // If we're in a test and mlock fails, ignore the failure silently
-  // The failure only changes perf, not correctness
+  if (res == 0) {
+    return;
+  }
+
+  // Failure to mlock changes perf, not correctness. On modern Linux the
+  // default RLIMIT_MEMLOCK is 64KB (vs effectively unlimited in 2014),
+  // so any non-trivial pool allocation hits ENOMEM/EPERM. Degrade
+  // silently rather than aborting -- this also covers static-init-time
+  // allocations that run before ExtraInit() sets the in-test flag.
+  if (errno == ENOMEM || errno == EPERM) {
+    return;
+  }
+
   if (Test::AvoidTheseWheneverPossible::IsInTest()) {
     return;
   }

--- a/orly/atom/kit2.h
+++ b/orly/atom/kit2.h
@@ -1225,7 +1225,7 @@ namespace Orly {
             return false;
           }
           case TTycon::Tuple: {
-            if (IndirectCoreArray.ElemCount == IndirectCoreArray.ElemCount) {
+            if (IndirectCoreArray.ElemCount == that_core.IndirectCoreArray.ElemCount) {
               void *lhs_pin_alloc = alloca(sizeof(TArena::TFinalPin) * 2);
               void *rhs_pin_alloc = reinterpret_cast<uint8_t *>(lhs_pin_alloc) + sizeof(TArena::TFinalPin);
               TArena::TFinalPin::TWrapper lhs_pin(this_arena->Pin(IndirectCoreArray.Offset,

--- a/orly/indy/fiber/fiber.h
+++ b/orly/indy/fiber/fiber.h
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <cassert>
+#include <cerrno>
 #include <memory>
 #include <mutex>
 #include <queue>
@@ -133,7 +134,13 @@ namespace Orly {
       inline void create_fiber(fiber_t &fib, void(*ufnc)(void *), void *uctx, size_t stack_size) {
         getcontext(&fib.fib);
         fib.start_of_stack = reinterpret_cast<uint8_t *>(malloc(stack_size));
-        Util::IfLt0(mlock(fib.start_of_stack, stack_size));
+        /* mlock keeps fiber stacks resident in RAM as a perf hint; on systems
+           where RLIMIT_MEMLOCK is small (modern Linux default is 64KB) this
+           fails with ENOMEM for MB-sized fiber stacks. The stack is still
+           valid memory, so degrade gracefully rather than aborting. */
+        if (mlock(fib.start_of_stack, stack_size) < 0 && errno != ENOMEM && errno != EPERM) {
+          Util::ThrowSystemError(errno);
+        }
         // init the fiber locals
         size_t bytes_of_loc = 0UL;
         fib.fib.uc_stack.ss_sp = fib.start_of_stack;


### PR DESCRIPTION
## Summary

Brings the `make debug` test suite from **178/188 passing → 186/188 passing** under modern Ubuntu (RLIMIT_MEMLOCK=64KB by default, gcc 13).

The bulk of the recovery is one fix in `base/mlock.cc`. The rest is a fiber-stack analogue and a clearly-buggy self-comparison surfaced during the investigation.

## Root cause

Several test binaries declare large memory pools at file scope:

```cpp
Disk::TBufBlock::Pool(BlockSize, 20000);   // ~1.28 GB
TPool TUpdate::Pool(sizeof(TUpdate), "Update", 1000000UL);
```

The pool initialiser calls `Base::MlockRaw(...)`, which `mlock(2)`s the entire allocation. Modern Linux defaults `RLIMIT_MEMLOCK` to **64 KB** (vs effectively unlimited on systems from the original development era), so any non-trivial pool's `mlock` fails with `ENOMEM` and the process aborts.

`MlockRaw` already had an "ignore failures in tests" gate keyed on `Test::AvoidTheseWheneverPossible::IsInTest()`, but that flag is set by `main() → ExtraInit()`. The pools above are initialised as global statics, which run **before** `main()`, so the flag is still false and the abort fires before any test fixture begins.

## What changed

### `base/mlock.cc`

`mlock` is a perf hint, not a correctness requirement. Swallow `ENOMEM`/`EPERM` unconditionally before the in-test gate. The gate is preserved for any other failure mode. This single change unblocks 8 previously-crashing test binaries:

- `orly/server/pov.test`
- `orly/server/session.test`
- `orly/indy/memory_layer.test`
- `orly/durable/kit.test`
- `orly/indy/disk/data_file.test`
- `orly/indy/disk/merge_data_file.test`
- `orly/indy/disk/present_walk_file.test`
- `orly/indy/disk/update_walk_file.test`

### `orly/indy/fiber/fiber.h`

Same root cause for fiber stack allocation. `create_fiber()` wraps `mlock()` in `Util::IfLt0()`, which throws `system_error` for MB-sized fiber stacks. Replaced with an explicit check that lets `ENOMEM`/`EPERM` slide silently. Unblocks `fiber/fiber.test` fixtures `SpawnAndSync`, `CatchLeakedFrame`, `SwitchRunnerToRunnerRAII`, `Sem`.

### `orly/atom/kit2.h`

Pre-existing self-comparison bug in `TCore::MatchType`'s Tuple case:

```diff
-if (IndirectCoreArray.ElemCount == IndirectCoreArray.ElemCount) {
+if (IndirectCoreArray.ElemCount == that_core.IndirectCoreArray.ElemCount) {
```

The surrounding lines (1234-1235) already use `that_core` for the other accesses, so the intent is unambiguous. Surfaced because #5 added `-Wno-tautological-compare` to suppress the gcc 13 warning; the bug itself predates that.

## Known remaining test failures (out of scope)

- **`orly/atom/kit2.test :: PinnedLongStr`** — a long string in a tuple cannot be re-pinned via the tuple element's offset. Independent arena/sabot bug; fix needs reasoning about offset reconstruction in `NewElem`. The non-tuple-wrapped equivalent (`ConfirmStrSize`) passes with the same string.

- **`orly/server/ws.test :: Typical`** — `boost::asio: set_option: Bad file descriptor`. websocketpp 0.8.2 changed the timing of `set_socket_init_handler` callbacks; `ws.cc`'s call to `s.set_option(no_delay)` now runs before the socket is fully open. Likely a small adjustment in `ws.cc` (move the option-set to a later hook) but I haven't verified.

## Test plan

- [x] `make clean && make debug` succeeds (1707/1707 jobs)
- [x] Direct execution of all 188 test binaries: 186 pass, 2 known failures listed above (no regressions vs master)
- [x] No new test binaries crash during static init
- [x] Slow tests (`durable/kit.test`, `indy/disk/merge_data_file.test`) complete cleanly when given >30s