### PR TITLE
orly/server/ws: Move TCP_NODELAY to set_tcp_pre_init_handler

### DIFF
--- a/orly/server/ws.cc
+++ b/orly/server/ws.cc
@@ -78,10 +78,15 @@ class TWsImpl final
     WsServer.set_open_handler(bind(&TWsImpl::OnOpen, this, _1));
     WsServer.set_close_handler(bind(&TWsImpl::OnClose, this, _1));
     WsServer.set_message_handler(bind(&TWsImpl::OnMsg, this, _1, _2));
-    WsServer.set_socket_init_handler(
-          [] (websocketpp::connection_hdl /*hdl*/, boost::asio::ip::tcp::socket &s) {
+    /* In websocketpp 0.8.2 set_socket_init_handler fires during
+       init_asio(), before the socket has an underlying file descriptor,
+       so set_option on it fails with EBADF. set_tcp_pre_init_handler
+       runs after the raw TCP connection has been established, which is
+       when TCP_NODELAY can actually be applied. */
+    WsServer.set_tcp_pre_init_handler(
+          [this] (websocketpp::connection_hdl hdl) {
             boost::asio::ip::tcp::no_delay option(true);
-            s.set_option(option);
+            WsServer.get_con_from_hdl(hdl)->get_raw_socket().set_option(option);
           }
     );
     WsServer.set_listen_backlog(8192);


### PR DESCRIPTION
## Summary

Fixes the `orly/server/ws.test :: Typical` failure called out in #7. Brings the test suite to **187/188 passing**.

## Root cause

In **websocketpp 0.3.0**, `set_socket_init_handler`'s callback fired after the socket was fully open, so `set_option(no_delay)` on the passed `boost::asio::ip::tcp::socket &` worked. In **0.8.2** (introduced by #5), the callback fires during `init_asio()`, immediately after the socket object is constructed but *before* it has an underlying file descriptor:

```cpp
// websocketpp/transport/asio/security/none.hpp:165
lib::error_code init_asio(io_service_ptr service, strand_ptr, bool) {
    ...
    m_socket.reset(new lib::asio::ip::tcp::socket(*service));   // not opened
    if (m_socket_init_handler) {
        m_socket_init_handler(m_hdl, *m_socket);                // <-- fired here
    }
    m_state = READY;
    ...
}
```

So `set_option` fails with `EBADF` ("Bad file descriptor") and `ws.test` aborts before it can run anything real.

## Fix

`set_tcp_pre_init_handler` is the correct hook in 0.8.2:

> The tcp pre init handler is called after the raw tcp connection has been established but before any additional wrappers (proxy connects, TLS handshakes, etc) have been performed.

```diff
-WsServer.set_socket_init_handler(
-      [] (websocketpp::connection_hdl /*hdl*/, boost::asio::ip::tcp::socket &s) {
+WsServer.set_tcp_pre_init_handler(
+      [this] (websocketpp::connection_hdl hdl) {
         boost::asio::ip::tcp::no_delay option(true);
-        s.set_option(option);
+        WsServer.get_con_from_hdl(hdl)->get_raw_socket().set_option(option);
       }
);
```

The signature of `tcp_init_handler` is just `void(connection_hdl)` — no socket reference is passed — so we retrieve the connection from the handle and `get_raw_socket()` to set the option.

## Production impact

The old hook was effectively a no-op against modern websocketpp (it errored synchronously during init), so `TCP_NODELAY` was never being applied to **any** `orlyi` connection. This commit makes it actually take effect again.

## Test plan

- [x] `orly/server/ws.test :: Typical` now passes
- [x] Full sweep: 187/188 test binaries pass (was 186/188 after #7). Only known remaining failure is `kit2.test :: PinnedLongStr` (deep arena bug, out of scope).