### PR TITLE
Fix temporary-lifetime UB in PinnedLongStr fixture (188/188 tests pass)

### DIFF
--- a/orly/atom/kit2.test.cc
+++ b/orly/atom/kit2.test.cc
@@ -271,7 +271,13 @@ FIXTURE(PinnedLongStr) {
   TTestArena arena;
   void *state_alloc_1 = alloca(Sabot::State::GetMaxStateSize());
   void *state_alloc_2 = alloca(Sabot::State::GetMaxStateSize());
-  Sabot::State::TAny::TWrapper tpl_state(TCore(make_tuple(expected), &arena, state_alloc_1).NewState(&arena, state_alloc_2));
+  /* tpl_core must outlive tpl_state: the SS::TTuple constructed in
+     state_alloc_2 caches a pointer back to this TCore and reads from
+     it later when Pin() is called. Using a temporary here (as the
+     original code did) is a stack-lifetime bug that happened to work
+     under older compilers but reads freed memory under gcc 13. */
+  TCore tpl_core(make_tuple(expected), &arena, state_alloc_1);
+  Sabot::State::TAny::TWrapper tpl_state(tpl_core.NewState(&arena, state_alloc_2));
   auto tpl = dynamic_cast<Sabot::State::TTuple *>(tpl_state.get());
   if (EXPECT_TRUE(tpl)) {
     void *state_pin_alloc_1 = alloca(Sabot::State::GetMaxStatePinSize());


### PR DESCRIPTION
## Summary

Fixes the final remaining test failure called out in #7 and #8. **188/188 test binaries now pass.**

## Root cause

The fixture constructed a `TCore` from a temporary and immediately called `NewState` on it:

```cpp
Sabot::State::TAny::TWrapper tpl_state(
    TCore(make_tuple(expected), &arena, state_alloc_1)
        .NewState(&arena, state_alloc_2));
```

`SS::TTuple::TTuple(TArena *arena, const TCore *core)` caches the `TCore *` for later use. The temporary `TCore` is destroyed at the end of the full-expression, but `tpl_state` (and the `SS::TTuple` inside `state_alloc_2`) still holds a pointer back to it. Every subsequent access of `Core->IndirectCoreArray.Offset` — most notably the `tpl->Pin()` call a few lines later — reads freed stack memory.

The companion fixture `ConfirmStrSize`, which has always passed, binds the `TCore` to a named local:

```cpp
TCore core(expected, &arena, state_temp);
Sabot::State::TAny::TWrapper state(core.NewState(&arena, state_temp));
```

That's why it's been working. The bug has been latent in `PinnedLongStr` since 2014; gcc 4.9 happened to leave the temporary's stack slot intact long enough for the test to pass. gcc 13 reuses the slot aggressively, so a junk offset gets driven into `TArena::TryAcquireNote` and the test throws `TNotFound`.

I confirmed this with printf tracing: directly after `EXPECT_TRUE(tpl)` passed, `tpl->Pin()` was calling `TryAcquireNote(offset=0x55b263e035c8, size=40202034872)` — neither value matches the real tuple-note offset (`0x55b270d8e5a0`) or array byte-size (32). Reads of the destroyed TCore's bytes give garbage.

## Fix

Bind the `TCore` to a named local so it outlives `tpl_state` and the `SS::TTuple` that references it.

```diff
-Sabot::State::TAny::TWrapper tpl_state(TCore(make_tuple(expected), &arena, state_alloc_1).NewState(&arena, state_alloc_2));
+TCore tpl_core(make_tuple(expected), &arena, state_alloc_1);
+Sabot::State::TAny::TWrapper tpl_state(tpl_core.NewState(&arena, state_alloc_2));
```

Plus a comment explaining the lifetime contract for future readers.

## Production impact

None — `SS::TTuple` and the `Core *` caching design itself are unchanged. The fix is purely in test code. The lifetime contract this fixture violated has always been the contract; nobody in production code constructs a `TCore` and then `NewState`s it from a temporary in one expression.

## Test plan

- [x] `orly/atom/kit2.test :: PinnedLongStr` now passes
- [x] All 31 fixtures in `kit2.test` pass (was 30/31)
- [x] Full sweep: **188/188 test binaries pass** (was 187/188 after #8)