### PR TITLE
orly/rt/str_replace: Fix pointer-invalidation bug in Replace()

### DIFF
--- a/orly/rt/str_replace.h
+++ b/orly/rt/str_replace.h
@@ -39,15 +39,30 @@ namespace Orly {
       using TRegex = Utf8::TRegex;
 
       static std::string Replace(std::string oldstr, const std::string &regex, const std::string &newstr) {
-	TRegex Regex(regex.c_str());
-	TPiece match_delim;  // going to use this to figure out where to call string::replace
-	const char *curr_start = oldstr.c_str();
-	const char *old_string = oldstr.c_str();
-	while (Regex.TryGetMatch(curr_start, match_delim, 0)) {
-	  oldstr.replace(match_delim.GetStart() - old_string, match_delim.GetLimit() - match_delim.GetStart(), newstr);
-	  curr_start = match_delim.GetLimit();
-	}
-	return oldstr;
+        TRegex Regex(regex.c_str());
+        TPiece match_delim;
+        /* Track position by index, not pointer. std::string::replace() may
+           shift the buffer contents (and on some implementations reallocate),
+           which invalidates any pointer kept across the call. The previous
+           implementation cached match_delim.GetLimit() and oldstr.c_str() as
+           raw pointers, then dereferenced them after a mutation -- silently
+           UB. Worked for like-for-like replacements (t1) and for monotonically
+           shrinking replacements that didn't reuse stale pointer values
+           (t3), but corrupted output for any growing or repeated replacement
+           (t2). */
+        size_t pos = 0;
+        while (pos <= oldstr.size()
+               && Regex.TryGetMatch(oldstr.c_str() + pos, match_delim, 0)) {
+          const size_t match_offset =
+              (match_delim.GetStart() - oldstr.c_str());
+          const size_t match_len =
+              (match_delim.GetLimit() - match_delim.GetStart());
+          oldstr.replace(match_offset, match_len, newstr);
+          /* Step past the newly inserted text. For zero-length matches we
+             must advance at least one position or we loop forever. */
+          pos = match_offset + (match_len == 0 ? 1 : newstr.size());
+        }
+        return oldstr;
       }
 
     };  // TStrReplace


### PR DESCRIPTION
## Summary

Fixes the long-standing pointer-invalidation bug in `Rt::TStrReplace::Replace`. Brings the lang_test suite to **124 passed / 3 failed / 0 changed** (was 123 / 4 / 1 after #11). `strreplace.orly :: t2` now passes.

## Root cause

The old implementation cached two raw `const char*` into `oldstr.c_str()` across calls to `oldstr.replace()`:

```cpp
const char *curr_start = oldstr.c_str();
const char *old_string = oldstr.c_str();
while (Regex.TryGetMatch(curr_start, match_delim, 0)) {
  oldstr.replace(match_delim.GetStart() - old_string,
                 match_delim.GetLimit() - match_delim.GetStart(),
                 newstr);
  curr_start = match_delim.GetLimit();
}
```

That's undefined behavior. `std::string::replace` is permitted to shift the buffer contents (and on some implementations reallocate), leaving the cached pointers dangling or pointing at the wrong characters.

The classic failure is `t2` in `strreplace.orly`:

```orly
replace(.oldstr:"Silly", .regex:"l+", .newstr:"cil") == "Sicily"
```

After the first match (`"ll"` at offset 2) is replaced with `"cil"`, `oldstr` becomes `"Sicily"`, but the cached `curr_start` still pointed at offset 4 of the original buffer — which now contains `"l"` (the shifted-over `"l"` of the original `"ly"`), not the post-match `"y"`. `TryGetMatch` re-matched that residual `"l"` and triggered a second replacement, yielding `"Sicicly"` instead of `"Sicily"`.

`t1` was silent because length-preserving single-char replacements don't shift the buffer. `t3` is length-shrinking, which happens to produce correct text in the cases the test exercises, masking the same UB.

## Fix

Track positions by `size_t` index instead of raw pointer. Recompute the offset from the current `c_str()` every loop iteration. Also handle zero-length matches to avoid a previously-possible infinite loop on regexes like `a*`.

## Was it ever working?

The test file has no captured `.test.state` snapshot, suggesting this fixture has been failing since it was added. No relevant history on either file in `git log` beyond mechanical org renames.

## Test plan

- [x] `t1`, `t2`, `t3` in `strreplace.orly` all pass under `orlyc --v`
- [x] `python3 tools/lang_test.py -d orly/data orly/lang_tests` reports **124/3/0** (was 123/4/1). The 3 remaining failures all match their captured snapshots — no new regressions.
- [x] No new compile warnings or errors