### PR TITLE
ci: First GitHub Actions workflow + Makefile PATH fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,101 @@
+# Build & test orly on Ubuntu 24.04 / gcc 13.
+#
+# This is the first CI for the project. Keep it intentionally simple:
+# one workflow, three jobs (debug+test, release-build, lang-tests),
+# all on stock ubuntu-24.04 runners. No caching yet -- the build is
+# ~10-15 min from scratch but each job's cold-start cost is dwarfed by
+# the LTO link in release; we can layer caching on once we have signal.
+name: ci
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  debug-and-test:
+    name: make debug + make test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential gcc g++ \
+            uuid-dev libgmp-dev libaio-dev libsnappy-dev \
+            libreadline-dev libboost-system-dev zlib1g-dev \
+            bison flex valgrind
+
+      - name: make debug
+        run: make debug
+
+      - name: List built binaries
+        run: |
+          ls -la ../out_orly/debug/orly/orlyc \
+                 ../out_orly/debug/orly/server/orlyi \
+                 ../out_orly/debug/orly/spa/spa \
+                 ../out_orly/debug/orly/client/orly_client
+
+      - name: make test
+        run: make test
+
+  release-build:
+    name: jhm -c release
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential gcc g++ \
+            uuid-dev libgmp-dev libaio-dev libsnappy-dev \
+            libreadline-dev libboost-system-dev zlib1g-dev \
+            bison flex valgrind
+
+      # Bootstrap first (same path make debug takes), then drive jhm
+      # directly. `make release` works but its Makefile wrapper has a
+      # cosmetic broken-pipe quirk at EOF -- direct jhm exits cleanly
+      # with the full status trace. Tracked in #10.
+      - name: Bootstrap jhm
+        run: make bootstrap
+
+      - name: jhm -c release
+        run: jhm -c release
+
+      - name: Smoke each release binary with --help
+        run: |
+          ../out_orly/release/orly/client/orly_client --help | head -1
+          ../out_orly/release/orly/orlyc --help | head -1
+          ../out_orly/release/orly/spa/spa --help | head -1
+          # orlyi's --help prints a huge memory-tuning header first;
+          # asserting non-empty output is enough for a smoke check.
+          ../out_orly/release/orly/server/orlyi --help > /tmp/orlyi-help.txt
+          test -s /tmp/orlyi-help.txt
+
+  lang-tests:
+    name: lang_test.py
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential gcc g++ \
+            uuid-dev libgmp-dev libaio-dev libsnappy-dev \
+            libreadline-dev libboost-system-dev zlib1g-dev \
+            bison flex valgrind
+
+      - name: make debug
+        run: make debug
+
+      - name: python3 tools/lang_test.py
+        run: python3 tools/lang_test.py -d orly/data orly/lang_tests

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 .NOTPARALLEL:
 
+# jhm itself lives in tools/ after bootstrap, and it spawns make_dep_file
+# (also in tools/) as a subprocess. Put tools/ on PATH so every recipe
+# can find both binaries by name -- matches how bootstrap.sh invokes them.
+export PATH := $(CURDIR)/tools:$(PATH)
+
 PREFIX=/usr/local
 BINDIR=$(PREFIX)/bin
 PACKAGE_DIR=$(PREFIX)/packages


### PR DESCRIPTION
## Summary

Adds the project's first CI: `.github/workflows/ci.yml` with three parallel jobs on `ubuntu-24.04` runners, and a load-bearing one-line Makefile fix that makes any of this actually work from a clean checkout.

## Jobs

| Job | Steps |
|---|---|
| **debug-and-test** | `make debug` → list binaries → `make test` (188 binaries) |
| **release-build** | `make bootstrap` → `jhm -c release` direct (bypasses the cosmetic broken-pipe quirk of the `make release` Makefile target — see #10) → smoke each binary with `--help` |
| **lang-tests** | `make debug` → `python3 tools/lang_test.py -d orly/data orly/lang_tests` |

All three install the same system deps documented in the README quick-start (`uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind`).

No caching yet — the build is ~10–15 minutes cold but we have no signal on runner timing to know where to invest. Easy follow-up once the workflow is green.

## Makefile change

`export PATH := $(CURDIR)/tools:$(PATH)` — load-bearing.

`jhm` lives in `tools/` after bootstrap, and at runtime it `execvp`s `make_dep_file` (also in `tools/`) as a subprocess. Without this line, `make debug` from a fresh checkout would fail with `jhm: command not found` — the README quick-start was implicitly relying on the user already having `tools/` in PATH from a previous bootstrap, which a fresh clone doesn't have. Putting `tools/` on PATH at the Makefile level matches how `bootstrap.sh` invokes them and removes the need for callers to PATH-wrap their make invocations.

This is the same fix I've been applying manually via `PATH="$PWD/tools:$PATH" make debug` throughout this revival pass.

## Triggers

`push` to `master` + `pull_request`. The pull_request trigger means this very PR should kick off the first run.

## Test plan

- [x] YAML validates (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`)
- [x] Locally: `make debug` works from a stock PATH after the Makefile change
- [ ] The first CI run on this PR will be the real test. If anything regresses (apt deps, runner quirks, file path assumptions), it'll show up there.