### PR TITLE
ci: Fix release job by invoking tools/jhm directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,10 @@ jobs:
       - name: Bootstrap jhm
         run: make bootstrap
 
-      - name: jhm -c release
-        run: jhm -c release
+      # tools/jhm because the Makefile's `export PATH` only applies inside
+      # make's environment; this is a separate shell invocation.
+      - name: tools/jhm -c release
+        run: tools/jhm -c release
 
       - name: Smoke each release binary with --help
         run: |


### PR DESCRIPTION
## Summary

First CI run after #15 went 2-for-3:

| Job | Result | Time |
|---|---|---|
| debug-and-test | ✅ | 11m7s |
| lang-tests | ✅ | — |
| release-build | ❌ exit 127 | 1m27s |

The release job failed because `run: jhm -c release` is a fresh shell step that doesn't inherit the Makefile's `export PATH := $(CURDIR)/tools:$(PATH)` — that only applies inside make's environment. The preceding `make bootstrap` step built `tools/jhm` to disk, but the next step couldn't find it on PATH.

Fix: invoke `tools/jhm -c release` by explicit path. Matches how `bootstrap.sh` and the README quick-start refer to these tools during bootstrap, and doesn't bury the fix in an env block.

## Test plan

This PR's own CI run will be the test.