### PR TITLE
ci: Also set PATH for jhm's children in the release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,11 @@ jobs:
         run: make bootstrap
 
       # tools/jhm because the Makefile's `export PATH` only applies inside
-      # make's environment; this is a separate shell invocation.
+      # make's environment. PATH also has to include tools/ so that jhm
+      # itself can execvp `make_dep_file` (a sibling in tools/).
+      # Mirrors the last line of bootstrap.sh.
       - name: tools/jhm -c release
-        run: tools/jhm -c release
+        run: PATH="$PWD/tools:$PATH" tools/jhm -c release
 
       - name: Smoke each release binary with --help
         run: |


### PR DESCRIPTION
## Summary

#16 fixed `jhm: command not found` by invoking `tools/jhm` by explicit path. The follow-up run still failed, this time deeper: jhm started correctly, then tried to spawn its `make_dep_file` subprocess via `execvp("make_dep_file")`. That resolves against the inheriting PATH, which doesn't have `tools/`, so the first dep job exits with "No such file or directory" and jhm aborts.

```
terminate called after throwing an instance of 'std::system_error'
  what():  No such file or directory
[0/69] waiting: 23
ERROR: dependency_file{orly/data/twitter_live.cc -> [orly/data/twitter_live.cc.dep]} returned 1
```

The make-based jobs (`debug-and-test`, `lang-tests`) don't hit this because the Makefile does `export PATH := $(CURDIR)/tools:$(PATH)`, which make propagates to its child jhm and then to jhm's children. Going direct loses that.

Fix: set PATH inline in the step, matching the last line of `bootstrap.sh`:

```yaml
run: PATH="$PWD/tools:$PATH" tools/jhm -c release
```

## Test plan

This PR's CI run is the test. If the release job goes green this time we're done with #10's CI box.
