### PR TITLE
ci: Cache apt deps + build outputs; nightly no-cache schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,26 @@
 # Build & test orly on Ubuntu 24.04 / gcc 13.
 #
-# This is the first CI for the project. Keep it intentionally simple:
-# one workflow, three jobs (debug+test, release-build, lang-tests),
-# all on stock ubuntu-24.04 runners. No caching yet -- the build is
-# ~10-15 min from scratch but each job's cold-start cost is dwarfed by
-# the LTO link in release; we can layer caching on once we have signal.
+# Three jobs run on every push to master and every pull_request:
+#   1. debug-and-test  -- make debug + make test (188 binaries)
+#   2. release-build   -- jhm -c release direct + --help smoke on each binary
+#   3. lang-tests      -- make debug + python3 tools/lang_test.py
+#
+# Caching: both apt packages and the build output tree (../out_orly,
+# ../.jhm) are cached across runs. Incremental builds rely on jhm's own
+# per-file checksum tracking, which we know works (it's how `make debug`
+# after a fresh bootstrap takes seconds). To guard against silent stale-
+# cache bugs masking real issues, a `schedule:` trigger runs the
+# same jobs daily with caching disabled. If the nightly ever diverges
+# from the cached PR runs, that's the signal to investigate.
 name: ci
 
 on:
   push:
     branches: [master]
   pull_request:
+  schedule:
+    # Daily at 05:17 UTC -- off-peak, avoids the top-of-hour scheduler rush.
+    - cron: '17 5 * * *'
 
 jobs:
   debug-and-test:
@@ -21,13 +31,24 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential gcc g++ \
-            uuid-dev libgmp-dev libaio-dev libsnappy-dev \
-            libreadline-dev libboost-system-dev zlib1g-dev \
-            bison flex valgrind
+        uses: awalsh128/cache-apt-pkgs-action@v1.5.3
+        with:
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind
+          version: 1.0
+
+      - name: Cache build outputs
+        if: github.event_name != 'schedule'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ../out_orly
+            ../.jhm
+            tools/jhm
+            tools/make_dep_file
+          key: orly-debug-${{ runner.os }}-${{ hashFiles('root.jhm', 'debug.jhm', 'bootstrap.jhm', 'Makefile', 'bootstrap.sh') }}-${{ github.sha }}
+          restore-keys: |
+            orly-debug-${{ runner.os }}-${{ hashFiles('root.jhm', 'debug.jhm', 'bootstrap.jhm', 'Makefile', 'bootstrap.sh') }}-
+            orly-debug-${{ runner.os }}-
 
       - name: make debug
         run: make debug
@@ -50,13 +71,24 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential gcc g++ \
-            uuid-dev libgmp-dev libaio-dev libsnappy-dev \
-            libreadline-dev libboost-system-dev zlib1g-dev \
-            bison flex valgrind
+        uses: awalsh128/cache-apt-pkgs-action@v1.5.3
+        with:
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind
+          version: 1.0
+
+      - name: Cache build outputs
+        if: github.event_name != 'schedule'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ../out_orly
+            ../.jhm
+            tools/jhm
+            tools/make_dep_file
+          key: orly-release-${{ runner.os }}-${{ hashFiles('root.jhm', 'release.jhm', 'bootstrap.jhm', 'Makefile', 'bootstrap.sh') }}-${{ github.sha }}
+          restore-keys: |
+            orly-release-${{ runner.os }}-${{ hashFiles('root.jhm', 'release.jhm', 'bootstrap.jhm', 'Makefile', 'bootstrap.sh') }}-
+            orly-release-${{ runner.os }}-
 
       # Bootstrap first (same path make debug takes), then drive jhm
       # directly. `make release` works but its Makefile wrapper has a
@@ -90,13 +122,24 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential gcc g++ \
-            uuid-dev libgmp-dev libaio-dev libsnappy-dev \
-            libreadline-dev libboost-system-dev zlib1g-dev \
-            bison flex valgrind
+        uses: awalsh128/cache-apt-pkgs-action@v1.5.3
+        with:
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind
+          version: 1.0
+
+      - name: Cache build outputs
+        if: github.event_name != 'schedule'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ../out_orly
+            ../.jhm
+            tools/jhm
+            tools/make_dep_file
+          key: orly-debug-${{ runner.os }}-${{ hashFiles('root.jhm', 'debug.jhm', 'bootstrap.jhm', 'Makefile', 'bootstrap.sh') }}-${{ github.sha }}
+          restore-keys: |
+            orly-debug-${{ runner.os }}-${{ hashFiles('root.jhm', 'debug.jhm', 'bootstrap.jhm', 'Makefile', 'bootstrap.sh') }}-
+            orly-debug-${{ runner.os }}-
 
       - name: make debug
         run: make debug


### PR DESCRIPTION
## Summary

Adds two layers of caching to the CI workflow and a nightly no-cache run that guards against silent stale-cache bugs.

## Caching

1. **apt packages** via [`awalsh128/cache-apt-pkgs-action@v1.5.3`](https://github.com/awalsh128/cache-apt-pkgs-action). Saves ~30-60s of apt install per job. Cache key bound to the packages list, so a deps change auto-invalidates.

2. **Build outputs** (`../out_orly`, `../.jhm`, `tools/jhm`, `tools/make_dep_file`) via [`actions/cache@v4`](https://github.com/actions/cache). Key is per-job-type (debug vs release), per-runner OS, hashed against the config files that invalidate jhm's whole graph (`root.jhm`, `debug.jhm` / `release.jhm`, `bootstrap.jhm`, `Makefile`, `bootstrap.sh`) and tagged with the commit SHA for write-back. `restore-keys` falls back to "any cache for this job + config hash" for incremental builds.

   `debug-and-test` and `lang-tests` share the same cache key prefix (they both run `make debug`), so whichever finishes first populates the cache for the next run of either.

   Correctness relies on jhm's per-file checksum tracking — the same logic that makes `make debug` after a fresh bootstrap take seconds.

## Nightly no-cache schedule

```yaml
on:
  schedule:
    - cron: '17 5 * * *'    # daily 05:17 UTC, off-peak
```

The cache steps are gated by `if: github.event_name != 'schedule'`. The scheduled trigger runs the same jobs daily with caching disabled. If the nightly ever fails while cached PR runs are green, that's the signal jhm's cache logic has a bug or some other stale-cache trap is masking a real regression. This is the recommended mitigation given the user's preference for safety here.

## Expected timing impact

| Scenario | Before | After (warm cache) |
|---|---|---|
| Cold (no cache) | 11-15 min/job | 11-15 min/job (nightly) |
| Source unchanged | 11-15 min | 2-5 min |
| Small header change | 11-15 min | 5-7 min |
| Config file change | 11-15 min | 11-15 min (config-hash mismatch invalidates) |

## Test plan

- [x] YAML validates
- [ ] First run on this PR exercises the cold path (no cache to restore). Subsequent runs should show the warm-cache speedup.
- [ ] First nightly should match the cold-cache PR runs in time.