### PR TITLE
ci: Bump action pins to current major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,17 +28,17 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install system dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1.5.3
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
           packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind
           version: 1.0
 
       - name: Cache build outputs
         if: github.event_name != 'schedule'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ../out_orly
@@ -68,17 +68,17 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install system dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1.5.3
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
           packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind
           version: 1.0
 
       - name: Cache build outputs
         if: github.event_name != 'schedule'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ../out_orly
@@ -119,17 +119,17 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install system dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1.5.3
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
           packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind
           version: 1.0
 
       - name: Cache build outputs
         if: github.event_name != 'schedule'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ../out_orly


### PR DESCRIPTION
## Summary

| Action | From | To |
|---|---|---|
| `actions/checkout` | `v4` | `v6` |
| `actions/cache` | `v4` | `v5` |
| `awalsh128/cache-apt-pkgs-action` | `v1.5.3` | `v1.6.0` |

The `checkout` bump is the load-bearing one: `v4` runs on Node.js 20, which GHA is sunsetting:
- warning on every run today
- default Node 24 switch on 2026-06-16
- Node 20 removed from runners on 2026-09-16

`v5` and `v6` both moved to Node.js 24. Going directly to `v6` since it's the current head and the `v5 → v6` deltas are not relevant to us.

`actions/cache@v5` is the matching latest. `cache-apt-pkgs@v1.6.0` just picks up upstream fixes.

## Test plan

This PR's CI run is the test. If all three jobs pass on the new pins, we're done with the Node 20 deprecation followup from #10.
