### PR TITLE
orlyi: Auto-round mem_sim block counts to satisfy stripe alignment

### DIFF
--- a/orly/indy/disk/sim/mem_engine.h
+++ b/orly/indy/disk/sim/mem_engine.h
@@ -39,16 +39,29 @@ namespace Orly {
             const size_t logical_block_size = 512;
             const size_t physical_block_size = 512;
             const size_t num_logical_block_per_stripe = 1024UL;
-            const size_t num_fast_logical_block = num_mb * ((1024 * 1024) / logical_block_size);
-            const size_t num_slow_logical_block = num_slow_mb * ((1024 * 1024) / logical_block_size);
+            /* Per-device capacity has to be a multiple of the stripe size --
+               enforced by TVolume's constructor and otherwise throws
+               "Device Capacity must be a multiple of the striping factor."
+               at server startup. So the total logical-block count has to be
+               a multiple of (stripe_size * num_devices). Round the requested
+               MB count up to satisfy that, and log if we did, so the server's
+               auto-scaled --mem_sim_mb (which is computed from available RAM
+               and doesn't know about stripes) doesn't blow up on init. */
+            auto round_up_blocks = [num_logical_block_per_stripe](size_t requested, size_t num_devices, const char *label) {
+              const size_t alignment = num_logical_block_per_stripe * num_devices;
+              const size_t rounded = ((requested + alignment - 1) / alignment) * alignment;
+              if (rounded != requested) {
+                syslog(LOG_INFO, "TMemEngine: rounded %s logical-block count %zu -> %zu to satisfy stripe alignment (%zu blocks/stripe x %zu devices)",
+                       label, requested, rounded, num_logical_block_per_stripe, num_devices);
+              }
+              return rounded;
+            };
+            const size_t num_fast_logical_block =
+                round_up_blocks(num_mb * ((1024 * 1024) / logical_block_size), NumFastMemDevice, "fast");
+            const size_t num_slow_logical_block =
+                round_up_blocks(num_slow_mb * ((1024 * 1024) / logical_block_size), NumSlowMemDevice, "slow");
             const size_t min_discard_blocks = 8UL;
             const double high_utilization_threshold = 0.85;
-            if (num_fast_logical_block % NumFastMemDevice != 0) {
-              throw std::runtime_error("TMemEngine num_fast_logical_block must be a multiple of NumFastMemDevice");
-            }
-            if (num_slow_logical_block % NumSlowMemDevice != 0) {
-              throw std::runtime_error("TMemEngine num_slow_logical_block must be a multiple of NumSlowMemDevice");
-            }
             CacheCb = [this](Util::TCacheInstr cache_instr, const Util::TOffset logical_start_offset, void *buf, size_t count) {
               switch (cache_instr) {
                 case Util::TCacheInstr::CacheAll: {


### PR DESCRIPTION
## Summary

`orlyi --mem_sim` throws at startup whenever the resolved `--mem_sim_mb` isn't aligned to the volume stripe size:

```
TServer::Init() caught exception [Device Capacity must be a multiple of the striping factor.]
```

The check fires in `TVolume`'s constructor (orly/indy/disk/util/volume_manager.cc:2683):

```cpp
if (Desc.DeviceDesc.Capacity % (Desc.NumLogicalBlockPerStripe * Desc.DeviceDesc.LogicalBlockSize) != 0) {
    throw std::runtime_error("Device Capacity must be a multiple of the striping factor.");
}
```

For the simulator's defaults (NumFastMemDevice=4, 1024 blocks/stripe, 512 byte blocks) this works out to *"`mem_sim_mb` must be even"*. Two ways to hit it:

1. **Pass an odd value explicitly**: `--mem_sim_mb=1025`.
2. **Default scaling**: `TCmd`'s constructor multiplies the default 1024 MB by `mult_factor = avail_pages / 4GB-equivalent`. Whether the product is even depends on host RAM at startup. On a host with ~10966 MB available, the auto-scaled value is 2741 MB — odd — and the server fails to start. That's the local repro that prompted this PR (also called out in #10).

## Fix

In `TMemEngine`: round both fast and slow logical-block counts up to the next multiple of `(num_logical_block_per_stripe * num_devices)` before constructing the memory devices, and `syslog(LOG_INFO, ...)` when we did. Per-device capacity is then guaranteed to be a multiple of the stripe size, so `TVolume`'s constructor doesn't throw.

Replaces the existing "must be a multiple of NumFastMemDevice / NumSlowMemDevice" `runtime_error` guards — the new alignment is a strict superset, so those checks become unreachable.

## Test plan

- [x] Default `orlyi --mem_sim --no_realtime ...` (with auto-scaled sizes): starts cleanly. Previously failed.
- [x] `--mem_sim_mb=1025`: starts cleanly, log shows
  ```
  TMemEngine: rounded fast logical-block count 2099200 -> 2101248 to satisfy stripe alignment (1024 blocks/stripe x 4 devices)
  ```
- [x] Even values (e.g. `--mem_sim_mb=2048`): no rounding, no log emitted.
- [x] The 7 test binaries that touch `mem_engine.h` (`transaction_base`, `in_file`, `update_walk_file`, `present_walk_file`, `snappy`, `index_manager`, `data_file`) all pass locally: 15/0 fixtures across them.
