### PR TITLE
orly/server: Return UnknownCommand instead of crashing on unimplemented memcache opcodes

### DIFF
--- a/orly/server/server.cc
+++ b/orly/server/server.cc
@@ -2480,8 +2480,25 @@ void TServer::ServeMemcacheClient(TFd &&fd_original, const TAddress &client_addr
           break;
         }
         default: {
+          /* Many opcodes (Delete, Increment, Version, Add, Replace, Append,
+             Prepend, Flush, State, and all the quiet variants) are still
+             stubbed -- see orly/mynde/binary_protocol.cc for the full parser
+             but only Get/Set/NoOp/Quit handled above. Previously this path
+             called NOT_IMPLEMENTED() which throws std::logic_error and the
+             outer catch closes the connection. That meant a routine client
+             probing for Version (a common no-op for memcache clients) would
+             see a socket reset and treat the server as broken.
+             Per the memcached binary spec, status 0x81 (UnknownCommand) is
+             the correct reply for opcodes we don't service; the body
+             carries a human-readable explanation. Returning that keeps the
+             connection alive for whatever the client wants to do next. */
           syslog(LOG_INFO, "Memcache not implemented opcode: %02X", req.GetBinaryOpcode());
-          NOT_IMPLEMENTED();
+          hdr.Status = Mynde::TResponseStatus::UnknownCommand;
+          const char err_msg[] = "Not implemented";
+          hdr.TotalBodyLength = sizeof(err_msg) - 1;
+          out << hdr;
+          out.Write(err_msg, sizeof(err_msg) - 1);
+          break;
         }
       }
 


### PR DESCRIPTION
## Summary

Many memcache binary-protocol opcodes are still stubbed — only `Get`, `Set`, `NoOp`, and `Quit` have handlers in the dispatch switch in `orly/server/server.cc`. Every other opcode (`Delete`, `Version`, `Add`, `Replace`, `Increment`, `Decrement`, `Append`, `Prepend`, `Flush`, `State`, and all the quiet variants) hit the default case which called `NOT_IMPLEMENTED()` — a macro that throws `std::logic_error`. The outer `catch` then closed the connection.

In practice that meant any client probing for a feature — including the very common case of a client sending `Version` (0x0B) right after connecting to detect server capabilities — saw a socket reset and treated the server as broken or unreachable. There was no way to distinguish "unknown command" from "server crashed" from outside.

## Fix

Per the [memcached binary spec](https://github.com/memcached/memcached/wiki/BinaryProtocolRevamped#response-status), status `0x81 (UnknownCommand)` is the correct response for opcodes we don't service; the body carries a human-readable explanation. Returning that keeps the connection alive so the client can fall back to features that are implemented.

```cpp
hdr.Status = Mynde::TResponseStatus::UnknownCommand;
const char err_msg[] = "Not implemented";
hdr.TotalBodyLength = sizeof(err_msg) - 1;
out << hdr;
out.Write(err_msg, sizeof(err_msg) - 1);
```

No behaviour change for `Get` / `Set` / `NoOp` / `Quit`; the default case is the only thing touched.

## Test plan

Run `orlyi --enable_memcache --mem_sim ...` and speak the binary protocol directly:

```py
SET    : status=0x00 body=b''
GET    : status=0x00 body=b'\x00\x00\x00\x00v'
VERSION: status=0x81 body=b'Not implemented'
DELETE : status=0x81 body=b'Not implemented'
GET2   : status=0x00 body=b'\x00\x00\x00\x00v'
```

- [x] `Set` / `Get` round-trip unchanged
- [x] `Version` returns 0x81 + `Not implemented` instead of crashing the connection
- [x] `Delete` (and any other unimplemented opcode) likewise
- [x] Connection survives multiple unimplemented opcodes — the `GET2` after them returns the value set at the start of the session
- [x] Builds cleanly; orlyi starts and serves on port 11211 as expected
