### PR TITLE
orly/server: Implement memcache Version (0x0B) opcode

### DIFF
--- a/orly/server/server.cc
+++ b/orly/server/server.cc
@@ -2479,6 +2479,22 @@ void TServer::ServeMemcacheClient(TFd &&fd_original, const TAddress &client_addr
           }
           break;
         }
+        case Mynde::TRequest::TOpcode::Version: {
+          /* The memcache binary spec puts the version string in the response
+             body. Clients (libmemcached, mc-cli, etc) typically send Version
+             right after connecting as a liveness/capability probe; they're
+             happy with any non-empty string. We deliberately don't claim to
+             be a specific memcached release so clients don't infer feature
+             support that isn't there -- the supported opcode set is still
+             much smaller than upstream memcached's (see UnknownCommand path
+             below, and docs/memcached.md for the broader picture). */
+          context.reset();
+          static const char version[] = "orly-0.5";
+          hdr.TotalBodyLength = sizeof(version) - 1;
+          out << hdr;
+          out.Write(version, sizeof(version) - 1);
+          break;
+        }
         default: {
           /* Many opcodes (Delete, Increment, Version, Add, Replace, Append,
              Prepend, Flush, State, and all the quiet variants) are still


### PR DESCRIPTION
## Summary

Wires up the binary-protocol `Version` (opcode 0x0B) handler. Returns status `0 (NoError)` with the body `"orly-0.5"` rather than the `status 0x81 (UnknownCommand) "Not implemented"` reply that #22 added as the safe default for unimplemented opcodes.

## Why Version specifically

`Version` is the most common probe memcache clients send right after connecting — `libmemcached`, `mc-cli`, k8s healthcheck probes all do it as a server-alive check, and a non-empty response is usually all those clients need to mark the server as healthy. Before #22 unknown opcodes crashed the connection; after #22 they returned `UnknownCommand`. With this commit the most common probe just works.

## Why "orly-0.5" rather than a memcached version

Deliberately not a memcached release number, so clients can't infer feature support that isn't there. `Add`, `Replace`, `Delete`, `Increment`, `Decrement`, `Append`, `Prepend`, `Flush`, `State` and the quiet variants are all still `UnknownCommand`. `0.5` matches the version `orlyc --help` already advertises.

## Test plan

Speak the binary protocol directly against `orlyi --enable_memcache`:

```
VERSION   : status=0x00 body=b'orly-0.5'
SET       : status=0x00 body=b''
VERSION 2 : status=0x00 body=b'orly-0.5'        -- mid-session OK
DELETE    : status=0x81 body=b'Not implemented' -- still unimpl
VERSION 3 : status=0x00 body=b'orly-0.5'        -- connection alive
```

- [x] `VERSION` returns `0x00 + "orly-0.5"` instead of `0x81 + "Not implemented"`
- [x] Works mid-session after a `SET`
- [x] Works after a still-unimplemented opcode (`DELETE` returns `0x81`, then next `VERSION` succeeds)
- [x] No regressions in `Set` / `Get` / `NoOp` / `Quit`
- [x] Builds cleanly
