### PR TITLE
jhm: Fix make-release late-stage crash (SIGPIPE + non-idempotent pipe teardown)

### DIFF
--- a/base/pump.cc
+++ b/base/pump.cc
@@ -16,6 +16,7 @@
 
 #include <base/pump.h>
 
+#include <cstdio>
 #include <sys/epoll.h>
 #include <fcntl.h>
 
@@ -154,19 +155,29 @@ class TPump::TPipe {
     }
   }
 
+  /* Idempotent. Safe to call from either Service()'s read-error fallback
+     after the write-error fallback has already invoked it, and safe from
+     ~TPipe after a Service() call has already torn the read side down. */
   void StopWriting() {
     assert(this);
-    if (Writing) {
+    if (Writing && WriteFd.IsOpen()) {
       Pump->PartEpoll(WriteFd);
-      Writing = false;
     }
+    Writing = false;
   }
 
+  /* Same idempotency contract as StopWriting -- Service() can reach this
+     more than once on a single iteration (EOF on the read side, then an
+     unrelated error on the write side that re-invokes StopReading), and
+     with NDEBUG the historical assert(ReadFd.IsOpen()) doesn't catch the
+     double-call. Without the open-check the second PartEpoll passes -1
+     and EBADF terminates jhm. */
   void StopReading() {
     assert(this);
-    assert(ReadFd.IsOpen());
-    Pump->PartEpoll(ReadFd);
-    ReadFd.Reset();
+    if (ReadFd.IsOpen()) {
+      Pump->PartEpoll(ReadFd);
+      ReadFd.Reset();
+    }
   }
 
   /* Pointer to the pump so we can register / deregister as needed, as well as */
@@ -276,10 +287,20 @@ void TPump::JoinEpoll(int fd, uint32_t events, TPipe *pipe) {
   epoll_event event;
   event.events = events;
   event.data.ptr = pipe;
-  IfLt0(epoll_ctl(Epoll, EPOLL_CTL_ADD, fd, &event));
+  int rc = epoll_ctl(Epoll, EPOLL_CTL_ADD, fd, &event);
+  if (rc < 0) {
+    std::fprintf(stderr, "TPump::JoinEpoll(Epoll=%d, fd=%d) failed errno=%d\n",
+                 static_cast<int>(Epoll), fd, errno);
+    Util::ThrowSystemError(errno);
+  }
 }
 
 void TPump::PartEpoll(int fd) {
   assert(this);
-  IfLt0(epoll_ctl(Epoll, EPOLL_CTL_DEL, fd, nullptr));
+  int rc = epoll_ctl(Epoll, EPOLL_CTL_DEL, fd, nullptr);
+  if (rc < 0) {
+    std::fprintf(stderr, "TPump::PartEpoll(Epoll=%d, fd=%d) failed errno=%d\n",
+                 static_cast<int>(Epoll), fd, errno);
+    Util::ThrowSystemError(errno);
+  }
 }

--- a/jhm/jhm.cc
+++ b/jhm/jhm.cc
@@ -23,11 +23,13 @@
    See the License for the specific language governing permissions and
    limitations under the License. */
 
+#include <csignal>
 #include <iomanip>
 #include <iostream>
 #include <string>
 #include <thread>
 
+#include <base/backtrace.h>
 #include <base/cmd.h>
 #include <base/path.h>
 #include <base/split.h>
@@ -288,6 +290,21 @@ class TJhm : public TCmd {
 };
 
 int main(int argc, char *argv[]) {
+  /* Ignore SIGPIPE so a subprocess closing its read end mid-write doesn't
+     kill jhm. TPump's background thread writes through pipes that connect
+     to child stdin / our buffered read of child stdout/stderr. When a
+     child exits (normal flow at end of build, especially in the LTO link
+     region with hundreds of input fds in flight), one of those writes can
+     hit a closed read end. Default SIGPIPE terminates the process; with
+     this handler write() just returns -1/EPIPE and the existing
+     pump.cc:117-124 fallthrough flags the pipe dead and continues. */
+  std::signal(SIGPIPE, SIG_IGN);
+
+  /* Backtrace on terminate so an uncaught std::system_error in a worker
+     thread (e.g. TPump's background thread) doesn't disappear into a bare
+     `terminate called after throwing` line. */
+  Base::SetBacktraceOnTerminate();
+
   try {
     return TJhm(argc, argv).Run();
   }

--- a/jhm/make_dep_file.cc
+++ b/jhm/make_dep_file.cc
@@ -16,6 +16,7 @@
    See the License for the specific language governing permissions and
    limitations under the License. */
 
+#include <csignal>
 #include <fstream>
 #include <iostream>
 #include <stdexcept>
@@ -155,6 +156,12 @@ void MakeDepFile(const string &filename, const string &out_name, const vector<st
 }
 
 int main(int argc, const char *argv[]) {
+  /* Same SIGPIPE reasoning as jhm: TPump-managed pipes can write to a
+     reader that's already closed (the g++ subprocess we spawn for -M -MG
+     exits after producing its output). Default SIGPIPE terminates us;
+     ignoring lets write() return EPIPE and the pump cleans up. */
+  std::signal(SIGPIPE, SIG_IGN);
+
   if (argc < 3) {
     //TODO: add '-o' to specify output filename.
     cout << "USAGE: " << argv[0] << "input_name output_name [misc_flags]\n"


### PR DESCRIPTION
## Summary

`make release` had been failing at the very end of the LTO link phase for both local builds and CI — locally with `Broken pipe` (exit 141), in CI with `terminate ... std::system_error: Bad file descriptor` (exit 134). Same family of fault, different surface. Turned out to be a sequence of two bugs.

## Bug 1: jhm had no SIGPIPE handler

`TPump`'s background thread writes through pipes connected to child subprocess fds. When a child closes its read end mid-write — normal during teardown in the LTO link region, where many fds are shuffling — the `write()` raises `SIGPIPE`, which terminates jhm by default. That's the local exit 141.

**Fix:** `signal(SIGPIPE, SIG_IGN)` at the top of `main()` in both `jhm` and `make_dep_file`. Then `write()` returns `-1`/`EPIPE` and the existing pump.cc EPIPE fallthrough at line 117 already handles the cleanup correctly.

## Bug 2: `TPipe::StopReading` / `StopWriting` were not idempotent

`Service()`'s write-error fallback unconditionally calls both `StopReading()` and `StopWriting()` to tear the pipe down. But `Service()`'s read path can also call `StopReading()` (on EOF) earlier in the same `Service()` iteration. On the second call, `ReadFd` has already been `Reset()` to `-1` and the historical `assert(ReadFd.IsOpen())` is compiled out under `-DNDEBUG`. `PartEpoll` then calls `epoll_ctl(EPOLL_CTL_DEL, -1)` which returns `EBADF`, and the `std::system_error` from `Util::IfLt0` escapes the background thread uncaught → `terminate` → `abort`. Decoded backtrace:

```
Util::ThrowSystemError<int>
Base::TPump::BackgroundMain.cold
std::terminate (via our SetBacktraceOnTerminate handler)
```

**Bug 1 was hiding bug 2:** the `SIGPIPE` killed jhm before the write fallthrough got a chance to fire the double-`StopReading()`. With SIGPIPE ignored the `EPIPE` path runs and we hit the `EBADF` instead — exactly the failure CI had been showing all along.

**Fix:** guard the actual close in both `StopReading` and `StopWriting` on `IsOpen()` / `Writing` so a second call is a no-op.

## Also includes

- `Base::SetBacktraceOnTerminate()` in jhm's `main()` so a future uncaught exception in a worker thread surfaces with a backtrace instead of disappearing into a bare `terminate called after throwing` line.
- One-line `fprintf` in `TPump::{Join,Part}Epoll` on `epoll_ctl` failure so the next time something pathological happens with our fd bookkeeping the error message names the operation and the fd rather than just `Bad file descriptor`.

## Test plan

- [x] `make release` exit 0, 1109/1109 jobs, all four binaries produced
- [x] `make test` exit 0 (188/188 test binaries still pass)
- [x] `make debug` exit 0 (no regressions)
- [x] Reverting bug-1's fix alone reintroduces the SIGPIPE termination (exit 141 at ~job 1016)
- [x] Reverting bug-2's fix alone with bug 1 fixed reintroduces the EBADF abort (exit 134 at ~job 1108/1109)
- [x] CI should now pass the `release-build` job for the first time without manual intervention
EOF
)