### PR TITLE
build: Enable parallel LTRANS (-flto -> -flto=auto)

### DIFF
--- a/bootstrap.jhm
+++ b/bootstrap.jhm
@@ -6,7 +6,7 @@
       "-O3",
       "-g1",
       "-DNDEBUG",
-      "-flto",
+      "-flto=auto",
       "-Wno-unused",
       "-Wno-unused-parameter",
       "-Wno-unused-result",
@@ -17,7 +17,7 @@
       "-O3",
       "-g1",
       "-DNDEBUG",
-      "-flto",
+      "-flto=auto",
       "-DBOOTSTRAP"
     ],
     "flex": {
@@ -26,7 +26,7 @@
         "-O3",
         "-g1",
         "-DNDEBUG",
-        "-flto",
+        "-flto=auto",
         "-DBOOTSTRAP"
       ]
     },
@@ -36,14 +36,14 @@
         "-O3",
         "-g1",
         "-DNDEBUG",
-        "-flto",
+        "-flto=auto",
         "-DBOOTSTRAP"
       ]
     },
     "ld": {
       "+flags": [
         "-O3",
-        "-flto"
+        "-flto=auto"
       ]
     }
   }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -18,7 +18,7 @@ set -e
 
 CC=g++
 common_flags=(
-  -O3 -DNDEBUG -flto
+  -O3 -DNDEBUG -flto=auto
   -std=c++17
   -Wall -Werror -Wextra -Wold-style-cast
   -Wno-unused -Wno-unused-parameter -Wno-unused-result

--- a/release.jhm
+++ b/release.jhm
@@ -5,7 +5,7 @@
       "-O3",
       "-g1",
       "-DNDEBUG",
-      "-flto",
+      "-flto=auto",
       "-Wno-unused",
       "-Wno-unused-parameter",
       "-Wno-unused-result"
@@ -15,7 +15,7 @@
       "-O3",
       "-g1",
       "-DNDEBUG",
-      "-flto"
+      "-flto=auto"
     ],
     "flex": {
       "+g++": [
@@ -23,7 +23,7 @@
         "-O3",
         "-g1",
         "-DNDEBUG",
-        "-flto"
+        "-flto=auto"
       ]
     },
     "bison": {
@@ -32,13 +32,13 @@
         "-O3",
         "-g1",
         "-DNDEBUG",
-        "-flto"
+        "-flto=auto"
       ]
     },
     "ld": {
       "+flags": [
         "-O3",
-        "-flto"
+        "-flto=auto"
       ]
     }
   }


### PR DESCRIPTION
## Summary

Every link in the LTO path was emitting:

```
lto-wrapper: warning: using serial compilation of N LTRANS jobs
lto-wrapper: note: see the '-flto' option documentation for more information
```

Plain `-flto` runs the LTRANS phase serially — gcc's `lto-wrapper` partitions the merged IR into N chunks but only processes one at a time unless told otherwise. On our biggest link (`orlyi`, ~5 partitions) that's measurable serial wall-clock waste.

## Fix

`-flto` → `-flto=auto` in `bootstrap.sh`, `bootstrap.jhm`, and `release.jhm` (debug builds don't use LTO at all). `-flto=auto` tells gcc to detect available cores and parallelize the LTRANS phase itself.

This is *per-link* parallelism, not cross-link. jhm's existing top-level scheduler is unaffected; multiple links can still run concurrently with multiple LTRANS workers each. Per-compile `-flto` behavior is unchanged — the `=N` argument only matters at link time.

We don't use `-flto=jobserver`. That would require the Makefile recipe to be prefixed with `+` (so make passes its jobserver fd) AND jhm to thread the jobserver to its subprocesses; neither is in place today. auto-detect is good enough.

## Test plan

- [x] `./bootstrap.sh` exits 0; no `lto-wrapper` warning lines anywhere in the output (previously fired during the bootstrap's own self-link)
- [x] Bootstrap produces working `tools/jhm` and `tools/make_dep_file`
- [ ] CI's `release-build` will exercise the change against a full LTO link of all four release binaries. The warning should disappear there too.

## Notes

- No code paths touched. Same artifacts produced.
- Once this lands, the only "Still open" residual in #10 is memcache opcode coverage.
