### PR TITLE
third_party: Document vendored library versions and update strategy

### DIFF
--- a/third_party/README.md
+++ b/third_party/README.md
@@ -1,10 +1,18 @@
 ## third_party
 
-Third party libraries and tools which have been or are used with or by Orly.
+Third party libraries that ship in this repo as source-tree snapshots. Each subdirectory has a `VENDORED.md` describing what version is pinned, when it was last bumped, why we vendor it rather than pulling from a system package, and how to update.
+
+| Library | Version | Used by |
+| --- | --- | --- |
+| [`linenoise`](linenoise/VENDORED.md) | ~2013 snapshot (antirez/linenoise) | `base/repl`, `jhm/status_line` |
+| [`mongoose`](mongoose/VENDORED.md) | 3.0 (last MIT release) | `orly/spa/spa.cc` |
+| [`websocketpp`](websocketpp/VENDORED.md) | 0.8.2 | `orly/server/ws.cc` |
+
+When bumping any of these, update the corresponding `VENDORED.md`. When adding a new vendored dep, write one before opening the PR.
 
 -----
 
-README.md Copyright 2010-2014 OrlyAtomics, Inc.
+README.md Copyright 2010-2026 Atomic Kismet Company
 
 README.md is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License.
 

--- a/third_party/linenoise/VENDORED.md
+++ b/third_party/linenoise/VENDORED.md
@@ -1,0 +1,39 @@
+# linenoise
+
+Single-file C readline replacement. Used by `base/repl.h` / `base/repl.cc` for the interactive REPL in `orly_client`, and by `jhm/status_line.h` for terminal-aware status output.
+
+## Vendored version
+
+- **Version:** unversioned (upstream does not tag releases)
+- **Snapshot date:** approximately 2013, based on the `Copyright (c) 2010-2013` line in `linenoise.c`. Best guess: the snapshot was taken when this codebase was first written.
+- **Upstream:** https://github.com/antirez/linenoise
+- **License:** BSD 2-Clause (`README.markdown`)
+- **Size at vendoring:** 1156 lines across `linenoise.c` + `linenoise.h`
+
+## Why vendored rather than system package
+
+Linenoise's upstream model is "drop the two files in your project." It's never been packaged for distros and the maintainer (antirez, of Redis) treats it as a sample / reference rather than a library. Vendoring is the recommended distribution.
+
+## Local modifications
+
+None known. The vendored files appear to be verbatim antirez/linenoise from circa 2013.
+
+## Bump notes
+
+Linenoise's API has been remarkably stable — function signatures haven't changed in years. A drop-in replacement from current upstream HEAD should work without touching `base/repl.cc` or `jhm/status_line.h`. The upside is mostly hygiene (we'd pick up bug fixes from the intervening ~12 years); there's no functional pressure to bump.
+
+## To update
+
+Upstream doesn't tag releases. Pin to a commit:
+
+```sh
+cd /tmp
+git clone --depth=1 https://github.com/antirez/linenoise.git
+cd <REPO_ROOT>/third_party/linenoise
+# Replace only the source files; keep README and Makefile in case ours have local tweaks
+cp /tmp/linenoise/linenoise.c .
+cp /tmp/linenoise/linenoise.h .
+# verify `orly_client` interactive shell still works and jhm status line still renders
+```
+
+Then record the new upstream commit SHA in this file.

--- a/third_party/mongoose/VENDORED.md
+++ b/third_party/mongoose/VENDORED.md
@@ -1,0 +1,33 @@
+# mongoose
+
+Small embeddable C HTTP server. Used by `orly/spa/spa.cc` for the HTTP front-end of the `spa` (single-process app) server.
+
+## Vendored version
+
+- **Version:** 3.0 (`#define MONGOOSE_VERSION "3.0"` in `mongoose.c`)
+- **Upstream (then):** https://github.com/valenok/mongoose (original maintainer Sergey Lyubka)
+- **Upstream (now):** https://github.com/cesanta/mongoose (forked + relicensed)
+- **Vendored:** pre-2014, exact date unknown (predates the Apache foundation migration in this repo's history)
+- **License at vendoring time:** MIT (`LICENSE`, `mongoose.c` header)
+
+## Why vendored rather than system package
+
+Mongoose 3.0 is *only* available as this vendored snapshot. The upstream project was forked to cesanta/mongoose and relicensed to GPLv2 / commercial dual-license starting around v3.1. None of the major distros package the MIT-licensed 3.x branch. Even if they did, upstream's API changed dramatically in 5.x and again in 7.x, so a system package would not satisfy `orly/spa/spa.cc`'s expectations of the v3-era callback model (`mg_event`, `mg_request_info`, `OnEvent`).
+
+## Local modifications
+
+None to the source. The build adds several `-Wno-*` suppressions in `root.jhm`'s `gcc` section (because gcc 13 flags things gcc 4.9 didn't — `-Wcast-function-type`, `-Wmaybe-uninitialized`, etc.) but the C code is verbatim 3.0.
+
+## Bump notes
+
+This snapshot is essentially frozen. Bumping options, none of them attractive:
+
+1. **Stay on 3.0** (current): compiles, links, works. License compatible with this repo. Aging gracefully behind warning suppressions.
+2. **Bump to a newer cesanta/mongoose**: triggers the GPLv2/commercial license question, and requires rewriting `orly/spa/spa.cc` against the v7.x API (which is `mg_http_serve_dir`, `MG_EV_HTTP_MSG`, etc. — completely different model). Effectively rewriting the SPA HTTP layer.
+3. **Replace with a different lib**: `boost::beast` (boost is already a dep) or `cpphttplib` would let us drop this directory entirely. Same scope of work as option 2.
+
+Recommendation: leave on 3.0 until the SPA HTTP layer needs other changes anyway, at which point options 2 or 3 become incremental.
+
+## To update (if option 1)
+
+There is no newer 3.x to update to — the MIT branch ended at 3.x. This entry exists for completeness.

--- a/third_party/websocketpp/VENDORED.md
+++ b/third_party/websocketpp/VENDORED.md
@@ -1,0 +1,36 @@
+# websocketpp
+
+Header-only C++ WebSocket library. Used by `orly/server/ws.cc` for the WebSocket protocol surface that `orlyi` exposes on port 8082.
+
+## Vendored version
+
+- **Version:** 0.8.2
+- **Upstream:** https://github.com/zaphoyd/websocketpp
+- **Tarball:** https://github.com/zaphoyd/websocketpp/archive/refs/tags/0.8.2.tar.gz
+- **Vendored:** 2026-05-29 (PR #5), bumped from 0.3.0 (2013)
+- **License:** BSD 3-Clause (`COPYING`)
+
+## Why vendored rather than system package
+
+Not packaged in Ubuntu / Debian / Fedora repositories. Upstream's recommended distribution model is exactly this — header-only source drop. Some distros ship `libwebsocketpp-dev` but the packaging is inconsistent across versions and lags upstream by years.
+
+## Local modifications
+
+None. The vendored tree is the upstream 0.8.2 tarball contents, verbatim.
+
+## Bump notes
+
+- The 0.3.0 → 0.8.2 bump in #5 was forced: 0.3.0 used `boost::asio::strand(io_service)` which no longer exists in boost ≥ 1.74. `Ubuntu 24.04` ships boost 1.83, so 0.3.0 wouldn't compile at all.
+- 0.8.2 is the last header-only release before 0.9.0 introduced larger restructuring. No reason to bump further unless a CVE shows up.
+- `orly/server/ws.cc` was adjusted alongside the bump (#8) because `set_socket_init_handler`'s callback timing changed between 0.3.0 and 0.8.2.
+
+## To update
+
+```sh
+cd /tmp
+wget https://github.com/zaphoyd/websocketpp/archive/refs/tags/<NEW_TAG>.tar.gz
+tar -xzf <NEW_TAG>.tar.gz
+rm -rf <REPO_ROOT>/third_party/websocketpp
+mv websocketpp-<NEW_TAG> <REPO_ROOT>/third_party/websocketpp
+# verify `make debug` and `orly/server/ws.test` still pass
+```


### PR DESCRIPTION
## Summary

Adds a `VENDORED.md` in each `third_party/<lib>` directory recording what version is pinned, when it was last bumped, why we vendor rather than use a system package, and how to update. Rewrites the formerly-empty `third_party/README.md` as a one-line index pointing at each.

The intent is **paper trail, not process** — no build or runtime changes. Next time anyone bumps one of these libs or wonders why the mongoose snapshot looks ancient, the answer is in the directory.

## What got captured

| Library | Version | Notes |
|---|---|---|
| `websocketpp` | 0.8.2 | Bumped from 0.3.0 in #5; license still BSD; trivial to update further |
| `mongoose` | 3.0 | Last MIT-licensed release; upstream moved to GPLv2/commercial after 3.x, so this snapshot is effectively frozen unless we rewrite `orly/spa/spa.cc` against a different lib |
| `linenoise` | ~2013 snapshot (no upstream tags) | API stable, drop-in updates fine |

Each `VENDORED.md` includes a short "To update" recipe so future bumps are mechanical.

## Also

Bumps `third_party/README.md`'s own copyright footer from `2010-2014 OrlyAtomics, Inc.` to `2010-2026 Atomic Kismet Company`. That file is ours (it describes how *we* organize `third_party/`), not vendored, and was collateral damage from #12's deliberate skip of the entire `third_party/` tree.

## Test plan

Documentation only — no code path touched.

- [x] All four markdown files render cleanly (verified via diff)
- [x] All links in `third_party/README.md`'s index resolve to the right `VENDORED.md`
- [x] `make debug` / `make test` unaffected (no source changes)
