### PR TITLE
orly/compiler: Symmetric warning config + drop -Werror on orlyc's shell-out

### DIFF
--- a/orly/compiler.cc
+++ b/orly/compiler.cc
@@ -221,55 +221,59 @@ Package::TVersionedName Orly::Compiler::Compile(
       out_strm << "MM_NOTICE: Compiling C++" << endl;
     }
 
-    // TODO: Check these compile flags.
     vector<string> gcc_cmd{"g++", "-std=c++17", "-xc++", "-I" + GetSrcRoot(), "-fPIC", "-shared", "-o",
                            AsStr(out_tree.GetAbsPath(SwapExtension(
                                TPath(core_rel.Path), {to_string(packages[core_rel]->GetVersion()), "so"}))),
                            "-iquote", AsStr(out_tree),
                            AsStr(out_tree.GetAbsPath(SwapExtension(TPath(core_rel.Path), {"link", "cc"})))};
-    // Take all the packages needed directly or indirectly by the compilation and link  them together in one swoop.
+    // Take all the packages needed directly or indirectly by the compilation and link them together in one swoop.
     for (const auto &package : packages) {
       gcc_cmd.emplace_back(AsStr(out_tree.GetAbsPath(SwapExtension(TPath(package.first.Path), {"cc"}))));
     }
+
+    /* Warning configuration applied to both debug and release.
+       Deliberately NO -Werror -- warnings come overwhelmingly from the
+       orly headers themselves (e.g. -Waddress-of-packed-member on
+       TCore's union, -Wclass-memaccess on packed serialization layouts)
+       rather than from anything the user's .orly file caused us to
+       emit. Errror'ing on them just breaks `orlyc` for users whenever
+       a new gcc release adds a warning category, with no recourse
+       except waiting for a fix in this repo. Print warnings, but don't
+       fail the compile.
+       The -Wno-* list mirrors root.jhm so generated-code compilation
+       sees the same noise filter as the in-tree build. */
+    const char *common_warning_args[] = {
+        "-Wall", "-Wextra",
+        "-Wno-unused-variable", "-Wno-unused-parameter", "-Wno-unused-result",
+        "-Wno-parentheses", "-Wno-type-limits",
+        "-Wno-address-of-packed-member", "-Wno-deprecated-declarations",
+        "-Wno-class-memaccess", "-Wno-stringop-overflow", "-Wno-stringop-overread",
+        "-Wno-array-bounds", "-Wno-restrict", "-Wno-pessimizing-move",
+        "-Wno-redundant-move", "-Wno-mismatched-new-delete",
+        "-Wno-dangling-reference", "-Wno-tautological-compare",
+        "-Wno-implicit-fallthrough", "-Wno-overloaded-virtual",
+        "-Wno-deprecated", "-Wno-deprecated-copy", "-Wno-c++20-compat",
+        "-Wno-volatile", "-Wno-narrowing", "-Wno-maybe-uninitialized",
+        "-Wno-init-list-lifetime", "-Wno-deprecated-enum-enum-conversion",
+        "-Wno-deprecated-enum-float-conversion", "-Wno-int-in-bool-context",
+        "-Wno-uninitialized", "-Wno-sign-compare", "-Wno-empty-body",
+        "-Wno-misleading-indentation", "-Wno-terminate", "-Wno-noexcept-type",
+        "-Wno-comment", "-Wno-reorder", "-Wno-strict-overflow",
+        "-Wno-shift-negative-value", "-Wno-zero-as-null-pointer-constant",
+        "-Wno-write-strings", "-Wno-multichar", "-Wno-int-to-pointer-cast",
+        "-Wno-pointer-arith", "-Wno-format", "-Wno-format-security",
+        "-Wno-ignored-qualifiers", "-Wno-cast-function-type",
+        "-Wno-aligned-new", "-Wno-placement-new",
+        "-Wno-format-truncation", "-Wno-format-overflow",
+        "-Wno-nonnull-compare", "-Wno-nonnull",
+    };
+    for (auto &arg : common_warning_args) {
+      gcc_cmd.emplace_back(arg);
+    }
     if (debug_cc) {
-      const char *debug_args[] = {
-          "-g",      "-Wno-unused-variable", "-Wno-type-limits",
-          "-Werror", "-Wno-parentheses",     "-Wall",
-          "-Wextra", "-Wno-unused-parameter",
-          // The same gcc 13-era suppressions used by root.jhm, mirrored here
-          // because orlyc shells out to g++ on the generated .cc and the system
-          // toolchain has many more warnings than the gcc 4.9 era this was tuned
-          // for. Without these, every package compile reports diagnostics from
-          // the orly headers (e.g. -Waddress-of-packed-member on TCore's union).
-          "-Wno-address-of-packed-member", "-Wno-deprecated-declarations",
-          "-Wno-class-memaccess", "-Wno-stringop-overflow", "-Wno-stringop-overread",
-          "-Wno-array-bounds", "-Wno-restrict", "-Wno-pessimizing-move",
-          "-Wno-redundant-move", "-Wno-mismatched-new-delete",
-          "-Wno-dangling-reference", "-Wno-tautological-compare",
-          "-Wno-implicit-fallthrough", "-Wno-overloaded-virtual",
-          "-Wno-deprecated", "-Wno-deprecated-copy", "-Wno-c++20-compat",
-          "-Wno-volatile", "-Wno-narrowing", "-Wno-maybe-uninitialized",
-          "-Wno-init-list-lifetime", "-Wno-deprecated-enum-enum-conversion",
-          "-Wno-deprecated-enum-float-conversion", "-Wno-int-in-bool-context",
-          "-Wno-uninitialized", "-Wno-sign-compare", "-Wno-empty-body",
-          "-Wno-misleading-indentation", "-Wno-terminate", "-Wno-noexcept-type",
-          "-Wno-comment", "-Wno-unused-result", "-Wno-reorder",
-          "-Wno-strict-overflow", "-Wno-shift-negative-value",
-          "-Wno-zero-as-null-pointer-constant", "-Wno-write-strings",
-          "-Wno-multichar", "-Wno-int-to-pointer-cast", "-Wno-pointer-arith",
-          "-Wno-error=return-type", "-Wno-error=switch", "-Wno-format",
-          "-Wno-format-security", "-Wno-error=format-security",
-          "-Wno-ignored-qualifiers", "-Wno-cast-function-type",
-          "-Wno-aligned-new", "-Wno-placement-new",
-          "-Wno-format-truncation", "-Wno-format-overflow",
-          "-Wno-nonnull-compare", "-Wno-nonnull", "-Wno-error=cpp",
-      };
-      for (auto &arg : debug_args) {
-        gcc_cmd.emplace_back(arg);
-      }
+      gcc_cmd.push_back("-g");
     } else {
       // TODO: Better optimization flags.
-      // TODO: vector append
       gcc_cmd.push_back("-O2");
       gcc_cmd.push_back("-DNDEBUG");
     }


### PR DESCRIPTION
## Summary

`orlyc` shells out to `g++` to compile each `.orly` package into a `.so`. The flag set there had two related problems I noticed while auditing the codebase:

### 1. Asymmetric: debug had all the warning suppressions, release had none

PR #11 added a wave of gcc 13-era `-Wno-*` flags to the `debug_cc` branch (because the debug path enables `-Wall -Wextra -Werror`). The release branch had no warning configuration at all — just `-O2 -DNDEBUG`. Release packages compiled because gcc emits little without `-Wall`, but in the alternate world where anyone added `-Wall` to the base flags, the release path would have hit the same wave of warnings the debug path used to.

### 2. `-Werror` in the debug path was a maintenance trap

Every warning gcc emits about our orly headers — `TCore`'s packed union, the various `class-memaccess` / `dangling-reference` diagnostics, etc. — is something **the user can't fix**. It's our code, not theirs. `-Werror` plus a hand-maintained `-Wno-*` list means each new gcc release that introduces a warning category breaks `orlyc --debug` for users until somebody (us) adds another `-Wno-*`. The list was already 30+ entries from #11.

## Fix

- Hoist the warning configuration to apply to **both** debug and release. Both now see `-Wall -Wextra` + the same `-Wno-*` set.
- Drop `-Werror` entirely. We still print warnings (so genuine codegen issues surface), we just don't fail compiles on them.
- `debug_cc` now adds only `-g`; release branch keeps `-O2 -DNDEBUG`.

Net effect for users: a future gcc 14 with a new warning category doesn't silently break `orlyc --debug`. Generated-code bugs that manifest as warnings are still visible in the orlyc output.

## Test plan

- [x] `orlyc --debug fizzbuzz.orly` produces `fizzbuzz.1.so` (3.0 MB with `-g`)
- [x] `orlyc fizzbuzz.orly` (no `--debug`) produces `fizzbuzz.1.so` (125 KB after `-O2` + strip)
- [x] `lang_test.py`: 124 passed / 3 failed / 0 changed (same baseline, the 3 always-failing snapshot tests are unchanged)
- [x] `make debug` and `make test` unaffected (jhm's own flag set is in `root.jhm`, not here)
EOF
)