### PR TITLE
Remove 1477 noise `assert(&ref);` statements

### DIFF
--- a/base/bg_generator.cc
+++ b/base/bg_generator.cc
@@ -153,7 +153,6 @@ void TAnyBgGenerator::RequireBgHasYielded() const {
 }
 
 void TAnyBgGenerator::Swap(TAnyBgGenerator &that) noexcept {
-  assert(&that);
   /* If this assertion fails, it means this or that generator has already
      started running and so cannot be swapped. */
   assert(State == Unstarted);

--- a/base/bg_generator.h
+++ b/base/bg_generator.h
@@ -268,7 +268,6 @@ namespace Base {
     /* Swap this generator with that one.  NOTE: It's an error to do this if
        either generator has already started running. */
     TBgGenerator &Swap(TBgGenerator &that) noexcept {
-      assert(&that);
       TAnyBgGenerator::Swap(that);
       std::swap(Cache, that.Cache);
       std::swap(Generate, that.Generate);
@@ -285,7 +284,6 @@ namespace Base {
          operator++(). */
       Generate(
           [this](const TVal &val) {
-            assert(&val);
             assert(!Cache);
             Cache = &val;
             return BgYield();

--- a/base/bg_generator.test.cc
+++ b/base/bg_generator.test.cc
@@ -67,7 +67,6 @@ static const vector<string> Strings = {
 
 static bool GenerateStrings(
     const function<bool (const string &)> &cb, size_t max_count) {
-  assert(&cb);
   assert(cb);
   const TExistenceChecker existence_checker;
   size_t count = 0;

--- a/base/booster.test.manual.cc
+++ b/base/booster.test.manual.cc
@@ -162,8 +162,6 @@ class TTester {
    The boosted version should generally succeed more often than the unboosted version,
    but it's not perfect.  The ratio should be large but probably won't be 1.0. */
 static void GetBoostedSuccessRatio(size_t &boosted_successes, size_t &unboosted_successes) {
-  assert(&boosted_successes);
-  assert(&unboosted_successes);
   boosted_successes = 0;
   unboosted_successes = 0;
   int worker_count = 5, push_count = 10;

--- a/base/chrono.cc
+++ b/base/chrono.cc
@@ -35,8 +35,6 @@ using namespace Base::Chrono;
 /* TODO */
 template <typename TVal>
 static void Read(TConverter &converter, TVal &part, const char *name, const char delimiter) {
-  assert(&converter);
-  assert(&part);
   converter.Read(part);
   if (delimiter != '\0') {
     if (*converter != delimiter) {
@@ -107,7 +105,6 @@ TTimeDiffInfo::TTimeDiffInfo(
 
 /* TODO */
 TTimeDiffInfo::TTimeDiffInfo(const std::string &str) {
-  assert(&str);
   TConverter converter(AsPiece(str));
   TOpt<bool> sign = converter.TryReadSign();
   IsForward = sign ? *sign : true;
@@ -126,7 +123,6 @@ TTimeDiffInfo::TTimeDiffInfo(const std::string &str) {
 /* TODO */
 TTimeDiffInfo::TTimeDiffInfo(const TTimeDiff &time_diff)
     : Nanosecond(time_diff.count()) {
-  assert(&time_diff);
   IsForward = (Nanosecond >= 0);
   Day = Nanosecond / NumNanosecond::Day;
   Nanosecond %= NumNanosecond::Day;
@@ -156,7 +152,6 @@ TTimeDiff TTimeDiffInfo::AsTimeDiff() const {
 
 /* TODO */
 void TTimeDiffInfo::Write(std::ostream &strm) const {
-  assert(&strm);
   strm
     << (IsForward ? '+' : '-')
     << Day << 'T'
@@ -184,7 +179,6 @@ TTimePntInfo::TTimePntInfo(
 /* TODO */
 TTimePntInfo::TTimePntInfo(const std::string &str)
     : UtcOffset(0) {
-  assert(&str);
   TConverter converter(AsPiece(str));
   READ(Year, '-');
   READ(Month, '-');
@@ -215,7 +209,6 @@ TTimePntInfo::TTimePntInfo(const std::string &str)
    then use info in std::tm to construct */
 TTimePntInfo::TTimePntInfo(const TTimePnt &time_pnt)
     : UtcOffset(0) { // Always go to zulu time
-  assert(&time_pnt);
 
   /* std::tm doesn't support nanoseconds so will need to add something */
   auto ms = time_pnt.time_since_epoch().count();
@@ -299,7 +292,6 @@ void TTimePntInfo::Validate(const TCodeLocation &here) const {
 
 /* TODO */
 void TTimePntInfo::Write(std::ostream &strm) const {
-  assert(&strm);
   strm
     << Year << '-'
     << Month << '-'

--- a/base/chrono.h
+++ b/base/chrono.h
@@ -213,13 +213,11 @@ namespace Base {
     TTimePnt Now();
 
     inline std::ostream &operator<<(std::ostream &strm, const TTimeDiff &that) {
-      assert(&strm);
       Base::Chrono::TTimeDiffInfo(that).Write(strm);
       return strm;
     }
 
     inline std::ostream &operator<<(std::ostream &strm, const TTimePnt &that) {
-      assert(&strm);
       Base::Chrono::TTimePntInfo(that).Write(strm);
       return strm;
     }
@@ -238,7 +236,6 @@ namespace std {
     typedef Base::Chrono::TTimeDiff argument_type;
 
     result_type operator()(const argument_type &that) const {
-      assert(&that);
       return _Hash_impl::hash(&that, sizeof(that));
     }
 
@@ -252,7 +249,6 @@ namespace std {
     typedef Base::Chrono::TTimePnt argument_type;
 
     result_type operator()(const argument_type &that) const {
-      assert(&that);
       return _Hash_impl::hash(&that, sizeof(that));
     }
 

--- a/base/cmd.cc
+++ b/base/cmd.cc
@@ -39,7 +39,6 @@ TCmd::TMeta::~TMeta() {
 }
 
 void TCmd::TMeta::Dump(ostream &strm, const TCmd *cmd) const {
-  assert(&strm);
   for (auto &param: Params) {
     auto arg = param->TryGetArg();
     if (arg) {
@@ -64,7 +63,6 @@ bool TCmd::TMeta::Parse(TCmd *cmd, int argc, char *argv[], const TMessageConsume
 void TCmd::TMeta::WriteAfterDesc(ostream &) const {}
 
 void TCmd::TMeta::WriteHelp(ostream &strm, const TCmd *cmd, size_t line_size, size_t pad_size) const {
-  assert(&strm);
   if (!line_size) {
     struct winsize ws;
     ioctl(0, TIOCGWINSZ, &ws);
@@ -126,8 +124,6 @@ void TCmd::TMeta::WriteHelp(ostream &strm, const TCmd *cmd, size_t line_size, si
 }
 
 bool TCmd::TMeta::WriteToStdErr(const string &msg, size_t &count) {
-  assert(&msg);
-  assert(&count);
   cerr << msg << endl;
   ++count;
   return true;
@@ -182,7 +178,6 @@ bool TCmd::TMeta::TParam::TArg::Parse(TCmd *cmd, const TJson &json, const TMessa
 TCmd::TMeta::TParam::~TParam() {}
 
 bool TCmd::TMeta::TParam::ForEachName(const function<bool (const char *)> &cb) const {
-  assert(&cb);
   if (Names) {
     for (const char *name = Names; *name; name += strlen(name) + 1) {
       if (!cb(name)) {
@@ -206,7 +201,6 @@ bool TCmd::TMeta::TParam::Matches(const char *target_name) const {
 }
 
 void TCmd::TMeta::TParam::WriteHelp(ostream &strm, const TCmd *cmd) const {
-  assert(&strm);
   strm << Desc;
   int cnt = 0;
   ForEachHelpPiece(strm, cmd, [&strm, &cnt] {
@@ -224,7 +218,6 @@ void TCmd::TMeta::TParam::WriteHelp(ostream &strm, const TCmd *cmd) const {
 }
 
 void TCmd::TMeta::TParam::WriteLineItem(ostream &strm) const {
-  assert(&strm);
   if (!Names) {
     const char *lhs, *rhs;
     switch (Basis) {
@@ -258,9 +251,7 @@ void TCmd::TMeta::TParam::WriteLineItem(ostream &strm) const {
 }
 
 bool TCmd::TMeta::TParam::ForEachHelpPiece(ostream &strm, const TCmd *cmd, const function<bool ()> &cb) const {
-  assert(&strm);
   assert(cmd);
-  assert(&cb);
   const TArg *arg = TryGetArg();
   if (!Names && arg && arg->GetIsRequired()) {
     if (!cb()) {
@@ -351,9 +342,6 @@ void TCmd::TMeta::AppendParam(TParam *param_raw) {
 }
 
 void TCmd::TMeta::WriteWrapped(ostream &strm, size_t col1_size, size_t line_size, const string &col1, const string &col2) {
-  assert(&strm);
-  assert(&col1);
-  assert(&col2);
   strm << col1;
   for (size_t i = 0; i < col1_size - col1.size(); ++i) {
     strm << ' ';
@@ -444,7 +432,6 @@ const TCmd::TMeta::TParam *TCmd::TMeta::TParser::TryFindParam(const char *name) 
 
 bool TCmd::TMeta::TParser::TRun::operator()(const TParser *parser, TCmd *cmd, int argc, char *argv[], const TMessageConsumer &cb) {
   assert(parser);
-  assert(&cb);
   char *path = argv[0], *slash = strrchr(path, '/');
   if (slash) {
     *slash = '\0';
@@ -520,8 +507,6 @@ bool TCmd::TMeta::TParser::TRun::operator()(const TParser *parser, TCmd *cmd, in
 }
 
 bool TCmd::TMeta::TParser::TRun::CheckForRequired(const vector<const TParam *> &params, const TMessageConsumer &cb) const {
-  assert(&params);
-  assert(&cb);
   std::unordered_set<const TParam *> missing_params;
   for (auto param: params) {
     if (Contains(missing_params, param)) {
@@ -554,7 +539,6 @@ bool TCmd::CheckArgs(const TMeta::TMessageConsumer &) {
 }
 
 void TCmd::Parse(int argc, char *argv[], const TMeta &meta) {
-  assert(&meta);
   if (meta.Parse(this, argc, argv)) {
     exit(EXIT_FAILURE);
   }

--- a/base/cmd.h
+++ b/base/cmd.h
@@ -253,14 +253,11 @@ namespace Base {
 
             /* Read a value from a stream. */
             static void Read(std::istream &strm, TVal &val) {
-              assert(&strm);
-              assert(&val);
               strm >> val;
             }
 
             /* Read a value from a JSON object. For unknown json types, treat it as a string. */
             static void Read(const TJson &json, TVal &val) {
-              assert(&json);
               if (json.GetKind() != TJson::String) {
                 THROW_ERROR(std::invalid_argument) << "expected a json string";
               }
@@ -278,14 +275,11 @@ namespace Base {
 
             /* Write a value to a stream. */
             static void Write(std::ostream &strm, const TVal &val) {
-              assert(&strm);
-              assert(&val);
               strm << val;
             }
 
             /* Write a human-readable description of the value type. */
             static void WriteType(std::ostream &strm) {
-              assert(&strm);
               strm << Base::Demangle<TVal>();
             }
 
@@ -312,8 +306,6 @@ namespace Base {
           /* Write the contents of the container as a comma-separated list. */
           template <typename TContainer>
           static void WriteCsl(std::ostream &strm, const TContainer &container) {
-            assert(&strm);
-            assert(&container);
             bool sep_flag = true;
             for (const typename TContainer::value_type &val: container) {
               if (sep_flag) {
@@ -501,7 +493,6 @@ namespace Base {
 
         /* See base class. */
         virtual void WriteCmd(std::ostream &strm) const {
-          assert(&strm);
           strm << Base::Demangle<TSomeCmd>();
         }
 
@@ -576,7 +567,6 @@ namespace Base {
 
         /* See base class. */
         virtual void WriteCmd(std::ostream &strm) const {
-          assert(&strm);
           strm << Base::Demangle<TSomeCmd>();
         }
 
@@ -650,7 +640,6 @@ namespace Base {
           template<typename TSource>
           bool OnRecognition(const TParam *param, TCmd *cmd, TSource &&source, const TMessageConsumer &cb) {
             assert(param);
-            assert(&cb);
             size_t &count = CountByParam.insert(std::make_pair(param, Zero)).first->second;
             ++count;
             if (count > 1 && param->GetRecurrence() == Once) {
@@ -727,14 +716,10 @@ namespace Base {
     }
 
     static void Read(std::istream &strm, bool &val) {
-      assert(&strm);
-      assert(&val);
       strm >> std::boolalpha >> val;
     }
 
     static void Read(const TJson &json, bool &val) {
-      assert(&json);
-      assert(&val);
       if (json.GetKind() != TJson::Bool) {
         DEFINE_ERROR(error_t, std::invalid_argument, "incorrect type");
         THROW_ERROR(error_t) << "expected bool";
@@ -747,13 +732,10 @@ namespace Base {
     }
 
     static void Write(std::ostream &strm, const bool &val) {
-      assert(&strm);
-      assert(&val);
       strm << std::boolalpha << val;
     }
 
     static void WriteType(std::ostream &strm) {
-      assert(&strm);
       strm << "bool";
     }
 
@@ -776,14 +758,10 @@ namespace Base {
     }
 
     static void Read(std::istream &strm, double &val) {
-      assert(&strm);
-      assert(&val);
       strm >> val;
     }
 
     static void Read(const TJson &json, double &val) {
-      assert(&json);
-      assert(&val);
       if (json.GetKind() != TJson::Number) {
         DEFINE_ERROR(error_t, std::invalid_argument, "incorrect type");
         THROW_ERROR(error_t) << "expected double";
@@ -796,13 +774,10 @@ namespace Base {
     }
 
     static void Write(std::ostream &strm, const double &val) {
-      assert(&strm);
-      assert(&val);
       strm << val;
     }
 
     static void WriteType(std::ostream &strm) {
-      assert(&strm);
       strm << "double";
     }
   };  // TCmd::TMeta::TParam::TArg::ValInfo<double>
@@ -819,14 +794,10 @@ namespace Base {
     }
 
     static void Read(std::istream &strm, std::string &val) {
-      assert(&strm);
-      assert(&val);
       strm >> val;
     }
 
     static void Read(const TJson &json, std::string &val) {
-      assert(&json);
-      assert(&val);
       if (json.GetKind() != TJson::String) {
         DEFINE_ERROR(error_t, std::invalid_argument, "incorrect type");
         THROW_ERROR(error_t) << "expected string";
@@ -839,13 +810,10 @@ namespace Base {
     }
 
     static void Write(std::ostream &strm, const std::string &val) {
-      assert(&strm);
-      assert(&val);
       strm << val;
     }
 
     static void WriteType(std::ostream &strm) {
-      assert(&strm);
       strm << "string";
     }
 
@@ -864,7 +832,6 @@ namespace Base {
 
     template<typename TSource>
     static void Read(TSource &&src, std::vector<TVal> &vals) {
-      assert(&vals);
       TVal val;
       ValInfo<TVal>::Read(std::forward<TSource>(src), val);
       vals.push_back(val);
@@ -879,7 +846,6 @@ namespace Base {
     }
 
     static void WriteType(std::ostream &strm) {
-      assert(&strm);
       strm << "array of ";
       ValInfo<TVal>::WriteType(strm);
     }
@@ -900,7 +866,6 @@ namespace Base {
     template<typename TSource>
     static void Read(TSource &&src, std::set<TVal> &vals) {
       DEFINE_ERROR(error_t, std::invalid_argument, "duplicate value");
-      assert(&vals);
       TVal val;
       ValInfo<TVal>::Read(std::forward<TSource>(src), val);
       if (!vals.insert(val).second) {
@@ -917,7 +882,6 @@ namespace Base {
     }
 
     static void WriteType(std::ostream &strm) {
-      assert(&strm);
       strm << "set of ";
       ValInfo<TVal>::WriteType(strm);
     }

--- a/base/code_location.cc
+++ b/base/code_location.cc
@@ -28,7 +28,6 @@ const char *TCodeLocation::GetFile() const {
 }
 
 void TCodeLocation::Write(ostream &strm) const {
-  assert(&strm);
   strm << '[' << GetFile() << ", " << LineNumber << ']';
 }
 

--- a/base/code_location.h
+++ b/base/code_location.h
@@ -94,7 +94,6 @@ namespace Base {
 
   /* Standard stream inserter for Base::TCodeLocation. */
   inline std::ostream &operator<<(std::ostream &strm, const Base::TCodeLocation &that) {
-    assert(&that);
     that.Write(strm);
     return strm;
   }
@@ -111,7 +110,6 @@ namespace std {
     typedef Base::TCodeLocation argument_type;
 
     result_type operator()(const argument_type &that) const {
-      assert(&that);
       const char *const file = that.GetFile();
       const size_t len = strlen(file);
       return _Hash_impl::hash(file, len) ^ that.GetLineNumber();

--- a/base/convert.h
+++ b/base/convert.h
@@ -75,7 +75,6 @@ namespace Base {
 
     /* Reads in a character from Input and converts it to it's decimal value. */
     template<typename TVal> bool TryReadDigit(TVal &output) {
-      assert(&output);
       assert(std::numeric_limits<TVal>::is_exact);
       assert(std::numeric_limits<TVal>::min() <= 0);
       assert(std::numeric_limits<TVal>::max() >= 9);
@@ -94,7 +93,6 @@ namespace Base {
     /* Reads in an unsigned integer and stores it inside output. This operation is automic. The positive flag changes whether each digit is added or subtracted
        from the value to make the end result positive/negative. This is useful when the sign is known in advance so we can get more precise bounds checking. */
     template<typename TVal> bool TryReadUnsignedInt(TVal &output, bool positive=true) {
-      assert(&output);
       assert(std::numeric_limits<TVal>::is_integer);
       assert(std::numeric_limits<TVal>::is_exact);
       assert(positive || std::numeric_limits<TVal>::is_signed);
@@ -154,7 +152,6 @@ namespace Base {
        with the try_read flag set manually, rather call ReadInt if you mean try_read=false. At the moment this only supports decimal representations, but
        in the future will be expanded to support hexadecimal and octal. */
     template<typename TVal> bool TryReadInt(TVal &output,bool sign_required=false) {
-      assert(&output);
       assert(std::numeric_limits<TVal>::is_integer);
       assert(std::numeric_limits<TVal>::is_exact);
       assert(sign_required? std::numeric_limits<TVal>::is_signed : true);

--- a/base/dir_walker.cc
+++ b/base/dir_walker.cc
@@ -225,7 +225,6 @@ TDirWalker::TAction TDirWalker::OnSymLink(const TEntry &/*entry*/) {
 }
 
 void TDirWalker::InitEntry(TEntry &out, const FTSENT *in) {
-  assert(&out);
   assert(in);
   auto *st = in->fts_statp;
   assert(st);

--- a/base/epoll.h
+++ b/base/epoll.h
@@ -48,8 +48,6 @@ namespace Base {
     /* Returns the nth cached event. */
     void GetEvent(size_t n, int &fd, int &flags) const {
       assert(n < EventCount);
-      assert(&fd);
-      assert(&flags);
       const epoll_event &event = Events[n];
       fd = event.data.fd;
       flags = event.events;

--- a/base/fd.h
+++ b/base/fd.h
@@ -57,14 +57,12 @@ namespace Base {
 
     /* Move-construct, leaving the donor in the default-constructed state. */
     TFd(TFd &&that) {
-      assert(&that);
       OsHandle = that.OsHandle;
       that.OsHandle = -1;
     }
 
     /* Copy-construct, duplicating the file descriptor with the OS call dup(), if necessary. */
     TFd(const TFd &that) {
-      assert(&that);
       OsHandle = that.IsSystemFd() ? that.OsHandle : Util::IfLt0(dup(that.OsHandle));
     }
 
@@ -84,7 +82,6 @@ namespace Base {
 
     /* Swaperator. */
     TFd &operator=(TFd &&that) {
-      assert(&that);
       std::swap(OsHandle, that.OsHandle);
       return *this;
     }
@@ -136,8 +133,6 @@ namespace Base {
 
     /* Construct the read- and write-only ends of a pipe. */
     static void Pipe(TFd &readable, TFd &writeable, int flags = 0) {
-      assert(&readable);
-      assert(&writeable);
       int fds[2];
       Util::IfLt0(pipe2(fds, flags) < 0);
       readable = TFd(fds[0], NoThrow);
@@ -146,8 +141,6 @@ namespace Base {
 
     /* Construct both ends of a socket. */
     static void SocketPair(TFd &lhs, TFd &rhs, int domain, int type, int proto = 0) {
-      assert(&lhs);
-      assert(&rhs);
       int fds[2];
       Util::IfLt0(socketpair(domain, type, proto, fds));
       lhs = TFd(fds[0], NoThrow);

--- a/base/glob.cc
+++ b/base/glob.cc
@@ -37,7 +37,6 @@ using namespace Util;
 
 bool Base::Glob(const char *pattern, const function<bool (const char *)> &cb) {
   assert(pattern);
-  assert(&cb);
   /* Get the current working directory as an absolute path.
      This will start with a slash but will NOT end with a slash. */
   char root[PATH_MAX + 2];

--- a/base/hash.h
+++ b/base/hash.h
@@ -40,7 +40,6 @@ namespace Base {
 
     template <std::size_t Idx, typename TElem>
     void operator()(const TElem &elem) {
-      assert(&elem);
       Out ^= Util::RotatedLeft(std::hash<TElem>()(elem), Idx * 5);
     }
 
@@ -95,7 +94,6 @@ namespace std {
     using argument_type = array<TElem, size>;
 
     result_type operator()(const argument_type &that) const {
-      assert(&that);
       result_type result = 0;
       Util::ForEach(that, Base::TTupleHash(result));
       return result;
@@ -110,7 +108,6 @@ namespace std {
     using argument_type = map<TKey, TVal>;
 
     result_type operator()(const argument_type &that) const {
-      assert(&that);
       result_type result = 0;
       for (const auto &elem : that) {
         result ^= hash<pair<TKey, TVal>>()(elem);
@@ -127,7 +124,6 @@ namespace std {
     using argument_type = pair<TLhs, TRhs>;
 
     result_type operator()(const argument_type &that) const {
-      assert(&that);
       return hash<TLhs>()(that.first) ^ hash<TRhs>()(that.second);
     }
 
@@ -140,7 +136,6 @@ namespace std {
     using argument_type = set<TElem>;
 
     result_type operator()(const argument_type &that) const {
-      assert(&that);
       result_type result = 0;
       for (const auto &elem : that) {
         result ^= hash<TElem>()(elem);
@@ -157,7 +152,6 @@ namespace std {
     using argument_type = tuple<TElems...>;
 
     result_type operator()(const argument_type &that) const {
-      assert(&that);
       result_type result = 0;
       Util::ForEach(that, Base::TTupleHash(result));
       return result;
@@ -172,7 +166,6 @@ namespace std {
     using argument_type = unordered_map<TKey, TVal>;
 
     result_type operator()(const argument_type &that) const {
-      assert(&that);
       result_type result = 0;
       for (const auto &elem : that) {
         result ^= hash<pair<TKey, TVal>>()(elem);
@@ -189,7 +182,6 @@ namespace std {
     using argument_type = unordered_set<TElem>;
 
     result_type operator()(const argument_type &that) const {
-      assert(&that);
       result_type result = 0;
       for (const auto &elem : that) {
         result ^= hash<TElem>()(elem);
@@ -206,7 +198,6 @@ namespace std {
     using argument_type = vector<TElem>;
 
     result_type operator()(const argument_type &that) const {
-      assert(&that);
       result_type result = 0;
       for (std::size_t i = 0; i < that.size(); ++i) {
         result ^= Util::RotatedLeft(std::hash<TElem>()(that[i]), i * 5);

--- a/base/iter.h
+++ b/base/iter.h
@@ -101,8 +101,6 @@ namespace Base {
      be exhausted when this function returns. */
   template <typename TLhs, typename TRhs>
   int Compare(TIter<TLhs> &lhs, TIter<TRhs> &rhs) {
-    assert(&lhs);
-    assert(&rhs);
     for (; lhs && rhs; ++lhs, ++rhs) {
       if (*lhs < *rhs) {
         return -1;

--- a/base/iter.test.cc
+++ b/base/iter.test.cc
@@ -28,7 +28,6 @@ using namespace Base;
 /* Generic iter test suite. */
 template <typename TVal>
 void TestIter(TIter<TVal> &iter, TVal match[3]) {
-  assert(&iter);
   EXPECT_TRUE(iter);
   EXPECT_EQ(*iter, match[0]);
   EXPECT_EQ(*(++iter), match[1]);

--- a/base/json.h
+++ b/base/json.h
@@ -123,7 +123,6 @@ namespace Base {
     /* Read from the given input string to find a JSON string which starts/ends with '"' and properly unescape escaped
        characters. */
     static std::string ReadQuotedString(std::istream &strm) {
-      assert(&strm);
       /* Eat the opening quote. */
       if (unlikely(strm.peek() != '"')) {
         THROW_ERROR(TSyntaxError) << "missing opening quote";
@@ -264,7 +263,6 @@ namespace Base {
 
     /* The donor is left null. */
     TJson(TJson &&that) noexcept {
-      assert(&that);
       switch (that.Kind) {
         /* Do nothing. */
         case Null:   { break; }
@@ -282,7 +280,6 @@ namespace Base {
 
     /* Deep-copy. */
     TJson(const TJson &that) {
-      assert(&that);
       switch (that.Kind) {
         /* Do nothing. */
         case Null:   { break; }
@@ -393,7 +390,6 @@ namespace Base {
 
     /* The donor is left null. */
     TJson &operator=(TJson &&that) noexcept {
-      assert(&that);
       this->~TJson();
       new (this) TJson(std::move(that));
       return *this;
@@ -401,13 +397,11 @@ namespace Base {
 
     /* Deep-copy. */
     TJson &operator=(const TJson &that) {
-      assert(&that);
       return *this = TJson(that);
     }
 
     /* True iff. this object and that one are in the same state. */
     bool operator==(const TJson &that) const noexcept {
-      assert(&that);
       bool success = (Kind == that.Kind);
       if (success) {
         switch (Kind) {
@@ -443,21 +437,18 @@ namespace Base {
 
     /* Find or create an element contained in an object. */
     TJson &operator[](TString &&that) {
-      assert(&that);
       assert(Kind == Object);
       return Object_[std::move(that)];
     }
 
     /* Find or create an element contained in an object. */
     TJson &operator[](const TString &that) {
-      assert(&that);
       assert(Kind == Object);
       return Object_[that];
     }
 
     /* Find or create an element contained in an object. */
     const TJson &operator[](const TString &that) const {
-      assert(&that);
       assert(Kind == Object);
       const TJson *elem = TryFind(that);
       assert(elem);
@@ -466,7 +457,6 @@ namespace Base {
 
     /* Accept the visitor. */
     void Accept(const TVisitor &visitor) const {
-      assert(&visitor);
       switch (Kind) {
         case Null:   { visitor(       ); break; }
         case Bool:   { visitor(Bool_  ); break; }
@@ -484,7 +474,6 @@ namespace Base {
 
     /* Call back for each element contained in an array. */
     bool ForEachElem(const TArrayCb &cb) const {
-      assert(&cb);
       assert(cb);
       assert(Kind == Array);
       for (const auto &elem: Array_) {
@@ -497,7 +486,6 @@ namespace Base {
 
     /* Call back for each element contained in an object. */
     bool ForEachElem(const TObjectCb &cb) const {
-      assert(&cb);
       assert(cb);
       assert(Kind == Object);
       for (const auto &elem: Object_) {
@@ -510,7 +498,6 @@ namespace Base {
 
     /* Call back for each element contained in an array. */
     bool ForEachElem(const TArrayCbNonConst &cb) {
-      assert(&cb);
       assert(cb);
       assert(Kind == Array);
       for (auto &elem: Array_) {
@@ -523,7 +510,6 @@ namespace Base {
 
     /* Call back for each element contained in an object. */
     bool ForEachElem(const TObjectCbNonConst &cb) {
-      assert(&cb);
       assert(cb);
       assert(Kind == Object);
       for (auto &elem: Object_) {
@@ -584,7 +570,6 @@ namespace Base {
 
     /* Parse from the stream. */
     void Read(std::istream &strm) {
-      assert(&strm);
       int c = std::ws(strm).peek();
       switch (c) {
         case '[': {
@@ -659,7 +644,6 @@ namespace Base {
 
     /* Swap states. */
     TJson &Swap(TJson &that) noexcept {
-      assert(&that);
       TJson temp = std::move(*this);
       new (this) TJson(std::move(that));
       new (&that) TJson(std::move(temp));
@@ -796,7 +780,6 @@ namespace Base {
 
     /* Format to the stream. */
     void Write(std::ostream &strm) const {
-      assert(&strm);
       switch (Kind) {
         case Null: {
           strm << "null";
@@ -864,7 +847,6 @@ namespace Base {
        at the start of the list, a comma. */
     static bool ParseSep(
         std::istream &strm, char close_mark, bool at_start) {
-      assert(&strm);
       int c = std::ws(strm).peek();
       if (c == close_mark) {
         strm.ignore();
@@ -888,7 +870,6 @@ namespace Base {
 
     /* The stream must yield given char or throw a syntax error. */
     static void Match(std::istream &strm, char expected) {
-      assert(&strm);
       if (strm.peek() != expected) {
         THROW_ERROR(TSyntaxError) << "Expected '" << expected << "' but didn't find it. Found '" << char(strm.peek())
                                   << '\'';
@@ -917,20 +898,17 @@ namespace Base {
 
   /* Std stream extractor. */
   inline std::istream &operator>>(std::istream &strm, TJson &that) {
-    assert(&that);
     that.Read(strm);
     return strm;
   }
 
   /* Std stream inserter. */
   inline std::ostream &operator<<(std::ostream &strm, const TJson &that) {
-    assert(&that);
     that.Write(strm);
     return strm;
   }
 
   inline std::ostream &operator<<(std::ostream &strm, const TJson::TKind &kind) {
-    assert(&kind);
       switch (kind) {
         case TJson::Null:   {
           strm << "null";

--- a/base/log.cc
+++ b/base/log.cc
@@ -68,7 +68,6 @@ TLog::TCmd::TMeta::TMeta(const char *desc)
 }
 
 TLog::TLog(const TCmd &cmd) {
-  assert(&cmd);
   openlog(cmd.GetProg(), cmd.GetOpenFlags(), LOG_USER);
   setlogmask(cmd.GetMask());
   syslog(LOG_NOTICE, "log started");

--- a/base/opt.h
+++ b/base/opt.h
@@ -62,7 +62,6 @@ namespace Base {
 
     /* Move contructor.  We get the donor's value (if any) and the donor becomes unknown. */
     TOpt(TOpt &&that) {
-      assert(&that);
       if (that.Val) {
         Val = new (Storage) TVal(std::move(*that.Val));
         that.Reset();
@@ -73,20 +72,17 @@ namespace Base {
 
     /* Copy constructor. */
     TOpt(const TOpt &that) {
-      assert(&that);
       Val = that.Val ? new (Storage) TVal(*that.Val) : nullptr;
     }
 
     /* Construct by moving the given value into our internal storage.
        What remains of the donor is up to TVal. */
     TOpt(TVal &&that) {
-      assert(&that);
       Val = new (Storage) TVal(std::move(that));
     }
 
     /* Construct with a copy of the given value. */
     TOpt(const TVal &that) {
-      assert(&that);
       Val = new (Storage) TVal(that);
     }
 
@@ -97,7 +93,6 @@ namespace Base {
 
     /* Swaperator. */
     TOpt &operator=(TOpt &&that) {
-      assert(&that);
       if (this != &that) {
         if (Val && that.Val) {
           std::swap(*Val, *that.Val);
@@ -120,7 +115,6 @@ namespace Base {
     /* If we're already known, swap our value with the given one;
        otherwise, move-construct the value into our storage. */
     TOpt &operator=(TVal &&that) {
-      assert(&that);
       if (Val != &that) {
         if (Val) {
           std::swap(*Val, that);
@@ -199,7 +193,6 @@ namespace Base {
 
     /* Stream in. */
     void Read(Io::TBinaryInputStream &strm) {
-      assert(&strm);
       bool is_known;
       strm >> is_known;
       if (is_known) {
@@ -212,7 +205,6 @@ namespace Base {
     /* Forward our value to the out-parameter and resume the unknown state.
        We must already be known. */
     void Release(TVal &val) {
-      assert(&val);
       assert(Val);
       val = std::forward<TVal>(*Val);
       Val = nullptr;
@@ -239,7 +231,6 @@ namespace Base {
 
     /* Stream out. */
     void Write(Io::TBinaryOutputStream &strm) const {
-      assert(&strm);
       bool is_known = *this;
       strm << is_known;
       if (is_known) {
@@ -266,8 +257,6 @@ namespace Base {
   /* A std stream inserter for Base::TOpt<>.  If the TOpt<> is unknown, then this function inserts nothing. */
   template <typename TVal>
   std::ostream &operator<<(std::ostream &strm, const Base::TOpt<TVal> &that) {
-    assert(&strm);
-    assert(&that);
     if (that) {
       strm << *that;
     }
@@ -277,8 +266,6 @@ namespace Base {
   /* A std stream extractor for Base::TOpt<>. */
   template <typename TVal>
   std::istream &operator>>(std::istream &strm, Base::TOpt<TVal> &that) {
-    assert(&strm);
-    assert(&that);
     if (!strm.eof()) {
       strm >> that.MakeKnown();
     } else {
@@ -290,7 +277,6 @@ namespace Base {
   /* Binary stream inserter for Base::TOpt<>. */
   template <typename TVal>
   Io::TBinaryOutputStream &operator<<(Io::TBinaryOutputStream &strm, const Base::TOpt<TVal> &that) {
-    assert(&that);
     that.Write(strm);
     return strm;
   }
@@ -298,7 +284,6 @@ namespace Base {
   /* Binary stream extractor for Base::TOpt<>. */
   template <typename TVal>
   Io::TBinaryInputStream &operator>>(Io::TBinaryInputStream &strm, Base::TOpt<TVal> &that) {
-    assert(&that);
     that.Read(strm);
     return strm;
   }

--- a/base/ordered_array.h
+++ b/base/ordered_array.h
@@ -73,14 +73,12 @@ namespace Base {
     /* Move-construct into a new array, leaving the donor in the default-constructed state. */
     TOrderedArray(TOrderedArray &&that) noexcept
         : TOrderedArray() {
-      assert(&that);
       Swap(that);
     }
 
     /* Copy-construct into a new array. */
     TOrderedArray(const TOrderedArray &that)
         : Start(nullptr), Limit(nullptr), Capacity(nullptr), Comparator(that.Comparator) {
-      assert(&that);
       SetMaxSize(that.GetMaxSize());
       try {
         for (const TElem *elem = that.Start; elem < that.Limit; ++elem, ++Limit) {
@@ -100,7 +98,6 @@ namespace Base {
 
     /* Move into this array, leaving the donor in the default-constructed state. */
     TOrderedArray &operator=(TOrderedArray &&that) noexcept {
-      assert(&that);
       Swap(that);
       that.Reset();
       return *this;
@@ -108,7 +105,6 @@ namespace Base {
 
     /* Copy into this array. */
     TOrderedArray &operator=(const TOrderedArray &that) {
-      assert(&that);
       TOrderedArray temp(that);
       return Swap(temp);
     }
@@ -155,7 +151,6 @@ namespace Base {
 
     /* Call back for each key-value pair in the array, in key order. */
     bool ForEach(const TReader &cb) const {
-      assert(&cb);
       for (TElem *elem = Start; elem < Limit; ++elem) {
         if (!cb(elem->first, elem->second)) {
           return false;
@@ -166,7 +161,6 @@ namespace Base {
 
     /* Call back for each key-value pair in the array, in key order. */
     bool ForEach(const TWriter &cb) {
-      assert(&cb);
       for (TElem *elem = Start; elem < Limit; ++elem) {
         if (!cb(elem->first, elem->second)) {
           return false;
@@ -177,7 +171,6 @@ namespace Base {
 
     /* Call back for each key-value pair in the array, in key order, starting with the first key >= the given key. */
     bool ForEach(const TKey &key, const TReader &cb) const {
-      assert(&cb);
       TElem *elem;
       Search(key, elem);
       for (; elem < Limit; ++elem) {
@@ -190,7 +183,6 @@ namespace Base {
 
     /* Call back for each key-value pair in the array, in key order, starting with the first key >= the given key. */
     bool ForEach(const TKey &key, const TWriter &cb) {
-      assert(&cb);
       TElem *elem;
       Search(key, elem);
       for (; elem < Limit; ++elem) {
@@ -299,7 +291,6 @@ namespace Base {
 
     /* Swap this array with that one. */
     TOrderedArray &Swap(TOrderedArray &that) noexcept {
-      assert(&that);
       std::swap(Start,      that.Start     );
       std::swap(Limit,      that.Limit     );
       std::swap(Capacity,   that.Capacity  );
@@ -371,7 +362,6 @@ namespace Base {
        If we return true, then this post-condition holds: Start <= elem < Limit;
        otherwise, this post-condition holds: Start <= elem <= Limit. */
     bool Search(const TKey &key, TElem *&elem) const {
-      assert(&elem);
       assert(Comparator);
       elem = Start;
       TElem *limit = Limit;

--- a/base/ordered_array.test.cc
+++ b/base/ordered_array.test.cc
@@ -28,7 +28,6 @@ using namespace Base;
 
 template <typename TKey, typename TVal>
 string ToString(const Base::TOrderedArray<TKey, TVal> &that) {
-  assert(&that);
   ostringstream strm;
   bool has_written = false;
   that.ForEach(

--- a/base/path.test.broken.cc
+++ b/base/path.test.broken.cc
@@ -31,8 +31,6 @@ using namespace std;
 namespace std {
   template <typename TVal>
   ostream &operator<<(ostream &strm, const vector<TVal> &vec) {
-    assert(&strm);
-    assert(&vec);
     strm << '{' << Join(vec, ',') << '}';
     return strm;
   }

--- a/base/piece.h
+++ b/base/piece.h
@@ -66,7 +66,6 @@ namespace Base {
      appear at the end of this file. */
   template <typename TVal>
   inline size_t GetHashHelper(const TVal &val) {
-    assert(&val);
     return val.GetHash();
   }
 
@@ -125,7 +124,6 @@ namespace Base {
     /* Construct as a copy of a piece of compatible type. */
     template <typename TCompatVal>
     TPiece(const TPiece<TCompatVal> &that) {
-      assert(&that);
       Start = that.GetStart();
       Limit = that.GetLimit();
     }
@@ -152,7 +150,6 @@ namespace Base {
     /* Assign as a copy of a piece of compatible type. */
     template <typename TCompatVal>
     TPiece &operator=(const TPiece<TCompatVal> &that) {
-      assert(&that);
       Start = that.GetStart();
       Limit = that.GetLimit();
       return *this;
@@ -180,7 +177,6 @@ namespace Base {
 
     /* Return a slice of the piece. */
     TPiece operator[](const TSlice &slice) const {
-      assert(&slice);
       size_t start, limit;
       slice.GetAbsPair(GetSize(), start, limit);
       assert(start <= limit);
@@ -190,7 +186,6 @@ namespace Base {
     /* Compare this piece with that one on a lexicographical basis and return true iff. they are equal. */
     template <typename TCompatVal>
     bool operator==(const TPiece<TCompatVal> &that) const {
-      assert(&that);
       TVal *cursor = Start;
       TCompatVal *that_cursor = that.GetStart();
       for (; cursor < Limit && that_cursor < that.GetLimit(); ++cursor, ++that_cursor) {
@@ -204,7 +199,6 @@ namespace Base {
     /* Compare this piece with that one on a lexicographical basis and return true iff. they are not equal. */
     template <typename TCompatVal>
     bool operator!=(const TPiece<TCompatVal> &that) const {
-      assert(&that);
       TVal *cursor = Start;
       TCompatVal *that_cursor = that.GetStart();
       for (; cursor < Limit && that_cursor < that.GetLimit(); ++cursor, ++that_cursor) {
@@ -285,7 +279,6 @@ namespace Base {
 
     /* Returns true if the given slice can be made. */
     bool CanSlice(const TSlice &slice) const {
-      assert(&slice);
       return slice.CanGetAbsPair(GetSize());
     }
 
@@ -293,7 +286,6 @@ namespace Base {
        zero if the two pieces sort identically.  TVal and TCompatVal must support strict-weak ordering relative to each other based on operator<. */
     template <typename TCompatVal>
     int Compare(const TPiece<TCompatVal> &that) const {
-      assert(&that);
       TVal *cursor = Start;
       TCompatVal *that_cursor = that.GetStart();
       for (; cursor < Limit && that_cursor < that.GetLimit(); ++cursor, ++that_cursor) {
@@ -309,7 +301,6 @@ namespace Base {
 
     /* Redefines the piece to just the given slice. */
     TPiece &Constrain(const TSlice &slice) {
-      assert(&slice);
       size_t start, limit;
       slice.GetAbsPair(GetSize(), start, limit);
       Limit = Start + limit;
@@ -327,7 +318,6 @@ namespace Base {
     /* Return true if the other piece falls within (or is congruent to) this one. */
     template <typename TCompatVal>
     bool Contains(const TPiece<TCompatVal> &that) {
-      assert(&that);
       return Start <= that.Start && that.Limit <= Limit;
     }
 
@@ -395,7 +385,6 @@ namespace Base {
 
     /* Exchange the states of this piece with that one.  This is a guranteed no-throw. */
     TPiece &Swap(TPiece &that) noexcept {
-      assert(&that);
       std::swap(Start, that.Start);
       std::swap(Limit, that.Limit);
       return *this;
@@ -404,7 +393,6 @@ namespace Base {
     /* Return a pointer to the instance of val, if possible. */
     template <typename TCompatVal>
     TVal *Find(const TCompatVal &val) const {
-      assert(&val);
       for (auto cur = Start; cur < Limit; ++cur) {
         if (*cur == val) {
           return cur;
@@ -416,7 +404,6 @@ namespace Base {
     /* Return a pointer to an instance of an element in val_set, if possible. */
     template <typename TCompatVal>
     TVal *Find(const std::unordered_set<TCompatVal> &val_set) const {
-      assert(&val_set);
       for (auto cur = Start; cur < Limit; ++cur) {
         if (Util::Contains(val_set, *cur)) {
           return cur;
@@ -427,8 +414,6 @@ namespace Base {
 
     /* Return a slice of the piece (by out-param), if possible. */
     bool TrySlice(const TSlice &slice, TPiece &out) const {
-      assert(&slice);
-      assert(&out);
       size_t start, limit;
       bool success = slice.TryGetAbsPair(GetSize(), start, limit);
       if (success) {
@@ -457,8 +442,6 @@ namespace Base {
   /* Shallow-copy with explicit size. */
   template <typename TDestVal, typename TSrcVal>
   const TPiece<TDestVal> &ShallowCopy(const TPiece<TDestVal> &dest, const TPiece<TSrcVal> &src, size_t size) {
-    assert(&dest);
-    assert(&src);
     assert(dest.GetSize() >= size);
     assert(src.GetSize() >= size);
     assert(sizeof(TDestVal) == sizeof(TSrcVal));
@@ -469,8 +452,6 @@ namespace Base {
   /* Shallow-copy with implicit size. */
   template <typename TDestVal, typename TSrcVal>
   const TPiece<TDestVal> &ShallowCopy(const TPiece<TDestVal> &dest, const TPiece<TSrcVal> &src) {
-    assert(&dest);
-    assert(&src);
     return ShallowCopy(dest, src, std::min(dest.GetSize(), src.GetSize()));
   }
 
@@ -481,8 +462,6 @@ namespace Base {
   /* Copy with explicit size. */
   template <typename TDestVal, typename TSrcVal>
   const TPiece<TDestVal> &Copy(const TPiece<TDestVal> &dest, const TPiece<TSrcVal> &src, size_t size) {
-    assert(&dest);
-    assert(&src);
     assert(dest.GetSize() >= size);
     assert(src.GetSize() >= size);
     TSrcVal *src_val = src.GetStart();
@@ -496,8 +475,6 @@ namespace Base {
   /* Copy with implicit size. */
   template <typename TDestVal, typename TSrcVal>
   const TPiece<TDestVal> &Copy(const TPiece<TDestVal> &dest, const TPiece<TSrcVal> &src) {
-    assert(&dest);
-    assert(&src);
     return Copy(dest, src, std::min(dest.GetSize(), src.GetSize()));
   }
 
@@ -610,28 +587,24 @@ namespace Base {
   /* Constructs a TPiece<const TVal> spanning a constant standard vector of the same type. */
   template <typename TVal, typename TAlloc>
   TPiece<const TVal> AsPiece(const std::vector<TVal, TAlloc> &that) {
-    assert(&that);
     return TPiece<const TVal>(&that[0], that.size());
   }
 
   /* Constructs a TPiece<TVal> spanning a standard vector of the same type. */
   template <typename TVal, typename TAlloc>
   TPiece<TVal> AsPiece(std::vector<TVal, TAlloc> &that) {
-    assert(&that);
     return TPiece<TVal>(&that[0], that.size());
   }
 
   /* Constructs a TPiece<const TVal> spanning a constant standard basic_string of the same type. */
   template <typename TVal, typename TTraits, typename TAlloc>
   TPiece<const TVal> AsPiece(const std::basic_string<TVal, TTraits, TAlloc> &that) {
-    assert(&that);
     return TPiece<const TVal>(that.data(), that.size());
   }
 
   /* Constructs a TPiece<TVal> spanning a standard basic_string of the same type. */
   template <typename TVal, typename TTraits, typename TAlloc>
   TPiece<TVal> AsPiece(std::basic_string<TVal, TTraits, TAlloc> &that) {
-    assert(&that);
     return TPiece<TVal>(const_cast<TVal *>(that.data()), that.size());
   }
 
@@ -703,21 +676,18 @@ namespace Base {
   /* Special hasher for char. */
   template <>
   inline size_t GetHashHelper(const char &val) {
-    assert(&val);
     return val;
   }
 
   /* Special hasher for unsigned char. */
   template <>
   inline size_t GetHashHelper(const unsigned char &val) {
-    assert(&val);
     return val;
   }
 
   /* Special hasher for std::string. */
   template <>
   inline size_t GetHashHelper(const std::string &val) {
-    assert(&val);
     return AsPiece(val).GetHash();
   }
 

--- a/base/pos.h
+++ b/base/pos.h
@@ -67,13 +67,11 @@ namespace Base {
 
     /* Returns true iff. this pos is the same as that one. */
     bool operator==(const TPos &that) const {
-      assert(&that);
       return Offset == that.Offset && Dir == that.Dir;
     }
 
     /* Returns true iff. this pos is not the same as that one. */
     bool operator!=(const TPos &that) const {
-      assert(&that);
       return Offset != that.Offset || Dir != that.Dir;
     }
 

--- a/base/pump.cc
+++ b/base/pump.cc
@@ -32,9 +32,6 @@ class TPump::TPipe {
 
   public:
   TPipe(TPump *pump, TFd &read, TFd &write) : Pump(pump) {
-    assert(&pump);
-    assert(&write);
-    assert(&read);
 
     // TODO: The kernel already can do most of this with temporary memory backed files... It just doesn't let us
     //      make a never-blocking stream :(

--- a/base/ref_counted.h
+++ b/base/ref_counted.h
@@ -75,14 +75,12 @@ namespace Base {
 
       /* Swap constructor.  The donor ptr is left null. */
       TPtr(TPtr &&that) {
-        assert(&that);
         Obj = that.Obj;
         that.Obj = 0;
       }
 
       /* Copy constructor.  This increments the reference count. */
       TPtr(const TPtr &that) {
-        assert(&that);
         Obj = that.Obj;
         if (Obj) {
           Obj->IncrRefCount();
@@ -93,7 +91,6 @@ namespace Base {
          up-castable types. */
       template <typename TDown>
       TPtr(const TPtr<TDown> &that) {
-        assert(&that);
         Obj = that.Obj;
         if (Obj) {
           Obj->IncrRefCount();
@@ -110,7 +107,6 @@ namespace Base {
 
       /* Swaperator. */
       TPtr &operator=(TPtr &&that) {
-        assert(&that);
         std::swap(Obj, that.Obj);
         return *this;
       }

--- a/base/repl.cc
+++ b/base/repl.cc
@@ -48,9 +48,6 @@ static void ReplCompletionCallback(const char *buf, linenoiseCompletions *lc) {
 bool Base::Repl(const string &ps1,
                 const vector<TInfo> &completions,
                 const function<bool(const string &)> &process_cmd) {
-  assert(&ps1);
-  assert(&completions);
-  assert(&process_cmd);
 
   static bool InUse(false);
   // NOTE: This isn't a perfect lock. But it's good enough to catch most accidental misuses of the library.

--- a/base/scheduler.cc
+++ b/base/scheduler.cc
@@ -43,7 +43,6 @@ TScheduler::TPolicy::TPolicy(size_t min_worker_count, size_t max_worker_count, c
 }
 
 void TScheduler::TPolicy::RunUntilCtrlC(TMainJob &&main_job) const {
-  assert(&main_job);
   try {
     TMasker masker(*TSet(TSet::Full));
     THandlerInstaller handler(
@@ -78,7 +77,6 @@ TScheduler::TPolicy TScheduler::GetPolicy() const {
 }
 
 void TScheduler::SetPolicy(const TPolicy &policy) {
-  assert(&policy);
   unique_lock<mutex> lock(Mutex);
   Policy = policy;
   PolicyChangedOrJobPushed.notify_all();
@@ -86,7 +84,6 @@ void TScheduler::SetPolicy(const TPolicy &policy) {
 }
 
 bool TScheduler::Schedule(TJob &&job, int priority) {
-  assert(&job);
   unique_lock<mutex> lock(Mutex);
   bool success = (Policy.GetMaxWorkerCount() > 0);
   if (success) {
@@ -221,8 +218,6 @@ TScheduler::TScheduler(const TPolicy &policy, const TOpt<pthread_t> &ctrl_c_thre
 }
 
 bool TScheduler::TryPopJob(unique_lock<mutex> &lock, TJob &job) {
-  assert(&lock);
-  assert(&job);
   bool success;
   do {
     /* If there are too many workers, leave without a job.

--- a/base/scheduler.h
+++ b/base/scheduler.h
@@ -176,7 +176,6 @@ namespace Base {
 
       /* Higher priority jobs go first. */
       bool operator<(const TQueueItem &that) const {
-        assert(&that);
         return Priority > that.Priority;
       }
 

--- a/base/scheduler.test.cc
+++ b/base/scheduler.test.cc
@@ -33,13 +33,10 @@ using namespace Base;
 
 #if 0
 static void Push(TEventSemaphore &sem) {
-  assert(&sem);
   sem.Push();
 }
 
 static void PushPop(TEventSemaphore &sem1, TEventSemaphore &sem2) {
-  assert(&sem1);
-  assert(&sem2);
   sem1.Push();
   sem2.Pop();
 }

--- a/base/sigma_calc.cc
+++ b/base/sigma_calc.cc
@@ -43,10 +43,6 @@ void TSigmaCalc::Push(double val) {
 }
 
 size_t TSigmaCalc::Report(double &min, double &max, double &mean, double &sigma) const {
-  assert(&min);
-  assert(&max);
-  assert(&mean);
-  assert(&sigma);
   if (Count) {
     min   = Min;
     max   = Max;
@@ -57,8 +53,6 @@ size_t TSigmaCalc::Report(double &min, double &max, double &mean, double &sigma)
 }
 
 ostream &Base::operator<<(ostream &strm, const TSigmaCalc &that) {
-  assert(&strm);
-  assert(&that);
   double min, max, mean, sigma;
   size_t count = that.Report(min, max, mean, sigma);
   strm << "(count: " << count;

--- a/base/slice.h
+++ b/base/slice.h
@@ -47,13 +47,11 @@ namespace Base {
 
     /* Returns true iff. this slice is the same as that one. */
     bool operator==(const TSlice &that) const {
-      assert(&that);
       return Start == that.Start && Limit == that.Limit;
     }
 
     /* Returns true iff. this slice is not the same as that one. */
     bool operator!=(const TSlice &that) const {
-      assert(&that);
       return Start != that.Start || Limit != that.Limit;
     }
 
@@ -88,8 +86,6 @@ namespace Base {
     /* Tries to apply this slice to a sequence of the given size.  If the size is large enough to accomodate us, then this function sets the two out-parameters
        to the correct absolute offsets and returns true; otherwise, this function leaves the out-parameters alone and the returns false. */
     bool TryGetAbsPair(size_t size, size_t &start, size_t &limit) const {
-      assert(&start);
-      assert(&limit);
       ptrdiff_t start_offset = Start.GetAbsOffset(size),
                 limit_offset = Limit.GetAbsOffset(size);
       bool success =

--- a/base/split.cc
+++ b/base/split.cc
@@ -26,8 +26,6 @@ using namespace Base;
 
 void Base::Split(const char *tok, const string &src, vector<string> &pieces) {
   assert(tok);
-  assert(&src);
-  assert(&pieces);
 
   if(src.size() == 0) {
     return;

--- a/base/subprocess.cc
+++ b/base/subprocess.cc
@@ -57,7 +57,6 @@ void TSubprocess::ExecStr(const char *cmd) {
 }
 
 void TSubprocess::Exec(const vector<string> &cmd) {
-  assert(&cmd);
   // NOTE: This is lots of copies. We're going to get all overwritten / eaten by the child though, so no big worries.
   // Build an array
 
@@ -72,7 +71,6 @@ void TSubprocess::Exec(const vector<string> &cmd) {
 }
 
 TSubprocess::TSubprocess(TPump &pump) {
-  assert(&pump);
   /* Make the in/out/err pipes, then fork. */
   TFd stdin, stdout, stderr;
   pump.NewPipe(stdin, StdInToChild);

--- a/base/thrower.h
+++ b/base/thrower.h
@@ -144,7 +144,6 @@ namespace Base {
 
   template <typename TError, typename TVal>
   Base::TThrower<TError> &&operator<<(Base::TThrower<TError> &&thrower, const TVal &val) {
-    assert(&thrower);
     thrower.Write(val);
     return std::move(thrower);
   }

--- a/base/thrower.test.cc
+++ b/base/thrower.test.cc
@@ -28,7 +28,6 @@ using namespace Base;
 
 static void GetParts(const char *msg, vector<string> &parts) {
   assert(msg);
-  assert(&parts);
   parts.clear();
   const char
       *start  = nullptr,

--- a/base/uuid.h
+++ b/base/uuid.h
@@ -141,7 +141,6 @@ namespace Base {
 
     /* Swaperator. */
     TUuid &operator=(TUuid &&that) {
-      assert(&that);
       if (this != &that) {
         std::swap(Data, that.Data);
       }
@@ -150,7 +149,6 @@ namespace Base {
 
     /* Copy assignment. */
     TUuid &operator=(const TUuid &that) {
-      assert(&that);
       if (this != &that) {
         uuid_copy(Data, that.Data);
       }
@@ -159,7 +157,6 @@ namespace Base {
 
     /* Copy assignment. */
     TUuid &operator=(const uuid_t &that) {
-      assert(&that);
       if (&Data != &that) {
         uuid_copy(Data, that);
       }
@@ -178,43 +175,36 @@ namespace Base {
 
     /* Comparator. */
     bool operator==(const TUuid &that) const {
-      assert(&that);
       return uuid_compare(Data, that.Data) == 0;
     }
 
     /* Comparator. */
     bool operator!=(const TUuid &that) const {
-      assert(&that);
       return uuid_compare(Data, that.Data) != 0;
     }
 
     /* Comparator. */
     bool operator<(const TUuid &that) const {
-      assert(&that);
       return uuid_compare(Data, that.Data) < 0;
     }
 
     /* Comparator. */
     bool operator<=(const TUuid &that) const {
-      assert(&that);
       return uuid_compare(Data, that.Data) <= 0;
     }
 
     /* Comparator. */
     bool operator>(const TUuid &that) const {
-      assert(&that);
       return uuid_compare(Data, that.Data) > 0;
     }
 
     /* Comparator. */
     bool operator>=(const TUuid &that) const {
-      assert(&that);
       return uuid_compare(Data, that.Data) >= 0;
     }
 
     /* Comparator. */
     int Compare(const TUuid &that) const {
-      assert(&that);
       return uuid_compare(Data, that.Data);
     }
 
@@ -268,7 +258,6 @@ namespace Base {
 
     /* Read from std stream. */
     void Read(std::istream &strm) {
-      assert(&strm);
       char buf[MinBufSize];
       strm.read(buf, StrSize);
       buf[StrSize] = '\0';
@@ -277,7 +266,6 @@ namespace Base {
 
     /* Read from a binary stream. */
     void Read(Io::TBinaryInputStream &strm) {
-      assert(&strm);
       strm >> Data;
     }
 
@@ -289,7 +277,6 @@ namespace Base {
 
     /* Write to a std stream. */
     void Write(std::ostream &strm) const {
-      assert(&strm);
       char buf[MinBufSize];
       Format(buf);
       strm << buf;
@@ -297,7 +284,6 @@ namespace Base {
 
     /* Write to a binary stream. */
     void Write(Io::TBinaryOutputStream &strm) const {
-      assert(&strm);
       strm << Data;
     }
 
@@ -314,28 +300,24 @@ namespace Base {
 
   /* A standard stream extractor for Base::TUuid. */
   inline std::istream &operator>>(std::istream &strm, TUuid &that) {
-    assert(&that);
     that.Read(strm);
     return strm;
   }
 
   /* A standard stream inserter for Base::TUuid. */
   inline std::ostream &operator<<(std::ostream &strm, const TUuid &that) {
-    assert(&that);
     that.Write(strm);
     return strm;
   }
 
   /* Binary extractor for Base::TUuid. */
   inline Io::TBinaryInputStream &operator>>(Io::TBinaryInputStream &strm, TUuid &that) {
-    assert(&that);
     that.Read(strm);
     return strm;
   }
 
   /* Binary inserter for Base::TUuid. */
   inline Io::TBinaryOutputStream &operator<<(Io::TBinaryOutputStream &strm, const TUuid &that) {
-    assert(&that);
     that.Write(strm);
     return strm;
   }

--- a/base/var_int.cc
+++ b/base/var_int.cc
@@ -43,7 +43,6 @@ const char *Base::ReadVarInt(const char *buffer, uint32_t &value) {
 
 const char *Base::ReadVarInt(const char *buffer, uint64_t &value) {
   assert(buffer);
-  assert(&value);
   value = 0;
   uint64_t place = 1;
   for (;;) {

--- a/gz/file.cc
+++ b/gz/file.cc
@@ -51,7 +51,6 @@ TFile::TFile(int fd, const char *mode) {
 }
 
 TFile::TFile(Base::TFd &&fd, const char *mode) {
-  assert(&fd);
   assert(fd.IsOpen());
   assert(mode);
   Handle = gzdopen(fd, mode);

--- a/gz/file.h
+++ b/gz/file.h
@@ -45,7 +45,6 @@ namespace Gz {
 
     /* Move-construct from that file.  That file will end up closed. */
     TFile(TFile &&that) {
-      assert(&that);
       Handle = that.Handle;
       that.Handle = nullptr;
     }

--- a/gz/output_consumer.cc
+++ b/gz/output_consumer.cc
@@ -24,7 +24,6 @@ using namespace std;
 using namespace Gz;
 
 void TOutputConsumer::ConsumeOutput(const shared_ptr<const TChunk> &chunk) {
-  assert(&chunk);
   const char *start, *limit;
   chunk->GetData(start, limit);
   while (start < limit) {

--- a/inv_con/ordered_list.h
+++ b/inv_con/ordered_list.h
@@ -337,7 +337,6 @@ namespace InvCon {
       /* Set our key, relocating us within our collection, if necessary.
          If the new key is the same as the old, do nothing. */
       void SetKey(const TKey &key) {
-        assert(&key);
         if (Key != key) {
           Key = key;
           if (Collection) {

--- a/inv_con/unordered_multimap.h
+++ b/inv_con/unordered_multimap.h
@@ -63,7 +63,6 @@ namespace InvCon {
          the same key, call back for the first one in the collection.  You can use TryGetNextMemberWithSameKey()
          to spin through the rest.  If the callback returns false, stop generating immediately. */
       bool ForEachUniqueMember(const std::function<bool (TMember *)> &cb) const {
-        assert(&cb);
         auto csr = TryGetFirstMembership();
         bool result = true;
         while (csr) {
@@ -541,7 +540,6 @@ namespace InvCon {
       /* Set our key, relocating us within our collection, if necessary.
          If the new key is the same as the old, do nothing. */
       void SetKey(const TKey &key) {
-        assert(&key);
         if (Key != key) {
           Key = key;
           if (Bucket) {

--- a/io/binary_format.h
+++ b/io/binary_format.h
@@ -34,7 +34,6 @@ namespace Io {
 
     template <typename TVal>
     void ConvertInt(TVal &val) const {
-      assert(&val);
       if (UseNbo) {
         val = SwapEnds(val);
       }

--- a/io/binary_input_stream.h
+++ b/io/binary_input_stream.h
@@ -96,7 +96,6 @@ namespace Io {
 
     /* Read a string. */
     void Read(std::string &that) {
-      assert(&that);
       size_t size;
       Read(size);
       that.resize(size);
@@ -106,13 +105,11 @@ namespace Io {
     /* Read STL tuples. */
     template <typename... TArgs>
     void Read(std::tuple<TArgs...> &that) {
-      assert(&that);
       Util::ForEach(that, TTupleHelper(*this));
     }
 
     template <typename TRep, typename TPeriod>
     void Read(std::chrono::duration<TRep, TPeriod> &that) {
-      assert(&that);
       TRep rep;
       *this >> rep;
       that = std::chrono::duration<TRep, TPeriod>(rep);
@@ -153,7 +150,6 @@ namespace Io {
     /* Read an STL container that supports push_back(). */
     template <typename TThat>
     void ReadPushableContainer(TThat &that) {
-      assert(&that);
       size_t size;
       Read(size);
       that.clear();
@@ -168,7 +164,6 @@ namespace Io {
     /* Read a built-in, converting from NBO if necessary. */
     template <typename TThat>
     void ReadWithSwap(TThat &that) {
-      assert(&that);
       ReadExactly(&that, sizeof(that));
       GetFormat().ConvertInt(that);
     }
@@ -176,7 +171,6 @@ namespace Io {
     /* Read a built-in without converting from NBO. */
     template <typename TThat>
     void ReadWithoutSwap(TThat &that) {
-      assert(&that);
       ReadExactly(&that, sizeof(that));
     }
 
@@ -207,7 +201,6 @@ namespace Io {
   /* TODO */
   template <typename TThat>
   void TBinaryInputStream::ReadInsertableContainer(TThat &that) {
-    assert(&that);
     size_t size;
     Read(size);
     that.clear();
@@ -231,7 +224,6 @@ namespace Io {
 
     /* Stream in. */
     void Read(TBinaryInputStream &strm) {
-      assert(&strm);
       TSomeInt some_int;
       strm >> some_int;
       SomeEnum = static_cast<TSomeEnum>(some_int);
@@ -297,7 +289,6 @@ namespace Io {
   /* Stream extractor for enums. */
   template <typename TSomeEnum, typename TSomeInt>
   inline TBinaryInputStream &operator>>(TBinaryInputStream &strm, TBinaryInputEnum<TSomeEnum, TSomeInt> &&that) {
-    assert(&that);
     that.Read(strm);
     return strm;
   }
@@ -357,7 +348,6 @@ namespace Io {
   /* Stream extractor for enums. */
   template <typename TSomeEnum, typename TSomeInt>
   inline TBinaryInputStream &&operator>>(TBinaryInputStream &&strm, TBinaryInputEnum<TSomeEnum, TSomeInt> &&that) {
-    assert(&that);
     that.Read(strm);
     return std::move(strm);
   }

--- a/io/binary_output_stream.h
+++ b/io/binary_output_stream.h
@@ -100,19 +100,16 @@ namespace Io {
 
     template <typename... TArgs>
     void Write(const std::tuple<TArgs...> &that) {
-      assert(&that);
       *this << Base::Concat(that);
     }
 
     template <typename TRep, typename TPeriod>
     void Write(const std::chrono::duration<TRep, TPeriod> &that) {
-      assert(&that);
       Write(that.count());
     }
 
     template <typename TContainer, typename TDelimiter, typename TFormat>
     void Write(const Base::TJoin<TContainer, TDelimiter, TFormat> &that) {
-      assert(&that);
       Base::WriteJoin(*this, that);
     }
 
@@ -149,7 +146,6 @@ namespace Io {
     /* Write an STL container. */
     template <typename TThat>
     void WriteContainer(const TThat &that) {
-      assert(&that);
       Write(that.size());
       for (const typename TThat::value_type &val: that) {
         Write(val);

--- a/io/chunk_and_pool.cc
+++ b/io/chunk_and_pool.cc
@@ -43,8 +43,6 @@ size_t TChunk::Store(int fd) {
 }
 
 bool TChunk::Store(const char *&buf, size_t &size) {
-  assert(&buf);
-  assert(&size);
   assert(buf || !size);
   size_t copy_size = GetRemainingSize();
   bool success = (copy_size != 0);

--- a/io/chunk_and_pool.h
+++ b/io/chunk_and_pool.h
@@ -109,7 +109,6 @@ namespace Io {
        We will not own the storage space, merely point at it.
        We will not be recycled in a pool. */
     TChunk(TFull, const std::string &str) {
-      assert(&str);
       Start = const_cast<char *>(str.data());
       Limit = Start + str.size();
       Cursor = Limit;
@@ -133,8 +132,6 @@ namespace Io {
     /* Return pointers to the data in this chunk.
        Upon return, start will always be <= limit. */
     void GetData(const char *&start, const char *&limit) const NO_THROW {
-      assert(&start);
-      assert(&limit);
       start = Start;
       limit = Cursor;
     }

--- a/io/device.cc
+++ b/io/device.cc
@@ -29,7 +29,6 @@ TDevice::TTimeout::TTimeout()
     : runtime_error("timeout") {}
 
 void TDevice::ConsumeOutput(const shared_ptr<const TChunk> &chunk) {
-  assert(&chunk);
   assert(chunk);
   const char *start, *limit;
   chunk->GetData(start, limit);

--- a/io/device.test.cc
+++ b/io/device.test.cc
@@ -56,9 +56,6 @@ namespace std {
 
 template <typename TExpected, typename TActual = TExpected>
 static void RoundTrip(TBinaryOutputStream &out_strm, TBinaryInputStream &in_strm, const TExpected &expected) {
-  assert(&out_strm);
-  assert(&in_strm);
-  assert(&expected);
   out_strm << expected;
   out_strm.Flush();
   TActual actual;

--- a/io/input_consumer.cc
+++ b/io/input_consumer.cc
@@ -30,7 +30,6 @@ bool TInputConsumer::HasBufferedData() const {
 }
 
 void TInputConsumer::PeekAndDump(string &out) {
-  assert(&out);
   TryRefresh();
   size_t size = Limit - Cursor;
   ostringstream strm;

--- a/io/recorder_and_player.cc
+++ b/io/recorder_and_player.cc
@@ -27,7 +27,6 @@ void TRecorder::ConsumeOutput(const shared_ptr<const TChunk> &chunk) {
 }
 
 void TRecorder::CopyOut(string &out) const {
-  assert(&out);
   size_t size = 0;
   for (const auto &chunk: Chunks) {
     size += chunk->GetSize();

--- a/io/stream.h
+++ b/io/stream.h
@@ -179,7 +179,6 @@ namespace Io {
 
     /* Assign the argument to the field. */
     void Write(TStream<TFormat> &strm) const {
-      assert(&strm);
       strm.GetFormat().*Ptr = Arg;
     }
 
@@ -202,7 +201,6 @@ namespace Io {
   /* Inserter for Io::TSetFormat. */
   template <typename TFormat, typename TParam, typename TArg>
   TStream<TFormat> &operator<<(TStream<TFormat> &strm, const TSetFormat<TFormat, TParam, TArg> &manip) {
-    assert(&manip);
     manip.Write(strm);
     return strm;
   }

--- a/jhm/env.cc
+++ b/jhm/env.cc
@@ -223,7 +223,6 @@ void TEnv::SetFuncs(TFileCheckFunc &&buildable, TFileCheckFunc &&done) {
 }
 
 TFile *TEnv::TryGetFileFromPath(const std::string &name) {
-  assert(&name);
   assert(name.size()); // Name must be non-empty.
   // If the name starts with a '/' it's an absolute filesystem path
   TPath path(name);

--- a/jhm/jhm.cc
+++ b/jhm/jhm.cc
@@ -272,7 +272,6 @@ class TJhm : public TCmd {
     }
 
     virtual void WriteAfterDesc(ostream &strm) const {
-      assert(&strm);
       strm << "Copyright Atomic Kismet Company\n"
            << "Licensed under the Apache License, Version 2.0" << endl;
     }

--- a/jhm/work_finder.cc
+++ b/jhm/work_finder.cc
@@ -306,7 +306,6 @@ auto GrabOne(const std::unordered_set<TVal> &container) {
 }
 
 TFile *TWorkFinder::TryGetOutputFileFromPath(const std::string &filename) {
-  assert(&filename);
   TFile *ret = TryGetFileFromPath(filename);
   // If we aren't buildable, try finding the executable form.
   if (ret && !IsBuildable(ret)) {

--- a/multi_event/multi_event.cc
+++ b/multi_event/multi_event.cc
@@ -34,14 +34,10 @@ void TEvent::Fire() {
 }
 
 bool TWaiter::Wait(const TProducer &producer, const TConsumer &consumer, const Base::TOpt<chrono::milliseconds> &timeout) {
-  assert(&producer);
-  assert(&consumer);
-  assert(&timeout);
   Flag = false;
   try {
     /* Spin through our events. */
     producer([&consumer, this](const shared_ptr<TEvent> &event) {
-      assert(&event);
       assert(event);
       lock_guard<mutex> lock(event->Mutex);
       if (event->Flag) {

--- a/multi_event/multi_event.h
+++ b/multi_event/multi_event.h
@@ -119,7 +119,6 @@ namespace MultiEvent {
 
     /* Make a consumer which collects events into a set. */
     static TConsumer Consume(std::unordered_set<std::shared_ptr<TEvent>> &events) {
-      assert(&events);
       return std::bind(
         [](const std::shared_ptr<TEvent> &event, std::unordered_set<std::shared_ptr<TEvent>> &events) {
           events.insert(event);
@@ -132,8 +131,6 @@ namespace MultiEvent {
     /* Make a consumer which trampolines an event to a callback by looking up the event's value. */
     template <typename TVal>
     static TConsumer Consume(const std::unordered_map<std::shared_ptr<TEvent>, TVal> &val_by_event, const std::function<void (const TVal &)> &cb) {
-      assert(&val_by_event);
-      assert(&cb);
       return std::bind(
         [](const std::shared_ptr<TEvent> &event,
            const std::unordered_map<std::shared_ptr<TEvent>, TVal> &val_by_event,
@@ -148,7 +145,6 @@ namespace MultiEvent {
 
     /* Produce (one at a time) all the events in a set. */
     static TProducer Produce(const std::unordered_set<std::shared_ptr<TEvent>> &events) {
-      assert(&events);
       return std::bind(
         [](const TConsumer &consumer, const std::unordered_set<std::shared_ptr<TEvent>> &events) {
           for (auto event: events) {
@@ -163,7 +159,6 @@ namespace MultiEvent {
     /* Produce (one at a time) all the events in a map which is keyed by events. */
     template <typename TVal>
     static TProducer Produce(const std::unordered_map<std::shared_ptr<TEvent>, TVal> &val_by_event) {
-      assert(&val_by_event);
       return std::bind(
         [](const TConsumer &consumer, const std::unordered_map<std::shared_ptr<TEvent>, TVal> &val_by_event) {
           for (const auto &event_and_val: val_by_event) {

--- a/orly/atom/comparison.h
+++ b/orly/atom/comparison.h
@@ -58,8 +58,6 @@ namespace Orly {
        bool TLhs::operator<(const TRhs &) must be defined. */
     template <typename TLhs, typename TRhs>
     TComparison CompareOrdered(const TLhs &lhs, const TRhs &rhs) {
-      assert(&lhs);
-      assert(&rhs);
       return (lhs < rhs) ? TComparison::Lt : (rhs < lhs) ? TComparison::Gt : TComparison::Eq;
     }
 
@@ -72,8 +70,6 @@ namespace Orly {
     /* Compare two objects of the same type (TObj) by comparing their members in the given order. */
     template <typename TObj, typename TVal, typename... TMoreMembers>
     TComparison CompareOrderedMembers(const TObj &lhs, const TObj &rhs, TVal (TObj::*member), TMoreMembers... more_members) {
-      assert(&lhs);
-      assert(&rhs);
       TComparison result = CompareOrdered(lhs.*member, rhs.*member);
       if (result == TComparison::Eq) {
         result = CompareOrderedMembers(lhs, rhs, more_members...);
@@ -85,8 +81,6 @@ namespace Orly {
        bool TLhs::operator==(const TRhs &) must be defined. */
     template <typename TLhs, typename TRhs>
     TComparison CompareUnordered(const TLhs &lhs, const TRhs &rhs) {
-      assert(&lhs);
-      assert(&rhs);
       return (lhs == rhs) ? TComparison::Eq : TComparison::Ne;
     }
 

--- a/orly/atom/core_vector.cc
+++ b/orly/atom/core_vector.cc
@@ -36,7 +36,6 @@ TCoreVector::TCoreVector(TBinaryInputStream &strm) : Arena(strm) {
 
 TCoreVector::TPackedArena::TPackedArena(TBinaryInputStream &strm)
     : TCore::TArena(false) {
-  assert(&strm);
   uint32_t raw_size;
   strm /*>> Offsets*/ >> raw_size;
   RawSize = raw_size;

--- a/orly/atom/core_vector_builder.cc
+++ b/orly/atom/core_vector_builder.cc
@@ -37,7 +37,6 @@ TCoreVectorBuilder::~TCoreVectorBuilder() {
 }
 
 void TCoreVectorBuilder::Write(TBinaryOutputStream &strm) const {
-  assert(&strm);
   /* Pass once over the notes to build up a map of old offset to new. */
   uint32_t raw_size = 0;
   map<TOffset, TOffset> offset_map;
@@ -99,7 +98,6 @@ TCoreVectorBuilder::TDirtyArena::~TDirtyArena() {
 }
 
 bool TCoreVectorBuilder::TDirtyArena::ForEachNote(const function<bool (const TNote *)> &cb) const {
-  assert(&cb);
   for (const auto &item: NotesByDepth) {
     for (const TNote *note: item.second) {
       if (!cb(note)) {
@@ -134,7 +132,6 @@ const TCoreVectorBuilder::TNote *TCoreVectorBuilder::TDirtyArena::TryAcquireNote
 }
 
 void TCoreVectorBuilder::SetDepth(const Sabot::State::TAny::TWrapper &state) {
-  assert(&state);
   Depth = Sabot::GetDepth(*Sabot::Type::TAny::TWrapper(state->GetType(TypeBuffer)));
 }
 

--- a/orly/atom/kit2.cc
+++ b/orly/atom/kit2.cc
@@ -259,7 +259,6 @@ TCore::TCore(TExtensibleArena *arena, const Type::TAny &type) {
     TExtensibleArena *Arena;
     TCore *Core;
   };
-  assert(&type);
   type.Accept(visitor_t(arena, this));
 }
 
@@ -599,8 +598,6 @@ bool TCore::TrySplit(TArena *arena, size_t lhs_size,
   assert(arena);
   assert(lhs_arena);
   assert(rhs_arena);
-  assert(&lhs_core);
-  assert(&rhs_core);
   void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
   Sabot::State::TAny::TWrapper my_state(NewState(arena, state_alloc));
   const Sabot::State::TTuple *tuple_state = dynamic_cast<const Sabot::State::TTuple *>(my_state.get());
@@ -630,7 +627,6 @@ TCore::TCore(TExtensibleArena *arena, const char *c_str) {
 }
 
 void TCore::CopyOut(TArena *arena, string &out) const {
-  assert(&out);
   if (Tycon == TTycon::Str) {
     assert(arena);
     void *pin_alloc = alloca(sizeof(TArena::TFinalPin));
@@ -688,8 +684,6 @@ void TCore::InitStr(TExtensibleArena *arena, const char *start, const char *limi
 
 void TCore::InitIndirectCoreArray(TTycon tycon, TExtensibleArena *arena, const Type::TUnary &type, const State::TArrayOfSingleStates &state) {
   assert(arena);
-  assert(&type);
-  assert(&state);
   if (!TryInitIndirectCoreArray(tycon, arena, state)) {
     InitIndirectCoreArray(tycon, arena, type, true);
   }
@@ -697,7 +691,6 @@ void TCore::InitIndirectCoreArray(TTycon tycon, TExtensibleArena *arena, const T
 
 void TCore::InitIndirectCoreArray(TTycon tycon, TExtensibleArena *arena, const Type::TUnary &type, bool is_exemplar) {
   assert(arena);
-  assert(&type);
   TInit1 init1 =
       [arena, &type](size_t, void *elem) {
         void *pin_alloc = alloca(Type::GetMaxTypePinSize());
@@ -710,8 +703,6 @@ void TCore::InitIndirectCoreArray(TTycon tycon, TExtensibleArena *arena, const T
 
 void TCore::InitIndirectCoreArray(TTycon tycon, TExtensibleArena *arena, const Type::TBinary &type, const State::TArrayOfPairsOfStates &state) {
   assert(arena);
-  assert(&type);
-  assert(&state);
   size_t elem_count = state.GetElemCount();
   if (elem_count) {
     void *pin_alloc = alloca(State::GetMaxStatePinSize());
@@ -731,7 +722,6 @@ void TCore::InitIndirectCoreArray(TTycon tycon, TExtensibleArena *arena, const T
 
 void TCore::InitIndirectCoreArray(TTycon tycon, TExtensibleArena *arena, const Type::TBinary &type, bool is_exemplar) {
   assert(arena);
-  assert(&type);
   TInit2 init2 =
       [arena, &type](size_t, void *lhs, void *rhs) {
         void *pin_alloc = alloca(Type::GetMaxTypePinSize());
@@ -745,7 +735,6 @@ void TCore::InitIndirectCoreArray(TTycon tycon, TExtensibleArena *arena, const T
 
 void TCore::InitIndirectCoreArray(TExtensibleArena *arena, const Type::TTuple &type, bool is_exemplar) {
   assert(arena);
-  assert(&type);
   TInit1 init1 =
       [arena, &type](size_t elem_idx, void *elem) {
         void *pin_alloc = alloca(Type::GetMaxTypePinSize());
@@ -759,7 +748,6 @@ void TCore::InitIndirectCoreArray(TExtensibleArena *arena, const Type::TTuple &t
 
 void TCore::InitIndirectCoreArray(TExtensibleArena *arena, const Type::TRecord &type, bool is_exemplar) {
   assert(arena);
-  assert(&type);
   TInit2 init2 =
       [arena, &type](size_t elem_idx, void *lhs, void *rhs) {
         string field_name;
@@ -1150,7 +1138,6 @@ TCore::TNote *TCore::TNote::New(const char *start, const char *limit, bool is_ex
 }
 
 TCore::TNote *TCore::TNote::New(TTycon tycon, size_t elem_count, bool is_exemplar, const TInit1 &init1) {
-  assert(&init1);
   size_t raw_size = elem_count * sizeof(TCore);
   TNote *note = new (raw_size) TNote(tycon, is_exemplar, false , raw_size);
   try {
@@ -1166,7 +1153,6 @@ TCore::TNote *TCore::TNote::New(TTycon tycon, size_t elem_count, bool is_exempla
 }
 
 TCore::TNote *TCore::TNote::New(TTycon tycon, size_t elem_count, bool is_exemplar, const TInit2 &init2) {
-  assert(&init2);
   size_t raw_size = elem_count * sizeof(TPairOfCores);
   TNote *note = new (raw_size) TNote(tycon, is_exemplar, false, raw_size);
   try {

--- a/orly/atom/kit2.h
+++ b/orly/atom/kit2.h
@@ -363,7 +363,6 @@ namespace Orly {
       template <typename TVal>
       void InitDirect(TTycon tycon, const TVal &val) {
         static_assert(sizeof(TVal) <= MaxDirectSize, "TVal is value too large to store directly.");
-        assert(&val);
         Init(tycon);
         new (DirectBlob) TVal(val);
       }
@@ -883,7 +882,6 @@ namespace Orly {
 
     inline bool TCore::TryQuickOrderComparison(TArena *this_arena, const TCore &that_core, TArena *that_arena, Atom::TComparison &comp) const {
       assert(this_arena);
-      assert(&that_core);
       assert(that_arena);
       bool success = Tycon == that_core.Tycon &&
         Tycon >= TTycon::Blob &&
@@ -1109,7 +1107,6 @@ namespace Orly {
 
     inline bool TCore::MatchType(TArena *this_arena, const TCore &that_core, TArena *that_arena) const {
       assert(this_arena);
-      assert(&that_core);
       assert(that_arena);
       if (Tycon == that_core.Tycon) {
         switch (Tycon) {
@@ -1259,7 +1256,6 @@ namespace Orly {
 
     inline Orly::Sabot::TMatchResult TCore::PrefixMatch(TArena *this_arena, const TCore &that_core, TArena *that_arena) const {
       assert(this_arena);
-      assert(&that_core);
       assert(that_arena);
       assert(Tycon == TTycon::Tuple);
       assert(that_core.Tycon == TTycon::Tuple);
@@ -1319,7 +1315,6 @@ namespace Orly {
     }
 
     inline bool TCore::TryGetQuickHash(size_t &out_hash) const {
-      assert(&out_hash);
       switch (Tycon) {
         case TTycon::Int8: {
           out_hash = std::_Hash_impl::hash(&ForceAs<int8_t>(), sizeof(int8_t));
@@ -1399,7 +1394,6 @@ namespace Orly {
     }
 
     inline bool TCore::TryGetStoredHash(size_t &out_hash) const {
-      assert(&out_hash);
       bool success = Tycon >= TTycon::Blob &&
         IndirectCoreArray.StoresHash &&
         IndirectCoreArray.UsesFullNote;
@@ -1427,8 +1421,6 @@ namespace Orly {
 
     template <typename TVal>
     inline void TCore::TNote::GetArray(TVal *&start, TVal *&limit) const {
-      assert(&start);
-      assert(&limit);
       #ifndef NDEBUG
       if (RawSize % sizeof(TVal)) {
         throw TCorrupt(HERE);

--- a/orly/atom/kit2.test.cc
+++ b/orly/atom/kit2.test.cc
@@ -383,7 +383,6 @@ const TSomeState *TryAsState(const Sabot::State::TAny &state) {
       this->Out = &that;
     }
   };
-  assert(&state);
   visitor_t visitor;
   visitor.Out = nullptr;
   state.Accept(visitor);

--- a/orly/atom/transport_arena2.cc
+++ b/orly/atom/transport_arena2.cc
@@ -34,8 +34,6 @@ TTransportArena::~TTransportArena() {
 }
 
 TTransportArena *TTransportArena::Read(Io::TBinaryInputStream &strm, TCore &core) {
-  assert(&strm);
-  assert(&core);
   auto transport_arena = new TTransportArena(strm);
   try {
     strm.ReadExactly(&core, sizeof(TCore));
@@ -47,9 +45,7 @@ TTransportArena *TTransportArena::Read(Io::TBinaryInputStream &strm, TCore &core
 }
 
 void TTransportArena::Write(TBinaryOutputStream &strm, TSuprena *suprena, const TCore &core) {
-  assert(&strm);
   assert(suprena);
-  assert(&core);
   /* Get the notes from the arena and put them into merge order. */
   std::vector<const TNote *> notes;
   OrderNotes(notes, suprena->GetNotes(), suprena);
@@ -97,7 +93,6 @@ void TTransportArena::Write(TBinaryOutputStream &strm, TSuprena *suprena, const 
 
 TTransportArena::TTransportArena(TBinaryInputStream &strm)
     : TCore::TArena(false) {
-  assert(&strm);
   uint32_t raw_size;
   strm >> Offsets >> raw_size;
   RawSize = raw_size;

--- a/orly/balancer/balancer.cc
+++ b/orly/balancer/balancer.cc
@@ -50,9 +50,7 @@ void TBalancer::AcceptClientConnections() {
   }
 }
 
-void TBalancer::ServeClient(TFd &fd, const TAddress &client_address) {
-  assert(&fd);
-  assert(&client_address);
+void TBalancer::ServeClient(TFd &fd, const TAddress &) {
   const size_t buf_size = 4096;
   /* Figure out which host to route to. */
   const Socket::TAddress &server_address = ChooseHost();

--- a/orly/balancer/balancer.test.cc
+++ b/orly/balancer/balancer.test.cc
@@ -263,9 +263,7 @@ class TTestServer {
     Finish.notify_all();
   }
 
-  void ServeClient(TFd &fd, const TAddress &client_address) {
-    assert(&fd);
-    assert(&client_address);
+  void ServeClient(TFd &fd, const TAddress &) {
     std::shared_ptr<TConnection> connection = make_shared<TConnection>(this, std::move(fd));
     try {
       /* Run the server thru one cycle. */ {

--- a/orly/client/program/parse_image.cc
+++ b/orly/client/program/parse_image.cc
@@ -31,7 +31,6 @@ using namespace Orly::Client::Program;
 
 static bool ForEachXact(const Tools::Nycr::TContextBuilt<TProgram> &program, const TForXact &cb) {
   ThrowSyntaxErrors(program);
-  assert(&cb);
   auto image = dynamic_cast<const TImage *>(program.Get()->GetTop());
   if (!image) {
     DEFINE_ERROR(error_t, runtime_error, "not an image");
@@ -61,7 +60,6 @@ bool Orly::Client::Program::ParseImageStr(const char *str, const TForXact &cb) {
 
 bool Orly::Client::Program::TranslateXact(const TXact *xact, const TForKv &cb) {
   assert(xact);
-  assert(&cb);
   void
       *lhs_alloc = alloca(Sabot::State::GetMaxStateSize()),
       *rhs_alloc = alloca(Sabot::State::GetMaxStateSize());

--- a/orly/client/program/parse_stmt.cc
+++ b/orly/client/program/parse_stmt.cc
@@ -29,8 +29,6 @@ using namespace Base;
 using namespace Orly::Client::Program;
 
 static void ForStmt(const Tools::Nycr::TContextBuilt<TProgram> &program, const TForStmt &cb) {
-  assert(&program);
-  assert(&cb);
   ThrowSyntaxErrors(program);
   auto stmt = dynamic_cast<const TStmt *>(program.Get()->GetTop());
   if (!stmt) {

--- a/orly/client/program/translate_expr.cc
+++ b/orly/client/program/translate_expr.cc
@@ -30,15 +30,12 @@ using namespace Orly;
 using namespace Orly::Client::Program;
 
 void Orly::Client::Program::TranslatePackage(vector<string> &package_name, uint64_t &version_number, const TPackageName *root) {
-  assert(&package_name);
-  assert(&version_number);
   assert(root);
   TranslatePathName(package_name, root->GetNameList());
   version_number = root->GetIntExpr()->GetLexeme().AsInt();
 }
 
 void Orly::Client::Program::TranslatePathName(vector<string> &path_name, const TNameList *root) {
-  assert(&path_name);
   assert(root);
   path_name.clear();
   do {
@@ -303,7 +300,6 @@ Type::TRecordType::TPin::TPin(const TRecordType *record_type)
 }
 
 Sabot::Type::TAny *Type::TRecordType::TPin::NewElem(size_t elem_idx, string &name, void *type_alloc) const {
-  assert(&name);
   auto member = RecordType->Members[elem_idx];
   name = member->GetName()->GetLexeme().GetText();
   return NewTypeSabot(member->GetType(), type_alloc);
@@ -343,7 +339,6 @@ Type::TRecordExpr::TPin::TPin(const TRecordExpr *record_expr)
 }
 
 Sabot::Type::TAny *Type::TRecordExpr::TPin::NewElem(size_t elem_idx, string &name, void *type_alloc) const {
-  assert(&name);
   auto member = RecordExpr->Members[elem_idx];
   name = member->GetName()->GetLexeme().GetText();
   return NewTypeSabot(member->GetExpr(), type_alloc);

--- a/orly/client/test_server.cc
+++ b/orly/client/test_server.cc
@@ -228,7 +228,6 @@ size_t TTestServer::TConn::HandleIoResult(ssize_t actl) {
 }
 
 void TTestServer::AcceptorMain(const string &worker_name) {
-  assert(&worker_name);
   /* Loop here, accepting connections and launching sessions, until the server begins stopping. */
   while (!Stopping) {
     syslog(LOG_INFO, "%s; waiting for connection", worker_name.c_str());
@@ -256,7 +255,6 @@ void TTestServer::AcceptorMain(const string &worker_name) {
 }
 
 void TTestServer::ConnectionMain(const string &worker_name, TFd &client) {
-  assert(&worker_name);
   /* Make an object to manage the I/O over this connection,
      then give the client a few tries to establish a session. */
   TConn conn(this, move(client));
@@ -313,8 +311,6 @@ void TTestServer::ConnectionMain(const string &worker_name, TFd &client) {
 }
 
 void TTestServer::LaunchWorker(string &&worker_name, function<void (const string &)> &&entry_point) {
-  assert(&worker_name);
-  assert(&entry_point);
   /* If we're stopping, throw. */
   if (Stopping) {
     throw TInterrupted();
@@ -340,8 +336,6 @@ void TTestServer::LaunchWorker(string &&worker_name, function<void (const string
 }
 
 void TTestServer::WorkerWrapper(const string &worker_name, const function<void (const string &)> &entry_point) {
-  assert(&worker_name);
-  assert(&entry_point);
   assert(entry_point);
   /* Cache the handle to the thread we're in. */
   auto self = pthread_self();

--- a/orly/client/test_server.h
+++ b/orly/client/test_server.h
@@ -83,7 +83,6 @@ namespace Orly {
       }
 
       static TMsgHdr *TryDecode(char *&buf, TByteOrder &byte_order) {
-        assert(&byte_order);
         /* Cast to point at a potential message header. */
         auto *msg_hdr = Cast(buf);
         /* Is the byte order good? */
@@ -119,7 +118,6 @@ namespace Orly {
       }
 
       static TMsgHdr *Cast(char *&buf) {
-        assert(&buf);
         assert(buf);
         auto *msg_hdr = reinterpret_cast<TMsgHdr *>(buf);
         buf += sizeof(TMsgHdr);

--- a/orly/closure.cc
+++ b/orly/closure.cc
@@ -29,7 +29,6 @@ using namespace Orly;
 using namespace Orly::Atom;
 
 Sabot::Type::TAny *TClosure::TType::TPin::NewElem(size_t elem_idx, string &name, void *type_alloc) const {
-  assert(&name);
   auto iter = Walker[elem_idx];
   name = iter->first;
   return iter->second.GetType(Walker.GetClosure()->Arena.get(), type_alloc);
@@ -67,7 +66,6 @@ TClosure::TState::TPinBase *TClosure::TState::Pin(void *alloc) const {
 }
 
 void TClosure::Read(TBinaryInputStream &strm) {
-  assert(&strm);
   Reset();
   strm >> MethodName;
   TCore core;
@@ -110,7 +108,6 @@ void TClosure::Read(TBinaryInputStream &strm) {
 }
 
 bool TClosure::AddCore(const string &name, const TCore &core) {
-  assert(&core);
   return CoreByName.insert(make_pair(name, core)).second;
 }
 
@@ -120,7 +117,6 @@ void TClosure::Reset() {
 }
 
 void TClosure::Write(TBinaryOutputStream &strm) const {
-  assert(&strm);
   strm << MethodName;
   TState state(this);
   TCore core(Arena.get(), &state);

--- a/orly/closure.h
+++ b/orly/closure.h
@@ -303,14 +303,12 @@ namespace Orly {
 
   /* Binary stream extractor for Orly::TClosure. */
   inline Io::TBinaryInputStream &operator>>(Io::TBinaryInputStream &strm, TClosure &that) {
-    assert(&that);
     that.Read(strm);
     return strm;
   }
 
   /* Binary stream inserter for Orly::TClosure. */
   inline Io::TBinaryOutputStream &operator<<(Io::TBinaryOutputStream &strm, const TClosure &that) {
-    assert(&that);
     that.Write(strm);
     return strm;
   }

--- a/orly/code_gen/basic_ctor.h
+++ b/orly/code_gen/basic_ctor.h
@@ -136,8 +136,6 @@ namespace Orly {
     }; // TBasicCtor
 
     inline void WriteCtorStart(const TBasicCtor<TDictContainer> &ctor, TCppPrinter &out) {
-      assert(&ctor);
-      assert(&out);
       out << "DictCtor<" << ctor.GetNumElements() << '>';
     }
 

--- a/orly/code_gen/binary.cc
+++ b/orly/code_gen/binary.cc
@@ -22,9 +22,7 @@ using namespace Orly::CodeGen;
 
 TBinary::TBinary(const L0::TPackage *package, const Type::TType &ret_type, TOp op, const TInline::TPtr &lhs, const TInline::TPtr &rhs)
       : TInline(package, ret_type), Op(op), Lhs(lhs), Rhs(rhs) {
-  assert(&lhs);
   assert(lhs);
-  assert(&rhs);
   assert(rhs);
 }
 
@@ -76,24 +74,20 @@ void TBinary::WriteExpr(TCppPrinter &out) const {
 }
 
 void TBinary::Template(TCppPrinter &out, const char *name) const {
-  assert(&out);
   assert(name);
   out << name << '<' << GetReturnType() << ">(" << Lhs << ", " << Rhs << ')';
 }
 
 void TBinary::Infix(TCppPrinter &out, char op) const {
-  assert(&out);
   out << '(' << Lhs << ' ' << op << ' ' << Rhs << ')';
 }
 
 void TBinary::Call(TCppPrinter &out, const char *func) const {
-  assert(&out);
   assert(func);
   out << func << '(' << Lhs << ", " << Rhs << ')';
 }
 
 void TBinary::CallReverse(TCppPrinter &out, const char *func) const {
-  assert(&out);
   assert(func);
   out << func << '(' << Rhs << ", " << Lhs << ')';
 }

--- a/orly/code_gen/binary.h
+++ b/orly/code_gen/binary.h
@@ -75,7 +75,6 @@ namespace std {
     typedef Orly::CodeGen::TBinary::TOp argument_type;
 
     result_type operator()(const argument_type &that) {
-      assert(&that);
       return static_cast<result_type>(that);
     }
 

--- a/orly/code_gen/binary_scoped_rhs.cc
+++ b/orly/code_gen/binary_scoped_rhs.cc
@@ -37,7 +37,6 @@ TBinaryScopedRhs::TBinaryScopedRhs(const L0::TPackage *package,
         Op(op),
         Lhs(lhs),
         Rhs(TInlineScope::New(package, rhs)) {
-  assert(&lhs);
   assert(lhs);
 }
 

--- a/orly/code_gen/binary_scoped_rhs.h
+++ b/orly/code_gen/binary_scoped_rhs.h
@@ -69,7 +69,6 @@ namespace std {
     typedef Orly::CodeGen::TBinaryScopedRhs::TOp argument_type;
 
     result_type operator()(const argument_type &that) {
-      assert(&that);
       return static_cast<result_type>(that);
     }
 

--- a/orly/code_gen/builder.cc
+++ b/orly/code_gen/builder.cc
@@ -193,7 +193,6 @@ bool IsCoreSeq(const Expr::TExpr::TPtr &expr) {
 }
 
 TInline::TPtr BuildOptInline(const L0::TPackage *package, const Expr::TExpr::TPtr &expr) {
-  assert(&expr);
 
   if (expr) {
     return BuildInline(package, expr, false);
@@ -205,7 +204,6 @@ TInline::TPtr BuildOptInline(const L0::TPackage *package, const Expr::TExpr::TPt
 void Build(const L0::TPackage *package, const Symbol::Stmt::TStmtBlock::TPtr &stmts);
 
 void Build(const L0::TPackage *package, const Symbol::Stmt::TStmt::TPtr &stmt) {
-  assert(&stmt);
   assert(stmt);
 
   class TVisitor : public Symbol::Stmt::TStmt::TVisitor {
@@ -267,7 +265,6 @@ void Build(const L0::TPackage *package, const Symbol::Stmt::TStmt::TPtr &stmt) {
 }
 
 void Build(const L0::TPackage *package, const Symbol::Stmt::TStmtBlock::TPtr &stmts)  {
-  assert(&stmts);
   assert(stmts);
 
   for(auto &stmt: stmts->GetStmts()) {
@@ -283,7 +280,6 @@ void Build(const L0::TPackage *package, const Symbol::Stmt::TStmtBlock::TPtr &st
    used. This allows us to use the same visitor to generate code for the implicit function needed for a map as well
    as code for general use with only a single expr visitor. */
 TInline::TPtr Orly::CodeGen::Build(const L0::TPackage *package, const Expr::TExpr::TPtr &expr, bool keep_mutable, bool keep_sequence) {
-  assert(&expr);
   assert(expr);
 
   class TVisitor : public Expr::TExpr::TVisitor {
@@ -731,7 +727,6 @@ TInline::TPtr Orly::CodeGen::Build(const L0::TPackage *package, const Expr::TExp
 }
 
 TInline::TPtr BuildMap(const L0::TPackage *package, const Expr::TExpr::TPtr &expr, bool keep_mutable) {
-  assert(&expr);
   assert(expr->GetType().Is<Type::TSeq>());
   assert(!IsCoreSeq(expr));
 

--- a/orly/code_gen/built_in_call.cc
+++ b/orly/code_gen/built_in_call.cc
@@ -30,7 +30,6 @@ TBuiltInCall::TBuiltInCall(const L0::TPackage *package,
       Func(func) {}
 
 void TBuiltInCall::WriteExpr(TCppPrinter &out) const {
-  assert(&out);
 
   out << Func->GetName() << '('
       << Base::Join(Func->GetOrderedParams(),

--- a/orly/code_gen/call.cc
+++ b/orly/code_gen/call.cc
@@ -30,7 +30,6 @@ TCall::TCall(const L0::TPackage *package,
       Func(func) {}
 
 void TCall::WriteExpr(TCppPrinter &out) const {
-  assert(&out);
 
   Func->WriteName(out);
   out << '(';

--- a/orly/code_gen/collated_by.cc
+++ b/orly/code_gen/collated_by.cc
@@ -35,7 +35,6 @@ TCollatedBy::TPtr TCollatedBy::New(
 }
 
 void TCollatedBy::WriteExpr(TCppPrinter &out) const {
-  assert(&out);
   out << "TCollatedByGenerator<"
       << Type::UnwrapSequence(GetReturnType())
       << ", " << Type::UnwrapSequence(Seq->GetReturnType())

--- a/orly/code_gen/collected_by.cc
+++ b/orly/code_gen/collected_by.cc
@@ -33,7 +33,6 @@ TCollectedBy::TPtr TCollectedBy::New(
 }
 
 void TCollectedBy::WriteExpr(TCppPrinter &out) const {
-  assert(&out);
   auto type = Seq->GetReturnType();
   auto seq = type.As<Type::TSeq>();
   auto elem = seq->GetElem();

--- a/orly/code_gen/context_var.cc
+++ b/orly/code_gen/context_var.cc
@@ -45,7 +45,6 @@ Type::TType TContextVar::GetType(TOp Op) {
 TContextVar::TContextVar(const L0::TPackage *package, TOp op) : TInline(package, GetType(op)), Op(op) {}
 
 void TContextVar::WriteExpr(TCppPrinter &out) const {
-  assert(&out);
 
   out << "ctx.";
   switch(Op) {

--- a/orly/code_gen/cpp_printer.h
+++ b/orly/code_gen/cpp_printer.h
@@ -60,7 +60,6 @@ namespace Orly {
 
       template <typename TVal>
       void Write(const TVal &val) {
-        assert(&val);
         if(StartOfLine) {
           //TODO: Might be better to cache the string here rather than recaluclate it.
           for(auto i = 0u; i < Indent; ++i) {
@@ -107,13 +106,11 @@ namespace Orly {
     template <typename TContainer, typename TDelimiter, typename TFormat>
     TCppPrinter &operator<<(TCppPrinter &printer,
                             const Base::TJoin<TContainer, TDelimiter, TFormat> &that) {
-      assert(&printer);
       return Base::WriteJoin(printer, that);
     }
 
     template <typename TVal>
     TCppPrinter &operator<<(TCppPrinter &printer, const TVal &val) {
-      assert(&printer);
       printer.Write(val);
 
       return printer;

--- a/orly/code_gen/effect.cc
+++ b/orly/code_gen/effect.cc
@@ -105,7 +105,6 @@ void TNew::Write(TCppPrinter &out) const {
 TNew::TNew(const TPtrC<TInline> &val) : Val(val) {}
 
 void TMutate::Write(TCppPrinter &out) const {
-  assert(&out);
 
   if(Mutable->GetReturnType().Is<Type::TSeq>()) {
     out << "for(auto it = " << Mutable << "->NewCursor(); it; ++it) {" << Eol
@@ -211,13 +210,10 @@ void TMutate::Write(TCppPrinter &out) const {
 TStmtBlock::TStmtBlock() {}
 
 void TStmtBlock::Add(const TPtrC<TStmt> &stmt) {
-  assert(&stmt);
   Stmts.push_back(stmt);
 }
 
 void TStmtBlock::Add(const L0::TPackage *package, const TPtrC<TInline> &key, TMutator mutation, const TPtrC<TInline> &rhs) {
-  assert(&key);
-  assert(&rhs);
   assert(key);
   assert(rhs);
 
@@ -233,15 +229,12 @@ void TStmtBlock::Add(const L0::TPackage *package, const TPtrC<TInline> &key, TMu
 }
 
 void TStmtBlock::AddDelete(const L0::TPackage *package, const TPtrC<TInline> &key, const Type::TType &val_type) {
-  assert(&key);
   assert(key);
 
   Stmts.push_back(TPtrC<TStmt>(new TMutate(package, key, TDelete::New(val_type))));
 }
 
 void TStmtBlock::AddNew(const L0::TPackage *package, const TPtrC<TInline> &key, const TPtrC<TInline> &val) {
-  assert(&key);
-  assert(&val);
   assert(key);
   assert(val);
 
@@ -253,7 +246,6 @@ bool TStmtBlock::IsEmpty() const {
 }
 
 void TStmtBlock::Write(TCppPrinter &out) const {
-  assert(&out);
 
   for(auto &it: Stmts) {
     it->Write(out);
@@ -291,7 +283,6 @@ TStmtBlock &TIf::GetElseClause() {
 }
 
 void TIf::Write(TCppPrinter &out) const {
-  assert(&out);
 
   out << Base::Join(IfClauses,
                     " else ",

--- a/orly/code_gen/filter.cc
+++ b/orly/code_gen/filter.cc
@@ -32,7 +32,6 @@ TFilter::TPtr TFilter::New(
 }
 
 void TFilter::WriteExpr(TCppPrinter &out) const {
-  assert(&out);
   out << "TFilterGenerator<" << Type::UnwrapSequence(GetReturnType()) << ">::New(";
   Func->WriteName(out);
   out << ", " << Seq << ')';

--- a/orly/code_gen/function.cc
+++ b/orly/code_gen/function.cc
@@ -110,7 +110,6 @@ bool TFunction::HasArgs() const {
 }
 
 void TFunction::WriteArgs(TCppPrinter &out) const {
-  assert(&out);
 
   out << Join(Args,
               ", ",
@@ -122,7 +121,6 @@ void TFunction::WriteArgs(TCppPrinter &out) const {
 }
 
 void TFunction::WriteBody(TCppPrinter &out) const {
-  assert(&out);
 
   assert(Body); // NOTE: If this assertion fails, it means that Build() function probably wasn't called.
 
@@ -190,10 +188,8 @@ TFunction::TFunction(const L0::TPackage *package, const TIdScope::TPtr &id_scope
 }
 
 void TFunction::PostCtor(const TNamedArgs &args, const Expr::TExpr::TPtr &expr, bool keep_mutable, bool implicit) {
-  assert(&args);
   assert(Args.empty());
   assert(!Expr);
-  assert(&expr);
   assert(expr);
   Expr = expr;
   KeepMutable = keep_mutable;

--- a/orly/code_gen/id.h
+++ b/orly/code_gen/id.h
@@ -76,8 +76,6 @@ namespace Orly {
 
     template <TIdKind Kind>
     TCppPrinter &operator<<(TCppPrinter &out, const TId<Kind> &id) {
-      assert(&out);
-      assert(&id);
 
       id.Write(out);
 

--- a/orly/code_gen/if_else.cc
+++ b/orly/code_gen/if_else.cc
@@ -31,7 +31,6 @@ TIfElse::TPtr TIfElse::New(
 }
 
 void TIfElse::WriteExpr(TCppPrinter &out) const {
-  assert(&out);
 
   //TODO: Building into the sum type if true case and false case return different types.
   out << "Predicate<" << GetReturnType() << ">(ctx, " << Predicate << ", " << True;

--- a/orly/code_gen/inline.cc
+++ b/orly/code_gen/inline.cc
@@ -25,7 +25,6 @@ using namespace Orly::CodeGen;
 
 /* Writes the common subexpression eliminated variant of this inline. */
 void TInline::Write(TCppPrinter &out) const {
-  assert(&out);
 
   if (Id) {
     out << *Id;
@@ -59,7 +58,6 @@ void TInline::SetCommonSubexpressionId(TId<TIdKind::Var> &&id) const {
 TInline::TInline(const L0::TPackage *package, Type::TType type) : Package(package), ReturnType(type) {}
 
 TCppPrinter &Orly::CodeGen::operator<<(TCppPrinter &out, const std::shared_ptr<const Orly::CodeGen::TInline> &ptr) {
-  assert(&ptr);
   assert(ptr);
 
   ptr->Write(out);

--- a/orly/code_gen/inline_func.cc
+++ b/orly/code_gen/inline_func.cc
@@ -29,7 +29,6 @@ bool TInlineFunc::IsTopLevel() const {
 }
 
 void TInlineFunc::WriteDecl(TCppPrinter &out) const {
-  assert(&out);
 
   out << "std::function<" << GetReturnType() << " (";
   WriteArgs(out);
@@ -37,7 +36,6 @@ void TInlineFunc::WriteDecl(TCppPrinter &out) const {
 }
 
 void TInlineFunc::WriteDef(TCppPrinter &out) const {
-  assert(&out);
 
   WriteName(out);
   out << " = [=, &ctx](";
@@ -48,7 +46,6 @@ void TInlineFunc::WriteDef(TCppPrinter &out) const {
 }
 
 void TInlineFunc::WriteName(TCppPrinter &out) const {
-  assert(&out);
 
   out << Id;
 }

--- a/orly/code_gen/inline_scope.cc
+++ b/orly/code_gen/inline_scope.cc
@@ -32,7 +32,6 @@ TInlineScope::TPtr TInlineScope::New(const L0::TPackage *package, const Expr::TE
 }
 
 void TInlineScope::WriteExpr(TCppPrinter &out) const {
-  assert(&out);
   out << "[=, &ctx] () -> " << GetReturnType() << " {" << Eol;
   /* Indent */ {
     TIndent indent(out);

--- a/orly/code_gen/keys.cc
+++ b/orly/code_gen/keys.cc
@@ -35,7 +35,6 @@ TKeys::TKeys(const L0::TPackage *package,
       ValType(val_type) {}
 
 void TKeys::WriteExpr(TCppPrinter &out) const {
-  assert(&out);
 
   #if 0
   out << "ctx.New<" << Type::UnwrapSequence(GetReturnType()) << ">(ctx.GetFlux(), Var::TVar::Addr({";

--- a/orly/code_gen/map.cc
+++ b/orly/code_gen/map.cc
@@ -41,7 +41,6 @@ TMap::TMap(const L0::TPackage *package,
       Seqs(seqs) {}
 
 void TMap::WriteExpr(TCppPrinter &out) const {
-  assert(&out);
   if(Seqs.size() != 1) {
     //NOTE: For proper code printing we must take all the correllated sequences as a sequence of objects.
     NOT_IMPLEMENTED_S("Maps containing more than one sequence do not yet have proper code printing");

--- a/orly/code_gen/match.cc
+++ b/orly/code_gen/match.cc
@@ -33,7 +33,6 @@ TMatch::TPtr TMatch::New(
 }
 
 void TMatch::WriteExpr(TCppPrinter &out) const {
-  assert(&out);
   out
     << "TMatchGenerator::New("
     << MatchFromText << ", " << Regex << ')';

--- a/orly/code_gen/member.cc
+++ b/orly/code_gen/member.cc
@@ -23,7 +23,6 @@
 using namespace Orly::CodeGen;
 
 void TMutableRewrap::WriteExpr(TCppPrinter &out) const {
-  assert(&out);
   if(GetReturnType().Is<Type::TMutable>()) {
     out << "[](const " << Src->GetReturnType() << " &src) {" << Eol
         << "  return MakeMutable(src.GetOptAddr(), src.GetParts(), src.GetVal()";
@@ -43,19 +42,16 @@ TAddrMember::TAddrMember(const L0::TPackage *package, const Type::TType &return_
     : TMutableRewrap(package, return_type, addr), Index(index) {}
 
 void TAddrMember::WritePartId(TCppPrinter &out) const {
-  assert(&out);
 
   out << Index;
 }
 
 void TAddrMember::WritePostfixOp(TCppPrinter &out) const {
-  assert(&out);
 
   out << ".Get<" << Index << ">()";
 }
 
 void TAddrMember::WriteExpr(TCppPrinter &out) const {
-  assert(&out);
   if(GetReturnType().Is<Type::TMutable>()) {
     out << "[](const " << Src->GetReturnType() << " &src) {" << Eol
         << "  return MakeMutable(src.GetOptAddr(), src.GetParts(), Rt::UnwrapDesc(std::get<" << Index << ">(src.GetVal())));" << Eol
@@ -69,13 +65,11 @@ TObjMember::TObjMember(const L0::TPackage *package, const Type::TType &return_ty
     : TMutableRewrap(package, return_type, obj), Name(name) {}
 
 void TObjMember::WritePartId(TCppPrinter &out) const {
-  assert(&out);
 
   out << Name;
 }
 
 void TObjMember::WritePostfixOp(TCppPrinter &out) const {
-  assert(&out);
 
   out << ".GetV" << Name << "()";
 }

--- a/orly/code_gen/obj.cc
+++ b/orly/code_gen/obj.cc
@@ -38,7 +38,6 @@ using namespace Orly::Type;
 TObjCtor::TObjCtor(const L0::TPackage *package, const Type::TType &type, TArgs &&args) : TInline(package, type), Args(args) {}
 
 void TObjCtor::WriteExpr(TCppPrinter &out) const {
-  assert(&out);
 
   out
     << GetReturnType() << '('
@@ -70,8 +69,6 @@ void WriteLessExpr(TCppPrinter &out, Type::TObjElems::const_iterator iter, const
 }
 
 void Orly::CodeGen::GenObjHeader(const std::string &out_dir, const Type::TType &obj_type) {
-  assert(&out_dir);
-  assert(&obj_type);
 
   auto obj_name = obj_type.GetMangledName();
 
@@ -461,8 +458,6 @@ void Orly::CodeGen::GenObjHeader(const std::string &out_dir, const Type::TType &
 }
 
 void Orly::CodeGen::GenObjInclude(const Type::TType &obj_type, TCppPrinter &out) {
-  assert(&obj_type);
-  assert(&out);
 
   // Check for TimePnt and TimeDiff structural types so we don't regenerate them
   const Type::TObj *result = obj_type.TryAs<Type::TObj>();

--- a/orly/code_gen/package.cc
+++ b/orly/code_gen/package.cc
@@ -48,9 +48,7 @@ using namespace Util;
 
 void ForEachExprInTestBlock(const function<void (const Expr::TExpr::TPtr &expr)> &cb,
       const Symbol::Test::TTestCaseBlock::TPtr &block) {
-  assert(&cb);
   assert(cb);
-  assert(&block);
   assert(block);
 
   for(auto &test: block->GetTestCases()) {
@@ -161,7 +159,6 @@ TPackage::TPackage(const Symbol::TPackage::TPtr &package) : L0::TPackage(package
 TPackage::~TPackage() {}
 
 void TPackage::Emit(const Jhm::TTree &out_dir) const {;
-  assert(&out_dir);
 
   /* Emit the following files:
 

--- a/orly/code_gen/reduce.cc
+++ b/orly/code_gen/reduce.cc
@@ -32,7 +32,6 @@ TReduce::TPtr TReduce::New(const L0::TPackage *package,
 }
 
 void TReduce::WriteExpr(TCppPrinter &out) const {
-  assert(&out);
 
   out << "Reduce" << '(' << Seq << ", ";
   Func->WriteName(out);

--- a/orly/code_gen/scope.cc
+++ b/orly/code_gen/scope.cc
@@ -49,15 +49,12 @@ TCodeScope::~TCodeScope() {
 }
 
 void TCodeScope::AddAssertion(const std::string &name, const TInline::TPtr &assertion) {
-  assert(&name);
-  assert(&assertion);
 
   Assertions.push_back(std::make_pair(name, assertion));
 }
 
 /* Makes a new id, and adds the given inline to our list of locals. */
 void TCodeScope::AddLocal(const TInline::TPtr &inline_) {
-  assert(&inline_);
 
   //Fast exit if we already have been common subexpression eliminated.
   if(inline_->HasId()) {
@@ -100,7 +97,6 @@ TId<TIdKind::Arg> TCodeScope::NewArg() {
 }
 
 void TCodeScope::WriteStart(TCppPrinter &out) const {
-  assert(&out);
 
   for(auto &it: Locals) {
     out << "auto " << it->GetId() << " = ";

--- a/orly/code_gen/skip.cc
+++ b/orly/code_gen/skip.cc
@@ -32,7 +32,6 @@ TSkip::TPtr TSkip::New(
 }
 
 void TSkip::WriteExpr(TCppPrinter &out) const {
-  assert(&out);
   out
     << "TSkipGenerator<" << Type::UnwrapSequence(GetReturnType()) << ">::New("
     << Count << ", " << Seq << ')';

--- a/orly/code_gen/slice.cc
+++ b/orly/code_gen/slice.cc
@@ -34,7 +34,6 @@ TSlice::TSlice(const L0::TPackage *package,
 
 
 void TSlice::WriteExpr(TCppPrinter &out) const {
-  assert(&out);
 
   out << "Slice" << (Colon ? "Range" : "Single");
   if(OptLhs && OptRhs) {

--- a/orly/code_gen/sort.cc
+++ b/orly/code_gen/sort.cc
@@ -30,7 +30,6 @@ TSort::TPtr TSort::New(const L0::TPackage *package,
 }
 
 void TSort::WriteExpr(TCppPrinter &out) const {
-  assert(&out);
 
   out << "Sort(" << Container << ", ";
   Func->WriteName(out);

--- a/orly/code_gen/split.cc
+++ b/orly/code_gen/split.cc
@@ -33,7 +33,6 @@ TSplit::TPtr TSplit::New(
 }
 
 void TSplit::WriteExpr(TCppPrinter &out) const {
-  assert(&out);
   out
     << "TSplitGenerator::New("
     << SplitThisText << ", " << Regex << ')';

--- a/orly/code_gen/take.cc
+++ b/orly/code_gen/take.cc
@@ -32,7 +32,6 @@ TTake::TPtr TTake::New(
 }
 
 void TTake::WriteExpr(TCppPrinter &out) const {
-  assert(&out);
   out
     << "TTakeGenerator<" << Type::UnwrapSequence(GetReturnType()) << ">::New("
     << Count << ", " << Seq << ')';

--- a/orly/code_gen/test.cc
+++ b/orly/code_gen/test.cc
@@ -85,7 +85,6 @@ Type::TType TTestCase::GetType() const {
 }
 
 void TTestCase::Write(TCppPrinter &out) const {
-  assert(&out);
 
   WriteDef(out);
   out << Eol << Eol;
@@ -125,7 +124,6 @@ void TTestCase::Write(TCppPrinter &out) const {
 }
 
 void TTestCase::WriteName(TCppPrinter &out) const {
-  assert(&out);
 
   out << Id;
 }
@@ -170,7 +168,6 @@ TTestBlock::~TTestBlock() {
 }
 
 void TTestBlock::Write(TCppPrinter &out) const {
-  assert(&out);
 
   for(auto &test: Children) {
     test->Write(out);
@@ -178,7 +175,6 @@ void TTestBlock::Write(TCppPrinter &out) const {
 }
 
 void TTestBlock::WriteMeta(TCppPrinter &out) const {
-  assert(&out);
 
   out
     << "Package::TTestBlock{"
@@ -272,7 +268,6 @@ const TId<TIdKind::Test> &TTest::GetId() const {
 }
 
 void TTest::Write(TCppPrinter &out) const {
-  assert(&out);
 
   Tests.Write(out);
 

--- a/orly/code_gen/top_func.cc
+++ b/orly/code_gen/top_func.cc
@@ -28,7 +28,6 @@ bool TTopFunc::IsTopLevel() const {
 }
 
 void TTopFunc::WriteDecl(TCppPrinter &out) const {
-  assert(&out);
 
   //NOTE: We prefix with 'F' to make the function name never conflict with a C++ builtin.
   out << GetReturnType() << ' ';
@@ -43,7 +42,6 @@ void TTopFunc::WriteDecl(TCppPrinter &out) const {
 }
 
 void TTopFunc::WriteDef(TCppPrinter &out) const {
-  assert(&out);
 
   WriteDecl(out);
   WriteBody(out);

--- a/orly/code_gen/unary.cc
+++ b/orly/code_gen/unary.cc
@@ -107,13 +107,11 @@ void TUnary::WriteExpr(TCppPrinter &out) const {
 }
 
 void TUnary::Call(TCppPrinter &out, const char *func) const {
-  assert(&out);
   assert(func);
   out << func << '(' << Expr << ')';
 }
 
 void TUnary::Postfix(TCppPrinter &out, const char *func) const {
-  assert(&out);
   assert(func);
   out << Expr << '.' << func << "()";
 }

--- a/orly/code_gen/unary.h
+++ b/orly/code_gen/unary.h
@@ -67,7 +67,6 @@ namespace std {
     typedef Orly::CodeGen::TUnary::TOp argument_type;
 
     result_type operator()(const argument_type &that) const {
-      assert(&that);
       return static_cast<result_type>(that);
     }
 

--- a/orly/code_gen/while.cc
+++ b/orly/code_gen/while.cc
@@ -32,7 +32,6 @@ TWhile::TPtr TWhile::New(
 }
 
 void TWhile::WriteExpr(TCppPrinter &out) const {
-  assert(&out);
   out << "TWhileGenerator<" << Type::UnwrapSequence(GetReturnType()) << ">::New(";
   Func->WriteName(out);
   out << ", " << Seq << ')';

--- a/orly/csv_to_bin/field.h
+++ b/orly/csv_to_bin/field.h
@@ -93,8 +93,6 @@ namespace Orly {
     /* Some JSON types pass thru to native types directly. */
     template <typename TVal>
     inline void JsonAs(TVal &val, const TJson &json) {
-      assert(&val);
-      assert(&json);
       if (!json.TryAs(val)) {
         THROW_ERROR(TJsonMismatch)
             << "cannot translate from JSON " << json.GetKind()
@@ -119,8 +117,6 @@ namespace Orly {
     /* Translate TTimePnts from JSON strings. */
     inline void TranslateJson(
         Base::Chrono::TTimePnt &val, const TJson &json) {
-      assert(&val);
-      assert(&json);
       std::string temp;
       JsonAs(temp, json);
       struct tm tm;
@@ -138,8 +134,6 @@ namespace Orly {
 
     /* Translate UUIDs from JSON strings. */
     inline void TranslateJson(Base::TUuid &val, const TJson &json) {
-      assert(&val);
-      assert(&json);
       std::string temp;
       JsonAs(temp, json);
       val = Base::TUuid(temp.c_str());
@@ -148,8 +142,6 @@ namespace Orly {
     /* Translate objects as JSON objects, re-entering the translation layer
        to handle the fields. */
     inline void TranslateJson(TObj &val, const TJson &json) {
-      assert(&val);
-      assert(&json);
       val.GetFields().TranslateJson(&val, json);
     }
 
@@ -157,8 +149,6 @@ namespace Orly {
        type inside the TOpt. */
     template <typename TVal>
     inline void TranslateJson(Base::TOpt<TVal> &val, const TJson &json) {
-      assert(&val);
-      assert(&json);
       if (json.IsNull()) {
         val.Reset();
       } else {
@@ -173,8 +163,6 @@ namespace Orly {
     template <typename TVal, typename TAlloc>
     inline void TranslateJson(
         std::vector<TVal, TAlloc> &val, const TJson &json) {
-      assert(&val);
-      assert(&json);
       if (json.GetKind() != TJson::Array) {
         THROW_ERROR(TJsonMismatch)
             << "cannot translate from JSON " << json.GetKind()
@@ -194,8 +182,6 @@ namespace Orly {
     template <typename TVal, typename TDel>
     inline void TranslateJson(
         std::unique_ptr<TVal, TDel> &ptr, const TJson &json) {
-      assert(&ptr);
-      assert(&json);
       ptr.reset(new TVal);
       TranslateJson(*ptr, json);
     }
@@ -214,7 +200,6 @@ namespace Orly {
     template <typename TVal>
     struct NoJson<Base::TOpt<TVal>> final {
       static inline bool TrySetNull(Base::TOpt<TVal> &val) {
-        assert(&val);
         val.Reset();
         return true;
       }
@@ -225,7 +210,6 @@ namespace Orly {
     template <typename TVal, typename TDel>
     struct NoJson<std::unique_ptr<TVal, TDel>> final {
       static inline bool TrySetNull(std::unique_ptr<TVal, TDel> &val) {
-        assert(&val);
         val.reset();
         return true;
       }
@@ -286,7 +270,6 @@ namespace Orly {
          JSON object's type isn't compatible with the field, throw. */
       virtual void SetVal(TSomeObj *that, const TJson &json) const override {
         assert(that);
-        assert(&json);
         TranslateJson(that->*Member, json);
       }
 
@@ -330,7 +313,6 @@ namespace Orly {
 
       /* Add a field to the collection. */
       void AddField(std::unique_ptr<TAnyField<TSomeObj>> &&field_ptr) {
-        assert(&field_ptr);
         assert(field_ptr);
         FieldPtrs.push_back(std::move(field_ptr));
       }
@@ -347,7 +329,6 @@ namespace Orly {
       virtual void TranslateJson(
           TObj *that, const TJson &json) const override {
         assert(that);
-        assert(&json);
         auto *obj = dynamic_cast<TSomeObj *>(that);
         if (!obj) {
           THROW_ERROR(TJsonMismatch)

--- a/orly/csv_to_bin/level2.cc
+++ b/orly/csv_to_bin/level2.cc
@@ -215,6 +215,5 @@ void TLevel2::Update() {
 }
 
 ostream &operator<<(ostream &strm, TLevel2::TState that) {
-  assert(&strm);
   return strm << TLevel2::GetName(that);
 }

--- a/orly/csv_to_bin/level3.cc
+++ b/orly/csv_to_bin/level3.cc
@@ -24,45 +24,37 @@ using namespace std;
 using namespace Orly::CsvToBin;
 
 void Orly::CsvToBin::EndOfField(TLevel3 &that) {
-  assert(&that);
   that.MatchState(TLevel2::EndOfField);
 }
 
 void Orly::CsvToBin::EndOfFile(TLevel3 &that) {
-  assert(&that);
   that.MatchState(TLevel2::EndOfFile);
 }
 void Orly::CsvToBin::EndOfRecord(TLevel3 &that) {
-  assert(&that);
   that.MatchState(TLevel2::EndOfRecord);
 }
 
 void Orly::CsvToBin::SkipBytes(TLevel3 &that) {
-  assert(&that);
   while (that.RefreshBytes(false)) {
     that.Cursor = that.Limit;
   }
 }
 
 void Orly::CsvToBin::StartOfField(TLevel3 &that) {
-  assert(&that);
   that.MatchState(TLevel2::StartOfField);
 }
 
 void Orly::CsvToBin::StartOfFile(TLevel3 &that) {
-  assert(&that);
   that.MatchState(TLevel2::StartOfFile);
 }
 
 void Orly::CsvToBin::StartOfRecord(TLevel3 &that) {
-  assert(&that);
   that.MatchState(TLevel2::StartOfRecord);
 }
 
 const TLevel3::TOptions TLevel3::DefaultOptions = { "true", "false" };
 
 TLevel3 &TLevel3::operator>>(bool &that) {
-  assert(&that);
   uint8_t c = tolower(Peek());
   const char *kwd;
   bool result;
@@ -83,7 +75,6 @@ TLevel3 &TLevel3::operator>>(bool &that) {
 }
 
 TLevel3 &TLevel3::operator>>(Base::TUuid &that) {
-  assert(&that);
   static constexpr size_t size = Base::TUuid::StrSize;
   char buf[size + 1];
   for (size_t i = 0; i < size; ++i) {
@@ -95,7 +86,6 @@ TLevel3 &TLevel3::operator>>(Base::TUuid &that) {
 }
 
 TLevel3 &TLevel3::operator>>(int64_t &that) {
-  assert(&that);
   uint8_t c = Peek();
   int64_t sign;
   if (c == '+') {
@@ -115,7 +105,6 @@ TLevel3 &TLevel3::operator>>(int64_t &that) {
 }
 
 TLevel3 &TLevel3::operator>>(double &that) {
-  assert(&that);
   /* TODO: Yeah, this is cheating.  We really shouldn't be consuming all the
      bytes in the field and then translating just the prefix into a number.
      We should scan property to conserve the rest of the field. */
@@ -126,7 +115,6 @@ TLevel3 &TLevel3::operator>>(double &that) {
 }
 
 TLevel3 &TLevel3::operator>>(std::string &that) {
-  assert(&that);
   string temp;
   while (RefreshBytes(false)) {
     temp.append(Cursor, Limit);
@@ -137,7 +125,6 @@ TLevel3 &TLevel3::operator>>(std::string &that) {
 }
 
 TLevel3 &TLevel3::operator>>(Base::Chrono::TTimePnt &that) {
-  assert(&that);
   /* Parse something like 2014-07-04. */
   int64_t year;
   size_t size;
@@ -310,8 +297,6 @@ void TLevel3::MatchState(TLevel2::TState state) {
 }
 
 void TLevel3::ReadDecimalInt(int64_t &value, size_t &size) {
-  assert(&value);
-  assert(&size);
   size = 0;
   __int128 result = 0;
   uint8_t c;
@@ -396,7 +381,6 @@ bool TLevel3::TryMatchByte(const char *expected) {
 }
 
 bool TLevel3::TryMatchByte(const char *expected, uint8_t &match) {
-  assert(&match);
   uint8_t c = Peek();
   bool success = (strchr(expected, c) != nullptr);
   if (success) {

--- a/orly/csv_to_bin/symbol/kit.cc
+++ b/orly/csv_to_bin/symbol/kit.cc
@@ -22,7 +22,6 @@ using namespace std;
 using namespace Orly::CsvToBin::Symbol;
 
 void TTable::AddCol(std::unique_ptr<TCol> &&col) {
-  assert(&col);
   assert(col);
   if (TryFindCol(col->GetName())) {
     THROW_ERROR(TSemanticError)
@@ -32,7 +31,6 @@ void TTable::AddCol(std::unique_ptr<TCol> &&col) {
 }
 
 void TTable::AddSecondaryKey(std::unique_ptr<TSecondaryKey> &&key) {
-  assert(&key);
   assert(key);
   if (TryFindSecondaryKey(key->GetName())) {
     THROW_ERROR(TSemanticError)
@@ -66,9 +64,7 @@ const TCol *TTable::FindCol(const std::string &name) const {
 
 bool TTable::ForEachColNotInKey(
     const std::function<bool (const TCol *)> &cb, const TKey *key) const {
-  assert(&cb);
   assert(cb);
-  assert(&key);
   for (const auto &col: Cols) {
     bool found = false;
     for (const auto &field : key->GetFields()) {

--- a/orly/csv_to_bin/symbol/kit.h
+++ b/orly/csv_to_bin/symbol/kit.h
@@ -78,7 +78,6 @@ namespace Orly {
         /* Call back for each column. */
         bool ForEachCol(
             const std::function<bool (const TCol *)> &cb) const {
-          assert(&cb);
           assert(cb);
           for (const auto &col: Cols) {
             if (!cb(col.get())) {
@@ -105,7 +104,6 @@ namespace Orly {
         /* Call back for each secondary key. */
         bool ForEachSecondaryKey(
             const std::function<bool (const TSecondaryKey *)> &cb) const {
-          assert(&cb);
           assert(cb);
           for (const auto &key: SecondaryKeys) {
             if (!cb(key.get())) {
@@ -134,7 +132,6 @@ namespace Orly {
         /* Assign the table its primary key.  You must do this exactly
            once. */
         void SetPrimaryKey(std::unique_ptr<TPrimaryKey> &&key) {
-          assert(&key);
           assert(key);
           if (PrimaryKey) {
             THROW_ERROR(TSemanticError)

--- a/orly/csv_to_bin/synth.cc
+++ b/orly/csv_to_bin/synth.cc
@@ -154,7 +154,6 @@ static void TranslateDef(TContext &ctx, Symbol::TTable *table_symbol, const Synt
 
 unique_ptr<Symbol::TTable> Orly::CsvToBin::NewTable(
     ostream &strm, const char *src_text) {
-  assert(&strm);
   auto symbol = make_unique<Symbol::TTable>();
   Tools::Nycr::TContext ctx;
   try {

--- a/orly/csv_to_bin/time_pnt_parser.cc
+++ b/orly/csv_to_bin/time_pnt_parser.cc
@@ -22,7 +22,6 @@ using namespace std;
 using namespace Orly::CsvToBin;
 
 void TTimePntParser::Parse(TTimePnt &that) {
-  assert(&that);
   /* Parse something like 2014-07-04. */
   int64_t year;
   size_t size;
@@ -144,8 +143,6 @@ void TTimePntParser::MatchKeyword(const char *keyword) {
 }
 
 void TTimePntParser::ReadDecimalInt(int64_t &value, size_t &size) {
-  assert(&value);
-  assert(&size);
   size = 0;
   __int128 result = 0;
   uint8_t c;
@@ -203,7 +200,6 @@ bool TTimePntParser::TryMatchByte(const char *expected) {
 }
 
 bool TTimePntParser::TryMatchByte(const char *expected, uint8_t &match) {
-  assert(&match);
   uint8_t c = Peek();
   bool success = (strchr(expected, c) != nullptr);
   if (success) {

--- a/orly/csv_to_bin/write_cc.cc
+++ b/orly/csv_to_bin/write_cc.cc
@@ -100,7 +100,6 @@ void WriteForEachRecord(ostream &strm, const Symbol::TTable *table) {
 }
 
 void Orly::CsvToBin::WriteCc(ostream &strm, const Symbol::TTable *table) {
-  assert(&strm);
   assert(table);
   strm
       << "#include <syslog.h>" << endl
@@ -163,7 +162,6 @@ void Orly::CsvToBin::WriteCc(ostream &strm, const Symbol::TTable *table) {
 }
 
 void Orly::CsvToBin::WriteValRecordForKey(std::ostream &strm, const Symbol::TTable *table, const Symbol::TKey *key, const char *name) {
-  assert(&strm);
   assert(table);
   assert(key);
   assert(name);
@@ -205,7 +203,6 @@ void Orly::CsvToBin::WriteValRecordForKey(std::ostream &strm, const Symbol::TTab
 }
 
 void Orly::CsvToBin::WriteKeyTupleType(std::ostream &strm, const Symbol::TKey *key) {
-  assert(&strm);
   assert(key);
   const auto &fields = key->GetFields();
   assert(!fields.empty());
@@ -227,7 +224,6 @@ void Orly::CsvToBin::WriteKeyTupleType(std::ostream &strm, const Symbol::TKey *k
 }
 
 void Orly::CsvToBin::DefKeyTupleType(std::ostream &strm, const Symbol::TKey *key, const char *name) {
-  assert(&strm);
   assert(key);
   assert(name);
   strm << "using TKey" << name << " = ";

--- a/orly/csv_to_bin/write_orly.cc
+++ b/orly/csv_to_bin/write_orly.cc
@@ -27,7 +27,6 @@ inline bool KeyRequiresStruct(const Symbol::TTable *table, const Symbol::TKey *k
 }
 
 void WriteFuncParam(TCppPrinter &strm, const Symbol::TCol *col) {
-  assert(&strm);
   assert(col);
   strm << col->GetName() << " = given::(";
   PrintOrlyType(strm, col->GetType(), col->IsNull());
@@ -35,7 +34,6 @@ void WriteFuncParam(TCppPrinter &strm, const Symbol::TCol *col) {
 }
 
 void WriteKeyInsert(TCppPrinter &strm, const Symbol::TTable *table, const Symbol::TKey *key, const char *name) {
-  assert(&strm);
   assert(table);
   assert(key);
   assert(name);
@@ -63,7 +61,6 @@ void WriteKeyInsert(TCppPrinter &strm, const Symbol::TTable *table, const Symbol
 }
 
 void WriteInsertFunc(TCppPrinter &strm, const Symbol::TTable *table) {
-  assert(&strm);
   assert(table);
   strm << "NewRow = ((true) effecting {" << Eol;
   /* insert function effecting indent. */ {
@@ -86,7 +83,6 @@ void WriteInsertFunc(TCppPrinter &strm, const Symbol::TTable *table) {
 }
 
 void WriteGetterFuncsForKey(TCppPrinter &strm, const Symbol::TTable *table, const Symbol::TKey *key, const char *name) {
-  assert(&strm);
   assert(table);
   assert(key);
   const auto &fields = key->GetFields();
@@ -188,7 +184,6 @@ void WriteGetterFuncsForKey(TCppPrinter &strm, const Symbol::TTable *table, cons
 }
 
 void Orly::CsvToBin::WriteOrly(TCppPrinter &strm, const Symbol::TTable *table) {
-  assert(&strm);
   assert(table);
   strm << "package #1;" << Eol << Eol;
   // write out row object type
@@ -216,7 +211,6 @@ void Orly::CsvToBin::WriteOrly(TCppPrinter &strm, const Symbol::TTable *table) {
 }
 
 void Orly::CsvToBin::WriteValObjectTypeForRow(CodeGen::TCppPrinter &strm, const Symbol::TTable *table) {
-  assert(&strm);
   assert(table);
   strm << "row_obj is <{" << Eol;
   TIndent ind(strm);
@@ -235,7 +229,6 @@ void Orly::CsvToBin::WriteValObjectTypeForRow(CodeGen::TCppPrinter &strm, const 
 }
 
 void Orly::CsvToBin::WriteValObjectTypeForKey(TCppPrinter &strm, const Symbol::TTable *table, const Symbol::TKey *key, const char *name) {
-  assert(&strm);
   assert(table);
   assert(key);
   assert(name);
@@ -256,7 +249,6 @@ void Orly::CsvToBin::WriteValObjectTypeForKey(TCppPrinter &strm, const Symbol::T
 }
 
 void Orly::CsvToBin::WriteValObjectForKey(TCppPrinter &strm, const Symbol::TTable *table, const Symbol::TKey *key) {
-  assert(&strm);
   assert(table);
   assert(key);
   strm << "<{";
@@ -277,8 +269,6 @@ void Orly::CsvToBin::WriteValObjectForKey(TCppPrinter &strm, const Symbol::TTabl
 }
 
 void Orly::CsvToBin::PrintOrlyType(CodeGen::TCppPrinter &strm, Symbol::TType type, bool is_null) {
-  assert(&strm);
-  assert(&type);
   switch (type) {
     case Symbol::TType::Bool: {
       strm << "bool";

--- a/orly/data/twitter_live.cc
+++ b/orly/data/twitter_live.cc
@@ -275,7 +275,6 @@ constexpr int64_t PersonGeoGridSmall = 14;
 constexpr int64_t PersonGeoGridBig = 15;
 
 void TranslateFollow(TJsonIter &input, const std::string &username) {
-  assert(&input);
   // following
   using t_person_following_key = std::tuple<int64_t, int64_t, int64_t>;  // IndexId, follower user id, followed user id
   using t_person_following_val = std::tuple<std::string, std::string>;  // user handle (following), user handle (followed)
@@ -294,7 +293,6 @@ void TranslateFollow(TJsonIter &input, const std::string &username) {
 }
 
 void TranslateUser(TJsonIter &input, const std::string &username) {
-  assert(&input);
   // user screen name -> id
   using t_user_by_screen_key = std::tuple<std::string>;  // screen name
   using t_user_by_screen_val = int64_t;  // user_id
@@ -339,7 +337,6 @@ RECORD_ELEM(TPersonTweetedVal, Base::Chrono::TTimePnt, date);
 RECORD_ELEM(TPersonTweetedVal, std::string, text);
 RECORD_ELEM(TPersonTweetedVal, TPersonTweetedVal::TCoord, coordinates);
 void TranslateStatus(TJsonIter &input, const std::string &username) {
-  assert(&input);
   // person tweeted
   using t_person_tweeted_key = std::tuple<int64_t, int64_t>;  // user id, tweet id
   using t_person_tweeted_val = TPersonTweetedVal;  // text

--- a/orly/durable/kit.cc
+++ b/orly/durable/kit.cc
@@ -120,7 +120,6 @@ void TObj::SetTtl(const TTtl &ttl) {
 }
 
 void TObj::Write(TBinaryOutputStream &strm) const {
-  assert(&strm);
   strm << Ttl;
 }
 
@@ -133,7 +132,6 @@ TObj::TObj(TManager *manager, const TId &id, const TTtl &ttl)
 TObj::TObj(TManager *manager, const TId &id, Io::TBinaryInputStream &strm)
     : Manager(manager), Id(id), PtrCount(0), OnDisk(true) {
   assert(manager);
-  assert(&strm);
   Sem = new TSem;
   try {
     strm >> Ttl;

--- a/orly/durable/kit.h
+++ b/orly/durable/kit.h
@@ -438,14 +438,12 @@ namespace Orly {
 
     template <typename TSomeObj>
     TPtr<TSomeObj>::TPtr(TPtr &&that) {
-      assert(&that);
       SomeObj = that.SomeObj;
       that.SomeObj = nullptr;
     }
 
     template <typename TSomeObj>
     TPtr<TSomeObj>::TPtr(const TPtr &that) {
-      assert(&that);
       if ((SomeObj = that.SomeObj) != nullptr) {
         SomeObj->OnPtrAcquire();
       }
@@ -454,7 +452,6 @@ namespace Orly {
     template <typename TSomeObj>
     template <typename TOtherObj>
     TPtr<TSomeObj>::TPtr(const TPtr<TOtherObj> &that) {
-      assert(&that);
       if ((SomeObj = that.SomeObj) != nullptr) {
         SomeObj->OnPtrAcquire();
       }
@@ -469,7 +466,6 @@ namespace Orly {
 
     template <typename TSomeObj>
     TPtr<TSomeObj> &TPtr<TSomeObj>::operator=(TPtr &&that) {
-      assert(&that);
       std::swap(SomeObj, that.SomeObj);
       return *this;
     }

--- a/orly/durable/kit.test.cc
+++ b/orly/durable/kit.test.cc
@@ -83,7 +83,6 @@ class TFile final
   }
 
   virtual bool ForEachDependentPtr(const function<bool (TAnyPtr &)> &cb) noexcept override {
-    assert(&cb);
     for (auto &mod: Mods) {
       if (!cb(mod)) {
         return false;

--- a/orly/durable/test_manager.h
+++ b/orly/durable/test_manager.h
@@ -45,7 +45,6 @@ namespace Orly {
 
       /* TODO */
       virtual void CleanDisk(const TDeadline &now, TSem *sem) override {
-        assert(&now);
         assert(sem);
         std::unordered_map<TId, std::pair<TDeadline, std::string>> temp;
         for (const auto &item: BlobById) {
@@ -74,7 +73,6 @@ namespace Orly {
 
       /* TODO */
       virtual bool TryLoad(const TId &id, std::string &blob) override {
-        assert(&blob);
         auto iter = BlobById.find(id);
         bool success = (iter != BlobById.end());
         if (success) {

--- a/orly/expr/add.cc
+++ b/orly/expr/add.cc
@@ -43,7 +43,6 @@ TAdd::TAdd(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange &pos_
     : TBinary(lhs, rhs, pos_range) {}
 
 void TAdd::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/addr.cc
+++ b/orly/expr/addr.cc
@@ -37,7 +37,6 @@ TAddr::TAddr(const TMemberVec &members, const TPosRange &pos_range)
     : TCtor(members, pos_range) {}
 
 void TAddr::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/addr_member.cc
+++ b/orly/expr/addr_member.cc
@@ -34,7 +34,6 @@ TAddrMember::TAddrMember(const TExpr::TPtr &expr, size_t index, const TPosRange 
     : TUnary(expr, pos_range), Index(index) {}
 
 void TAddrMember::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/addr_of.cc
+++ b/orly/expr/addr_of.cc
@@ -36,7 +36,6 @@ TAddrOf::TAddrOf(const TExpr::TPtr &expr, const TPosRange &pos_range)
   : TUnary(expr, pos_range) {}
 
 void TAddrOf::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/addr_walker.cc
+++ b/orly/expr/addr_walker.cc
@@ -217,7 +217,6 @@ class expr_visitor_t
     }
   }
   void Yield(const TExpr::TPtr &expr) const {
-    assert(&expr);
     assert(expr);
     expr->Accept(*this);
   }
@@ -433,7 +432,6 @@ class expr_visitor_t
       }
     }
     void Yield(const TExpr::TPtr &expr) const {
-      assert(&expr);
       assert(expr);
       expr->Accept(*this);
     }

--- a/orly/expr/as.cc
+++ b/orly/expr/as.cc
@@ -39,7 +39,6 @@ TAs::TAs(const TExpr::TPtr &expr, const Type::TType &type, const TPosRange &pos_
     : TUnary(expr, pos_range), Type(type) {}
 
 void TAs::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/assert.cc
+++ b/orly/expr/assert.cc
@@ -84,12 +84,10 @@ TAssert::TAssert(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TThatableUnary(expr, pos_range) {}
 
 void TAssert::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
 void TAssert::Delete(const TAssertCase::TPtr &assert_case) {
-  assert(&assert_case);
   assert(assert_case);
   AssertCases.erase(assert_case);
 }
@@ -106,7 +104,6 @@ Type::TType TAssert::GetTypeImpl() const {
 }
 
 void TAssert::Insert(const TAssertCase::TPtr &assert_case) {
-  assert(&assert_case);
   assert(assert_case);
   auto result = AssertCases.insert(assert_case);
   assert(result.second);

--- a/orly/expr/ceiling.cc
+++ b/orly/expr/ceiling.cc
@@ -57,7 +57,6 @@ TCeiling::TCeiling(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TCeiling::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/collated_by.h
+++ b/orly/expr/collated_by.h
@@ -59,7 +59,6 @@ namespace Orly {
       }
 
       virtual void Accept(const TVisitor &visitor) const {
-        assert(&visitor);
         visitor(this);
       }
 

--- a/orly/expr/collected_by.h
+++ b/orly/expr/collected_by.h
@@ -47,7 +47,6 @@ namespace Orly {
       }
 
       virtual void Accept(const TVisitor &visitor) const {
-        assert(&visitor);
         visitor(this);
       }
 

--- a/orly/expr/comp_ops.cc
+++ b/orly/expr/comp_ops.cc
@@ -35,7 +35,6 @@ TEqEq::TEqEq(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange &po
     : TBinary(lhs, rhs, pos_range) {}
 
 void TEqEq::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -53,7 +52,6 @@ TNeq::TNeq(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange &pos_
     : TBinary(lhs, rhs, pos_range) {}
 
 void TNeq::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -71,7 +69,6 @@ TLt::TLt(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange &pos_ra
     : TBinary(lhs, rhs, pos_range) {}
 
 void TLt::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -89,7 +86,6 @@ TLtEq::TLtEq(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange &po
     : TBinary(lhs, rhs, pos_range) {}
 
 void TLtEq::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -107,7 +103,6 @@ TGt::TGt(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange &pos_ra
     : TBinary(lhs, rhs, pos_range) {}
 
 void TGt::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -125,7 +120,6 @@ TGtEq::TGtEq(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange &po
     : TBinary(lhs, rhs, pos_range) {}
 
 void TGtEq::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/dict.cc
+++ b/orly/expr/dict.cc
@@ -50,7 +50,6 @@ TDict::TDict(const TMemberMap &members, const TPosRange &pos_range)
 }
 
 void TDict::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/div.cc
+++ b/orly/expr/div.cc
@@ -44,7 +44,6 @@ TDiv::TDiv(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange &pos_
     : TBinary(lhs, rhs, pos_range) {}
 
 void TDiv::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/effect.cc
+++ b/orly/expr/effect.cc
@@ -29,7 +29,6 @@ TEffect::TEffect(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TThatableUnary(expr, pos_range), StmtBlock(nullptr) {}
 
 void TEffect::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/exists.cc
+++ b/orly/expr/exists.cc
@@ -37,7 +37,6 @@ TExists::TExists(const TExpr::TPtr &expr, const Type::TType &value_type, const T
     : TUnary(expr, pos_range), ValueType(value_type) {}
 
 void TExists::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/exp.cc
+++ b/orly/expr/exp.cc
@@ -44,7 +44,6 @@ TExp::TExp(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange &pos_
     : TBinary(lhs, rhs, pos_range) {}
 
 void TExp::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/filter.cc
+++ b/orly/expr/filter.cc
@@ -35,7 +35,6 @@ TFilter::TFilter(const TExpr::TPtr &lhs, const TPosRange &pos_range)
     : TThatableBinary(lhs, pos_range) {}
 
 void TFilter::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/floor.cc
+++ b/orly/expr/floor.cc
@@ -57,7 +57,6 @@ TFloor::TFloor(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TFloor::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/free.cc
+++ b/orly/expr/free.cc
@@ -31,7 +31,6 @@ TFree::TFree(const Type::TType &type, const TPosRange &pos_range, TAddrDir addr_
     : TLeaf(pos_range), Type(type), AddrDir(addr_dir) {}
 
 void TFree::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/function_app.cc
+++ b/orly/expr/function_app.cc
@@ -102,7 +102,6 @@ TFunctionApp::~TFunctionApp() {
 }
 
 void TFunctionApp::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/if_else.cc
+++ b/orly/expr/if_else.cc
@@ -46,7 +46,6 @@ TIfElse::TIfElse(
                            Base::AssertTrue(false_case)}}, pos_range) {}
 
 void TIfElse::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/in.cc
+++ b/orly/expr/in.cc
@@ -35,7 +35,6 @@ TIn::TIn(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange &pos_ra
     : TBinary(lhs, rhs, pos_range) {}
 
 void TIn::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/is_empty.cc
+++ b/orly/expr/is_empty.cc
@@ -36,7 +36,6 @@ TIsEmpty::TIsEmpty(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TIsEmpty::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/keys.cc
+++ b/orly/expr/keys.cc
@@ -35,7 +35,6 @@ TKeys::TKeys(const TAddr::TMemberVec &members, const Type::TType &value_type, co
 }
 
 void TKeys::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/known.cc
+++ b/orly/expr/known.cc
@@ -83,7 +83,6 @@ TIsKnown::TIsKnown(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TIsKnown::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -101,7 +100,6 @@ TIsUnknown::TIsUnknown(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TIsUnknown::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -119,7 +117,6 @@ TIsKnownExpr::TIsKnownExpr(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const
     : TBinary(lhs, rhs, pos_range) {}
 
 void TIsKnownExpr::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -161,7 +158,6 @@ TKnown::TKnown(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TKnown::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/length_of.cc
+++ b/orly/expr/length_of.cc
@@ -36,7 +36,6 @@ TLengthOf::TLengthOf(const TExpr::TPtr &container, const TPosRange &pos_range)
     : TUnary(container, pos_range) {}
 
 void TLengthOf::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/lhs_and_rhs.cc
+++ b/orly/expr/lhs_and_rhs.cc
@@ -35,7 +35,6 @@ TLhs::TLhs(const TLhsRhsable *lhsrhsable, const TPosRange &pos_range)
     : TLeaf(pos_range), LhsRhsable(Base::AssertTrue(lhsrhsable)) {}
 
 void TLhs::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -55,7 +54,6 @@ TRhs::TRhs(const TLhsRhsable *lhsrhsable, const TPosRange &pos_range)
     : TLeaf(pos_range), LhsRhsable(Base::AssertTrue(lhsrhsable)) {}
 
 void TRhs::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/list.cc
+++ b/orly/expr/list.cc
@@ -49,7 +49,6 @@ TList::TList(const TExprVec &exprs, const TPosRange &pos_range)
 }
 
 void TList::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/literal.cc
+++ b/orly/expr/literal.cc
@@ -32,7 +32,6 @@ TLiteral::TLiteral(const Var::TVar &val, const TPosRange &pos_range)
     : TLeaf(pos_range), Val(val) {}
 
 void TLiteral::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/log.cc
+++ b/orly/expr/log.cc
@@ -57,7 +57,6 @@ TLog::TLog(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TLog::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -75,7 +74,6 @@ TLog2::TLog2(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TLog2::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -93,7 +91,6 @@ TLog10::TLog10(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TLog10::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/logical_ops.cc
+++ b/orly/expr/logical_ops.cc
@@ -45,7 +45,6 @@ TAnd::TAnd(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange &pos_
     : TBinary(lhs, rhs, pos_range) {}
 
 void TAnd::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -63,7 +62,6 @@ TAndThen::TAndThen(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRan
     : TBinary(lhs, rhs, pos_range) {}
 
 void TAndThen::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -81,7 +79,6 @@ TNot::TNot(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TNot::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -120,7 +117,6 @@ TOr::TOr(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange &pos_ra
     : TBinary(lhs, rhs, pos_range) {}
 
 void TOr::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -138,7 +134,6 @@ TOrElse::TOrElse(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange
     : TBinary(lhs, rhs, pos_range) {}
 
 void TOrElse::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -156,7 +151,6 @@ TXor::TXor(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange &pos_
     : TBinary(lhs, rhs, pos_range) {}
 
 void TXor::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/match.cc
+++ b/orly/expr/match.cc
@@ -38,7 +38,6 @@ TMatch::TMatch(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange &
     : TBinary(lhs, rhs, pos_range) {}
 
 void TMatch::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/mod.cc
+++ b/orly/expr/mod.cc
@@ -44,7 +44,6 @@ TMod::TMod(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange &pos_
     : TBinary(lhs, rhs, pos_range) {}
 
 void TMod::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/mult.cc
+++ b/orly/expr/mult.cc
@@ -44,7 +44,6 @@ TMult::TMult(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange &po
     : TBinary(lhs, rhs, pos_range) {}
 
 void TMult::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/n_ary.h
+++ b/orly/expr/n_ary.h
@@ -43,8 +43,6 @@ namespace Orly {
       /* TList and TSet */
       template <typename TCompatContainer>
       static void ForEachExpr(const TCompatContainer &container, const TCallback &cb) {
-        assert(&container);
-        assert(&cb);
         assert(cb);
         for (auto elem : container) {
           cb(elem);
@@ -53,8 +51,6 @@ namespace Orly {
 
       /* TIfElse, TRange */
       static void ForEachExpr(const std::array<TExpr::TPtr, 3U> &exprs, const TCallback &cb) {
-        assert(&exprs);
-        assert(&cb);
         assert(cb);
         for (auto expr : exprs) {
           if (expr) {
@@ -67,8 +63,6 @@ namespace Orly {
       static void ForEachExpr(
           const std::vector<std::pair<TAddrDir, TExpr::TPtr>> &addr_members,
           const TCallback &cb) {
-        assert(&addr_members);
-        assert(&cb);
         assert(cb);
         for (auto addr_member : addr_members) {
           cb(addr_member.second);
@@ -79,8 +73,6 @@ namespace Orly {
       static void ForEachExpr(
           const std::unordered_map<TExpr::TPtr, TExpr::TPtr> &dict_members,
           const TCallback &cb) {
-        assert(&dict_members);
-        assert(&cb);
         assert(cb);
         for (auto dict_member : dict_members) {
           cb(dict_member.first);
@@ -92,8 +84,6 @@ namespace Orly {
       static void ForEachExpr(
           const std::map<std::string, TExpr::TPtr> &obj_members,
           const TCallback &cb) {
-        assert(&obj_members);
-        assert(&cb);
         assert(cb);
         for (auto obj_member : obj_members) {
           cb(obj_member.second);

--- a/orly/expr/now.cc
+++ b/orly/expr/now.cc
@@ -35,7 +35,6 @@ TNow::TNow(const TPosRange &pos_range)
     : TLeaf(pos_range) {}
 
 void TNow::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/obj.cc
+++ b/orly/expr/obj.cc
@@ -35,7 +35,6 @@ TObj::TObj(const TMemberMap &members, const TPosRange &pos_range)
     : TCtor(members, pos_range) {}
 
 void TObj::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/obj_member.cc
+++ b/orly/expr/obj_member.cc
@@ -37,7 +37,6 @@ TObjMember::TObjMember(const TExpr::TPtr &expr, const std::string &name, const T
     : TUnary(expr, pos_range), Name(name) {}
 
 void TObjMember::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/range.cc
+++ b/orly/expr/range.cc
@@ -47,7 +47,6 @@ TRange::TRange(
 
 
 void TRange::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/read.cc
+++ b/orly/expr/read.cc
@@ -36,7 +36,6 @@ TRead::TRead(const TExpr::TPtr &expr, const Type::TType &type, const TPosRange &
     : TUnary(expr, pos_range), Type(type) {}
 
 void TRead::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/reduce.cc
+++ b/orly/expr/reduce.cc
@@ -40,7 +40,6 @@ TReduce::TReduce(
       : TThatableBinary(lhs, pos_range) {}
 
 void TReduce::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/ref.cc
+++ b/orly/expr/ref.cc
@@ -41,7 +41,6 @@ TRef::TRef(const Symbol::TDef *def, const TPosRange &pos_range)
     : TLeaf(pos_range), Def(Base::AssertTrue(def)) {}
 
 void TRef::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/reverse_of.cc
+++ b/orly/expr/reverse_of.cc
@@ -36,7 +36,6 @@ TReverseOf::TReverseOf(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TReverseOf::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/sequence_of.cc
+++ b/orly/expr/sequence_of.cc
@@ -36,7 +36,6 @@ TSequenceOf::TSequenceOf(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TSequenceOf::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/session_id.cc
+++ b/orly/expr/session_id.cc
@@ -33,7 +33,6 @@ TSessionId::TSessionId(const TPosRange &pos_range)
     : TLeaf(pos_range) {}
 
 void TSessionId::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/set.cc
+++ b/orly/expr/set.cc
@@ -48,7 +48,6 @@ TSet::TSet(const TExprSet &exprs, const TPosRange &pos_range)
 }
 
 void TSet::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/set_ops.cc
+++ b/orly/expr/set_ops.cc
@@ -43,7 +43,6 @@ TIntersection::TIntersection(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, con
     : TBinary(lhs, rhs, pos_range) {}
 
 void TIntersection::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -61,7 +60,6 @@ TSymmetricDiff::TSymmetricDiff(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, c
     : TBinary(lhs, rhs, pos_range) {}
 
 void TSymmetricDiff::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -79,7 +77,6 @@ TUnion::TUnion(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange &
     : TBinary(lhs, rhs, pos_range) {}
 
 void TUnion::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/sign.cc
+++ b/orly/expr/sign.cc
@@ -64,7 +64,6 @@ TNegative::TNegative(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TNegative::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -82,7 +81,6 @@ TPositive::TPositive(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TPositive::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/skip.cc
+++ b/orly/expr/skip.cc
@@ -380,7 +380,6 @@ TSkip::TSkip(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange &po
     : TBinary(lhs, rhs, pos_range) {}
 
 void TSkip::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/slice.cc
+++ b/orly/expr/slice.cc
@@ -47,7 +47,6 @@ TSlice::TSlice(
         Colon(colon) {}
 
 void TSlice::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/sort.cc
+++ b/orly/expr/sort.cc
@@ -36,7 +36,6 @@ TSort::TSort(const TExpr::TPtr &lhs, const TPosRange &pos_range)
     : TBinary(lhs, pos_range) {};
 
 void TSort::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/split.cc
+++ b/orly/expr/split.cc
@@ -38,7 +38,6 @@ TSplit::TSplit(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange &
     : TBinary(lhs, rhs, pos_range) {}
 
 void TSplit::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/start.cc
+++ b/orly/expr/start.cc
@@ -32,7 +32,6 @@ TStart::TStart(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TStart::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/string.cc
+++ b/orly/expr/string.cc
@@ -57,7 +57,6 @@ TToLower::TToLower(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TToLower::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -75,7 +74,6 @@ TToUpper::TToUpper(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TToUpper::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/sub.cc
+++ b/orly/expr/sub.cc
@@ -43,7 +43,6 @@ TSub::TSub(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange &pos_
     : TBinary(lhs, rhs, pos_range) {}
 
 void TSub::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/take.cc
+++ b/orly/expr/take.cc
@@ -380,7 +380,6 @@ TTake::TTake(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange &po
     : TBinary(lhs, rhs, pos_range) {}
 
 void TTake::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/that.cc
+++ b/orly/expr/that.cc
@@ -36,7 +36,6 @@ TThat::TThat(const TThatable *thatable, const TPosRange &pos_range)
     : TLeaf(pos_range), Thatable(thatable) {}
 
 void TThat::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/time_obj.cc
+++ b/orly/expr/time_obj.cc
@@ -38,7 +38,6 @@ TTimeObj::TTimeObj(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TTimeObj::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/trig.cc
+++ b/orly/expr/trig.cc
@@ -58,7 +58,6 @@ TCos::TCos(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TCos::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -77,7 +76,6 @@ TSin::TSin(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TSin::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -96,7 +94,6 @@ TTan::TTan(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TTan::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -115,7 +112,6 @@ TAcos::TAcos(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TAcos::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -134,7 +130,6 @@ TAsin::TAsin(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TAsin::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -153,7 +148,6 @@ TAtan::TAtan(const TExpr::TPtr &expr, const TPosRange &pos_range)
     : TUnary(expr, pos_range) {}
 
 void TAtan::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -172,7 +166,6 @@ TAtan2::TAtan2(const TExpr::TPtr &lhs, const TExpr::TPtr &rhs, const TPosRange &
     : TBinary(lhs, rhs, pos_range) {}
 
 void TAtan2::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/unknown.cc
+++ b/orly/expr/unknown.cc
@@ -35,7 +35,6 @@ TUnknown::TUnknown(const Type::TType &type, const TPosRange &pos_range)
     : TLeaf(pos_range), Type(type) {}
 
 void TUnknown::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/user_id.cc
+++ b/orly/expr/user_id.cc
@@ -34,7 +34,6 @@ TUserId::TUserId(const TPosRange &pos_range)
     : TLeaf(pos_range) {}
 
 void TUserId::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/walker.cc
+++ b/orly/expr/walker.cc
@@ -321,7 +321,6 @@ void Orly::Expr::ForEachExpr(const TExpr::TPtr &root, const TCb &cb, bool includ
       Binary(that);
     }
     void Yield(const TExpr::TPtr &expr) const {
-      assert(&expr);
       assert(expr);
       // For this callback, true means stop, false means keep going
       if (!Cb(expr)) {

--- a/orly/expr/where.cc
+++ b/orly/expr/where.cc
@@ -33,7 +33,6 @@ TWhere::TWhere(const TPosRange &pos_range)
     : TUnary(pos_range) {}
 
 void TWhere::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/expr/while.cc
+++ b/orly/expr/while.cc
@@ -35,7 +35,6 @@ TWhile::TWhile(const TExpr::TPtr &lhs, const TPosRange &pos_range)
     : TThatableBinary(lhs, pos_range) {}
 
 void TWhile::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/indy/disk/data_file.cc
+++ b/orly/indy/disk/data_file.cc
@@ -44,7 +44,6 @@ class TIndexFile
           Note(note) {}
 
     bool operator<(const TOrderedNote &that) const {
-      assert(&that);
       assert(Note);
       assert(that.Note);
       assert(Arena);
@@ -66,7 +65,6 @@ class TIndexFile
     }
 
     bool operator==(const TOrderedNote &that) const {
-      assert(&that);
       assert(Note);
       assert(that.Note);
       assert(Arena);
@@ -85,7 +83,6 @@ class TIndexFile
     }
 
     bool operator!=(const TOrderedNote &that) const {
-      assert(&that);
       assert(Note);
       assert(that.Note);
       assert(Arena);
@@ -119,7 +116,6 @@ class TIndexFile
 
     /* TODO */
     bool operator<(const THashObj &that) const {
-      assert(&that);
       return Hash < that.Hash;
     }
 

--- a/orly/indy/disk/data_file.h
+++ b/orly/indy/disk/data_file.h
@@ -46,13 +46,11 @@ namespace Orly {
 
         /* TODO */
         bool operator==(const TRemapObj &that) const {
-          assert(&that);
           return Arena == that.Arena && OldKey == that.OldKey;
         }
 
         /* TODO */
         bool operator!=(const TRemapObj &that) const {
-          assert(&that);
           return Arena != that.Arena || OldKey != that.OldKey;
         }
 
@@ -124,7 +122,6 @@ namespace Orly {
 
           /* TODO */
           bool operator<(const TUpdateObj &that) const {
-            assert(&that);
             return SequenceNumber < that.SequenceNumber;
           }
 

--- a/orly/indy/disk/durable_manager.cc
+++ b/orly/indy/disk/durable_manager.cc
@@ -720,9 +720,6 @@ size_t TDurableManager::TSortedInFile::FindPageIdOfByte(size_t offset) const {
 }
 
 void TDurableManager::TSortedInFile::FindInHash(TSequenceNumber &cur_max_seq_num, const Durable::TId &id, std::string &serialized_form_out) const {
-  assert(&id);
-  assert(&serialized_form_out);
-  assert(&cur_max_seq_num);
   assert(InStream);
   uuid_t cur_id;
   TInStream hash_stream(HERE, Source::DurableMergeFileHash, RealTime, this, PageCache, HashIndexOffset);

--- a/orly/indy/disk/merge_data_file.cc
+++ b/orly/indy/disk/merge_data_file.cc
@@ -827,7 +827,6 @@ class TMergeDataFileImpl {
 
     /* TODO */
     bool operator<(const TUpdateObj &that) const {
-      assert(&that);
       return SequenceNumber < that.SequenceNumber;
     }
 
@@ -873,7 +872,6 @@ class TMergeDataFileImpl {
 
     /* TODO */
     bool operator<(const TL0MergeNote &that) const {
-      assert(&that);
       assert(Arena);
       assert(that.Arena);
       assert(Note);
@@ -895,7 +893,6 @@ class TMergeDataFileImpl {
 
     /* TODO */
     bool operator==(const TL0MergeNote &that) const {
-      assert(&that);
       assert(Arena);
       assert(that.Arena);
       assert(Note);
@@ -915,7 +912,6 @@ class TMergeDataFileImpl {
 
     /* TODO */
     bool operator!=(const TL0MergeNote &that) const {
-      assert(&that);
       assert(Arena);
       assert(that.Arena);
       assert(Note);
@@ -980,7 +976,6 @@ class TMergeDataFileImpl {
 
     /* TODO */
     bool operator==(const TMergeNote &that) const {
-      assert(&that);
       assert(Arena == that.Arena);
       assert(Note);
       assert(that.Note);
@@ -991,7 +986,6 @@ class TMergeDataFileImpl {
 
     /* TODO */
     bool operator!=(const TMergeNote &that) const {
-      assert(&that);
       assert(Arena == that.Arena);
       assert(Note);
       assert(that.Note);
@@ -2050,7 +2044,6 @@ class TMergeDataFileImpl {
           : Core(core), Hash(hash), Offset(offset) {}
 
       bool operator<(const THashObj &that) const {
-        assert(&that);
         return Hash < that.Hash;
       }
 

--- a/orly/indy/disk/present_walk_file.h
+++ b/orly/indy/disk/present_walk_file.h
@@ -58,13 +58,11 @@ namespace Orly {
 
         /* TODO */
         inline bool operator==(const TWalkerKey &that) const {
-          assert(&that);
           return FileId == that.FileId && GenId == that.GenId && IndexId == that.IndexId;
         }
 
         /* TODO */
         inline bool operator!=(const TWalkerKey &that) const {
-          assert(&that);
           return FileId != that.FileId || GenId != that.GenId || IndexId != that.IndexId;
         }
 

--- a/orly/indy/disk/read_file.h
+++ b/orly/indy/disk/read_file.h
@@ -63,13 +63,11 @@ namespace Orly {
 
         /* TODO */
         inline bool operator==(const TFileKey &that) const {
-          assert(&that);
           return FileId == that.FileId && GenId == that.GenId;
         }
 
         /* TODO */
         inline bool operator!=(const TFileKey &that) const {
-          assert(&that);
           return FileId != that.FileId || GenId != that.GenId;
         }
 
@@ -794,8 +792,6 @@ namespace Orly {
 
           /* TODO */
           bool BinaryLowerBoundOnKey(const TKey &key, size_t &out_offset, TInStream &in_stream, TArena *file_arena) const {
-            assert(&key);
-            assert(&out_offset);
             assert(NumCurKeys > 0);
             size_t first = 0U;
             size_t it = 0;

--- a/orly/indy/disk/util/volume_manager.h
+++ b/orly/indy/disk/util/volume_manager.h
@@ -565,7 +565,6 @@ namespace Orly {
             const size_t NumLogicalBlock;
             const size_t Capacity;
             bool operator !=(const TDesc &that) const {
-              assert(&that);
               return Kind != that.Kind
                 || LogicalBlockSize != that.LogicalBlockSize
                 || PhysicalBlockSize != that.PhysicalBlockSize

--- a/orly/indy/fiber/fiber.h
+++ b/orly/indy/fiber/fiber.h
@@ -165,7 +165,6 @@ namespace Orly {
 
       /* TODO */
       inline void free_fiber(fiber_t &fib) {
-        assert(&fib);
         assert(fib.start_of_stack);
         free(fib.start_of_stack);
       }
@@ -199,7 +198,6 @@ namespace Orly {
 
       /* TODO */
       inline void free_fiber(fiber_t &fib) {
-        assert(&fib);
         assert(fib.uc_stack.ss_sp);
         free(fib.uc_stack.ss_sp);
       }

--- a/orly/indy/key.h
+++ b/orly/indy/key.h
@@ -202,7 +202,6 @@ namespace Orly {
 
     /* A standard stream inserter for Orly::Indy::TKey. */
     inline std::ostream &operator<<(std::ostream &strm, const TKey &that) {
-      assert(&that);
       that.Dump(strm);
       return strm;
     }
@@ -284,7 +283,6 @@ namespace Orly {
     inline TKey::TKey(TKey &&that) : Arena(that.Arena), Core(that.Core), HashIsCached(that.HashIsCached), CachedHash(that.CachedHash) {}
 
     inline TKey &TKey::operator=(const TKey &that) {
-      assert(&that);
       Arena = that.Arena;
       Core = that.Core;
       HashIsCached = that.HashIsCached;
@@ -293,7 +291,6 @@ namespace Orly {
     }
 
     inline TKey &TKey::operator=(TKey &&that) {
-      assert(&that);
       std::swap(Arena, that.Arena);
       std::swap(Core, that.Core);
       std::swap(HashIsCached, that.HashIsCached);
@@ -302,8 +299,6 @@ namespace Orly {
     }
 
     inline bool TKey::EqEq(const Atom::TCore &lhs, Atom::TCore::TArena *lhs_arena, const Atom::TCore &rhs, Atom::TCore::TArena *rhs_arena) {
-      assert(&lhs);
-      assert(&rhs);
       size_t lhs_hash, rhs_hash;
       if (lhs.TryGetQuickHash(lhs_hash) && rhs.TryGetQuickHash(rhs_hash)) {
         return lhs_hash == rhs_hash && Atom::IsEq(TKey::Compare(lhs, lhs_arena, rhs, rhs_arena));
@@ -312,8 +307,6 @@ namespace Orly {
     }
 
     inline bool TKey::TupleEqEq(const Atom::TCore &lhs, Atom::TCore::TArena *lhs_arena, const Atom::TCore &rhs, Atom::TCore::TArena *rhs_arena) {
-      assert(&lhs);
-      assert(&rhs);
       return lhs.ForceGetIndirectHash() == rhs.ForceGetIndirectHash() && Atom::IsEq(TKey::Compare(lhs, lhs_arena, rhs, rhs_arena));
     }
 
@@ -322,15 +315,11 @@ namespace Orly {
     }
 
     inline bool TKey::NeEq(const Atom::TCore &lhs, Atom::TCore::TArena *lhs_arena, const Atom::TCore &rhs, Atom::TCore::TArena *rhs_arena) {
-      assert(&lhs);
-      assert(&rhs);
       size_t lhs_hash, rhs_hash;
       return (lhs.TryGetQuickHash(lhs_hash) && rhs.TryGetQuickHash(rhs_hash) && (lhs_hash != rhs_hash)) || Atom::IsNe(TKey::Compare(lhs, lhs_arena, rhs, rhs_arena));
     }
 
     inline bool TKey::TupleNeEq(const Atom::TCore &lhs, Atom::TCore::TArena *lhs_arena, const Atom::TCore &rhs, Atom::TCore::TArena *rhs_arena) {
-      assert(&lhs);
-      assert(&rhs);
       return (lhs.ForceGetIndirectHash() != rhs.ForceGetIndirectHash()) ||
               Atom::IsNe(TKey::Compare(lhs, lhs_arena, rhs, rhs_arena));
     }
@@ -340,28 +329,22 @@ namespace Orly {
     }
 
     inline bool TKey::operator<(const TKey &that) const {
-      assert(&that);
       return Atom::IsLt(Compare(that));
     }
 
     inline bool TKey::operator<=(const TKey &that) const {
-      assert(&that);
       return Atom::IsLe(Compare(that));
     }
 
     inline bool TKey::operator>(const TKey &that) const {
-      assert(&that);
       return Atom::IsGt(Compare(that));
     }
 
     inline bool TKey::operator>=(const TKey &that) const {
-      assert(&that);
       return Atom::IsGe(Compare(that));
     }
 
     inline Atom::TComparison TKey::Compare(const Atom::TCore &lhs, Atom::TCore::TArena *lhs_arena, const Atom::TCore &rhs, Atom::TCore::TArena *rhs_arena) {
-      assert(&lhs);
-      assert(&rhs);
       Atom::TComparison comp;
       if (lhs_arena && rhs_arena && lhs.TryQuickOrderComparison(lhs_arena, rhs, rhs_arena, comp)) {
         return comp;

--- a/orly/indy/manager.cc
+++ b/orly/indy/manager.cc
@@ -166,14 +166,12 @@ TManager::~TManager() {
 L0::TManager::TPtr<TRepo> TManager::NewSafeRepo(const TUuid &repo_id,
                                         const Base::TOpt<TTtl> &ttl,
                                         const Base::TOpt<L0::TManager::TPtr<L0::TManager::TRepo>> &parent_repo) {
-  assert(&repo_id);
   return New(repo_id, *ttl, parent_repo, true);
 }
 
 L0::TManager::TPtr<TRepo> TManager::NewFastRepo(const TUuid &repo_id,
                                         const Base::TOpt<TTtl> &ttl,
                                         const Base::TOpt<L0::TManager::TPtr<L0::TManager::TRepo>> &parent_repo) {
-  assert(&repo_id);
   return New(repo_id, *ttl, parent_repo, false);
 }
 
@@ -1093,7 +1091,6 @@ L0::TManager::TRepo *TManager::ConstructRepo(const TUuid &repo_id,
     syslog(LOG_INFO, "Create Repo [%s] with ttl=[%ld], is_safe=[%s], create=[%s]", ss.str().c_str(), ttl ? ttl->count() : 0, is_safe ? "true" : "false", create ? "true" : "false");
   }
   void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
-  assert(&repo_id);
   if (repo_id != SystemRepoId) {
     assert(SystemRepo);
     if (create) {
@@ -1195,7 +1192,6 @@ L0::TManager::TRepo *TManager::ConstructRepo(const TUuid &repo_id,
 }
 
 L0::TManager::TRepo *TManager::ReconstructRepo(const TUuid &repo_id) {
-  assert(&repo_id);
   if (repo_id != SystemRepoId) { /* construct a regular repo */
     auto deadline = TDeadline::max(); /* TODO: we should figure out the right deadline here */
     return TSafeRepo::ReConstructFromDisk(this, repo_id, deadline);

--- a/orly/indy/manager.h
+++ b/orly/indy/manager.h
@@ -655,7 +655,6 @@ namespace Orly {
       template<>
       template<>
       inline TManager::TPtr<Indy::TRepo>::TPtr(const TPtr<L0::TManager::TRepo> &that) {
-        assert(&that);
         if ((SomeObj = dynamic_cast<Indy::TRepo *>(that.SomeObj)) != nullptr) {
           SomeObj->OnPtrAcquire();
         }

--- a/orly/indy/manager_base.h
+++ b/orly/indy/manager_base.h
@@ -1078,14 +1078,12 @@ namespace Orly {
 
       template <typename TSomeObj>
       TManager::TPtr<TSomeObj>::TPtr(TPtr &&that) {
-        assert(&that);
         SomeObj = that.SomeObj;
         that.SomeObj = nullptr;
       }
 
       template <typename TSomeObj>
       TManager::TPtr<TSomeObj>::TPtr(const TPtr &that) {
-        assert(&that);
         if ((SomeObj = that.SomeObj) != nullptr) {
           SomeObj->OnPtrAcquire();
         }
@@ -1094,7 +1092,6 @@ namespace Orly {
       template <typename TSomeObj>
       template <typename TOtherObj>
       TManager::TPtr<TSomeObj>::TPtr(const TPtr<TOtherObj> &that) {
-        assert(&that);
         if ((SomeObj = reinterpret_cast<TSomeObj *>(that.SomeObj)) != nullptr) {
           SomeObj->OnPtrAcquire();
         }
@@ -1109,7 +1106,6 @@ namespace Orly {
 
       template <typename TSomeObj>
       TManager::TPtr<TSomeObj> &TManager::TPtr<TSomeObj>::operator=(TPtr &&that) {
-        assert(&that);
         std::swap(SomeObj, that.SomeObj);
         return *this;
       }

--- a/orly/indy/replication.cc
+++ b/orly/indy/replication.cc
@@ -40,7 +40,6 @@ TReplicationQueue::~TReplicationQueue() {
 }
 
 void TReplicationQueue::Swap(TReplicationQueue &that) {
-  assert(&that);
   for (auto item = that.ItemCollection.TryGetFirstMember(); item; item = that.ItemCollection.TryGetFirstMember()) {
     item->QueueMembership.Remove();
     ItemCollection.Insert(&item->QueueMembership);

--- a/orly/indy/transaction_base.cc
+++ b/orly/indy/transaction_base.cc
@@ -436,7 +436,6 @@ TTransaction::TReplica::TReplica() {}
 TTransaction::TReplica::~TReplica() {}
 
 TTransaction::TReplica &TTransaction::TReplica::operator=(TReplica &&that) {
-  assert(&that);
   std::swap(MutationList, that.MutationList);
   return *this;
 }
@@ -479,7 +478,6 @@ TTransaction::TReplica::TMutation::TUpdate::TUpdate(const Orly::Indy::TUpdate *t
 TTransaction::TReplica::TMutation::TUpdate::~TUpdate() {}
 
 TTransaction::TReplica::TMutation::TUpdate &TTransaction::TReplica::TMutation::TUpdate::operator=(TUpdate &&that) {
-  assert(&that);
   std::swap(Suprena, that.Suprena);
   Metadata = that.Metadata;
   Id = that.Id;
@@ -570,7 +568,6 @@ TTransaction::TReplica::TMutation::TMutation(TKind kind, const Base::TUuid &repo
 TTransaction::TReplica::TMutation::~TMutation() {}
 
 TTransaction::TReplica::TMutation &TTransaction::TReplica::TMutation::operator=(TMutation &&that) {
-  assert(&that);
   std::swap(Kind, that.Kind);
   std::swap(RepoId, that.RepoId);
   std::swap(Update, that.Update);

--- a/orly/indy/util/min_heap.h
+++ b/orly/indy/util/min_heap.h
@@ -48,7 +48,6 @@ namespace Orly {
 
           /* TODO */
           TMinHeapElem &operator=(TMinHeapElem &&that) {
-            assert(&that);
             if (this != &that) {
               std::swap(Val, that.Val);
               std::swap(Ref, that.Ref);
@@ -194,7 +193,6 @@ namespace Orly {
 
           /* TODO */
           TMinHeapElem &operator=(TMinHeapElem &&that) {
-            assert(&that);
             if (this != &that) {
               std::swap(Val, that.Val);
               std::swap(Ref, that.Ref);

--- a/orly/key_generator.h
+++ b/orly/key_generator.h
@@ -278,8 +278,6 @@ namespace Orly {
     /* TODO: This is an odd place for this. Oh well. */
     template <typename TRet, typename TAddr>
     TMutable<TAddr, TRet> Read(TContextBase &ctx, const TAddr &addr, const Base::TUuid &index_id) {
-      assert(&ctx);
-      assert(&addr);
 
       /* TODO: Copy copy copy copy copy! */
       void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
@@ -300,8 +298,6 @@ namespace Orly {
     /* TODO: This is an odd place for this. Oh well. */
     template <typename TAddr>
     bool Exists(TContextBase &ctx, const TAddr &addr, const Base::TUuid &index_id) {
-      assert(&ctx);
-      assert(&addr);
       void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
       return ctx.Exists(Indy::TIndexKey(index_id, Indy::TKey(Atom::TCore(ctx.GetArena(), Sabot::State::TAny::TWrapper(Native::State::New(addr, state_alloc))), ctx.GetArena())));
     }

--- a/orly/manual.cc
+++ b/orly/manual.cc
@@ -44,8 +44,6 @@ namespace Wrapper {
      calls the actual Sum function, then converts the result back to a core.
      (One entry like this per function in this package.) */
   Atom::TCore Sum(Package::TContext &ctx, const Package::TArgMap &args) {
-    assert(&ctx);
-    assert(&args);
     assert(args.size() == 2);
     void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
     return Atom::TCore(

--- a/orly/method_request.cc
+++ b/orly/method_request.cc
@@ -44,7 +44,6 @@ TMethodRequest::TMethodRequest(const TId &pov_id, const TPackage &package, const
 }
 
 void TMethodRequest::Read(TBinaryInputStream &strm) {
-  assert(&strm);
   strm >> PovId >> TimeToLive >> TrackingId >> Package >> Closure;
   if (!IsValid()) {
     *this = TMethodRequest();
@@ -54,7 +53,6 @@ void TMethodRequest::Read(TBinaryInputStream &strm) {
 }
 
 void TMethodRequest::Write(TBinaryOutputStream &strm) const {
-  assert(&strm);
   strm << PovId << TimeToLive << TrackingId << Package << Closure;
 }
 

--- a/orly/method_request.h
+++ b/orly/method_request.h
@@ -119,14 +119,12 @@ namespace Orly {
 
   /* Binary stream extractor for Orly::TMethodRequest. */
   inline Io::TBinaryInputStream &operator>>(Io::TBinaryInputStream &strm, Orly::TMethodRequest &that) {
-    assert(&that);
     that.Read(strm);
     return strm;
   }
 
   /* Binary stream inserter for Orly::TMethodRequest. */
   inline Io::TBinaryOutputStream &operator<<(Io::TBinaryOutputStream &strm, const Orly::TMethodRequest &that) {
-    assert(&that);
     that.Write(strm);
     return strm;
   }

--- a/orly/method_request.test.cc
+++ b/orly/method_request.test.cc
@@ -31,7 +31,6 @@ using namespace Io;
 using namespace Orly;
 
 void CheckMethodRequest(const TMethodRequest &method_request) {
-  assert(&method_request);
   EXPECT_TRUE(method_request.GetPovId());
   EXPECT_EQ(method_request.GetPackage().size(), 3u);
   EXPECT_EQ(method_request.GetClosure().GetMethodName(), string("deal"));

--- a/orly/method_result.cc
+++ b/orly/method_result.cc
@@ -39,7 +39,6 @@ TMethodResult::TMethodResult(TArena *arena, const Atom::TCore &value, const Base
 }
 
 void TMethodResult::Read(TBinaryInputStream &strm) {
-  assert(&strm);
   Reset();
   Arena.reset(TTransportArena::Read(strm, Value));
   strm >> Tracker >> Error;
@@ -52,7 +51,6 @@ void TMethodResult::Reset() {
 }
 
 void TMethodResult::Write(TBinaryOutputStream &strm) const {
-  assert(&strm);
   auto temp = dynamic_pointer_cast<TSuprena>(Arena);
   assert(temp);
   TTransportArena::Write(strm, temp.get(), Value);

--- a/orly/method_result.h
+++ b/orly/method_result.h
@@ -95,14 +95,12 @@ namespace Orly {
 
   /* Binary stream extractor for Orly::TMethodResult. */
   inline Io::TBinaryInputStream &operator>>(Io::TBinaryInputStream &strm, TMethodResult &that) {
-    assert(&that);
     that.Read(strm);
     return strm;
   }
 
   /* Binary stream inserter for Orly::TMethodResult. */
   inline Io::TBinaryOutputStream &operator<<(Io::TBinaryOutputStream &strm, const TMethodResult &that) {
-    assert(&that);
     that.Write(strm);
     return strm;
   }

--- a/orly/mynde/protocol.cc
+++ b/orly/mynde/protocol.cc
@@ -56,8 +56,6 @@ void TBuffer::Fill(uint32_t size, Strm::Bin::TIn &in) {
 }
 
 Strm::Bin::TOut &Orly::Mynde::operator<<(Strm::Bin::TOut &out, const TBuffer &that) {
-  assert(&out);
-  assert(&that);
   out.Write(that.GetData(), that.GetSize());
 
   return out;

--- a/orly/native/state.h
+++ b/orly/native/state.h
@@ -101,7 +101,6 @@ namespace Orly {
         /* Cache the reference to the value. */
         TScalar(const typename TScalarSabotState::TVal &val)
             : Val(val) {
-          assert(&val);
         }
 
         private:

--- a/orly/notification/all.cc
+++ b/orly/notification/all.cc
@@ -26,17 +26,14 @@ using namespace Io;
 using namespace Orly::Notification;
 
 void TPovFailure::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(*this);
 }
 
 void TSystemShutdown::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(*this);
 }
 
 void TUpdateProgress::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(*this);
 }
 
@@ -95,13 +92,11 @@ void Orly::Notification::Write(TBinaryOutputStream &strm, const TNotification *t
     private:
     TBinaryOutputStream &Strm;
   };
-  assert(&strm);
   assert(that);
   that->Accept(visitor_t(strm));
 }
 
 TNotification *Orly::Notification::New(TBinaryInputStream &strm) {
-  assert(&strm);
   TNotification *result;
   char code;
   strm >> code;

--- a/orly/notification/pov_failure.cc
+++ b/orly/notification/pov_failure.cc
@@ -22,18 +22,15 @@ using namespace Io;
 using namespace Orly::Notification;
 
 bool TPovFailure::Matches(const TPovFailure &that) const {
-  assert(&that);
   return TNotification::Matches(that) && PovId == that.PovId;
 }
 
 void TPovFailure::Write(TBinaryOutputStream &strm) const {
-  assert(&strm);
   TNotification::Write(strm);
   strm << PovId;
 }
 
 TPovFailure::TPovFailure(TBinaryInputStream &strm)
     : TNotification(strm) {
-  assert(&strm);
   strm >> PovId;
 }

--- a/orly/notification/system_shutdown.cc
+++ b/orly/notification/system_shutdown.cc
@@ -22,18 +22,15 @@ using namespace Io;
 using namespace Orly::Notification;
 
 bool TSystemShutdown::Matches(const TSystemShutdown &that) const {
-  assert(&that);
   return TNotification::Matches(that) && Ttl == that.Ttl;
 }
 
 void TSystemShutdown::Write(TBinaryOutputStream &strm) const {
-  assert(&strm);
   TNotification::Write(strm);
   strm << Ttl;
 }
 
 TSystemShutdown::TSystemShutdown(TBinaryInputStream &strm)
     : TNotification(strm) {
-  assert(&strm);
   strm >> Ttl;
 }

--- a/orly/notification/update_progress.cc
+++ b/orly/notification/update_progress.cc
@@ -22,18 +22,15 @@ using namespace Io;
 using namespace Orly::Notification;
 
 bool TUpdateProgress::Matches(const TUpdateProgress &that) const {
-  assert(&that);
   return TNotification::Matches(that) && PovId == that.PovId && UpdateId == that.UpdateId && Response == that.Response;
 }
 
 void TUpdateProgress::Write(TBinaryOutputStream &strm) const {
-  assert(&strm);
   TNotification::Write(strm);
   strm << PovId << UpdateId << Response;
 }
 
 TUpdateProgress::TUpdateProgress(TBinaryInputStream &strm)
     : TNotification(strm) {
-  assert(&strm);
   strm >> PovId >> UpdateId >> TBinaryInputEnum<TResponse>(Response);
 }

--- a/orly/orlyc.cc
+++ b/orly/orlyc.cc
@@ -61,7 +61,6 @@ class TCompilerConfig : public Base::TCmd {
 
     private:
     virtual void WriteAfterDesc(std::ostream &strm) const {
-      assert(&strm);
       strm << "Build: Unknown" << endl // TODO: Version from SCM.
            << endl
            << "Copyright Atomic Kismet Company" << endl
@@ -88,7 +87,6 @@ class TCompilerConfig : public Base::TCmd {
 };
 
 int CompileCode(const TCompilerConfig &cmd) {
-  assert(&cmd);
 
   //TODO: This 'make absolute' is something we do fairly commonly. (At least here and <jhm/jhm>). Should canonicalize.
   string src = cmd.Source;

--- a/orly/package/loaded.cc
+++ b/orly/package/loaded.cc
@@ -56,7 +56,6 @@ bool TLoaded:: ForEachTest(const function<bool (const TTest *)> &cb) const {
 }
 
 TFuncHolder::TPtr TLoaded::GetFunctionInfo(const Base::TPiece<const char> &func) const {
-  assert(&func);
   string func_name(func.GetStart(), func.GetLimit());
   auto iter = LinkInfo->PrimaryInfo->Functions.find(func_name);
   if (iter == LinkInfo->PrimaryInfo->Functions.end()) {
@@ -144,14 +143,11 @@ const Orly::Type::TType &TFuncHolder::GetReturnType() const {
 }
 
 Orly::Atom::TCore TFuncHolder::Call(TContext &ctx, const TArgMap &args) const {
-  assert(&ctx);
-  assert(&args);
 
   return (Func->Runner)(ctx, args);
 }
 
 TFuncHolder::TFuncHolder(const TLoaded::TPtr &package, const TFuncInfo *func) : Package(package), Func(func) {
-  assert(&package);
   assert(package);
   assert(func);
 }

--- a/orly/package/manager.cc
+++ b/orly/package/manager.cc
@@ -41,7 +41,6 @@ TManager::TManager(const Jhm::TTree &package_dir) : PackageDir(package_dir) {}
 TManager::~TManager() {}
 
 TLoaded::TPtr TManager::Get(const TName &package) const {
-  assert(&package);
 
   shared_lock<shared_timed_mutex> lock(InstallLock);
   auto it = Installed.find(package);
@@ -56,7 +55,6 @@ void TManager::Install(const TVersionedNames &packages, const std::function<void
 }
 
 void TManager::Load(const TVersionedNames &packages, const std::function<void(TLoaded::TPtr, bool)> &pre_install_step) {
-  assert(&packages);
 
   unique_lock<shared_timed_mutex> lock(InstallLock);
 
@@ -111,7 +109,6 @@ void TManager::SetPackageDir(const Jhm::TTree &package_dir) {
 
 
 void TManager::Uninstall(const TVersionedNames &packages) {
-  assert(&packages);
 
   unique_lock<shared_timed_mutex> lock(InstallLock);
   TInstalled installed(Installed);

--- a/orly/package/name.cc
+++ b/orly/package/name.cc
@@ -54,7 +54,6 @@ TName TName::Parse(const std::string &name) {
 }
 
 TVersionedName TVersionedName::Parse(const TPiece<const char> &name) {
-  assert(&name);
 
   auto dot_pos = find('.', name.GetLimit() - 1, name.GetStart() - 1);
   if (!dot_pos) {
@@ -69,7 +68,6 @@ TVersionedName TVersionedName::Parse(const TPiece<const char> &name) {
 }
 
 bool TVersionedName::operator==(const TVersionedName &that) const {
-  assert(&that);
 
   return that.Version == Version && that.Name == Name;
 }
@@ -83,8 +81,6 @@ Jhm::TRelPath TVersionedName::GetSoRelPath() const {
 }
 
 ostream &Orly::Package::operator<<(ostream &out, const TVersionedName &that) {
-  assert(&out);
-  assert(&that);
 
   out << that.Name << '.' << that.Version;
 

--- a/orly/package/name.h
+++ b/orly/package/name.h
@@ -68,7 +68,6 @@ namespace std {
   struct hash<Orly::Package::TName> {
 
     size_t operator()(const Orly::Package::TName &that) const {
-      assert(&that);
       return Base::ChainHashes(that.Name);
     }
 
@@ -81,7 +80,6 @@ namespace std {
     typedef Orly::Package::TVersionedName argument_type;
 
     result_type operator()(const argument_type &that) const {
-      assert(&that);
       return Base::ChainHashes(that.Name, that.Version);
     }
 

--- a/orly/package/rt.cc
+++ b/orly/package/rt.cc
@@ -23,8 +23,6 @@ using namespace Orly::Package;
 
 #if 0
 void TContext::AddEffect(const Var::TVar &addr, const Var::TPtr<Var::TChange> &change) {
-  assert(&addr);
-  assert(&change);
   assert(change);
 
   Spa::FluxCapacitor::TKV kv(addr);

--- a/orly/package/rt.h
+++ b/orly/package/rt.h
@@ -54,8 +54,6 @@ namespace Orly {
          change. */
       template <typename TVal>
       void AddEffect(const TVal &addr, const Base::TUuid &index_id, const Var::TPtr<Var::TChange> &change) {
-        assert(&addr);
-        assert(&change);
         assert(change);
         void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
         Indy::TIndexKey index_key(index_id, Indy::TKey(Atom::TCore(Arena, Sabot::State::TAny::TWrapper(Native::State::New(addr, state_alloc))), Arena));

--- a/orly/rt/built_in.h
+++ b/orly/rt/built_in.h
@@ -41,7 +41,6 @@ namespace Orly {
 
     template <int size, typename TKey, typename TVal>
     const TDict<TKey, TVal> &DictCtor(const TDict<TKey, TVal> &out) {
-      assert(&out);
       if (out.size() != size) {
         throw TSystemError(HERE, "Duplicate keys in a dictionary constructor. Since execution order is arbitrary, this is not allowed.");
       }

--- a/orly/rt/containers.h
+++ b/orly/rt/containers.h
@@ -34,16 +34,12 @@ namespace Orly {
     /* Match */
     template <typename TVal>
     bool Match(const TVal &lhs, const TVal &rhs) {
-      assert(&lhs);
-      assert(&rhs);
       return lhs == rhs;
     }
 
     /* MatchLess */
     template <typename TVal>
     bool MatchLess(const TVal &lhs, const TVal &rhs) {
-      assert(&lhs);
-      assert(&rhs);
       return lhs < rhs;
     }
 
@@ -78,8 +74,6 @@ namespace Orly {
     /* Match an TOpt<TVal> and TOpt<TVal> */
     template <typename TVal>
     bool Match(const TOpt<TVal> &lhs, const TOpt<TVal> &rhs) {
-      assert(&lhs);
-      assert(&rhs);
       return lhs.IsKnown() && rhs.IsKnown() ? Match(lhs.GetVal(), rhs.GetVal())
         : lhs.IsUnknown() && rhs.IsUnknown() ? true : false;
     }
@@ -87,8 +81,6 @@ namespace Orly {
     /* Match an TOpt<TVal> and TOpt<TVal> */
     template <typename TVal>
     bool MatchLess(const TOpt<TVal> &lhs, const TOpt<TVal> &rhs) {
-      assert(&lhs);
-      assert(&rhs);
       return lhs.IsKnown() && rhs.IsKnown() ? MatchLess(lhs.GetVal(), rhs.GetVal())
         : lhs.IsUnknown() && rhs.IsUnknown() ? false : lhs.IsUnknown() ? true : false;
     }
@@ -96,8 +88,6 @@ namespace Orly {
     /* Match an TList<TVal> and TList<TVal> */
     template <typename TVal>
     bool Match(const std::vector<TVal> &lhs, const std::vector<TVal> &rhs) {
-      assert(&lhs);
-      assert(&rhs);
       if (lhs.size() != rhs.size()) {
         return false;
       }
@@ -114,8 +104,6 @@ namespace Orly {
     /* Match an TList<TVal> and TList<TVal> */
     template <typename TVal>
     bool MatchLess(const std::vector<TVal> &lhs, const std::vector<TVal> &rhs) {
-      assert(&lhs);
-      assert(&rhs);
       auto lhs_iter = lhs.begin();
       auto rhs_iter = rhs.begin();
       for (; lhs_iter != lhs.end() && rhs_iter != rhs.end(); ++lhs_iter, ++rhs_iter) {
@@ -134,8 +122,6 @@ namespace Orly {
     /* Match an TSet<TVal> and TSet<TVal> */
     template <typename TVal>
     bool Match(const TSet<TVal> &lhs, const TSet<TVal> &rhs) {
-      assert(&lhs);
-      assert(&rhs);
       if (lhs.size() != rhs.size()) {
         return false;
       }
@@ -150,8 +136,6 @@ namespace Orly {
     /* Match an TDict<TVal> and TDict<TVal> */
     template <typename TKey, typename TVal>
     bool Match(const TDict<TKey, TVal> &lhs, const TDict<TKey, TVal> &rhs) {
-      assert(&lhs);
-      assert(&rhs);
       if (lhs.size() != rhs.size()) {
         return false;
       }
@@ -183,7 +167,6 @@ namespace std {
     typedef Orly::Rt::TDict<TKey, TVal> argument_type;
 
     result_type operator()(const argument_type &that) const {
-      assert(&that);
       result_type result = 0;
       for (const auto &elem : that) {
         result ^= hash<pair<TKey, TVal>>()(elem);
@@ -201,7 +184,6 @@ namespace std {
     typedef Orly::Rt::TSet<TVal> argument_type;
 
     result_type operator()(const argument_type &that) const {
-      assert(&that);
       result_type result = 0;
       for (const auto &elem : that) {
         result ^= hash<TVal>()(elem);

--- a/orly/rt/div.h
+++ b/orly/rt/div.h
@@ -44,8 +44,6 @@ namespace Orly {
 
     template <typename TLhs, typename TRhs>
     TOpt<int64_t> Div(TLhs &&lhs, TRhs &&rhs) {
-      assert(&lhs);
-      assert(&rhs);
       return IsKnown(lhs) && IsKnown(rhs) ? Div(GetVal(lhs), GetVal(rhs)) : TOpt<int64_t>();
     }
 

--- a/orly/rt/generator.h
+++ b/orly/rt/generator.h
@@ -185,9 +185,7 @@ namespace Orly {
 
 
       static TMapGenerator::TPtr New(const TFunc &func, const TValGenPtr &val_gen) {
-        assert(&func);
         assert(func);
-        assert(&val_gen);
 
         return TPtr(new TMapGenerator(func, val_gen));
       }

--- a/orly/rt/get_size.h
+++ b/orly/rt/get_size.h
@@ -34,34 +34,29 @@ namespace Orly {
 
     /* size() overload for std::string<TVal> */
     inline int64_t GetSize(const std::string &val) {
-      assert(&val);
       return val.size();
     }
 
     /* size() overload for std::vector<TVal> */
     template <typename TVal>
     int64_t GetSize(const std::vector<TVal> &val) {
-      assert(&val);
       return val.size();
     }
 
     /* size() overload for TSet<TVal> */
     template <typename TVal>
     int64_t GetSize(const TSet<TVal> &val) {
-      assert(&val);
       return val.size();
     }
 
     /* size() overload for TDict<TVal> */
     template <typename TKey, typename TVal>
     int64_t GetSize(const TDict<TKey, TVal> &val) {
-      assert(&val);
       return val.size();
     }
 
     template <typename TAddr, typename TVal>
     int64_t GetSize(const TMutable<TAddr, TVal> &val) {
-      assert(&val);
       return GetSize(val.GetVal());
     }
 
@@ -70,7 +65,6 @@ namespace Orly {
              which is invalid in Orlyscript */
     template <typename TVal>
     TOpt<int64_t> GetSize(const TOpt<TVal> &opt_val) {
-      assert(&opt_val);
       return opt_val.IsKnown() ? GetSize(opt_val.GetVal()) : TOpt<int64_t>();
     }
 

--- a/orly/rt/is_empty.h
+++ b/orly/rt/is_empty.h
@@ -35,28 +35,24 @@ namespace Orly {
 
     /* empty() overload for std::string<TVal> */
     inline bool IsEmpty(const std::string &val) {
-      assert(&val);
       return val.empty();
     }
 
     /* empty() overload for std::vector<TVal> */
     template <typename TVal>
     bool IsEmpty(const std::vector<TVal> &val) {
-      assert(&val);
       return val.empty();
     }
 
     /* empty() overload for TSet<TVal> */
     template <typename TVal>
     bool IsEmpty(const TSet<TVal> &val) {
-      assert(&val);
       return val.empty();
     }
 
     /* empty() overload for std::TDict<TVal> */
     template <typename TKey, typename TVal>
     bool IsEmpty(const TDict<TKey, TVal> &val) {
-      assert(&val);
       return val.empty();
     }
 
@@ -65,7 +61,6 @@ namespace Orly {
              which is invalid in Orlyscript */
     template <typename TVal>
     TOpt<bool> IsEmpty(const TOpt<TVal> &opt) {
-      assert(&opt);
       return opt.IsKnown() ? TOpt<bool>(IsEmpty(opt.GetVal())) : TOpt<bool>();
     }
 

--- a/orly/rt/mutable.h
+++ b/orly/rt/mutable.h
@@ -118,9 +118,6 @@ namespace Orly {
     TMutable<TAddr, TResVal> RewrapMutable(const TMutable<TAddr, TVal> &src_mutable, const TMutableParts &parts,
           const TResVal &res_val) {
 
-      assert(&src_mutable);
-      assert(&parts);
-      assert(&res_val);
       TMutableParts final_parts = src_mutable.GetParts();
       final_parts.insert(final_parts.end(), parts.begin(), parts.end());
       return TMutable<TAddr, TResVal>(src_mutable.GetOptAddr(), final_parts, res_val);
@@ -131,9 +128,6 @@ namespace Orly {
     TMutable<TAddr, TResVal> RewrapMutable(const TMutable<TAddr, TVal> &src_mutable, const Var::TVar &part,
           const TResVal &res_val) {
 
-      assert(&src_mutable);
-      assert(&part);
-      assert(&res_val);
       TMutableParts final_parts = src_mutable.GetParts();
       final_parts.push_back(part);
       return TMutable<TAddr, TResVal>(src_mutable.GetOptAddr(), final_parts, res_val);

--- a/orly/rt/operator.h
+++ b/orly/rt/operator.h
@@ -36,8 +36,6 @@ namespace Orly {
       NO_CONSTRUCTION(EqEqStruct);
 
       static bool Do(const TLhs &lhs, const TRhs &rhs) {
-        assert(&lhs);
-        assert(&rhs);
         return lhs == rhs;
       }
 
@@ -49,8 +47,6 @@ namespace Orly {
       NO_CONSTRUCTION(NeqStruct);
 
       static bool Do(const TLhs &lhs, const TRhs &rhs) {
-        assert(&lhs);
-        assert(&rhs);
         return lhs != rhs;
       }
 
@@ -62,8 +58,6 @@ namespace Orly {
       NO_CONSTRUCTION(LtStruct);
 
       static bool Do(const TLhs &lhs, const TRhs &rhs) {
-        assert(&lhs);
-        assert(&rhs);
         return lhs < rhs;
       }
 
@@ -75,8 +69,6 @@ namespace Orly {
       NO_CONSTRUCTION(LtEqStruct);
 
       static bool Do(const TLhs &lhs, const TRhs &rhs) {
-        assert(&lhs);
-        assert(&rhs);
         return lhs <= rhs;
       }
 
@@ -88,8 +80,6 @@ namespace Orly {
       NO_CONSTRUCTION(GtStruct);
 
       static bool Do(const TLhs &lhs, const TRhs &rhs) {
-        assert(&lhs);
-        assert(&rhs);
         return lhs > rhs;
       }
 
@@ -101,8 +91,6 @@ namespace Orly {
       NO_CONSTRUCTION(GtEqStruct);
 
       static bool Do(const TLhs &lhs, const TRhs &rhs) {
-        assert(&lhs);
-        assert(&rhs);
         return lhs >= rhs;
       }
 
@@ -162,7 +150,6 @@ namespace Orly {
     /* Return true if the optional value is known. */
     template <typename TVal>
     bool IsKnown(const TOpt<TVal> &opt_val) {
-      assert(&opt_val);
       return opt_val.IsKnown();
     }
 
@@ -175,33 +162,28 @@ namespace Orly {
     /* Returns true if the optional value is unknown. */
     template <typename TVal>
     bool IsUnknown(const TOpt<TVal> &opt_val) {
-      assert(&opt_val);
       return opt_val.IsUnknown();
     }
 
     /* Pass-through. */
     template <typename TVal>
     const TVal &GetVal(const TVal &val) {
-      assert(&val);
       return val;
     }
 
     /* Returns the value that the optional contains. */
     template <typename TVal>
     const TVal &GetVal(const TOpt<TVal> &opt_val) {
-      assert(&opt_val);
       return opt_val.GetVal();
     }
 
     /* Returns true if the value is known and is equal to true. */
     inline bool IsKnownTrue(const TOpt<bool> &opt_val) {
-      assert(&opt_val);
       return opt_val.IsKnown() && opt_val.GetVal() == true;
     }
 
     /* Returns true if the value is known and is equal to false. */
     inline bool IsKnownFalse(const TOpt<bool> &opt_val) {
-      assert(&opt_val);
       return opt_val.IsKnown() && opt_val.GetVal() == false;
     }
 
@@ -211,8 +193,6 @@ namespace Orly {
 
     template <typename TLhs, typename TRhs>
     TOpt<bool> And(TLhs &&lhs, TRhs &&rhs) {
-      assert(&lhs);
-      assert(&rhs);
       return IsKnownFalse(lhs) || IsKnownFalse(rhs) ? false
           : IsKnown(lhs) && IsKnown(rhs) ? And(GetVal(lhs), GetVal(rhs)) : TOpt<bool>();
     }
@@ -225,7 +205,6 @@ namespace Orly {
     inline bool Not(bool val) { return !val; }
 
     inline TOpt<bool> Not(const TOpt<bool> &opt_val) {
-      assert(&opt_val);
       return opt_val.IsKnown() ? Not(opt_val.GetVal()) : TOpt<bool>();
     }
 
@@ -233,8 +212,6 @@ namespace Orly {
 
     template <typename TLhs, typename TRhs>
     TOpt<bool> Or(TLhs &&lhs, TRhs &&rhs) {
-      assert(&lhs);
-      assert(&rhs);
       return IsKnownTrue(lhs) || IsKnownTrue(rhs) ? true
           : IsKnown(lhs) && IsKnown(rhs) ? Or(GetVal(lhs), GetVal(rhs)) : TOpt<bool>();
     }
@@ -248,8 +225,6 @@ namespace Orly {
 
     template <typename TLhs, typename TRhs>
     TOpt<bool> Xor(TLhs &&lhs, TRhs &&rhs) {
-      assert(&lhs);
-      assert(&rhs);
       return IsKnown(lhs) && IsKnown(rhs) ? Xor(GetVal(lhs), GetVal(rhs)) : TOpt<bool>();
     }
 
@@ -257,8 +232,6 @@ namespace Orly {
     template <typename TVal>
     auto IsKnownExpr(const TOpt<TVal> &opt_val, const TVal &val)
         -> decltype(And(IsKnown(opt_val), EqEq(GetVal(opt_val), val))) {
-      assert(&opt_val);
-      assert(&val);
       return AndThen(IsKnown(opt_val), [&opt_val, &val]() { return EqEq(GetVal(opt_val), val); });
     }
 
@@ -267,9 +240,6 @@ namespace Orly {
       /* Compare an Rt::TOpt and an Rt::TOpt */
       template <typename TLhs, typename TRhs, typename TComp>
       static TOpt<bool> Compare(TLhs &&lhs, TRhs &&rhs, TComp &&comp) {
-        assert(&lhs);
-        assert(&rhs);
-        assert(&comp);
         assert(comp);
         return IsKnown(lhs) && IsKnown(rhs) ? comp(GetVal(lhs), GetVal(rhs)) : TOpt<bool>();
       }
@@ -283,8 +253,6 @@ namespace Orly {
       auto Equal(const TDict<TLhsKey, TLhsVal> &lhs, const TDict<TRhsKey, TRhsVal> &rhs, const bool is_eqeq)
               -> decltype(And(EqEq(lhs.begin()->first , rhs.begin()->first),
                               EqEq(lhs.begin()->second, rhs.begin()->second))) {
-        assert(&lhs);
-        assert(&rhs);
         if (lhs.size() != rhs.size()) {
           return !is_eqeq;
         }
@@ -332,8 +300,6 @@ namespace Orly {
       template <typename TLhs, typename TRhs>
       auto Equal(const std::vector<TLhs> &lhs, const std::vector<TRhs> &rhs, const bool is_eqeq)
             -> decltype(EqEq(*lhs.begin(), *rhs.begin())) {
-        assert(&lhs);
-        assert(&rhs);
         if (lhs.size() != rhs.size()) {
           return !is_eqeq;
         }
@@ -359,11 +325,7 @@ namespace Orly {
             const std::vector<TRhs> &rhs,
             const TElemComp &elem_comp,
             const TSizeComp &size_comp) -> decltype(elem_comp(*lhs.begin(), *rhs.begin())) {
-        assert(&lhs);
-        assert(&rhs);
-        assert(&elem_comp);
         assert(elem_comp);
-        assert(&size_comp);
         assert(size_comp);
         auto lhs_iter = lhs.begin();
         auto rhs_iter = rhs.begin();
@@ -384,8 +346,6 @@ namespace Orly {
       template <typename TLhs, typename TRhs>
       auto Equal(const TSet<TLhs> &lhs, const TSet<TRhs> &rhs, const bool is_eqeq)
             -> decltype(Contains(rhs, *lhs.begin())) {
-        assert(&lhs);
-        assert(&rhs);
         if (lhs.size() != rhs.size()) {
           return !is_eqeq;
         }
@@ -407,9 +367,6 @@ namespace Orly {
             const TSet<TLhs> &lhs,
             const TSet<TRhs> &rhs,
             const TSizeComp &size_comp) -> decltype(Contains(rhs, *lhs.begin())) {
-        assert(&lhs);
-        assert(&rhs);
-        assert(&size_comp);
         assert(size_comp);
         if (!size_comp(lhs.size(), rhs.size())) {
           return false;
@@ -1231,8 +1188,6 @@ namespace Orly {
 
     /* TODO */
     inline bool Contains(const std::string &container, const std::string &val) {
-      assert(&container);
-      assert(&val);
       return container.find(val) != std::string::npos;
     }
 
@@ -1240,8 +1195,6 @@ namespace Orly {
     template <typename TLhs, typename TRhs>
     auto Contains(const std::vector<TLhs> &container, const TRhs &val)
           -> decltype(EqEq(*container.begin(), val)) {
-      assert(&container);
-      assert(&val);
       bool unknown = false;
       auto iter = container.begin();
       for (; iter != container.end(); ++iter) {
@@ -1259,8 +1212,6 @@ namespace Orly {
     /* TODO */
     template <typename TLhs, typename TRhs>
     TOpt<bool> Contains(const TSet<TOpt<TLhs>> &container, const TRhs &val) {
-      assert(&container);
-      assert(&val);
       if (container.empty()) {
         return TOpt<bool>(false);
       }
@@ -1280,8 +1231,6 @@ namespace Orly {
     template <typename TLhs, typename TRhs>
     auto Contains(const TSet<TLhs> &container, const TRhs &val)
           -> decltype(EqEq(*container.begin(), val)) {
-      assert(&container);
-      assert(&val);
       if (container.empty()) {
         return false;
       }
@@ -1294,8 +1243,6 @@ namespace Orly {
     /* TODO */
     template <typename TLhsKey, typename TLhsVal, typename TRhsKey>
     TOpt<bool> Contains(const TDict<TOpt<TLhsKey>, TLhsVal> &container, const TRhsKey &key) {
-      assert(&container);
-      assert(&key);
       if (container.empty()) {
         return TOpt<bool>(false);
       }
@@ -1315,8 +1262,6 @@ namespace Orly {
     template <typename TLhsKey, typename TLhsVal, typename TRhsKey>
     auto Contains(const TDict<TLhsKey, TLhsVal> &container, const TRhsKey &key)
           -> decltype(EqEq(container.begin()->first, key)) {
-      assert(&container);
-      assert(&key);
       if (container.empty()) {
         return false;
       }
@@ -1329,14 +1274,12 @@ namespace Orly {
     /* TODO */
     template <typename TContainer, typename TVal>
     TOpt<bool> Contains(const TOpt<TContainer> &container, const TVal &val) {
-      assert(&container);
       return container.IsKnown() ? Contains(container.GetVal(), val) : TOpt<bool>();
     }
 
     /* TODO */
     template <typename TKey, typename TVal>
     TOpt<bool> Contains(const TOpt<TDict<TKey, TVal>> &container, const TKey &val) {
-      assert(&container);
       return container.IsKnown() ? Contains(container.GetVal(), val) : TOpt<bool>();
     }
 

--- a/orly/rt/opt.h
+++ b/orly/rt/opt.h
@@ -42,7 +42,6 @@ namespace Orly {
 
       /* Move contructor.  We get the donor's value (if any) and the donor becomes unknown. */
       TOpt(TOpt &&that) {
-        assert(&that);
         if (that.Val) {
           Val = new (Storage) TVal(std::move(*that.Val));
           that.Reset();
@@ -53,26 +52,22 @@ namespace Orly {
 
       /* Copy constructor. */
       TOpt(const TOpt &that) {
-        assert(&that);
         Val = that.Val ? new (Storage) TVal(*that.Val) : nullptr;
       }
 
       /* Construct by moving the given value into our internal storage.
          What remains of the donor is up to TVal. */
       TOpt(TVal &&that) {
-        assert(&that);
         Val = new (Storage) TVal(std::move(that));
       }
 
       /* Construct with a copy of the given value. */
       TOpt(const TVal &that) {
-        assert(&that);
         Val = new (Storage) TVal(that);
       }
 
       /* Move-construct from a Base::TOpt */
       TOpt(Base::TOpt<TVal> &&that) {
-        assert(&that);
         if (that.Val) {
           Val = new (Storage) TVal(std::move(*that));
           that.Reset();
@@ -83,7 +78,6 @@ namespace Orly {
 
       /* Copy-construct from a Base::TOpt */
       TOpt(const Base::TOpt<TVal> &that) {
-        assert(&that);
         Val = that ? new (Storage) TVal(*that) : nullptr;
       }
 
@@ -94,7 +88,6 @@ namespace Orly {
 
       /* Swaperator. */
       TOpt &operator=(TOpt &&that) {
-        assert(&that);
         if (this != &that) {
           if (Val && that.Val) {
             std::swap(*Val, *that.Val);
@@ -117,7 +110,6 @@ namespace Orly {
       /* If we're already known, swap our value with the given one;
          otherwise, move-construct the value into our storage. */
       TOpt &operator=(TVal &&that) {
-        assert(&that);
         if (Val != &that) {
           if (Val) {
             std::swap(*Val, that);

--- a/orly/rt/postfix_cast.h
+++ b/orly/rt/postfix_cast.h
@@ -385,7 +385,6 @@ namespace Orly {
       NO_CONSTRUCTION(CastAs);
 
       static TVal Do(const TMutable<TAddr, TVal> &from) {
-        assert(&from);
         return from;
       }
 

--- a/orly/rt/time_diff_obj.h
+++ b/orly/rt/time_diff_obj.h
@@ -72,18 +72,15 @@ namespace Orly {
         }
 
         bool EqEq(const TObjO6i3dayi4hourb10is_forwardi6minutei10nanosecondi6second &that) const {
-          assert(&that);
           return Rt::And(Rt::EqEq(Vday, that.Vday), Rt::And(Rt::EqEq(Vhour, that.Vhour), Rt::And(Rt::EqEq(Vis_forward, that.Vis_forward), Rt::And(Rt::EqEq(Vminute, that.Vminute), Rt::And(Rt::EqEq(Vnanosecond, that.Vnanosecond), Rt::And(Rt::EqEq(Vsecond, that.Vsecond), true))))));
         }
 
 
         bool Match(const TObjO6i3dayi4hourb10is_forwardi6minutei10nanosecondi6second &that) const {
-          assert(&that);
           return Rt::Match(Vday, that.Vday) && Rt::Match(Vhour, that.Vhour) && Rt::Match(Vis_forward, that.Vis_forward) && Rt::Match(Vminute, that.Vminute) && Rt::Match(Vnanosecond, that.Vnanosecond) && Rt::Match(Vsecond, that.Vsecond);
         }
 
         bool Neq(const TObjO6i3dayi4hourb10is_forwardi6minutei10nanosecondi6second &that) const {
-          assert(&that);
           return Rt::Or(Rt::Neq(Vday, that.Vday), Rt::Or(Rt::Neq(Vhour, that.Vhour), Rt::Or(Rt::Neq(Vis_forward, that.Vis_forward), Rt::Or(Rt::Neq(Vminute, that.Vminute), Rt::Or(Rt::Neq(Vnanosecond, that.Vnanosecond), Rt::Or(Rt::Neq(Vsecond, that.Vsecond), false))))));
         }
 

--- a/orly/rt/time_pnt_obj.h
+++ b/orly/rt/time_pnt_obj.h
@@ -72,18 +72,15 @@ namespace Orly {
         }
 
         bool EqEq(const TObjO8i3dayi4houri6minutei5monthi10nanosecondi6secondi10utc_offseti4year &that) const {
-          assert(&that);
           return Rt::And(Rt::EqEq(Vday, that.Vday), Rt::And(Rt::EqEq(Vhour, that.Vhour), Rt::And(Rt::EqEq(Vminute, that.Vminute), Rt::And(Rt::EqEq(Vmonth, that.Vmonth), Rt::And(Rt::EqEq(Vnanosecond, that.Vnanosecond), Rt::And(Rt::EqEq(Vsecond, that.Vsecond), Rt::And(Rt::EqEq(Vutc_offset, that.Vutc_offset), Rt::And(Rt::EqEq(Vyear, that.Vyear), true))))))));
         }
 
 
         bool Match(const TObjO8i3dayi4houri6minutei5monthi10nanosecondi6secondi10utc_offseti4year &that) const {
-          assert(&that);
           return Rt::Match(Vday, that.Vday) && Rt::Match(Vhour, that.Vhour) && Rt::Match(Vminute, that.Vminute) && Rt::Match(Vmonth, that.Vmonth) && Rt::Match(Vnanosecond, that.Vnanosecond) && Rt::Match(Vsecond, that.Vsecond) && Rt::Match(Vutc_offset, that.Vutc_offset) && Rt::Match(Vyear, that.Vyear);
         }
 
         bool Neq(const TObjO8i3dayi4houri6minutei5monthi10nanosecondi6secondi10utc_offseti4year &that) const {
-          assert(&that);
           return Rt::Or(Rt::Neq(Vday, that.Vday), Rt::Or(Rt::Neq(Vhour, that.Vhour), Rt::Or(Rt::Neq(Vminute, that.Vminute), Rt::Or(Rt::Neq(Vmonth, that.Vmonth), Rt::Or(Rt::Neq(Vnanosecond, that.Vnanosecond), Rt::Or(Rt::Neq(Vsecond, that.Vsecond), Rt::Or(Rt::Neq(Vutc_offset, that.Vutc_offset), Rt::Or(Rt::Neq(Vyear, that.Vyear), false))))))));
         }
 

--- a/orly/rt/unknown.h
+++ b/orly/rt/unknown.h
@@ -41,14 +41,12 @@ namespace Orly {
       ~TUnknown() {}
 
       /* TODO */
-      bool operator==(const TUnknown &that) const {
-        assert(&that);
+      bool operator==(const TUnknown &) const {
         return true;
       }
 
       /* TODO */
-      bool operator!=(const TUnknown &that) const {
-        assert(&that);
+      bool operator!=(const TUnknown &) const {
         return false;
       }
 

--- a/orly/sabot/compare_states.h
+++ b/orly/sabot/compare_states.h
@@ -37,7 +37,6 @@ namespace Orly {
       /* TODO. */
       TCompareStatesVisitor(Atom::TComparison &out)
           : Comparison(out) {
-        assert(&out);
       }
 
       /* Overrides. */

--- a/orly/sabot/compare_types.cc
+++ b/orly/sabot/compare_types.cc
@@ -33,7 +33,6 @@ class TCompareTypesVisitor final
   /* TODO. */
   TCompareTypesVisitor(Atom::TComparison &out)
       : Comparison(out) {
-    assert(&out);
   }
 
   /* Overrides. */

--- a/orly/sabot/get_depth.cc
+++ b/orly/sabot/get_depth.cc
@@ -30,7 +30,6 @@ class TDepthVisitor final
   /* TODO. */
   TDepthVisitor(size_t &out_depth)
       : Depth(out_depth) {
-    assert(&out_depth);
   }
 
   /* Overrides. */
@@ -107,7 +106,6 @@ void TDepthVisitor::operator()(const Type::TSet &type   ) const { OnUnaryType(ty
 void TDepthVisitor::operator()(const Type::TVector &type) const { OnUnaryType(type); }
 void TDepthVisitor::operator()(const Type::TMap &type   ) const { OnBinaryType(type); }
 void TDepthVisitor::operator()(const Type::TRecord &type) const {
-  assert(&type);
   size_t max_child_depth = 0UL;
   size_t elem_count = type.GetElemCount();
   void *pin_alloc = alloca(Type::GetMaxTypePinSize());
@@ -120,7 +118,6 @@ void TDepthVisitor::operator()(const Type::TRecord &type) const {
   Depth = max_child_depth + 1UL;
 }
 void TDepthVisitor::operator()(const Type::TTuple &type ) const {
-  assert(&type);
   size_t max_child_depth = 0UL;
   size_t elem_count = type.GetElemCount();
   void *pin_alloc = alloca(Type::GetMaxTypePinSize());
@@ -134,7 +131,6 @@ void TDepthVisitor::operator()(const Type::TTuple &type ) const {
 }
 
 void TDepthVisitor::OnBinaryType(const Type::TBinary &binary) const {
-  assert(&binary);
   void *pin_alloc = alloca(Type::GetMaxTypePinSize());
   void *type_alloc = alloca(Type::GetMaxTypeSize());
   Type::TBinary::TPin::TWrapper pin(binary.Pin(pin_alloc));
@@ -146,7 +142,6 @@ void TDepthVisitor::OnBinaryType(const Type::TBinary &binary) const {
 }
 
 void TDepthVisitor::OnUnaryType(const Type::TUnary &unary) const {
-  assert(&unary);
   void *pin_alloc = alloca(Type::GetMaxTypePinSize());
   void *type_alloc = alloca(Type::GetMaxTypeSize());
   Type::TUnary::TPin::TWrapper pin(unary.Pin(pin_alloc));

--- a/orly/sabot/get_hash.h
+++ b/orly/sabot/get_hash.h
@@ -39,7 +39,6 @@ namespace Orly {
       /* TODO */
       THashVisitor(size_t &val)
           : Hash(val) {
-        assert(&val);
       }
 
       /* Overrides. */

--- a/orly/sabot/get_tuple_size.cc
+++ b/orly/sabot/get_tuple_size.cc
@@ -29,7 +29,6 @@ class TGetTupleSizeVisitor final
   /* TODO. */
   TGetTupleSizeVisitor(size_t &size)
       : Size(size) {
-    assert(&size);
   }
 
   /* Overrides. */

--- a/orly/sabot/match_prefix_state.cc
+++ b/orly/sabot/match_prefix_state.cc
@@ -30,7 +30,6 @@ class TMatchPrefixStateVisitor final
   /* TODO. */
   TMatchPrefixStateVisitor(TMatchResult &out)
       : Result(out) {
-    assert(&out);
   }
 
   /* Overrides. */

--- a/orly/sabot/match_prefix_type.cc
+++ b/orly/sabot/match_prefix_type.cc
@@ -30,7 +30,6 @@ class TMatchPrefixTypeVisitor final
   /* TODO. */
   TMatchPrefixTypeVisitor(TMatchResult &out)
       : Result(out) {
-    assert(&out);
   }
 
   /* Overrides. */

--- a/orly/sabot/order_states.h
+++ b/orly/sabot/order_states.h
@@ -37,7 +37,6 @@ namespace Orly {
       /* TODO. */
       TOrderStatesVisitor(Atom::TComparison &out)
           : Comparison(out) {
-        assert(&out);
       }
 
       /* Overrides. */

--- a/orly/sabot/order_types.cc
+++ b/orly/sabot/order_types.cc
@@ -32,7 +32,6 @@ class TOrderTypesVisitor final
   /* TODO. */
   TOrderTypesVisitor(Atom::TComparison &out)
       : Comparison(out) {
-    assert(&out);
   }
 
   /* Overrides. */

--- a/orly/sabot/state_dumper.cc
+++ b/orly/sabot/state_dumper.cc
@@ -23,90 +23,73 @@ using namespace std;
 using namespace Orly::Sabot;
 
 void TStateDumper::operator()(const State::TFree &state) const {
-  assert(&state);
   void *type_alloc = alloca(Type::GetMaxTypeSize());
   Type::TAny::TWrapper(state.GetType(type_alloc))->Accept(TTypeDumper(Strm));
 }
 
 void TStateDumper::operator()(const State::TTombstone &state) const {
-  assert(&state);
   void *type_alloc = alloca(Type::GetMaxTypeSize());
   Type::TAny::TWrapper(state.GetType(type_alloc))->Accept(TTypeDumper(Strm));
 }
 
 void TStateDumper::operator()(const State::TVoid &state) const {
-  assert(&state);
   void *type_alloc = alloca(Type::GetMaxTypeSize());
   Type::TAny::TWrapper(state.GetType(type_alloc))->Accept(TTypeDumper(Strm));
 }
 
 void TStateDumper::operator()(const State::TInt8 &state) const {
-  assert(&state);
   Strm << static_cast<int>(state.Get());
 }
 
 void TStateDumper::operator()(const State::TInt16 &state) const {
-  assert(&state);
   Strm << state.Get();
 }
 
 void TStateDumper::operator()(const State::TInt32 &state) const {
-  assert(&state);
   Strm << state.Get();
 }
 
 void TStateDumper::operator()(const State::TInt64 &state) const {
-  assert(&state);
   Strm << state.Get();
 }
 
 void TStateDumper::operator()(const State::TUInt8 &state) const {
-  assert(&state);
   Strm << static_cast<unsigned>(state.Get());
 }
 
 void TStateDumper::operator()(const State::TUInt16 &state) const {
-  assert(&state);
   Strm << state.Get();
 }
 
 void TStateDumper::operator()(const State::TUInt32 &state) const {
-  assert(&state);
   Strm << state.Get();
 }
 
 void TStateDumper::operator()(const State::TUInt64 &state) const {
-  assert(&state);
   Strm << state.Get();
 }
 
 void TStateDumper::operator()(const State::TBool &state) const {
-  assert(&state);
   Strm << (state.Get() ? "true" : "false");
 }
 
 void TStateDumper::operator()(const State::TChar &state) const {
-  assert(&state);
   Strm << '\'' << state.Get() << '\'';
 }
 
 void TStateDumper::operator()(const State::TFloat &state) const {
-  assert(&state);
   Strm << state.Get();
 }
 
 void TStateDumper::operator()(const State::TDouble &state) const {
-  assert(&state);
   Strm << state.Get();
 }
 
 void TStateDumper::operator()(const State::TDuration &state) const {
-  assert(&state);
   Strm << state.Get().count() << "ns";
 }
 
 void TStateDumper::operator()(const State::TTimePoint &state) const {
-  assert(&state);
   auto sys_tick = TStdTimePoint::clock::to_time_t(std::chrono::time_point_cast<std::chrono::seconds>(state.Get()));
   char buf[20];
   strftime(buf, sizeof(buf), "%Y:%m:%d:%H:%M:%S", gmtime(&sys_tick));
@@ -114,12 +97,10 @@ void TStateDumper::operator()(const State::TTimePoint &state) const {
 }
 
 void TStateDumper::operator()(const State::TUuid &state) const {
-  assert(&state);
   Strm << state.Get();
 }
 
 void TStateDumper::operator()(const State::TBlob &state) const {
-  assert(&state);
   Strm << "{{ ";
   void *pin_alloc = alloca(State::GetMaxStatePinSize());
   State::TBlob::TPin::TWrapper pin(state.Pin(pin_alloc));
@@ -139,7 +120,6 @@ void TStateDumper::operator()(const State::TBlob &state) const {
 }
 
 void TStateDumper::operator()(const State::TStr &state) const {
-  assert(&state);
   Strm << '"';
   void *pin_alloc = alloca(State::GetMaxStatePinSize());
   State::TStr::TPin::TWrapper pin(state.Pin(pin_alloc));
@@ -201,7 +181,6 @@ void TStateDumper::operator()(const State::TMap &state) const {
 }
 
 void TStateDumper::operator()(const State::TRecord &state) const {
-  assert(&state);
   size_t elem_count = state.GetElemCount();
   Strm << "record(";
   void *pin_alloc = alloca(State::GetMaxStatePinSize());
@@ -225,14 +204,12 @@ void TStateDumper::operator()(const State::TRecord &state) const {
 }
 
 void TStateDumper::operator()(const State::TTuple &state) const {
-  assert(&state);
   OnArrayOfSingleStates("tuple", nullptr, state);
 }
 
 void TStateDumper::OnArrayOfPairsOfStates(const char *name, const char *kwd_for_zero_size, const State::TArrayOfPairsOfStates &state) const {
   assert(name);
   assert(kwd_for_zero_size);
-  assert(&state);
   size_t elem_count = state.GetElemCount();
   if (elem_count) {
     Strm << name << '(';
@@ -258,7 +235,6 @@ void TStateDumper::OnArrayOfPairsOfStates(const char *name, const char *kwd_for_
 
 void TStateDumper::OnArrayOfSingleStates(const char *name, const char *kwd_for_zero_size, const State::TArrayOfSingleStates &state) const {
   assert(name);
-  assert(&state);
   size_t elem_count = state.GetElemCount();
   if (elem_count || !kwd_for_zero_size) {
     Strm << name << '(';

--- a/orly/sabot/state_dumper.h
+++ b/orly/sabot/state_dumper.h
@@ -35,7 +35,6 @@ namespace Orly {
       /* Caches a reference to the stream. */
       TStateDumper(std::ostream &strm)
           : Strm(strm) {
-        assert(&strm);
       }
 
       /* Overrides. */

--- a/orly/sabot/type_dumper.cc
+++ b/orly/sabot/type_dumper.cc
@@ -126,7 +126,6 @@ void TTypeDumper::operator()(const Type::TMap &type) const {
 }
 
 void TTypeDumper::operator()(const Type::TRecord &type) const {
-  assert(&type);
   Strm << "record(";
   size_t elem_count = type.GetElemCount();
   void *pin_alloc = alloca(Type::GetMaxTypePinSize());
@@ -145,7 +144,6 @@ void TTypeDumper::operator()(const Type::TRecord &type) const {
 }
 
 void TTypeDumper::operator()(const Type::TTuple &type) const {
-  assert(&type);
   Strm << "tuple(";
   size_t elem_count = type.GetElemCount();
   void *pin_alloc = alloca(Type::GetMaxTypePinSize());
@@ -161,7 +159,6 @@ void TTypeDumper::operator()(const Type::TTuple &type) const {
 }
 
 void TTypeDumper::OnBinaryType(const char *name, const Type::TBinary &binary) const {
-  assert(&binary);
   void *pin_alloc = alloca(Type::GetMaxTypePinSize());
   void *type_alloc = alloca(Type::GetMaxTypeSize());
   Type::TBinary::TPin::TWrapper pin(binary.Pin(pin_alloc));
@@ -173,7 +170,6 @@ void TTypeDumper::OnBinaryType(const char *name, const Type::TBinary &binary) co
 }
 
 void TTypeDumper::OnUnaryType(const char *name, const Type::TUnary &unary) const {
-  assert(&unary);
   void *pin_alloc = alloca(Type::GetMaxTypePinSize());
   void *type_alloc = alloca(Type::GetMaxTypeSize());
   Type::TUnary::TPin::TWrapper pin(unary.Pin(pin_alloc));

--- a/orly/sabot/type_dumper.h
+++ b/orly/sabot/type_dumper.h
@@ -37,7 +37,6 @@ namespace Orly {
       /* Caches a reference to the stream. */
       TTypeDumper(std::ostream &strm)
           : Strm(strm) {
-        assert(&strm);
       }
 
       /* Overrides. */

--- a/orly/server/pov.cc
+++ b/orly/server/pov.cc
@@ -56,7 +56,6 @@ TPov::TPov(Durable::TManager *manager, const Base::TUuid &id, Io::TBinaryInputSt
 TPov::~TPov() {}
 
 void TPov::Write(Io::TBinaryOutputStream &strm) const {
-  assert(&strm);
   TObj::Write(strm);
   strm << SessionId << reinterpret_cast<const char &>(Audience) << reinterpret_cast<const char &>(Policy);
   /* TODO: Why doesn't this work?: strm << SharedParents; */

--- a/orly/server/repo_tetris_manager.cc
+++ b/orly/server/repo_tetris_manager.cc
@@ -183,8 +183,6 @@ namespace Orly {
   namespace Rt {
     template <typename TVal>
     std::ostream &operator<<(std::ostream &out, const TOpt<TVal> &that) {
-      assert(&out);
-      assert(&that);
 
       if(that.IsKnown()) {
         out<<that.GetVal();
@@ -197,7 +195,6 @@ namespace Orly {
 }
 
 bool TRepoTetrisManager::TPlayer::TChild::TestAssertions(Indy::TContext &context) const {
-  assert(&context);
   void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
   for (const auto &item: FuncHolderByUpdateId) {
     const auto &entry = MetaRecord.GetEntry(item.first);

--- a/orly/server/server.cc
+++ b/orly/server/server.cc
@@ -684,7 +684,6 @@ TServer::TServer(TScheduler *scheduler, const TCmd &cmd)
     Orly::Indy::Disk::Util::PhysicalBlockSize,
     Orly::Indy::Disk::Util::CheckedPage, true>;
   assert(scheduler);
-  assert(&cmd);
   assert(cmd.StartingState.size());
   auto launch_slow_fiber_sched = [this](size_t core, Fiber::TRunner *runner) {
     cpu_set_t mask;
@@ -1381,7 +1380,6 @@ void TServer::TConnection::Run(TFd &fd) {
     TConnection *Connection;
     shared_ptr<TFuture<void>> &Ack;
   };
-  assert(&fd);
   /* Install the socket as our RPC device. */
   auto device = make_shared<TDevice>(move(fd));
   BinaryIoStream = make_shared<TBinaryIoStream>(device);
@@ -1449,7 +1447,6 @@ void TServer::TConnection::Run(TFd &fd) {
 
 shared_ptr<TServer::TConnection> TServer::TConnection::New(TServer *server, const Durable::TPtr<TSession> &session) {
   assert(server);
-  assert(&session);
   bool success = false;
   std::shared_ptr<TConnection> result = nullptr;
   /* acquire Connection lock */ {
@@ -1552,7 +1549,6 @@ void TServer::CleanHouse() {
 }
 
 string TServer::Echo(const string &msg) {
-  assert(&msg);
   if (msg[0] == '"' && msg[1] == '!') {
     string temp = msg.substr(2, msg.size() - 3);
     system(temp.c_str());
@@ -1586,7 +1582,6 @@ string TServer::ImportCoreVector(const string &file_pattern,
       2. merge all our generated files from the file system iteratively till we have 1 file
       3. insert that 1 file into our repo system
      */
-  assert(&file_pattern);
   string result;
   const size_t merge_simultaneous = merge_simultaneous_in;
   Disk::Util::TVolume::TDesc::TStorageSpeed storage_speed = Disk::Util::TVolume::TDesc::TStorageSpeed::Fast;
@@ -2130,8 +2125,6 @@ void TServer::InstallPackage(const vector<string> &package_name, uint64_t versio
 }
 
 void TServer::ServeClient(TFd &fd, const TAddress &client_address) {
-  assert(&fd);
-  assert(&client_address);
   string client_address_str;
   /* extra */ {
     ostringstream strm;
@@ -2237,9 +2230,7 @@ void TServer::ServeClient(TFd &fd, const TAddress &client_address) {
 template<uint64_t Length>
 constexpr uint64_t GetArrayLen(const char(&)[Length]) { return Length; }
 
-void TServer::ServeMemcacheClient(TFd &&fd_original, const TAddress &client_address) {
-  assert(&fd_original);
-  assert(&client_address);
+void TServer::ServeMemcacheClient(TFd &&fd_original, const TAddress &) {
 
   // NOTE: fd_original has it's ownership stolen at this point. Use of it will cause badness.
   Strm::TFd<> strm(std::move(fd_original));

--- a/orly/server/session.cc
+++ b/orly/server/session.cc
@@ -40,7 +40,6 @@ TMethodResult TSession::DoInPast(
 }
 
 bool TSession::ForEachNotification(const function<bool (uint32_t, const TNotification *)> &cb) const {
-  assert(&cb);
   lock_guard<mutex> lock(NotificationMutex);
   for (const auto &item: NotificationBySeqNumber) {
     if (!cb(item.first, item.second)) {
@@ -51,7 +50,6 @@ bool TSession::ForEachNotification(const function<bool (uint32_t, const TNotific
 }
 
 const TNotification *TSession::GetFirstNotification(uint32_t &seq_number) {
-  assert(&seq_number);
   lock_guard<mutex> lock(NotificationMutex);
   assert(!NotificationBySeqNumber.empty());
   auto iter = NotificationBySeqNumber.begin();
@@ -117,7 +115,6 @@ void TSession::SetTimeToLive(TServer *server, const TUuid &durable_id, const sec
 }
 
 void TSession::SetUserId(TServer */*server*/, const TUuid &user_id) {
-  assert(&user_id);
   if (UserId) {
     DEFINE_ERROR(error_t, runtime_error, "user_id already set");
     THROW_ERROR(error_t) << "existing uid = " << user_id;
@@ -247,7 +244,6 @@ bool TSession::RunTestSuite(TServer * /*server*/,
     uint64_t /*package_version*/, bool /*verbose*/) {
 #if 0
   assert(server);
-  assert(&package_name);
 
   server->InstallPackage(package_name, package_version);
   bool succeeded = true;
@@ -298,7 +294,6 @@ TSession::TSession(Durable::TManager *manager, const Base::TUuid &id, const Dura
 
 TSession::TSession(Durable::TManager *manager, const Base::TUuid &id, Io::TBinaryInputStream &strm)
     : TObj(manager, id, strm) {
-  assert(&strm);
   try {
     size_t size;
     strm >> UserId >> NextSeqNumber >> size;
@@ -341,7 +336,6 @@ void TSession::RunInPrivateChildPov(TServer *server,
     const Base::TUuid &parent_pov_id) {
   assert(server);
   assert(func);
-  assert(&parent_pov_id);
 
   Base::TUuid child_pov_id = NewFastPrivatePov(server, parent_pov_id, std::chrono::seconds(1000));
   Durable::TPtr<TPov> child_pov = server->GetDurableManager()->Open<TPov>(child_pov_id);
@@ -425,7 +419,6 @@ void TSession::AddPov(const Durable::TPtr<TPov> &pov) {
 }
 
 void TSession::Write(Io::TBinaryOutputStream &strm) const {
-  assert(&strm);
   lock_guard<mutex> lock(NotificationMutex);
   TObj::Write(strm);
   strm << UserId << NextSeqNumber << NotificationBySeqNumber.size();
@@ -444,7 +437,6 @@ void TSession::Cleanup() {
 TUuid TSession::NewPov(
     TServer *server, const Base::TOpt<Base::TUuid> &parent_pov_id, TPov::TAudience audience, TPov::TPolicy policy, const seconds &time_to_live) {
   assert(server);
-  assert(&parent_pov_id);
   printf("TSession::NewPov()\n");
   auto durable_manager = server->GetDurableManager();
   TPov::TSharedParents shared_parents;
@@ -462,7 +454,6 @@ TUuid TSession::NewPov(
 }
 
 bool TSession::ForEachDependentPtr(const function<bool (Durable::TAnyPtr &)> &cb) noexcept {
-  assert(&cb);
   std::lock_guard<std::mutex> lock(PovMutex);
   for (auto &pov: Povs) {
     if (!cb(pov)) {

--- a/orly/server/tetris_manager.test.broken.cc
+++ b/orly/server/tetris_manager.test.broken.cc
@@ -104,7 +104,6 @@ class TTetrisManager final
        If the queue is non-empty, pop the next value off it, return the value via out-param, and return true.
        If the queue is empty, leave the out-param alone and return false. */
     bool TryPop(int &value) {
-      assert(&value);
       //lock_guard<mutex> Lock(Mutex);
       TFiberLock::TLock lock(FiberMutex);
       bool success = !Values.empty();
@@ -284,8 +283,6 @@ class TTetrisManager final
 
   /* See our base class.  We construct one of our players. */
   virtual Orly::Server::TTetrisManager::TPlayer *NewPlayer(const TUuid &parent_pov_id, const TUuid &child_pov_id, bool is_paused, bool is_master) override {
-    assert(&parent_pov_id);
-    assert(&child_pov_id);
     return new TPlayer(this, parent_pov_id, child_pov_id, is_paused, is_master);
   }
 

--- a/orly/shared_enum.cc
+++ b/orly/shared_enum.cc
@@ -25,7 +25,6 @@
 using namespace Orly;
 
 std::ostream &Orly::Write(std::ostream &strm, TAddrDir dir) {
-  assert(&strm);
   switch (dir) {
     case TAddrDir::Asc: {
       strm << "asc";
@@ -42,7 +41,6 @@ std::ostream &Orly::Write(std::ostream &strm, TAddrDir dir) {
 
 
 std::ostream &Orly::WriteCppType(std::ostream &strm, TAddrDir dir) {
-  assert(&strm);
   strm << "Orly::TAddrDir::";
   switch (dir) {
     case TAddrDir::Asc: {

--- a/orly/shared_enum.h
+++ b/orly/shared_enum.h
@@ -53,7 +53,6 @@ namespace std {
     typedef Orly::TAddrDir argument_type;
 
     result_type operator()(const argument_type &that) {
-      assert(&that);
       return Orly::ToInt(that);
     }
 

--- a/orly/spa/checkpoint.cc
+++ b/orly/spa/checkpoint.cc
@@ -658,8 +658,6 @@ void PromiseWhenReached(const TPov *target, std::promise<void> &promise, const T
 
 void Spa::ReadCheckpoint(const char *path, TCheckpointStmts &stmts, TCheckpointPackages &packages, Atom::TCore::TExtensibleArena *arena) {
   assert(path);
-  assert(&stmts);
-  assert(&packages);
 
   auto checkpoint = Checkpoint::Syntax::TCheckpoint::ParseFile(path);
   if (checkpoint.HasErrors()) {

--- a/orly/spa/flux_capacitor/api.cc
+++ b/orly/spa/flux_capacitor/api.cc
@@ -34,8 +34,6 @@ TSessionObj::~TSessionObj() {
 void TSessionObj::Poll(const std::unordered_set<Base::TUuid> &notifiers,
       Base::TOpt<std::chrono::milliseconds> timeout,
       std::unordered_map<Base::TUuid, TNotifierState> &out) {
-  assert(&notifiers);
-  assert(&out);
 
   unordered_map<MultiEvent::TEvent::TPtr, TNotifier*> notifier_events;
 

--- a/orly/spa/flux_capacitor/api.h
+++ b/orly/spa/flux_capacitor/api.h
@@ -116,7 +116,6 @@ namespace Orly {
 
         /* TODO */
         void Callback(std::unordered_map<TUpdate *, int> &m) {
-          assert(&m);
           for (auto iter = m.begin(); iter != m.end(); ++iter) {
             iter->second = 1;
           }
@@ -328,7 +327,6 @@ namespace Orly {
 
 
         bool ForEach(const std::function<bool (TVal *)> &cb) const {
-          assert(&cb);
           assert(cb);
 
           //TODO //Joris can you verify this looks okay.

--- a/orly/spa/flux_capacitor/flux_capacitor.cc
+++ b/orly/spa/flux_capacitor/flux_capacitor.cc
@@ -101,7 +101,6 @@ TPov::~TPov() {
 }
 
 void TPov::GetIndex(TIndex<TKV> *&out) const {
-  assert(&out);
   out = KVIndex;
 }
 
@@ -187,7 +186,6 @@ void TChildPov::Unpause() {
 
 TChildPov::TChildPov(TParentPov *parent_pov, const TOnFail& on_fail, bool paused)
     : FlowState(paused ? Paused : Running), IsJoinedToTetris(false), OnFail(on_fail), ParentPov(parent_pov) {
-  assert(&on_fail);
   assert(parent_pov);
   lock_guard<recursive_mutex> lock(parent_pov->ChildListMutex);
   if (!paused) {
@@ -427,8 +425,6 @@ TUpdate::TUpdate(
       LocalCauseCount(0), IsLinkedToPov(false), NextTrailingUpdate(0), PrevTrailingUpdate(0),
       KVCluster(0), AssertChecker(assert_checker), OnPromote(std::move(on_promote)) {
   assert(private_pov);
-  assert(&causes);
-  assert(&op_by_kv);
   Pov = private_pov;
   std::vector<TSync::TSharedLock *> shared_lock_vec;
   try {
@@ -487,7 +483,6 @@ bool TUpdate::Assert(TContext &ctxt) const {
 void TUpdate::AugmentEffectsRecursively(
     unordered_set<const TUpdate *> &effects,
     const TPov *pov) const {
-  assert(&effects);
   if (pov->HasAncestor(Pov)) {
     auto result = effects.insert(this);
     if (result.second) {
@@ -499,7 +494,6 @@ void TUpdate::AugmentEffectsRecursively(
 }
 
 bool TUpdate::ForEachKey(const function<bool (const Var::TVar &)> &cb) const {
-  assert(&cb);
   const unordered_map<TKV, TVersion<TKV> *> &version_by_key = KVCluster->GetVersionByKey();
   for (const auto &item: version_by_key) {
     if (!cb(item.first.GetKey())) {
@@ -755,7 +749,6 @@ void TKVIndex::TKeyIndexCursor::GetValue() const {
 bool TNodeIndex::ForEachTour(
     const function<bool (TTour<TNode> *)> &callback,
     const string *location, const string *klass) const {
-  assert(&callback);
   if (location && klass) {
     TTour<TNode> *tour = TryGetTour(TNode(*location, *klass));
     if (tour && !callback(tour)) {

--- a/orly/spa/flux_capacitor/flux_capacitor.h
+++ b/orly/spa/flux_capacitor/flux_capacitor.h
@@ -1080,7 +1080,6 @@ namespace Orly {
         /* The cluster of KV versions for this update.  Null if this update does not update any KVs.
            We return by out-parameter in order to take advantage of function overloading in the template-based classes. */
         void GetCluster(TCluster<TKV> *&out) const {
-          assert(&out);
           out = KVCluster;
         }
 
@@ -1166,7 +1165,6 @@ namespace Orly {
            Return false from your callback to halt the iterator.
            If the iterator reaches the end, return true; if halted, return false. */
         bool ForEachTour(const std::function<bool (TTour<TKey> *)> &callback) const {
-          assert(&callback);
           bool result = true;
           for (auto iter = TourByKey.begin(); result && iter != TourByKey.end(); ++iter) {
             result = callback(iter->second);
@@ -1645,7 +1643,6 @@ namespace Orly {
 
         /* Add to the given set of causes any updates which are implied by our set of versions. */
         void AugmentCauses(std::unordered_set<TUpdate *> &causes, std::vector<TSync::TSharedLock *> &shared_lock_vec) const {
-          assert(&causes);
           for (auto iter = VersionByKey.begin(); iter != VersionByKey.end(); ++iter) {
             TVersion<TKey> *older_version = iter->second->TryGetAnyOlderVersion(shared_lock_vec);
             if (older_version) {
@@ -1834,7 +1831,6 @@ namespace Orly {
         /* Move-construct.  The donor object resets to the leaf of its point-of-view. */
         TContext(TContext &&that)
             : Pov(that.Pov) {
-          assert(&that);
           std::swap(InvalidUpdates, that.InvalidUpdates);
           std::swap(VersionByKV, that.VersionByKV);
           std::swap(SharedLockVec, that.SharedLockVec);
@@ -1871,7 +1867,6 @@ namespace Orly {
         #if 0
         /* Swaperator. */
         TContext &operator=(TContext &&that) {
-          assert(&that);
           std::swap(Pov, that.Pov);
           std::swap(InvalidUpdates, that.InvalidUpdates);
           std::swap(VersionByKV, that.VersionByKV);
@@ -2001,7 +1996,6 @@ namespace Orly {
         /* Invalidate the updates responsible for the current values of the given keys in the given context. */
         template <typename TKey>
         void AugmentInvalidUpdates(const TContext &that, const std::unordered_set<TKey> &keys) {
-          assert(&keys);
           for (auto iter = keys.begin(); iter != keys.end(); ++iter) {
             TVersion<TKey> *version = that.TryGetVersion(*iter);
             if (version) {

--- a/orly/spa/flux_capacitor/kv.h
+++ b/orly/spa/flux_capacitor/kv.h
@@ -42,8 +42,6 @@ namespace Orly {
 
           /* Compare. */
           bool operator()(const TKV &lhs, const TKV &rhs) const {
-            assert(&lhs);
-            assert(&rhs);
             int result = lhs.Key.Compare(rhs.Key);
             return result < 0;
           }
@@ -76,7 +74,6 @@ namespace Orly {
 
         /* TODO */
         TKV &operator=(TKV &&that) {
-          assert(&that);
           std::swap(Key, that.Key);
           std::swap(IndexId, that.IndexId);
           std::swap(Hash, that.Hash);
@@ -85,7 +82,6 @@ namespace Orly {
 
         /* TODO */
         TKV &operator=(const TKV &that) {
-          assert(&that);
           if (this != &that) {
             Key = that.Key;
             IndexId = that.IndexId;

--- a/orly/spa/flux_capacitor/rt.h
+++ b/orly/spa/flux_capacitor/rt.h
@@ -160,8 +160,6 @@ namespace Orly {
     /* TODO: This is an odd place for this. Oh well. */
     template <typename TRet, typename TAddr>
     TMutable<TAddr, TRet> Read(Spa::FluxCapacitor::TContext &ctx, const TAddr &addr) {
-      assert(&ctx);
-      assert(&addr);
 
       /* TODO: Copy copy copy copy copy! */
       auto ret = Var::TRead<TRet>::Do(ctx[Spa::FluxCapacitor::TKV(Var::TVar::Addr(addr))]);
@@ -175,8 +173,6 @@ namespace Orly {
     /* TODO: This is an odd place for this. Oh well. */
     template <typename TAddr>
     bool Exists(Spa::FluxCapacitor::TContext &ctx, const TAddr &addr) {
-      assert(&ctx);
-      assert(&addr);
 
       return ctx.Exists(Spa::FluxCapacitor::TKV(Var::TVar::Addr(addr)));
     }

--- a/orly/spa/flux_capacitor/sync.cc
+++ b/orly/spa/flux_capacitor/sync.cc
@@ -79,7 +79,6 @@ void TSync::TLocal::DeleteLocal(void *arg) {
 }
 
 TSync::TLocal *TSync::TLocal::GetLocal(const TSync &sync) {
-  assert(&sync);
   TLocal *local = static_cast<TLocal *>(pthread_getspecific(sync.Key));
   if (!local) {
     local = new TLocal(sync);

--- a/orly/spa/flux_capacitor/tetris_piece.cc
+++ b/orly/spa/flux_capacitor/tetris_piece.cc
@@ -26,7 +26,6 @@ using namespace Base;
 using namespace Orly::Spa::FluxCapacitor;
 
 void TTetrisPiece::PlayTetris(TContext &ctxt, const function<void (const function<void (TTetrisPiece *)> &)> &piece_generator) {
-  assert(&piece_generator);
   /* Age the generated pieces and fail any that are now too old.  Collect the rest into a group we need to process.
      If, for some reason, the generator yields a null pointer, just skip it. */
   vector<TTetrisPiece *> pieces;

--- a/orly/spa/flux_capacitor/tetris_piece.test.cc
+++ b/orly/spa/flux_capacitor/tetris_piece.test.cc
@@ -164,7 +164,6 @@ class TMyPlayer {
   private:
 
   void ApplyChanges(const TKvMap &changes) {
-    assert(&changes);
     for (auto change: changes) {
       Db[change.first] = change.second;
     }

--- a/orly/spa/orly_args.cc
+++ b/orly/spa/orly_args.cc
@@ -138,8 +138,6 @@ bool TArgs::TryGrabArg(const TStrPiece &name, string &out) {
 }
 
 void TArgs::GrabArg(const TStrPiece &name, string &out) {
-  assert(&name);
-  assert(&out);
 
   if(!TryGrabArg(name, out)) {
     ostringstream s;
@@ -152,8 +150,6 @@ void TArgs::GrabArg(const TStrPiece &name, string &out) {
 //TODO: Convert to Base::Convert.
 //TODO: This is very copy/pasty. Really should abstract it out more. arg value error builder :)
 void TArgs::Convert(const std::string &str, bool &val) {
-  assert(&str);
-  assert(&val);
 
   if(str == "true" || str == "t" || str == "1") {
     val = true;
@@ -165,8 +161,6 @@ void TArgs::Convert(const std::string &str, bool &val) {
 }
 
 void TArgs::Convert(const std::string &str, int &val) {
-  assert(&str);
-  assert(&val);
 
   istringstream iss(str);
   iss>>val;
@@ -177,8 +171,6 @@ void TArgs::Convert(const std::string &str, int &val) {
 }
 
 void TArgs::Convert(const std::string &str, uint64_t &val) {
-  assert(&str);
-  assert(&val);
 
   istringstream iss(str);
   iss>>val;
@@ -190,8 +182,6 @@ void TArgs::Convert(const std::string &str, uint64_t &val) {
 }
 
 void TArgs::Convert(const std::string &str, std::chrono::milliseconds &val) {
-  assert(&str);
-  assert(&val);
 
   uint64_t count;
 
@@ -200,8 +190,6 @@ void TArgs::Convert(const std::string &str, std::chrono::milliseconds &val) {
 }
 
 void TArgs::Convert(const std::string &str, long &val) {
-  assert(&str);
-  assert(&val);
 
   istringstream iss(str);
   iss>>val;
@@ -212,8 +200,6 @@ void TArgs::Convert(const std::string &str, long &val) {
 }
 
 void TArgs::Convert(const std::string &str, Base::TUuid &uuid) {
-  assert(&str);
-  assert(&uuid);
 
   if(!Base::TUuid::IsValidUuid(str.c_str())) {
     throw TIntArgError("uuid");
@@ -245,8 +231,6 @@ void TArgs::VerifyAllUsed() {
 
 template<>
 void TArgs::Get(const TStrPiece &name, std::string &str) {
-  assert(&name);
-  assert(&str);
 
   GrabArg(name, str);
 }

--- a/orly/spa/orly_args.h
+++ b/orly/spa/orly_args.h
@@ -95,8 +95,6 @@ namespace Orly {
 
         template<typename TVal>
         void Get(const TStrPiece &name, Base::TOpt<TVal> &val) {
-          assert(&name);
-          assert(&val);
 
           std::string arg;
           if(TryGrabArg(name, arg)) {
@@ -106,8 +104,6 @@ namespace Orly {
 
         template<typename TVal>
         void Get(const TStrPiece &name, TVal &val) {
-          assert(&name);
-          assert(&val);
 
           std::string arg;
           GrabArg(name, arg);
@@ -115,8 +111,6 @@ namespace Orly {
         }
 
         bool GetOpt(const TStrPiece &name, std::string &val) {
-          assert(&name);
-          assert(&val);
 
           return TryGrabArg(name, val);
         }
@@ -124,8 +118,6 @@ namespace Orly {
 
         template<typename TVal>
         bool GetOpt(const TStrPiece &name, TVal &val) {
-          assert(&name);
-          assert(&val);
 
           std::string arg;
           if(!TryGrabArg(name, arg)) {
@@ -140,7 +132,6 @@ namespace Orly {
         template<typename TVal>
         bool GetOpt(const char *prefix, std::unordered_map<std::string, TVal> &args) {
           assert(prefix);
-          assert(&args);
 
           //TODO: Ugly copies
           std::vector<std::string> to_delete;
@@ -212,8 +203,6 @@ namespace Orly {
 
         template<typename TVal>
         void Convert(const std::string &s, Base::TOpt<TVal> &opt_val) {
-          assert(&s);
-          assert(&opt_val);
 
           if(s.size() == 0) {
             opt_val.Reset();
@@ -228,8 +217,6 @@ namespace Orly {
 
         template<typename TVal>
         void Convert(const std::string &s, Rt::TOpt<TVal> &opt_val) {
-          assert(&s);
-          assert(&opt_val);
 
           if(s.size() == 0) {
             opt_val.Reset();

--- a/orly/spa/service.cc
+++ b/orly/spa/service.cc
@@ -74,9 +74,6 @@ void TService::CreateSession(const Base::TOpt<Base::TUuid> &acct, int ttl, Base:
 }
 
 void TService::CreatePrivatePov(const Base::TUuid &session_uuid, const TOpt<Base::TUuid> &parent, int ttl, bool paused, Base::TUuid &out) {
-  assert(&session_uuid);
-  assert(&parent);
-  assert(&out);
 
   if(parent) {
     out = TPrivatePovObj::TPrivatePovHandle::New(session_uuid, *parent, ttl, bind(&TService::OnPovFail, this, _1), paused)->GetUUID();
@@ -86,8 +83,6 @@ void TService::CreatePrivatePov(const Base::TUuid &session_uuid, const TOpt<Base
 }
 
 void TService::CreateSharedPov(const TOpt<Base::TUuid> &parent, int ttl, bool paused, Base::TUuid &out) {
-  assert(&parent);
-  assert(&out);
 
   if(parent) {
     out = TSharedPovObj::TSharedPovHandle::New(*parent, ttl, bind(&TService::OnPovFail, this, _1), paused)->GetUUID();
@@ -97,7 +92,6 @@ void TService::CreateSharedPov(const TOpt<Base::TUuid> &parent, int ttl, bool pa
 }
 
 void TService::SaveCheckpoint(const string &filename) {
-  assert(&filename);
 
   TSync::TExclusiveLock lock(GlobalPov.GetSync());
 
@@ -124,7 +118,6 @@ void TService::SaveCheckpoint(const string &filename) {
 
 /* TODO: Push Jhm::TAbsBase out to the api. */
 void TService::SetPackageDir(const string &dir) {
-  assert(&dir);
 
   PackageManager.SetPackageDir(dir);
 }
@@ -150,9 +143,6 @@ void TService::Poll(
       const unordered_set<Base::TUuid> &notifiers,
       TOpt<chrono::milliseconds> timeout,
       unordered_map<Base::TUuid, TNotifierState> &out) {
-  assert(&notifiers);
-  assert(&out);
-  assert(&session_uuid);
 
   auto session = TSessionObj::TSessionHandle::Rendezvous(session_uuid);
 
@@ -184,13 +174,7 @@ void TService::Try(
       Atom::TSuprena &result_arena,
       unordered_map<Base::TUuid, Base::TUuid> &notifiers) {
 
-  assert(&func);
   assert(func);
-  assert(&private_pov);
-  assert(&notify_povs);
-  assert(&result_core);
-  assert(&result_arena);
-  assert(&notifiers);
   assert(notifiers.empty()); // Currently if this is not true, the cleanup notifiers logic will die in bad ways.
 
   //Make the call
@@ -342,9 +326,6 @@ void RunTestAndPromoteOnceIfEffects(TService &service, const function<void(Packa
 }
 
 bool TService::RunTest(const Base::TUuid &session, const Base::TUuid &spov_outer, const Package::TTestCase &test, bool verbose) {
-  assert(&session);
-  assert(&spov_outer);
-  assert(&test);
 
   Base::TUuid spov;
   CreateSharedPov(spov_outer, 1000, true, spov);
@@ -408,8 +389,6 @@ bool TService::RunTest(const Base::TUuid &session, const Base::TUuid &spov_outer
 
 
 bool TService::RunTestBlock(const Base::TUuid &session, const Base::TUuid &spov, const Package::TTestBlock &test_block, bool verbose) {
-  assert(&session);
-  assert(&test_block);
 
   bool result = true;
 
@@ -421,7 +400,6 @@ bool TService::RunTestBlock(const Base::TUuid &session, const Base::TUuid &spov,
 }
 
 bool TService::RunTestSuite(const Package::TName &name, bool verbose) {
-  assert(&name);
 
   /* TODO: We really want an API for destroying sessions explicitly */
   Base::TUuid session;
@@ -438,7 +416,6 @@ bool TService::RunTestSuite(const Package::TName &name, bool verbose) {
         if (test->WithBlock) {
           RunTestAndPromoteOnceIfEffects(*this,
               [test](Package::TSpaContext &ctx) {
-                assert(&ctx);
                 assert(test->WithBlock->Runner);
                 test->WithBlock->Runner(ctx, Package::TArgMap());
               },

--- a/orly/spa/spa.cc
+++ b/orly/spa/spa.cc
@@ -163,7 +163,6 @@ class TKey {
 
   /* We're equal iff. both method and URI are equal. */
   bool operator==(const TKey &that) const {
-    assert(&that);
     return strcmp(Method, that.Method) == 0 && strcmp(Uri, that.Uri) == 0;
   }
 
@@ -204,8 +203,6 @@ namespace std {
   };  // hash<TKey>
 
   ostream &operator<<(ostream &out, const chrono::milliseconds &that) {
-    assert(&out);
-    assert(&that);
 
     out << that.count();
 
@@ -253,7 +250,6 @@ class TSpa : public Mongoose::TMongoose {
 
       private:
       virtual void WriteAfterDesc(std::ostream &strm) const {
-        assert(&strm);
         strm << "Build: Unknown" << endl // FIXME: Use Version from SCM to tag.
              << endl
              << "Copyright Atomic Kismet Company" << endl
@@ -358,8 +354,6 @@ class TSpa : public Mongoose::TMongoose {
 
   /* Handles "GET /sys/counters". */
   bool OnGetCounters(TArgs &args, ostream &strm) {
-    assert(&args);
-    assert(&strm);
 
     args.VerifyAllUsed();
 
@@ -376,8 +370,6 @@ class TSpa : public Mongoose::TMongoose {
 
   /* Handles "GET /sys/installed". */
   bool OnGetInstalled(TArgs &args, ostream &strm) {
-    assert(&args);
-    assert(&strm);
 
     args.VerifyAllUsed();
 
@@ -392,7 +384,6 @@ class TSpa : public Mongoose::TMongoose {
 
   /* Handles "GET /sys/health". */
   bool OnGetHealth(TArgs &args, ostream &/*strm*/) {
-    assert(&args);
 
     args.VerifyAllUsed();
 

--- a/orly/symbol/built_in_function.cc
+++ b/orly/symbol/built_in_function.cc
@@ -105,7 +105,6 @@ TBuiltInFunction::TBuiltInFunction(
         ReturnType(return_type) {}
 
 void TBuiltInFunction::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/symbol/function.cc
+++ b/orly/symbol/function.cc
@@ -46,7 +46,6 @@ TFunction::~TFunction() {
 }
 
 void TFunction::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/symbol/given_param_def.cc
+++ b/orly/symbol/given_param_def.cc
@@ -47,6 +47,5 @@ TGivenParamDef::~TGivenParamDef() {
 }
 
 void TGivenParamDef::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }

--- a/orly/symbol/result_def.cc
+++ b/orly/symbol/result_def.cc
@@ -42,7 +42,6 @@ TResultDef::~TResultDef() {
 }
 
 void TResultDef::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/symbol/scope.cc
+++ b/orly/symbol/scope.cc
@@ -31,14 +31,12 @@ TScope::TScope() {}
 TScope::~TScope() {}
 
 void TScope::Add(const TFunction::TPtr &function) {
-  assert(&function);
   assert(function);
   auto result = Functions.insert(function);
   assert(result.second);
 }
 
 void TScope::Add(const Test::TTest::TPtr &test) {
-  assert(&test);
   assert(test);
   Tests.push_back(test);
 }
@@ -52,13 +50,11 @@ const TScope::TTests &TScope::GetTests() const {
 }
 
 void TScope::Remove(const TFunction::TPtr &function) {
-  assert(&function);
   assert(function);
   Functions.erase(function);
 }
 
 void TScope::Remove(const Test::TTest::TPtr &test) {
-  assert(&test);
   assert(test);
   auto result = std::find(Tests.begin(), Tests.end(), test);
   if (result != Tests.end()) {

--- a/orly/symbol/stmt/if.cc
+++ b/orly/symbol/stmt/if.cc
@@ -67,7 +67,6 @@ TIf::TPtr TIf::New(const TIfClauseVec &if_cases, const TElseClause::TPtr &opt_el
 }
 
 void TIf::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/symbol/stmt/mutate.cc
+++ b/orly/symbol/stmt/mutate.cc
@@ -106,7 +106,6 @@ TMutate::TPtr TMutate::New(
 }
 
 void TMutate::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/symbol/stmt/new_and_delete.cc
+++ b/orly/symbol/stmt/new_and_delete.cc
@@ -51,7 +51,6 @@ TDelete::TPtr TDelete::New(const TStmtArg::TPtr &stmt_arg, Type::TType value_typ
 }
 
 void TDelete::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 
@@ -71,7 +70,6 @@ TNew::TPtr TNew::New(
 }
 
 void TNew::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/synth/addr_ctor.cc
+++ b/orly/synth/addr_ctor.cc
@@ -67,7 +67,6 @@ void TAddrCtor::Cleanup() {
 }
 
 void TAddrCtor::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   for (auto &member : Members) {
     (member.second)->ForEachInnerScope(cb);
@@ -75,7 +74,6 @@ void TAddrCtor::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
 }
 
 void TAddrCtor::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   for (auto &member : Members) {
     (member.second)->ForEachRef(cb);

--- a/orly/synth/addr_member_expr.cc
+++ b/orly/synth/addr_member_expr.cc
@@ -44,13 +44,11 @@ Expr::TExpr::TPtr TAddrMemberExpr::Build() const {
 }
 
 void TAddrMemberExpr::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   Expr->ForEachInnerScope(cb);
 }
 
 void TAddrMemberExpr::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   Expr->ForEachRef(cb);
 }

--- a/orly/synth/affix_expr.cc
+++ b/orly/synth/affix_expr.cc
@@ -37,13 +37,11 @@ Expr::TExpr::TPtr TAffixExpr::Build() const {
 }
 
 void TAffixExpr::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   Expr->ForEachInnerScope(cb);
 }
 
 void TAffixExpr::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   Expr->ForEachRef(cb);
 }

--- a/orly/synth/assert_expr.cc
+++ b/orly/synth/assert_expr.cc
@@ -41,13 +41,11 @@ Expr::TAssertCase::TPtr TAssertExpr::TAssertCase::Build(const Expr::TAssert::TPt
 }
 
 void TAssertExpr::TAssertCase::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   Expr->ForEachInnerScope(cb);
 }
 
 void TAssertExpr::TAssertCase::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   Expr->ForEachRef(cb);
 }
@@ -113,7 +111,6 @@ void TAssertExpr::Cleanup() {
 }
 
 void TAssertExpr::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   Expr->ForEachInnerScope(cb);
   for (auto &assert_case : AssertCases) {
@@ -122,7 +119,6 @@ void TAssertExpr::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
 }
 
 void TAssertExpr::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   Expr->ForEachRef(cb);
   for (auto &assert_case : AssertCases) {

--- a/orly/synth/binary_type.cc
+++ b/orly/synth/binary_type.cc
@@ -32,7 +32,6 @@ TBinaryType::~TBinaryType() {
 }
 
 void TBinaryType::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   Lhs->ForEachRef(cb);
   Rhs->ForEachRef(cb);

--- a/orly/synth/collated_by_expr.cc
+++ b/orly/synth/collated_by_expr.cc
@@ -64,7 +64,6 @@ Expr::TExpr::TPtr TCollatedByExpr::Build() const {
 }
 
 void TCollatedByExpr::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   Seq->ForEachInnerScope(cb);
   Reduce->ForEachInnerScope(cb);
@@ -72,7 +71,6 @@ void TCollatedByExpr::ForEachInnerScope(const std::function<void (TScope *)> &cb
 }
 
 void TCollatedByExpr::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   Seq->ForEachRef(cb);
   Reduce->ForEachRef(cb);

--- a/orly/synth/collected_by_expr.cc
+++ b/orly/synth/collected_by_expr.cc
@@ -56,14 +56,12 @@ Expr::TExpr::TPtr TCollectedByExpr::Build() const {
 }
 
 void TCollectedByExpr::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   Lhs->ForEachInnerScope(cb);
   Rhs->ForEachInnerScope(cb);
 }
 
 void TCollectedByExpr::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   Lhs->ForEachRef(cb);
   Rhs->ForEachRef(cb);

--- a/orly/synth/cst_utils.h
+++ b/orly/synth/cst_utils.h
@@ -64,7 +64,6 @@ namespace Orly {
         const typename ItemInfo<TItem>::TNode *node,
         const std::function<bool (const TItem *)> &cb) {
       assert(node);
-      assert(&cb);
       assert(cb);
       while (cb(ItemInfo<TItem>::GetItem(node)) && (node = ItemInfo<TItem>::TryGetNext(node)));
     }
@@ -75,7 +74,6 @@ namespace Orly {
         const typename ItemInfo<TItem>::TOptNode *opt_node,
         const std::function<bool (const TItem *)> &cb) {
       assert(opt_node);
-      assert(&cb);
       assert(cb);
       auto node = TryGetNode<typename ItemInfo<TItem>::TNode,
                              typename ItemInfo<TItem>::TNoNode>(opt_node);

--- a/orly/synth/db_keys_expr.cc
+++ b/orly/synth/db_keys_expr.cc
@@ -50,13 +50,11 @@ Expr::TExpr::TPtr TDbKeysExpr::TFixedMember::Build() const {
 }
 
 void TDbKeysExpr::TFixedMember::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   Expr->ForEachInnerScope(cb);
 }
 
 void TDbKeysExpr::TFixedMember::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   Expr->ForEachRef(cb);
 }
@@ -75,7 +73,6 @@ Expr::TExpr::TPtr TDbKeysExpr::TFreeMember::Build() const {
 void TDbKeysExpr::TFreeMember::ForEachInnerScope(const std::function<void (TScope *)> &) {}
 
 void TDbKeysExpr::TFreeMember::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   Type->ForEachRef(cb);
 }
@@ -161,7 +158,6 @@ void TDbKeysExpr::Cleanup() {
 }
 
 void TDbKeysExpr::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   for (auto member : Members) {
     member->ForEachInnerScope(cb);
@@ -169,7 +165,6 @@ void TDbKeysExpr::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
 }
 
 void TDbKeysExpr::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   for (auto member : Members) {
     member->ForEachRef(cb);

--- a/orly/synth/delete_stmt.cc
+++ b/orly/synth/delete_stmt.cc
@@ -49,14 +49,12 @@ Symbol::Stmt::TStmt::TPtr TDeleteStmt::Build() const {
 }
 
 void TDeleteStmt::ForEachRef(const std::function<void (TAnyRef &)> &cb) const {
-  assert(&cb);
   assert(cb);
   Expr->ForEachRef(cb);
   ValueType->ForEachRef(cb);
 }
 
 void TDeleteStmt::ForEachInnerScope(const std::function<void (TScope *)> &cb) const {
-  assert(&cb);
   assert(cb);
   Expr->ForEachInnerScope(cb);
 }

--- a/orly/synth/dict_ctor.cc
+++ b/orly/synth/dict_ctor.cc
@@ -70,7 +70,6 @@ void TDictCtor::Cleanup() {
 }
 
 void TDictCtor::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   for (auto member : Members) {
     (member.first)->ForEachInnerScope(cb);
@@ -79,7 +78,6 @@ void TDictCtor::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
 }
 
 void TDictCtor::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   for (auto member : Members) {
     (member.first)->ForEachRef(cb);

--- a/orly/synth/effecting_expr.cc
+++ b/orly/synth/effecting_expr.cc
@@ -64,7 +64,6 @@ Expr::TExpr::TPtr TEffectingExpr::Build() const {
 }
 
 void TEffectingExpr::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   Expr->ForEachInnerScope(cb);
   for(auto &stmt : StmtBlock->GetStmts()) {
@@ -73,7 +72,6 @@ void TEffectingExpr::ForEachInnerScope(const std::function<void (TScope *)> &cb)
 }
 
 void TEffectingExpr::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   Expr->ForEachRef(cb);
   StmtBlock->ForEachRef(cb);

--- a/orly/synth/empty_ctor.cc
+++ b/orly/synth/empty_ctor.cc
@@ -133,7 +133,6 @@ Expr::TExpr::TPtr TEmptyCtor::Build() const {
 }
 
 void TEmptyCtor::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   assert(Type);
   Type->ForEachRef(cb);

--- a/orly/synth/exists_ctor.cc
+++ b/orly/synth/exists_ctor.cc
@@ -66,7 +66,6 @@ Expr::TExpr::TPtr TExistsCtor::Build() const {
 }
 
 void TExistsCtor::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   assert(ValueType);
   Expr->ForEachRef(cb);

--- a/orly/synth/filter_expr.cc
+++ b/orly/synth/filter_expr.cc
@@ -56,14 +56,12 @@ Expr::TExpr::TPtr TFilterExpr::Build() const {
 }
 
 void TFilterExpr::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   Lhs->ForEachInnerScope(cb);
   Rhs->ForEachInnerScope(cb);
 }
 
 void TFilterExpr::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   Lhs->ForEachRef(cb);
   Rhs->ForEachRef(cb);

--- a/orly/synth/given_expr.cc
+++ b/orly/synth/given_expr.cc
@@ -33,6 +33,5 @@ Expr::TExpr::TPtr TGivenExpr::Build() const {
 }
 
 void TGivenExpr::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   ParamFuncDef->GetType()->ForEachRef(cb);
 }

--- a/orly/synth/if_stmt.cc
+++ b/orly/synth/if_stmt.cc
@@ -94,7 +94,6 @@ void TIfStmt::Cleanup() {
 }
 
 void TIfStmt::ForEachRef(const std::function<void (TAnyRef &)> &cb) const {
-  assert(&cb);
   assert(cb);
   for (auto if_clause : IfClauses) {
     if_clause->ForEachRef(cb);
@@ -105,7 +104,6 @@ void TIfStmt::ForEachRef(const std::function<void (TAnyRef &)> &cb) const {
 }
 
 void TIfStmt::ForEachInnerScope(const std::function<void (TScope *)> &cb) const {
-  assert(&cb);
   assert(cb);
   for (auto if_clause : IfClauses) {
     if_clause->ForEachInnerScope(cb);

--- a/orly/synth/mutate_stmt.cc
+++ b/orly/synth/mutate_stmt.cc
@@ -80,14 +80,12 @@ Symbol::Stmt::TStmt::TPtr TMutateStmt::Build() const {
 }
 
 void TMutateStmt::ForEachRef(const std::function<void (TAnyRef &)> &cb) const {
-  assert(&cb);
   assert(cb);
   Lhs->ForEachRef(cb);
   Rhs->ForEachRef(cb);
 }
 
 void TMutateStmt::ForEachInnerScope(const std::function<void (TScope *)> &cb) const {
-  assert(&cb);
   assert(cb);
   Lhs->ForEachInnerScope(cb);
   Rhs->ForEachInnerScope(cb);

--- a/orly/synth/name.h
+++ b/orly/synth/name.h
@@ -69,14 +69,12 @@ namespace Orly {
       /* Copy the specified TName. */
       TName(const TName &that)
           : Text(nullptr), PosRange(nullptr), Lexeme(nullptr) {
-        assert(&that);
         *this = that;
       }
 
       /* Move constructor */
       TName(TName &&that)
           : Text(nullptr), PosRange(nullptr), Lexeme(nullptr) {
-        assert(&that);
         *this = that;
       }
 
@@ -100,7 +98,6 @@ namespace Orly {
 
       /* Regular assignment operator */
       TName &operator=(const TName &that) {
-        assert(&that);
         assert(that.Text);
         assert(that.PosRange);
         if (that.Lexeme) {
@@ -134,7 +131,6 @@ namespace Orly {
 
       /* Move assignment operator */
       TName &operator=(TName &&that) {
-        assert(&that);
         Cleanup();
         std::swap(Lexeme, that.Lexeme);
         std::swap(Text, that.Text);
@@ -145,20 +141,17 @@ namespace Orly {
       /* Two names are equal if their texts are equal or if they are both null.
          Positions are not considered. */
       bool operator==(const TName &that) const {
-        assert(&that);
         return GetText() == that.GetText();
       }
 
       /* Two names are unequal if their texts are unequal of if one is null and the other is not.
          Positions are not considered. */
       bool operator!=(const TName &that) const {
-        assert(&that);
         return GetText() != that.GetText();
       }
 
       /* */
       bool operator<(const TName &that) const {
-        assert(&that);
         return GetText() < that.GetText();
       }
 
@@ -231,7 +224,6 @@ namespace std {
     typedef Orly::Synth::TName argument_type;
 
     result_type operator()(const argument_type &that) const {
-      assert(&that);
       return that.GetHash();
     }
 

--- a/orly/synth/new_stmt.cc
+++ b/orly/synth/new_stmt.cc
@@ -56,14 +56,12 @@ Symbol::Stmt::TStmt::TPtr TNewStmt::Build() const {
 }
 
 void TNewStmt::ForEachRef(const std::function<void (TAnyRef &)> &cb) const {
-  assert(&cb);
   assert(cb);
   Lhs->ForEachRef(cb);
   Rhs->ForEachRef(cb);
 }
 
 void TNewStmt::ForEachInnerScope(const std::function<void (TScope *)> &cb) const {
-  assert(&cb);
   assert(cb);
   Lhs->ForEachInnerScope(cb);
   Rhs->ForEachInnerScope(cb);

--- a/orly/synth/obj_ctor.cc
+++ b/orly/synth/obj_ctor.cc
@@ -75,7 +75,6 @@ void TObjCtor::Cleanup() {
 }
 
 void TObjCtor::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   for (auto member : Members) {
     (member.second)->ForEachInnerScope(cb);
@@ -83,7 +82,6 @@ void TObjCtor::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
 }
 
 void TObjCtor::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   for (auto member : Members) {
     (member.second)->ForEachRef(cb);

--- a/orly/synth/obj_member_expr.cc
+++ b/orly/synth/obj_member_expr.cc
@@ -43,13 +43,11 @@ Expr::TExpr::TPtr TObjMemberExpr::Build() const {
 }
 
 void TObjMemberExpr::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   Expr->ForEachInnerScope(cb);
 }
 
 void TObjMemberExpr::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   Expr->ForEachRef(cb);
 }

--- a/orly/synth/postfix_call.cc
+++ b/orly/synth/postfix_call.cc
@@ -95,7 +95,6 @@ void TPostfixCall::Cleanup() {
 }
 
 void TPostfixCall::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   Expr->ForEachInnerScope(cb);
   for (auto arg : Args) {
@@ -104,7 +103,6 @@ void TPostfixCall::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
 }
 
 void TPostfixCall::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   Expr->ForEachRef(cb);
   for (auto arg : Args) {

--- a/orly/synth/postfix_cast.cc
+++ b/orly/synth/postfix_cast.cc
@@ -50,13 +50,11 @@ Expr::TExpr::TPtr TPostfixCast::Build() const {
 }
 
 void TPostfixCast::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   Lhs->ForEachInnerScope(cb);
 }
 
 void TPostfixCast::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   Lhs->ForEachRef(cb);
   Rhs->ForEachRef(cb);

--- a/orly/synth/postfix_is_known.cc
+++ b/orly/synth/postfix_is_known.cc
@@ -42,13 +42,11 @@ Expr::TExpr::TPtr TPostfixIsKnown::Build() const {
 }
 
 void TPostfixIsKnown::ForEachInnerScope(const std::function<void (TScope *cb)> &cb) {
-  assert(&cb);
   assert(cb);
   Expr->ForEachInnerScope(cb);
 }
 
 void TPostfixIsKnown::ForEachRef(const std::function<void (TAnyRef &cb)> &cb) {
-  assert(&cb);
   assert(cb);
   Expr->ForEachRef(cb);
 }

--- a/orly/synth/postfix_is_known_expr.cc
+++ b/orly/synth/postfix_is_known_expr.cc
@@ -52,14 +52,12 @@ Expr::TExpr::TPtr TPostfixIsKnownExpr::Build() const {
 }
 
 void TPostfixIsKnownExpr::ForEachInnerScope(const std::function<void (TScope *cb)> &cb) {
-  assert(&cb);
   assert(cb);
   Lhs->ForEachInnerScope(cb);
   Rhs->ForEachInnerScope(cb);
 }
 
 void TPostfixIsKnownExpr::ForEachRef(const std::function<void (TAnyRef &cb)> &cb) {
-  assert(&cb);
   assert(cb);
   Lhs->ForEachRef(cb);
   Rhs->ForEachRef(cb);

--- a/orly/synth/prefix_start.cc
+++ b/orly/synth/prefix_start.cc
@@ -49,13 +49,11 @@ Expr::TExpr::TPtr TPrefixStart::Build() const {
 }
 
 void TPrefixStart::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   Expr->ForEachInnerScope(cb);
 }
 
 void TPrefixStart::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   Expr->ForEachRef(cb);
 }

--- a/orly/synth/range_ctor.cc
+++ b/orly/synth/range_ctor.cc
@@ -96,7 +96,6 @@ void TRangeCtor::Cleanup() {
 }
 
 void TRangeCtor::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   Start->ForEachInnerScope(cb);
   if (OptStride) {
@@ -108,7 +107,6 @@ void TRangeCtor::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
 }
 
 void TRangeCtor::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   Start->ForEachRef(cb);
   if (OptStride) {

--- a/orly/synth/read_expr.cc
+++ b/orly/synth/read_expr.cc
@@ -61,13 +61,11 @@ Expr::TExpr::TPtr TReadExpr::Build() const {
 }
 
 void TReadExpr::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   Expr->ForEachInnerScope(cb);
 }
 
 void TReadExpr::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   Expr->ForEachRef(cb);
   Type->ForEachRef(cb);

--- a/orly/synth/reduce_expr.cc
+++ b/orly/synth/reduce_expr.cc
@@ -57,14 +57,12 @@ Expr::TExpr::TPtr TReduceExpr::Build() const {
 }
 
 void TReduceExpr::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   Lhs->ForEachInnerScope(cb);
   Rhs->ForEachInnerScope(cb);
 }
 
 void TReduceExpr::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   Lhs->ForEachRef(cb);
   Rhs->ForEachRef(cb);

--- a/orly/synth/ref_expr.cc
+++ b/orly/synth/ref_expr.cc
@@ -33,7 +33,6 @@ Expr::TExpr::TPtr TRefExpr::Build() const {
 }
 
 void TRefExpr::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   cb(FuncDef);
 }

--- a/orly/synth/scope_and_def.cc
+++ b/orly/synth/scope_and_def.cc
@@ -50,7 +50,6 @@ TScope::TScope(TScope *parent)
 void TScope::ForEachControlledRef(const std::function<void (TAnyRef &)> &) const {}
 
 TDef *TScope::TryGetAnyDef(const TName &name) const {
-  assert(&name);
   TDef *def;
   if (name) {
     const TScope *scope = this;
@@ -79,7 +78,6 @@ TDef *TScope::TryGetAnyDef(const TName &name) const {
 }
 
 void TScope::AddError(const TName &name, const char *expected_type) {
-  assert(&name);
   assert(expected_type);
   GetContext().AddError(name.GetPosRange(), Base::AsStr(std::quoted(name.GetText()), " does not refer to ", expected_type));
 }
@@ -94,7 +92,6 @@ void TDef::BindEachRef() {
 
 TAction TDef::BuildEachDef(int pass, const std::function<void (const std::function<bool (TDef *)> &)> &generate) {
   assert(pass > 0);
-  assert(&generate);
   TAction action = Finish;
   generate([pass, &action](TDef *def){
     bool keep_going;

--- a/orly/synth/set_ctor.cc
+++ b/orly/synth/set_ctor.cc
@@ -62,7 +62,6 @@ void TSetCtor::Cleanup() {
 }
 
 void TSetCtor::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   for (auto expr : Exprs) {
     expr->ForEachInnerScope(cb);
@@ -70,7 +69,6 @@ void TSetCtor::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
 }
 
 void TSetCtor::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   for (auto expr : Exprs) {
     expr->ForEachRef(cb);

--- a/orly/synth/sort_expr.cc
+++ b/orly/synth/sort_expr.cc
@@ -64,14 +64,12 @@ void TSortExpr::Cleanup() {
 }
 
 void TSortExpr::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   Lhs->ForEachInnerScope(cb);
   Rhs->ForEachInnerScope(cb);
 }
 
 void TSortExpr::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   Lhs->ForEachRef(cb);
   Rhs->ForEachRef(cb);

--- a/orly/synth/test_case_block.cc
+++ b/orly/synth/test_case_block.cc
@@ -137,7 +137,6 @@ Symbol::Test::TTestCaseBlock::TPtr TTestCaseBlock::Build() const {
 }
 
 void TTestCaseBlock::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   for (auto &test_case : TestCases) {
     test_case->ForEachInnerScope(cb);
@@ -145,7 +144,6 @@ void TTestCaseBlock::ForEachInnerScope(const std::function<void (TScope *)> &cb)
 }
 
 void TTestCaseBlock::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   for (auto &test_case : TestCases) {
     test_case->ForEachRef(cb);

--- a/orly/synth/test_def.cc
+++ b/orly/synth/test_def.cc
@@ -88,7 +88,6 @@ TAction TTestDef::Build(int pass) {
 }
 
 void TTestDef::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   if (OptWithClause) {
     OptWithClause->ForEachInnerScope(cb);
@@ -97,7 +96,6 @@ void TTestDef::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
 }
 
 void TTestDef::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   if (OptWithClause) {
     OptWithClause->ForEachRef(cb);

--- a/orly/synth/test_kv_entry.cc
+++ b/orly/synth/test_kv_entry.cc
@@ -57,14 +57,12 @@ Symbol::Stmt::TNew::TPtr TTestKvEntry::Build() const {
 }
 
 void TTestKvEntry::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   Key->ForEachInnerScope(cb);
   Val->ForEachInnerScope(cb);
 }
 
 void TTestKvEntry::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   Key->ForEachRef(cb);
   Val->ForEachRef(cb);

--- a/orly/synth/unknown_ctor.cc
+++ b/orly/synth/unknown_ctor.cc
@@ -41,7 +41,6 @@ Expr::TExpr::TPtr TUnknownCtor::Build() const {
 }
 
 void TUnknownCtor::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   Type->ForEachRef(cb);
 }

--- a/orly/synth/where_expr.cc
+++ b/orly/synth/where_expr.cc
@@ -54,14 +54,12 @@ void TWhereExpr::BuildSymbol() {
 }
 
 void TWhereExpr::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   cb(this);
   Expr->ForEachInnerScope(cb);
 }
 
 void TWhereExpr::ForEachControlledRef(const std::function<void (TAnyRef &)> &cb) const {
-  assert(&cb);
   assert(cb);
   Expr->ForEachRef(cb);
 }
@@ -103,7 +101,6 @@ void TWhereExpr::TLocalDefFactory::operator()(const Package::Syntax::TUpgraderDe
 
 void TWhereExpr::TLocalDefFactory::OnTopLevel(const char *desc, const TPosRange &pos_range) const {
   assert(desc);
-  assert(&pos_range);
 
   GetContext().AddError(pos_range, Base::AsStr(desc," is not allowed within a where clause"));
 }

--- a/orly/synth/while_expr.cc
+++ b/orly/synth/while_expr.cc
@@ -56,14 +56,12 @@ Expr::TExpr::TPtr TWhileExpr::Build() const {
 }
 
 void TWhileExpr::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   Lhs->ForEachInnerScope(cb);
   Rhs->ForEachInnerScope(cb);
 }
 
 void TWhileExpr::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   Lhs->ForEachRef(cb);
   Rhs->ForEachRef(cb);

--- a/orly/synth/with_clause.cc
+++ b/orly/synth/with_clause.cc
@@ -64,7 +64,6 @@ void TWithClause::Cleanup() {
 }
 
 void TWithClause::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
-  assert(&cb);
   assert(cb);
   for (auto &test_kv_entry : TestKvEntries) {
     test_kv_entry->ForEachInnerScope(cb);
@@ -72,7 +71,6 @@ void TWithClause::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
 }
 
 void TWithClause::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   assert(cb);
   for (auto &test_kv_entry : TestKvEntries) {
     test_kv_entry->ForEachRef(cb);

--- a/orly/tracker.h
+++ b/orly/tracker.h
@@ -47,15 +47,11 @@ namespace Orly {
 
   /* Binary stream extractor for Orly::TTracker. */
   inline Io::TBinaryInputStream &operator>>(Io::TBinaryInputStream &strm, TTracker &that) {
-    assert(&strm);
-    assert(&that);
     return strm >> that.Id >> that.TimeToLive;
   }
 
   /* Binary stream inserter for Orly::TTracker. */
   inline Io::TBinaryOutputStream &operator<<(Io::TBinaryOutputStream &strm, const TTracker &that) {
-    assert(&strm);
-    assert(&that);
     return strm << that.Id << that.TimeToLive;
   }
 

--- a/orly/type/addr.cc
+++ b/orly/type/addr.cc
@@ -27,7 +27,6 @@ IMPL_INTERNED_TYPE(TAddr, TAddrElems);
 TAddr::~TAddr() {}
 
 void TAddr::Write(std::ostream &strm) const {
-  assert(&strm);
 
   #if 0
   strm << "Orly::Rt::TAddr<";

--- a/orly/type/addr.h
+++ b/orly/type/addr.h
@@ -35,7 +35,6 @@ namespace Orly {
       typedef TAddrElems TElems;
 
       static TType Get(const TElems &elems) {
-        assert(&elems);
         return TInternedType::Get(elems);
       }
       const TElems &GetElems() const {
@@ -62,7 +61,6 @@ namespace std {
   struct hash<Orly::Type::TAddrElems> {
 
     size_t operator()(const Orly::Type::TAddrElems &that) const {
-      assert(&that);
       size_t result = 0;
       for (const auto &elem: that) {
         //TODO: Find a better hash

--- a/orly/type/err.cc
+++ b/orly/type/err.cc
@@ -25,6 +25,5 @@ IMPL_UNARY_TYPE(TErr);
 TErr::~TErr() {}
 
 void TErr::Write(std::ostream &strm) const {
-  assert(&strm);
   strm << "Orly::Rt::TUserError<" << GetElem() << '>';
 }

--- a/orly/type/impl.h
+++ b/orly/type/impl.h
@@ -99,14 +99,12 @@ namespace Orly {
 
       /* TODO */
       TType(TType &&that) {
-        assert(&that);
         Init();
         std::swap(Impl, that.Impl);
       }
 
       /* TODO */
       TType(const TType &that) {
-        assert(&that);
         Impl = that.Impl;
       }
 
@@ -115,20 +113,17 @@ namespace Orly {
 
       /* TODO */
       TType &operator=(TType &&that) {
-        assert(&that);
         std::swap(Impl, that.Impl);
         return *this;
       }
 
       /* TODO */
       TType &operator=(const TType &that) {
-        assert(&that);
         return *this = TType(that);
       }
 
       /* TODO */
       bool operator==(const TType &that) const {
-        assert(&that);
         assert(Impl);
         assert(that.Impl);
         return Impl.get() == that.Impl.get();
@@ -136,7 +131,6 @@ namespace Orly {
 
       /* TODO */
       bool operator!=(const TType &that) const {
-        assert(&that);
         assert(Impl);
         assert(that.Impl);
         return Impl.get() != that.Impl.get();
@@ -147,7 +141,6 @@ namespace Orly {
 
       /* TODO */
       void Accept(const TVisitor &visitor) const {
-        assert(&visitor);
         assert(Impl);
         Impl->Accept(visitor);
       }
@@ -651,7 +644,6 @@ namespace std {
     typedef Orly::Type::TType argument_type;
 
     result_type operator()(const argument_type &that) const {
-      assert(&that);
       return that.GetHash();
     }
 

--- a/orly/type/managed_type.h
+++ b/orly/type/managed_type.h
@@ -60,7 +60,6 @@ namespace Orly {
       typedef std::unordered_map<TKey, TWeak> TTypeByKey;
 
       void Accept(const TType::TVisitor &visitor) const {
-        assert(&visitor);
         visitor(Base::AssertTrue(dynamic_cast<const TFinal*>(this)));
       }
 
@@ -165,7 +164,6 @@ namespace Orly {
       }
 
       void Accept(const TType::TVisitor &visitor) const {
-        assert(&visitor);
         assert(Ptr);
         visitor(Ptr->get());
       }
@@ -199,7 +197,6 @@ namespace Orly {
       public:
 
       static TType Get(const Type::TType &type) {
-        assert(&type);
         return TInternedType<TFinal, Type::TType>::Get(type);
       }
 

--- a/orly/type/new_sabot.cc
+++ b/orly/type/new_sabot.cc
@@ -79,7 +79,6 @@ Sabot::Type::TAny *Orly::Type::TryNewSabot(void *buf, const Type::TType &type) {
     void *Buf;
   };
   assert(buf);
-  assert(&type);
   Sabot::Type::TAny *result = nullptr;
   type.Accept(visitor_t(result, buf));
   return result;

--- a/orly/type/new_sabot.h
+++ b/orly/type/new_sabot.h
@@ -223,7 +223,6 @@ namespace Orly {
 
           /* See Sabot::Type::TRecord. */
           virtual Sabot::Type::TAny *NewElem(size_t elem_idx, std::string &name, void *buf) const override {
-            assert(&name);
             const auto &item = Record->Elems[elem_idx];
             name = item.first;
             return NewSabot(buf, item.second);

--- a/orly/type/obj.cc
+++ b/orly/type/obj.cc
@@ -25,6 +25,5 @@ IMPL_INTERNED_TYPE(TObj, TObjElems);
 TObj::~TObj() {}
 
 void TObj::Write(std::ostream &out) const {
-  assert(&out);
   out << "Orly::Rt::Objects::TObj" << AsType().GetMangledName();
 }

--- a/orly/type/obj.h
+++ b/orly/type/obj.h
@@ -180,7 +180,6 @@ namespace Orly {
       static bool AreComparable(const TObj *lhs, const TObj *rhs, bool &is_optional) {
         assert(lhs);
         assert(rhs);
-        assert(&is_optional);
         return lhs->IsSubsetOf(rhs, is_optional) || rhs->IsSubsetOf(lhs, is_optional);
       }
 
@@ -197,7 +196,6 @@ namespace Orly {
       /* TODO */
       bool IsSubsetOf(const TObj *that, bool &is_optional) const {
         assert(that);
-        assert(&is_optional);
         for (auto iter : GetElems()) {
           auto pos = that->GetElems().find(iter.first);
           if (pos == that->GetElems().end() || iter.second != pos->second) {

--- a/orly/type/part.h
+++ b/orly/type/part.h
@@ -75,7 +75,6 @@ namespace Orly {
       }
 
       void Accept(const TVisitor &visitor) const {
-        assert(&visitor);
         visitor(this);
       }
 
@@ -99,7 +98,6 @@ namespace Orly {
       static TPtr Get();
 
       void Accept(const TVisitor &visitor) const {
-        assert(&visitor);
         visitor(this);
       }
 
@@ -118,7 +116,6 @@ namespace Orly {
       static TPtr Get(const Type::TType &key_type);
 
       void Accept(const TVisitor &visitor) const {
-        assert(&visitor);
         visitor(this);
       }
 
@@ -146,7 +143,6 @@ namespace Orly {
       static TPtr Get(const std::string &name);
 
       void Accept(const TVisitor &visitor) const {
-        assert(&visitor);
         visitor(this);
       }
 

--- a/orly/type/sabot_to_type.h
+++ b/orly/type/sabot_to_type.h
@@ -47,7 +47,6 @@ namespace Orly {
       /* TODO */
       TToTypeVisitor(Type::TType &type)
           : Type(type) {
-        assert(&type);
       }
 
       /* Overrides. */

--- a/orly/type/seq.cc
+++ b/orly/type/seq.cc
@@ -25,6 +25,5 @@ IMPL_UNARY_TYPE(TSeq);
 TSeq::~TSeq() {}
 
 void TSeq::Write(std::ostream &out) const {
-  assert(&out);
   out << "Orly::Rt::TGenerator<" << GetElem() << ">::TPtr";
 }

--- a/orly/type/time_diff.cc
+++ b/orly/type/time_diff.cc
@@ -25,6 +25,5 @@ IMPL_SINGLETON_TYPE(TTimeDiff);
 TTimeDiff::~TTimeDiff() {}
 
 void TTimeDiff::Write(std::ostream &strm) const {
-  assert(&strm);
   strm << "Base::Chrono::TTimeDiff";
 }

--- a/orly/type/time_pnt.cc
+++ b/orly/type/time_pnt.cc
@@ -25,6 +25,5 @@ IMPL_SINGLETON_TYPE(TTimePnt);
 TTimePnt::~TTimePnt() {}
 
 void TTimePnt::Write(std::ostream &strm) const {
-  assert(&strm);
   strm << "Base::Chrono::TTimePnt";
 }

--- a/orly/var/addr.cc
+++ b/orly/var/addr.cc
@@ -45,7 +45,6 @@ void TAddr::Write(std::ostream &strm) const {
 }
 
 void TAddr::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/var/bool.cc
+++ b/orly/var/bool.cc
@@ -37,7 +37,6 @@ void TBool::Write(std::ostream &stream) const {
 }
 
 void TBool::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/var/dict.cc
+++ b/orly/var/dict.cc
@@ -57,7 +57,6 @@ void TDict::Write(std::ostream &strm) const {
 }
 
 void TDict::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/var/free.cc
+++ b/orly/var/free.cc
@@ -38,7 +38,6 @@ void TFree::Write(std::ostream &) const {
 }
 
 void TFree::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/var/id.cc
+++ b/orly/var/id.cc
@@ -36,7 +36,6 @@ void TId::Write(std::ostream &strm) const {
 }
 
 void TId::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/var/impl.cc
+++ b/orly/var/impl.cc
@@ -857,26 +857,22 @@ void TVar::TImpl::Delete(TImpl *impl) {
 }
 
 int TVar::Compare(const TVar &that) const {
-  assert(&that);
   int comp;
   Accept(*this, that, TCompareDoubleVisitor(comp, false));
   return comp;
 }
 
 bool TVar::operator==(const TVar &that) const {
-  assert(&that);
   int comp;
   Accept(*this, that, TCompareDoubleVisitor(comp, true));
   return comp == 0;
 }
 
 bool TVar::operator<(const TVar &that) const {
-  assert(&that);
   return Compare(that) < 0;
 }
 
 bool TVar::operator>(const TVar &that) const {
-  assert(&that);
   return Compare(that) > 0;
 }
 
@@ -923,13 +919,11 @@ void TVar::Init() {
 }
 
 TVar::TVar(TVar &&that) {
-  assert(&that);
   Init();
   std::swap(Impl, that.Impl);
 }
 
 TVar::TVar(const TVar &that) {
-  assert(&that);
   Impl = that.Impl;
 }
 
@@ -938,13 +932,11 @@ TVar TVar::Copy() const {
 }
 
 TVar &TVar::operator=(TVar &&that) {
-  assert(&that);
   std::swap(Impl, that.Impl);
   return *this;
 }
 
 TVar &TVar::operator=(const TVar &that) {
-  assert(&that);
   return *this = TVar(that);
 }
 

--- a/orly/var/impl.h
+++ b/orly/var/impl.h
@@ -331,7 +331,6 @@ namespace Orly {
 
       /* TODO */
       bool operator<=(const TVar &that) const {
-        assert(&that);
         return (*this < that) || (*this == that);
       }
 
@@ -340,7 +339,6 @@ namespace Orly {
 
       /* TODO */
       bool operator>=(const TVar &that) const {
-        assert(&that);
         return (*this > that) || (*this == that);
       }
 

--- a/orly/var/int.cc
+++ b/orly/var/int.cc
@@ -36,7 +36,6 @@ void TInt::Write(std::ostream &stream) const {
 }
 
 void TInt::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/var/list.cc
+++ b/orly/var/list.cc
@@ -51,7 +51,6 @@ void TList::Write(std::ostream &strm) const {
 }
 
 void TList::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/var/mutable.cc
+++ b/orly/var/mutable.cc
@@ -37,7 +37,6 @@ void TMutable::Write(std::ostream &) const {
 }
 
 void TMutable::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/var/new_sabot.cc
+++ b/orly/var/new_sabot.cc
@@ -69,7 +69,6 @@ Sabot::State::TAny *Var::TryNewSabot(void *buf, const TVar &var, TAddrDir addr_d
     void *Buf;
   };
   assert(buf);
-  assert(&var);
   Sabot::State::TAny *result = nullptr;
   if (var.Is<TFree>()) {
     result = new (buf) SS::TFree(var.As<TFree>(), addr_dir);

--- a/orly/var/obj.cc
+++ b/orly/var/obj.cc
@@ -44,7 +44,6 @@ void TObj::Write(std::ostream &) const {
 const TVar TObj::DefaultVar;
 
 void TObj::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/var/obj.h
+++ b/orly/var/obj.h
@@ -37,8 +37,6 @@ namespace Orly {
     template <typename TCompound>
     template <typename TVal>
     void TObj::Meta<TCompound>::TField<TVal>::GetVal(const TCompound &that, Var::TVar &out) const {
-      assert(&that);
-      assert(&out);
       out = Var::TVar(that.*Member);
     }
 
@@ -92,9 +90,6 @@ namespace Orly {
       /* TODO */
       template <typename TCompound, typename TVal>
       static void GetValFromField(const TCompound &compound, const typename Type::TObj::Meta<TCompound>::template TField<TVal> &field, TVar &out) {
-        assert(&compound);
-        assert(&field);
-        assert(&out);
         out = TVar(compound.*(field.Member));
       }
 

--- a/orly/var/opt.cc
+++ b/orly/var/opt.cc
@@ -45,7 +45,6 @@ void TOpt::Write(std::ostream &strm) const {
 }
 
 void TOpt::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/var/real.cc
+++ b/orly/var/real.cc
@@ -36,7 +36,6 @@ void TReal::Write(std::ostream &stream) const {
 }
 
 void TReal::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/var/sabot_to_var.h
+++ b/orly/var/sabot_to_var.h
@@ -47,7 +47,6 @@ namespace Orly {
       /* TODO */
       TToVarVisitor(Var::TVar &var)
           : Var(var) {
-        assert(&var);
       }
 
       /* Overrides. */

--- a/orly/var/set.cc
+++ b/orly/var/set.cc
@@ -43,7 +43,6 @@ void TSet::Write(std::ostream &strm) const {
 }
 
 void TSet::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/var/str.cc
+++ b/orly/var/str.cc
@@ -38,7 +38,6 @@ void TStr::Write(std::ostream &strm) const {
 }
 
 void TStr::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/var/time_diff.cc
+++ b/orly/var/time_diff.cc
@@ -32,12 +32,10 @@ Type::TType TTimeDiff::GetType() const {
 }
 
 void TTimeDiff::Write(std::ostream &strm) const {
-  assert(&strm);
   strm << "Base::Chrono::TTimeDiff(" << Val.count() << ')';
 }
 
 void TTimeDiff::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/var/time_pnt.cc
+++ b/orly/var/time_pnt.cc
@@ -32,14 +32,12 @@ Type::TType TTimePnt::GetType() const {
 }
 
 void TTimePnt::Write(std::ostream &strm) const {
-  assert(&strm);
   strm
     << "Base::Chrono::TTimePnt(Base::Chrono::TTimeDiff("
     << Base::Chrono::TimeDiffCast(Val.time_since_epoch()).count() << "))";
 }
 
 void TTimePnt::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/orly/var/unknown.cc
+++ b/orly/var/unknown.cc
@@ -39,7 +39,6 @@ void TUnknown::Write(std::ostream &) const {
 }
 
 void TUnknown::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/rpc/rpc.cc
+++ b/rpc/rpc.cc
@@ -134,7 +134,6 @@ TAnyFuture::TAnyFuture()
     : EventFd(eventfd(0, 0)), ResultStatus(NoResult) {}
 
 void TAnyFuture::SetErrorResult(string &error_msg) {
-  assert(&error_msg);
   ErrorMsg = move(error_msg);
   SetResultStatus(ErrorResult);
 }
@@ -149,8 +148,6 @@ void TAnyFuture::SetResultStatus(TResultStatus result_status) {
 TAnyRequest::~TAnyRequest() {}
 
 void TAnyRequest::WriteError(TBinaryOutputStream &strm, TRequestId request_id, const exception &ex) {
-  assert(&strm);
-  assert(&ex);
   strm << ErrorResultIntroducer << request_id << ex.what();
   strm.Flush();
 }

--- a/rpc/rpc.h
+++ b/rpc/rpc.h
@@ -354,7 +354,6 @@ namespace Rpc {
 
     /* See base class. */
     virtual void SetNormalResult(Io::TBinaryInputStream &strm) {
-      assert(&strm);
       strm >> Val;
       SetResultStatus(NormalResult);
     }
@@ -442,9 +441,7 @@ namespace Rpc {
     static void WriteReply(
         Io::TBinaryOutputStream &strm, TRequestId request_id, TSomeContext *context,
         TRet (TSomeContext::*handler)(typename Pass<TArgs>::type...), const std::tuple<TArgs...> &args) {
-      assert(&strm);
       assert(context);
-      assert(&args);
       TRet ret;
       try {
         ret = Unpack(handler, context, args);
@@ -465,9 +462,7 @@ namespace Rpc {
     static void WriteReply(
         Io::TBinaryOutputStream &strm, TRequestId request_id, TSomeContext *context,
         void (TSomeContext::*handler)(typename Pass<TArgs>::type...), const std::tuple<TArgs...> &args) {
-      assert(&strm);
       assert(context);
-      assert(&args);
       try {
         Unpack(handler, context, args);
       } catch (const std::exception &ex) {

--- a/server/perf_utils.cc
+++ b/server/perf_utils.cc
@@ -96,7 +96,6 @@ class TStats {
 };  // TStats
 
 ostream &operator<<(ostream &strm, const TStats &that) {
-  assert(&that);
   that.Write(strm);
   return strm;
 }

--- a/server/url_decode.cc
+++ b/server/url_decode.cc
@@ -47,8 +47,6 @@ static inline unsigned char HexToNum(const char *c_in, const char *start) {
 }
 
 void Server::UrlDecode(const TPiece<const char> &in, std::string &out) {
-  assert(&in);
-  assert(&out);
 
   //If the in string is empty, clear out and no-op.
   if(!in) {

--- a/signal/set.h
+++ b/signal/set.h
@@ -100,13 +100,11 @@ namespace Signal {
 
     /* Copy constructor. */
     TSet(const TSet &that) {
-      assert(&that);
       memcpy(&OsObj, &that.OsObj, sizeof(OsObj));
     }
 
     /* Assignment operator. */
     TSet &operator=(const TSet &that) {
-      assert(&that);
       memcpy(&OsObj, &that.OsObj, sizeof(OsObj));
       return *this;
     }

--- a/socket/address.cc
+++ b/socket/address.cc
@@ -69,7 +69,6 @@ TAddress::TAddress(TSpecial special, in_port_t port) {
 }
 
 TAddress::TAddress(istream &&strm) {
-  assert(&strm);
   if (ws(strm).peek() == '!') {
     /* We skipped whitespace and found the mark indicating an unspecified address.
        This is an easy, early-out for us. */
@@ -260,7 +259,6 @@ TAddress &TAddress::SetPath(const char *path) {
 }
 
 void TAddress::Write(ostream &strm) const {
-  assert(&strm);
   in_port_t port = 0;
   switch (Storage.ss_family) {
     case AF_UNSPEC: {
@@ -320,8 +318,6 @@ socklen_t TAddress::GetLen(sa_family_t family) {
 }
 
 void Socket::Bind(TNamedUnixSocket &socket, const TAddress &address) {
-  assert(&socket);
-  assert(&address);
   assert(address.GetFamily() == AF_LOCAL);
   string path(address.GetPath());
 

--- a/socket/address.h
+++ b/socket/address.h
@@ -90,7 +90,6 @@ namespace Socket {
 
     /* Swaperator. */
     TAddress &operator=(TAddress &&that) {
-      assert(&that);
       std::swap(Storage, that.Storage);
       return *this;
     }
@@ -141,7 +140,6 @@ namespace Socket {
 
     /* Copy the naked address to the given buffer. */
     void CopyOut(sockaddr_storage &storage) const {
-      assert(&storage);
       memcpy(&storage, &Storage, GetLen());
     }
 
@@ -233,7 +231,6 @@ namespace Socket {
 
   /* A version of accept() using TAddress. */
   inline int Accept(int socket, TAddress &address) {
-    assert(&address);
     int result;
     socklen_t len = TAddress::MaxLen;
     Util::IfLt0(result = accept(socket, address, &len));
@@ -243,7 +240,6 @@ namespace Socket {
 
   /* A version of bind() using TAddress. */
   inline void Bind(int socket, const TAddress &address) {
-    assert(&address);
     Util::IfLt0(bind(socket, address, address.GetLen()));
   }
 
@@ -253,7 +249,6 @@ namespace Socket {
 
   /* A version of connect() using TAddress. */
   inline void Connect(int socket, const TAddress &address) {
-    assert(&address);
     Util::IfLt0(connect(socket, address, address.GetLen()));
   }
 
@@ -277,7 +272,6 @@ namespace Socket {
 
   /* A version of recvfrom() using TAddress. */
   inline size_t RecvFrom(int socket, void *buffer, size_t max_size, int flags, TAddress &address) {
-    assert(&address);
     ssize_t result;
     socklen_t len = TAddress::MaxLen;
     Util::IfLt0(result = recvfrom(socket, buffer, max_size, flags, address, &len));
@@ -287,7 +281,6 @@ namespace Socket {
 
   /* A version of sendto() using TAddress. */
   inline size_t SendTo(int socket, const void *buffer, size_t max_size, int flags, const TAddress &address) {
-    assert(&address);
     ssize_t result;
     Util::IfLt0(result = sendto(socket, buffer, max_size, flags, address, address.GetLen()));
     return result;
@@ -296,8 +289,6 @@ namespace Socket {
   /* A async version of accept() using TAddress.
      Returns false iff. it would block. */
   inline bool TryAccept(int socket, int &new_socket, TAddress &address) {
-    assert(&new_socket);
-    assert(&address);
     socklen_t len = TAddress::MaxLen;
     int result = accept(socket, address, &len);
     if (result < 0) {
@@ -314,7 +305,6 @@ namespace Socket {
   /* An async version of connect() using TAddress.
      Returns false iff. it would block. */
   inline bool TryConnect(int socket, const TAddress &address) {
-    assert(&address);
     if (connect(socket, address, address.GetLen()) < 0) {
       if (errno == EWOULDBLOCK) {
         return false;
@@ -327,8 +317,6 @@ namespace Socket {
   /* An async version of recvfrom() using TAddress.
      Returns false iff. it would block. */
   inline bool TryRecvFrom(int socket, void *buffer, size_t max_size, int flags, TAddress &address, size_t &size) {
-    assert(&address);
-    assert(&size);
     socklen_t len = TAddress::MaxLen;
     ssize_t result = recvfrom(socket, buffer, max_size, flags, address, &len);
     if (result < 0) {
@@ -345,8 +333,6 @@ namespace Socket {
   /* An async version of sendto() using TAddress.
      Returns false iff. it would block. */
   inline bool TrySendTo(int socket, const void *buffer, size_t max_size, int flags, const TAddress &address, size_t &size) {
-    assert(&address);
-    assert(&size);
     ssize_t result = sendto(socket, buffer, max_size, flags, address, address.GetLen());
     if (result < 0) {
       if (errno == EWOULDBLOCK) {
@@ -360,14 +346,12 @@ namespace Socket {
 
   /* A standard stream extractor for Socket::TAddress. */
   inline std::istream &operator>>(std::istream &strm, TAddress &that) {
-    assert(&that);
     that = std::move(strm);
     return strm;
   }
 
   /* A standard stream inserter for Socket::TAddress. */
   inline std::ostream &operator<<(std::ostream &strm, const TAddress &that) {
-    assert(&that);
     that.Write(strm);
     return strm;
   }
@@ -380,7 +364,6 @@ namespace std {
   template <>
   struct hash<Socket::TAddress> {
     inline size_t operator()(const Socket::TAddress &that) const {
-      assert(&that);
       return that.GetHash();
     }
   };

--- a/socket/factory.cc
+++ b/socket/factory.cc
@@ -42,7 +42,6 @@ TFactory::~TFactory() {
 }
 
 TFd TFactory::New(TAddress &address) const {
-  assert(&address);
   /* Find a network interface that matches our criteria. */
   auto *sa = FindNetworkInterface();
   /* Open a socket that matches the network interface and is of the correct

--- a/socket/option.cc
+++ b/socket/option.cc
@@ -54,7 +54,6 @@ const TAnyOption *Socket::AllOptions[] = {
 };
 
 void Socket::DumpAllOptions(ostream &strm, int sock) {
-  assert(&strm);
   strm << "socket_ops: {";
   bool has_written = false;
   for (const TAnyOption *const *csr = AllOptions; *csr; ++csr) {

--- a/socket/option.h
+++ b/socket/option.h
@@ -72,7 +72,6 @@ namespace Socket {
      which is fine for everything but strings. */
   template <typename TArg>
   void GetSockOpt(int sock, int code, TArg &arg) {
-    assert(&arg);
     socklen_t dummy = sizeof(arg);
     Util::IfLt0(getsockopt(sock, SOL_SOCKET, code, &arg, &dummy));
   }
@@ -82,7 +81,6 @@ namespace Socket {
      which is fine for everything but strings. */
   template <typename TArg>
   void SetSockOpt(int sock, int code, const TArg &arg) {
-    assert(&arg);
     Util::IfLt0(setsockopt(sock, SOL_SOCKET, code, &arg, sizeof(arg)));
   }
 
@@ -140,7 +138,6 @@ namespace Socket {
 
     /* See forward declaration of generic Conv<>. */
     static void GetSockOpt(int sock, int code, TVal &val) {
-      assert(&val);
       int temp;
       Socket::GetSockOpt(sock, code, temp);
       val = (temp != 0);
@@ -186,7 +183,6 @@ namespace Socket {
 
     /* See forward declaration of generic Conv<>. */
     static void GetSockOpt(int sock, int code, TVal &val) {
-      assert(&val);
       linger temp;
       Socket::GetSockOpt(sock, code, temp);
       if (temp.l_onoff) {
@@ -198,7 +194,6 @@ namespace Socket {
 
     /* See forward declaration of generic Conv<>. */
     static void SetSockOpt(int sock, int code, const TVal &val) {
-      assert(&val);
       linger temp;
       temp.l_onoff = val;
       temp.l_linger = (temp.l_onoff ? val->count() : 0);
@@ -239,7 +234,6 @@ namespace Socket {
 
     /* See forward declaration of generic Conv<>. */
     static void GetSockOpt(int sock, int code, TVal &val) {
-      assert(&val);
       timeval temp;
       Socket::GetSockOpt(sock, code, temp);
       val = TTimeout(temp.tv_sec * 1000000 + temp.tv_usec);
@@ -247,7 +241,6 @@ namespace Socket {
 
     /* See forward declaration of generic Conv<>. */
     static void SetSockOpt(int sock, int code, const TVal &val) {
-      assert(&val);
       auto count = val.count();
       timeval temp;
       temp.tv_sec  = count / 1000000;
@@ -268,7 +261,6 @@ namespace Socket {
 
     /* See forward declaration of generic Conv<>. */
     static void GetSockOpt(int sock, int code, TVal &val) {
-      assert(&val);
       char temp[MaxSize];
       socklen_t size = MaxSize;
       Util::IfLt0(getsockopt(sock, SOL_SOCKET, code, temp, &size));
@@ -277,7 +269,6 @@ namespace Socket {
 
     /* See forward declaration of generic Conv<>. */
     static void SetSockOpt(int sock, int code, const TVal &val) {
-      assert(&val);
       Util::IfLt0(setsockopt(sock, SOL_SOCKET, code, val.c_str(), val.size()));
     }
 
@@ -310,7 +301,6 @@ namespace Socket {
 
     /* See forward declaration of generic Format<>. */
     static void Dump(std::ostream &strm, bool val) {
-      assert(&strm);
       strm << std::boolalpha << val;
     }
 
@@ -324,7 +314,6 @@ namespace Socket {
 
     /* See forward declaration of generic Format<>. */
     static void Dump(std::ostream &strm, int val) {
-      assert(&strm);
       strm << val;
     }
 
@@ -338,8 +327,6 @@ namespace Socket {
 
     /* See forward declaration of generic Format<>. */
     static void Dump(std::ostream &strm, const TLinger &val) {
-      assert(&strm);
-      assert(&val);
       if (val) {
         strm << val->count() << " sec(s)";
       } else {
@@ -357,8 +344,6 @@ namespace Socket {
 
     /* See forward declaration of generic Format<>. */
     static void Dump(std::ostream &strm, const ucred &val) {
-      assert(&strm);
-      assert(&val);
       strm << "{ pid: " << val.pid << ", uid: " << val.uid << ", gid: " << val.gid << " }";
     }
 
@@ -372,8 +357,6 @@ namespace Socket {
 
     /* See forward declaration of generic Format<>. */
     static void Dump(std::ostream &strm, const TTimeout &val) {
-      assert(&strm);
-      assert(&val);
       strm << val.count() << " usec(s)";
     }
 
@@ -387,8 +370,6 @@ namespace Socket {
 
     /* See forward declaration of generic Format<>. */
     static void Dump(std::ostream &strm, const std::string &val) {
-      assert(&strm);
-      assert(&val);
       strm << '"' << val << '"';
     }
 
@@ -462,7 +443,6 @@ namespace Socket {
 
     /* See base class. */
     virtual void Dump(std::ostream &strm, int sock) const override final {
-      assert(&strm);
       strm << TAnyOption::GetName() << ": ";
       TVal val;
       Get(sock, val);

--- a/strm/bin/in.cc
+++ b/strm/bin/in.cc
@@ -25,7 +25,6 @@ using namespace std;
 using namespace Strm::Bin;
 
 TIn &TIn::operator>>(bool &that) {
-  assert(&that);
   switch (Peek()) {
     case 'T': {
       that = true;
@@ -44,7 +43,6 @@ TIn &TIn::operator>>(bool &that) {
 }
 
 TIn &TIn::operator>>(string &that) {
-  assert(&that);
   size_t size;
   *this >> size;
   string temp;

--- a/strm/bin/in.h
+++ b/strm/bin/in.h
@@ -73,7 +73,6 @@ namespace Strm {
 
       /* Read a char as itself, a single byte. */
       TIn &operator>>(char &that) {
-        assert(&that);
         that = Pop();
         return *this;
       }
@@ -92,56 +91,48 @@ namespace Strm {
 
       /* Read an 8-bit signed integer as-is. */
       TIn &operator>>(int8_t &that) {
-        assert(&that);
         that = Pop();
         return *this;
       }
 
       /* Read a 16-bit signed integer as a zig-zag var-int. */
       TIn &operator>>(int16_t &that) {
-        assert(&that);
         that = FromZigZag<uint16_t>(ReadVarInt());
         return *this;
       }
 
       /* Read a 32-bit signed integer as a zig-zag var-int. */
       TIn &operator>>(int32_t &that) {
-        assert(&that);
         that = FromZigZag<uint32_t>(ReadVarInt());
         return *this;
       }
 
       /* Read a 64-bit signed integer as a zig-zag var-int. */
       TIn &operator>>(int64_t &that) {
-        assert(&that);
         that = FromZigZag<uint64_t>(ReadVarInt());
         return *this;
       }
 
       /* Read an 8-bit unsigned integer as-is. */
       TIn &operator>>(uint8_t &that) {
-        assert(&that);
         that = Pop();
         return *this;
       }
 
       /* Read a 16-bit unsigned integer as a var-int. */
       TIn &operator>>(uint16_t &that) {
-        assert(&that);
         that = ReadVarInt();
         return *this;
       }
 
       /* Read a 32-bit unsigned integer as a var-int. */
       TIn &operator>>(uint32_t &that) {
-        assert(&that);
         that = ReadVarInt();
         return *this;
       }
 
       /* Read a 64-bit unsigned integer as a var-int. */
       TIn &operator>>(uint64_t &that) {
-        assert(&that);
         that = ReadVarInt();
         return *this;
       }
@@ -153,7 +144,6 @@ namespace Strm {
          its underlying representation type. */
       template <typename TRep, typename TPeriod>
       TIn &operator>>(std::chrono::duration<TRep, TPeriod> &that) {
-        assert(&that);
         TRep temp;
         *this >> temp;
         that = std::chrono::duration<TRep, TPeriod>(temp);
@@ -165,7 +155,6 @@ namespace Strm {
       template <typename TClock, typename TDuration>
       TIn &operator>>(
           std::chrono::time_point<TClock, TDuration> &that) {
-        assert(&that);
         TDuration temp;
         *this >> temp;
         that = std::chrono::time_point<TClock, TDuration>(temp);
@@ -179,7 +168,6 @@ namespace Strm {
           typename = typename std::enable_if<
               std::is_enum<TSomeEnum>::value>::type>
       TIn &operator>>(TSomeEnum &that) {
-        assert(&that);
         using under_t = typename std::underlying_type<TSomeEnum>::type;
         return *this >> reinterpret_cast<under_t &>(that);
       }
@@ -189,7 +177,6 @@ namespace Strm {
          write a count, as it is implicitly exactly 2. */
       template <typename TFirst, typename TSecond>
       TIn &operator>>(std::pair<TFirst, TSecond> &that) {
-        assert(&that);
         return *this >> that.first >> that.second;
       }
 
@@ -356,7 +343,6 @@ namespace Strm {
           >::type
       >
       TIn &operator>>(TNbo<TVal> &&that) {
-        assert(&that);
         TVal temp;
         ReadShallow(temp);
         that.Val = Io::SwapEnds(temp);
@@ -381,7 +367,6 @@ namespace Strm {
       /* Used by the operator>> overloads for all varieties of std maps. */
       template <typename TCont>
       void ReadMap(TCont &that) {
-        assert(&that);
         size_t count;
         *this >> count;
         TCont temp;
@@ -396,7 +381,6 @@ namespace Strm {
       /* Used by the operator>> overloads for std lists and std vectors. */
       template <typename TCont>
       void ReadSeq(TCont &that) {
-        assert(&that);
         size_t count;
         *this >> count;
         TCont temp;
@@ -412,7 +396,6 @@ namespace Strm {
       /* Used by the operator>> overloads for all varieties of std sets. */
       template <typename TCont>
       void ReadSet(TCont &that) {
-        assert(&that);
         size_t count;
         *this >> count;
         TCont temp;

--- a/strm/bin/out.h
+++ b/strm/bin/out.h
@@ -161,7 +161,6 @@ namespace Strm {
          its underlying representation type. */
       template <typename TRep, typename TPeriod>
       TOut &operator<<(const std::chrono::duration<TRep, TPeriod> &that) {
-        assert(&that);
         return *this << that.count();
       }
 
@@ -170,7 +169,6 @@ namespace Strm {
       template <typename TClock, typename TDuration>
       TOut &operator<<(
           const std::chrono::time_point<TClock, TDuration> &that) {
-        assert(&that);
         return *this << that.time_since_epoch();
       }
 
@@ -415,7 +413,6 @@ namespace Strm {
           >::type
       >
       TOut &operator<<(const TNbo<TVal> &that) {
-        assert(&that);
         TVal temp = Io::SwapEnds(that.Val);
         WriteShallow(temp);
         return *this;

--- a/strm/bin/var_int.test.cc
+++ b/strm/bin/var_int.test.cc
@@ -52,7 +52,6 @@ FIXTURE(RoundTrip) {
   TVarIntDecoder decoder;
   ForEachItem(
     [&encoder, &decoder](const TItem &item) {
-      assert(&item);
       /* Encode the value and make sure the encoded form is the expected
          number of bytes. */
       encoder.Encode(item.first);

--- a/strm/in.h
+++ b/strm/in.h
@@ -107,8 +107,6 @@ namespace Strm {
 
       /* Peeks at the next bytes of data. */
       void Peek(const uint8_t *&start, const uint8_t *&limit) const {
-        assert(&start);
-        assert(&limit);
         Refresh();
         start = Cursor;
         limit = Limit;

--- a/test/app.h
+++ b/test/app.h
@@ -163,7 +163,6 @@ namespace Test {
   template <typename TVal>
   const Test::TApp::TLogger &operator<<(
       const Test::TApp::TLogger &logger, const TVal &val) {
-    assert(&logger);
     return logger.Write(val);
   }
 }

--- a/test/expect.h
+++ b/test/expect.h
@@ -133,8 +133,6 @@ namespace Test {
         const char *rhs_str, const TRhs &rhs) : CodeLocation(code_location) {
       assert(lhs_str);
       assert(rhs_str);
-      assert(&lhs);
-      assert(&rhs);
 
       const char *op_str = "ERROR";
       switch(op) {
@@ -166,8 +164,6 @@ namespace Test {
         : CodeLocation(code_location) {
       assert(lhs_str);
       assert(rhs_str);
-      assert(&lhs);
-      assert(&rhs);
 
       const char *op_str;
       switch (op) {
@@ -202,7 +198,6 @@ namespace Test {
         TPrefixOp op, const char *arg_str, const TArg &arg)
         : CodeLocation(code_location) {
       assert(arg_str);
-      assert(&arg);
       const char *op_str;
       std::ostringstream strm;
       switch (op) {
@@ -230,9 +225,7 @@ namespace Test {
       const Base::TCodeLocation &code_location,
       const char *exc_str,
       const std::function<void (bool &pass)> &func) : CodeLocation(code_location) {
-      assert(&code_location);
       assert(exc_str);
-      assert(&func);
       assert(func);
 
       std::ostringstream strm;
@@ -265,10 +258,8 @@ namespace Test {
     template <typename TLhs, typename TRhs>
     void WriteInfixOp(const char *lhs_str, const TLhs &lhs, const char *op_str, const char *rhs_str, const TRhs &rhs) {
       assert(lhs_str);
-      assert(&lhs);
       assert(op_str);
       assert(rhs_str);
-      assert(&rhs);
 
       std::ostringstream strm;
       WriteType<TLhs>(strm);
@@ -305,6 +296,5 @@ namespace Test {
 /* A stream inserter for Test::TExpect targets. */
 template <typename TVal>
 const Test::TExpect &operator<<(const Test::TExpect &expect, const TVal &val) {
-  assert(&expect);
   return expect.Write(val);
 }

--- a/test/life_tracker.h
+++ b/test/life_tracker.h
@@ -49,7 +49,6 @@ namespace Test {
 
       /* True iff. all counts equal. */
       bool operator==(const TCounts &that) const noexcept {
-        assert(&that);
         return
             MoveCtor == that.MoveCtor &&
             CopyCtor == that.CopyCtor &&
@@ -98,7 +97,6 @@ namespace Test {
 
     /* Take on the identity of our donor and count a move-assignment. */
     TLifeTracker &operator=(TLifeTracker &&that) noexcept {
-      assert(&that);
       Counts = that.Counts;
       ++(Counts->MoveAssign);
       return *this;
@@ -106,7 +104,6 @@ namespace Test {
 
     /* Take on the identity of our example and count a copy-assignment. */
     TLifeTracker &operator=(const TLifeTracker &that) {
-      assert(&that);
       Counts = that.Counts;
       ++(Counts->CopyAssign);
       return *this;
@@ -124,8 +121,6 @@ namespace Test {
 
     /* Count a swap against both objects. */
     friend void swap(TLifeTracker &lhs, TLifeTracker &rhs) noexcept {
-      assert(&rhs);
-      assert(&lhs);
       using std::swap;
       swap(lhs.Counts, rhs.Counts);
       ++(lhs.Counts->Swap);

--- a/tools/nycr/compound.cc
+++ b/tools/nycr/compound.cc
@@ -73,7 +73,6 @@ Symbol::TKind *TCompound::GetSymbolAsKind() const {
 }
 
 void TCompound::ForEachRef(const function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   TFinal::ForEachRef(cb);
   for (auto iter = Members.begin(); iter != Members.end(); ++iter) {
     (*iter)->ForEachRef(cb);
@@ -88,7 +87,6 @@ void TCompound::TErrorMember::Build(Symbol::TCompound *compound) {
 void TCompound::TErrorMember::ForEachRef(const std::function<void (TAnyRef &)> &) {}
 
 void TCompound::TMemberWithKind::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   cb(Kind);
 }
 

--- a/tools/nycr/decl.cc
+++ b/tools/nycr/decl.cc
@@ -98,7 +98,6 @@ void TDecl::Bind() {
 }
 
 void TDecl::BuildPredsAndSelf(int pass, bool &again) {
-  assert(&again);
   if (Readiness < pass) {
     switch (State) {
       case Unstarted: {
@@ -130,7 +129,6 @@ void TDecl::BuildPredsAndSelf(int pass, bool &again) {
 }
 
 void TDecl::ForEachUniqueDecl(const function<void (TDecl *)> &cb) {
-  assert(&cb);
   for (auto iter = DeclsByName.begin(); iter != DeclsByName.end(); ++iter) {
     const vector<TDecl *> &decls = iter->second;
     if (decls.size() == 1) {

--- a/tools/nycr/decl.h
+++ b/tools/nycr/decl.h
@@ -54,7 +54,6 @@ namespace Tools {
     template <typename TYesNode, typename TNoNode, typename TOptNode>
     static void GetOptInt(const TOptNode *opt_node, Base::TOpt<int> &out) {
       assert(opt_node);
-      assert(&out);
       const TYesNode *yes_node = TryGetNode<TYesNode, TNoNode>(opt_node);
       if (yes_node) {
         out = yes_node->GetIntLiteral()->GetLexeme().AsInt();

--- a/tools/nycr/escape.cc
+++ b/tools/nycr/escape.cc
@@ -24,7 +24,6 @@ using namespace std;
 using namespace Tools::Nycr;
 
 void TEscape::Write(ostream &strm) const {
-  assert(&strm);
   switch (EscapeStyle) {
     case TEscape::CStyle: {
       strm << '"';

--- a/tools/nycr/escape.h
+++ b/tools/nycr/escape.h
@@ -52,7 +52,6 @@ namespace Tools {
 
     /* TODO */
     inline std::ostream &operator<<(std::ostream &strm, const Tools::Nycr::TEscape &that) {
-      assert(&that);
       that.Write(strm);
       return strm;
     }

--- a/tools/nycr/indent.h
+++ b/tools/nycr/indent.h
@@ -45,7 +45,6 @@ namespace Tools {
 
     /* TODO */
     inline std::ostream &operator<<(std::ostream &strm, const Tools::Nycr::TIndent &that) {
-      assert(&that);
       that.Write(strm);
       return strm;
     }

--- a/tools/nycr/kind.cc
+++ b/tools/nycr/kind.cc
@@ -37,7 +37,6 @@ TKind::TKind(const Syntax::TName *name, const Syntax::TOptSuper *opt_super)
 }
 
 void TKind::ForEachPred(int pass, const function<void (TDecl *)> &cb) {
-  assert(&cb);
   switch (pass) {
     case 1: {
       break;
@@ -54,7 +53,6 @@ void TKind::ForEachPred(int pass, const function<void (TDecl *)> &cb) {
 }
 
 void TKind::ForEachRef(const function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   cb(Super);
 }
 

--- a/tools/nycr/lexeme.h
+++ b/tools/nycr/lexeme.h
@@ -97,7 +97,6 @@ namespace Tools {
 
       /* Used to dump the tree. */
       void Write(std::ostream &strm) const {
-        assert(&strm);
         strm << PosRange << ' ' << TEscape(Text);
       }
 
@@ -116,7 +115,6 @@ namespace Tools {
 
     /* Standard inserter for Tools::Nycr::TLexeme. */
     inline std::ostream &operator<<(std::ostream &strm, const Tools::Nycr::TLexeme &that) {
-      assert(&that);
       that.Write(strm);
       return strm;
     }

--- a/tools/nycr/nycr.cc
+++ b/tools/nycr/nycr.cc
@@ -154,7 +154,6 @@ class TNycr : public Base::TCmd {
 
     private:
     virtual void WriteAfterDesc(std::ostream &strm) const {
-      assert(&strm);
       strm << "Build: Unknown" << endl //TODO: Use Version from SCM.
            << endl
            << "Copyright Atomic Kismet Company" << endl

--- a/tools/nycr/operator.cc
+++ b/tools/nycr/operator.cc
@@ -42,7 +42,6 @@ TOperator::TOperator(const Syntax::TOper *decl)
 }
 
 void TOperator::ForEachRef(const function<void (TAnyRef &)> &cb) {
-  assert(&cb);
   TAtom::ForEachRef(cb);
   cb(PrecLevel);
 }

--- a/tools/nycr/pos.h
+++ b/tools/nycr/pos.h
@@ -68,7 +68,6 @@ namespace Tools {
 
       /* Compares by line, then by column. */
       int Compare(const TPos &that) const {
-        assert(&that);
         int result = LineNumber - that.LineNumber;
         if (!result) {
           result = ColumnNumber - that.ColumnNumber;
@@ -88,7 +87,6 @@ namespace Tools {
 
       /* Writes the position as line:col. */
       void Write(std::ostream &strm) const {
-        assert(&strm);
         strm << LineNumber << ':' << ColumnNumber;
       }
 
@@ -101,7 +99,6 @@ namespace Tools {
 
     /* Standard inserter for Tools::Nycr::TPos. */
     inline std::ostream &operator<<(std::ostream &strm, const Tools::Nycr::TPos &that) {
-      assert(&that);
       that.Write(strm);
       return strm;
     }

--- a/tools/nycr/pos_range.h
+++ b/tools/nycr/pos_range.h
@@ -50,13 +50,11 @@ namespace Tools {
 
       /* Equal iff. start and limit are equal. */
       bool operator==(const TPosRange &that) const {
-        assert(&that);
         return Start == that.Start && Limit == that.Limit;
       }
 
       /* Unequal iff. start or limit are unequal. */
       bool operator!=(const TPosRange &that) const {
-        assert(&that);
         return Start != that.Start || Limit != that.Limit;
       }
 
@@ -72,7 +70,6 @@ namespace Tools {
 
       /* Writes the range as line1:col1-line2:col2. */
       void Write(std::ostream &strm) const {
-        assert(&strm);
         strm << Start << '-' << Limit;
       }
 
@@ -91,7 +88,6 @@ namespace Tools {
 
     /* Standard inserter for Tools::Nycr::TPosRange. */
     inline std::ostream &operator<<(std::ostream &strm, const Tools::Nycr::TPosRange &that) {
-      assert(&that);
       that.Write(strm);
       return strm;
     }

--- a/tools/nycr/symbol/anonymous_member.cc
+++ b/tools/nycr/symbol/anonymous_member.cc
@@ -32,12 +32,10 @@ const TName &TAnonymousMember::GetName() const {
 }
 
 void TAnonymousMember::WriteRhs(ostream &strm) const {
-  assert(&strm);
   strm << TLower(GetKind()->GetName());
 }
 
 void TAnonymousMember::WriteXml(ostream &strm) const {
-  assert(&strm);
   strm << TXmlTag(TXmlTag::AnonymousMember, Open)
        << TXml(GetName())
        << TXmlTag(TXmlTag::Kind, Open)

--- a/tools/nycr/symbol/base.cc
+++ b/tools/nycr/symbol/base.cc
@@ -21,7 +21,6 @@
 using namespace Tools::Nycr::Symbol;
 
 void TBase::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/tools/nycr/symbol/error_member.cc
+++ b/tools/nycr/symbol/error_member.cc
@@ -36,12 +36,10 @@ const TKind *TErrorMember::TryGetKind() const {
 }
 
 void TErrorMember::WriteRhs(ostream &strm) const {
-  assert(&strm);
   strm << TLower(Name);
 }
 
 void TErrorMember::WriteXml(ostream &strm) const {
-  assert(&strm);
   strm << TXmlTag(TXmlTag::ErrorMember, Open)
        << TXml(Name)
        << TXmlTag(TXmlTag::ErrorMember, Close);

--- a/tools/nycr/symbol/for_each_final.cc
+++ b/tools/nycr/symbol/for_each_final.cc
@@ -34,7 +34,6 @@ using namespace Tools::Nycr::Symbol;
 void Tools::Nycr::Symbol::ForEachFinal(
     const TBase *base, const function<void (const TFinal *)> &cb) {
   assert(base);
-  assert(&cb);
   const TBase::TSubKinds &sub_kinds = base->GetSubKinds();
   for (auto iter = sub_kinds.begin(); iter != sub_kinds.end(); ++iter) {
     class TVisitor : public TKind::TVisitor {

--- a/tools/nycr/symbol/for_each_known_kind.cc
+++ b/tools/nycr/symbol/for_each_known_kind.cc
@@ -38,7 +38,6 @@ static void Visit(
 void Tools::Nycr::Symbol::ForEachKnownKind(
     const TKind *kind, const function<void (const TKind *)> &cb) {
   assert(kind);
-  assert(&cb);
   unordered_set<const TKind *> done;
   Visit(kind, cb, done);
 }
@@ -47,8 +46,6 @@ static void Visit(
     const TKind *kind, const function<void (const TKind *)> &cb,
     unordered_set<const TKind *> &done) {
   assert(kind);
-  assert(&cb);
-  assert(&done);
   if (done.insert(kind).second) {
     class TVisitor : public TKind::TVisitor {
       public:

--- a/tools/nycr/symbol/keyword.cc
+++ b/tools/nycr/symbol/keyword.cc
@@ -21,6 +21,5 @@
 using namespace Tools::Nycr::Symbol;
 
 void TKeyword::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }

--- a/tools/nycr/symbol/language.cc
+++ b/tools/nycr/symbol/language.cc
@@ -25,7 +25,6 @@ TLanguage::~TLanguage() {
 }
 
 void TLanguage::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }
 

--- a/tools/nycr/symbol/name.cc
+++ b/tools/nycr/symbol/name.cc
@@ -36,7 +36,6 @@ bool TName::operator<(const TName &that) const {
 }
 
 void TName::WriteLower(ostream &strm) const {
-  assert(&strm);
   for (auto iter = Parts.begin(); iter != Parts.end(); ++iter) {
     if (iter != Parts.begin()) {
       strm << '_';
@@ -46,7 +45,6 @@ void TName::WriteLower(ostream &strm) const {
 }
 
 void TName::WriteUpper(ostream &strm) const {
-  assert(&strm);
   for (auto iter = Parts.begin(); iter != Parts.end(); ++iter) {
     const string &part = *iter;
     strm << static_cast<char>(toupper(part[0])) << part.substr(1);
@@ -54,7 +52,6 @@ void TName::WriteUpper(ostream &strm) const {
 }
 
 void TName::WriteXml(ostream &strm) const {
-  assert(&strm);
   strm << TXmlTag(TXmlTag::Name, Open, Indent, NoEndl);
   for (auto iter = Parts.begin(); iter != Parts.end(); ++iter) {
     strm << TXmlTag(TXmlTag::Part, Open, NoIndent, NoEndl)

--- a/tools/nycr/symbol/name.h
+++ b/tools/nycr/symbol/name.h
@@ -159,21 +159,18 @@ namespace Tools {
 
 /* TODO */
 inline std::ostream &operator<<(std::ostream &strm, const Tools::Nycr::Symbol::TLower &that) {
-  assert(&that);
   that.Name.WriteLower(strm);
   return strm;
 }
 
 /* TODO */
 inline std::ostream &operator<<(std::ostream &strm, const Tools::Nycr::Symbol::TUpper &that) {
-  assert(&that);
   that.Name.WriteUpper(strm);
   return strm;
 }
 
 /* TODO */
 inline std::ostream &operator<<(std::ostream &strm, const Tools::Nycr::Symbol::TType &that) {
-  assert(&strm);
   strm << 'T';
   that.Name.WriteUpper(strm);
   return strm;
@@ -181,7 +178,6 @@ inline std::ostream &operator<<(std::ostream &strm, const Tools::Nycr::Symbol::T
 
 /* TODO */
 inline std::ostream &operator<<(std::ostream &strm, const Tools::Nycr::Symbol::TXml &that) {
-  assert(&strm);
   that.Name.WriteXml(strm);
   return strm;
 }

--- a/tools/nycr/symbol/named_member.cc
+++ b/tools/nycr/symbol/named_member.cc
@@ -32,12 +32,10 @@ const TName &TNamedMember::GetName() const {
 }
 
 void TNamedMember::WriteRhs(ostream &strm) const {
-  assert(&strm);
   strm << TLower(Name) << ':' << TLower(GetKind()->GetName());
 }
 
 void TNamedMember::WriteXml(ostream &strm) const {
-  assert(&strm);
   strm << TXmlTag(TXmlTag::NamedMember, Open)
        << TXml(GetName())
        << TXmlTag(TXmlTag::Kind, Open)

--- a/tools/nycr/symbol/operator.cc
+++ b/tools/nycr/symbol/operator.cc
@@ -21,6 +21,5 @@
 using namespace Tools::Nycr::Symbol;
 
 void TOperator::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }

--- a/tools/nycr/symbol/output_file.cc
+++ b/tools/nycr/symbol/output_file.cc
@@ -68,7 +68,6 @@ void Tools::Nycr::Symbol::CreateOutputFile(const char *root, const char *branch,
   assert(root);
   assert(language);
   assert(ext);
-  assert(&strm);
   ostringstream temp;
 
   temp << root << '/' << atom << '.' << TLower(language->GetName()) << ext;

--- a/tools/nycr/symbol/output_file.h
+++ b/tools/nycr/symbol/output_file.h
@@ -124,21 +124,18 @@ namespace Tools {
 
 /* Standard inserter for Tools::Nycr::Symbol::TPath. */
 inline std::ostream &operator<<(std::ostream &strm, const Tools::Nycr::Symbol::TPath &that) {
-  assert(&that);
   that.Write(strm);
   return strm;
 }
 
 /* Standard inserter for Tools::Nycr::Symbol::TScope. */
 inline std::ostream &operator<<(std::ostream &strm, const Tools::Nycr::Symbol::TScope &that) {
-  assert(&that);
   that.Write(strm);
   return strm;
 }
 
 /* Standard inserter for Tools::Nycr::Symbol::TUsingNamespace. */
 inline std::ostream &operator<<(std::ostream &strm, const Tools::Nycr::Symbol::TUsingNamespace &that) {
-  assert(&that);
   that.Write(strm);
   return strm;
 }
@@ -146,7 +143,6 @@ inline std::ostream &operator<<(std::ostream &strm, const Tools::Nycr::Symbol::T
 
 /* Standard inserter for Tools::Nycr::Symbol::TUnderscore. */
 inline std::ostream &operator<<(std::ostream &strm, const Tools::Nycr::Symbol::TUnderscore &that) {
-  assert(&that);
   that.Write(strm);
   return strm;
 }

--- a/tools/nycr/symbol/rule.cc
+++ b/tools/nycr/symbol/rule.cc
@@ -21,6 +21,5 @@
 using namespace Tools::Nycr::Symbol;
 
 void TRule::Accept(const TVisitor &visitor) const {
-  assert(&visitor);
   visitor(this);
 }

--- a/tools/nycr/symbol/write_bison.cc
+++ b/tools/nycr/symbol/write_bison.cc
@@ -67,7 +67,6 @@ static bool CompareOps(const TOperator *lhs, const TOperator *rhs) {
 
 static void CollectOperators(const TKind *kind, vector<const TOperator *> &ops) {
   assert(kind);
-  assert(&ops);
   class TVisitor : public TKind::TVisitor {
     public:
     TVisitor(vector<const TOperator *> &ops) : Ops(ops) {}
@@ -171,7 +170,6 @@ static void WriteBisonH(const char *root, const char *branch, const char *atom, 
 
 static void WriteRule(const TKind *kind, ostream &strm) {
   assert(kind);
-  assert(&strm);
   class TVisitor : public TKind::TVisitor {
     public:
     TVisitor(ostream &strm) : Strm(strm) {}
@@ -246,7 +244,6 @@ static void WriteRule(const TKind *kind, ostream &strm) {
 
 static void WriteTypeDecl(const TKind *kind, ostream &strm) {
   assert(kind);
-  assert(&strm);
   class TVisitor : public TKind::TVisitor {
     public:
     TVisitor(ostream &strm) : Strm(strm) {}
@@ -269,6 +266,5 @@ static void WriteTypeDecl(const TKind *kind, ostream &strm) {
 
 static void WriteUnionMember(const TKind *kind, ostream &strm) {
   assert(kind);
-  assert(&strm);
   strm << "  " << TType(kind->GetName()) << " *" << TLower(kind->GetName()) << ';' << endl;
 }

--- a/tools/nycr/symbol/write_cst.cc
+++ b/tools/nycr/symbol/write_cst.cc
@@ -321,13 +321,11 @@ static void WriteDecl(const TKind *kind, const string &namespace_prefix, ostream
     const string &NamespacePrefix;
   };
   assert(kind);
-  assert(&strm);
   kind->Accept(TVisitor(strm, namespace_prefix));
 }
 
 static void WriteDef(const TKind *kind, ostream &strm) {
   assert(kind);
-  assert(&strm);
   class TVisitor : public TKind::TVisitor {
     public:
     TVisitor(ostream &strm) : Strm(strm) {}
@@ -429,6 +427,5 @@ static void WriteDef(const TKind *kind, ostream &strm) {
 
 static void WriteFwdDecl(const TKind *kind, ostream &strm) {
   assert(kind);
-  assert(&strm);
   strm << "class " << TType(kind->GetName()) << ';' << endl;
 }

--- a/tools/nycr/symbol/write_flex.cc
+++ b/tools/nycr/symbol/write_flex.cc
@@ -52,7 +52,6 @@ void Tools::Nycr::Symbol::WriteFlex(const char *root, const char *branch, const 
 
 static void CollectAtoms(const TKind *kind, vector<const TAtom *> &atoms) {
   assert(kind);
-  assert(&atoms);
   class TVisitor : public TKind::TVisitor {
     public:
     TVisitor(vector<const TAtom *> &atoms) : Atoms(atoms) {}

--- a/tools/nycr/symbol/write_nycr.cc
+++ b/tools/nycr/symbol/write_nycr.cc
@@ -46,7 +46,6 @@ void Tools::Nycr::Symbol::WriteNycr(const char *root, const char *branch, const 
 
 void Tools::Nycr::Symbol::WriteNycrDecl(const TKind *kind, ostream &strm) {
   assert(kind);
-  assert(&strm);
   class TVisitor : public TKind::TVisitor {
     public:
     TVisitor(ostream &strm) : Strm(strm) {}

--- a/tools/nycr/symbol/write_xml.h
+++ b/tools/nycr/symbol/write_xml.h
@@ -83,7 +83,6 @@ namespace Tools {
 
       /* TODO */
       inline std::ostream &operator<<(std::ostream &strm, const TXmlTag &that) {
-        assert(&that);
         that.Write(strm);
         return strm;
       }

--- a/tools/nycr/syntax/nycr.cst.cc
+++ b/tools/nycr/syntax/nycr.cst.cc
@@ -55,7 +55,6 @@ TNycr::~TNycr() = default;
 
 
 void TNycr::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -85,7 +84,6 @@ bool TNycr::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) const 
 }
 
 void TNoDeclSeq::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -109,7 +107,6 @@ TDeclSeq::~TDeclSeq() = default;
 
 
 void TDeclSeq::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -150,7 +147,6 @@ TPrecLevel::~TPrecLevel() = default;
 
 
 void TPrecLevel::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -196,7 +192,6 @@ bool TPrecLevel::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) c
 }
 
 void TPrecKwd::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -217,7 +212,6 @@ bool TPrecKwd::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) con
 }
 
 void TName::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -238,7 +232,6 @@ bool TName::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) const 
 }
 
 void TSemi::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -262,7 +255,6 @@ TOper::~TOper() = default;
 
 
 void TOper::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -335,7 +327,6 @@ TSuper::~TSuper() = default;
 
 
 void TSuper::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -373,7 +364,6 @@ bool TSuper::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) const
 }
 
 void TColon::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -394,7 +384,6 @@ bool TColon::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) const
 }
 
 void TNoSuper::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -418,7 +407,6 @@ TPattern::~TPattern() = default;
 
 
 void TPattern::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -464,7 +452,6 @@ bool TPattern::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) con
 }
 
 void TEq::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -485,7 +472,6 @@ bool TEq::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) const {
 }
 
 void TSingleQuotedStrLiteral::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -506,7 +492,6 @@ bool TSingleQuotedStrLiteral::Test(::Tools::Nycr::Test::TNode *that, const char 
 }
 
 void TSingleQuotedRawStrLiteral::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -527,7 +512,6 @@ bool TSingleQuotedRawStrLiteral::Test(::Tools::Nycr::Test::TNode *that, const ch
 }
 
 void TDoubleQuotedStrLiteral::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -548,7 +532,6 @@ bool TDoubleQuotedStrLiteral::Test(::Tools::Nycr::Test::TNode *that, const char 
 }
 
 void TDoubleQuotedRawStrLiteral::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -572,7 +555,6 @@ TPriLevel::~TPriLevel() = default;
 
 
 void TPriLevel::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -610,7 +592,6 @@ bool TPriLevel::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) co
 }
 
 void TPriKwd::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -631,7 +612,6 @@ bool TPriKwd::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) cons
 }
 
 void TIntLiteral::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -652,7 +632,6 @@ bool TIntLiteral::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) 
 }
 
 void TNoPriLevel::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -673,7 +652,6 @@ bool TNoPriLevel::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) 
 }
 
 void TRightKwd::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -694,7 +672,6 @@ bool TRightKwd::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) co
 }
 
 void TNonassocKwd::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -715,7 +692,6 @@ bool TNonassocKwd::Test(::Tools::Nycr::Test::TNode *that, const char *as_member)
 }
 
 void TLeftKwd::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -739,7 +715,6 @@ TLanguage::~TLanguage() = default;
 
 
 void TLanguage::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -836,7 +811,6 @@ TRhs::~TRhs() = default;
 
 
 void TRhs::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -882,7 +856,6 @@ bool TRhs::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) const {
 }
 
 void TArrow::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -903,7 +876,6 @@ bool TArrow::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) const
 }
 
 void TNoMemberSeq::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -927,7 +899,6 @@ TMemberSeq::~TMemberSeq() = default;
 
 
 void TMemberSeq::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -968,7 +939,6 @@ TNamedMember::~TNamedMember() = default;
 
 
 void TNamedMember::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1017,7 +987,6 @@ TErrorMember::~TErrorMember() = default;
 
 
 void TErrorMember::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1047,7 +1016,6 @@ bool TErrorMember::Test(::Tools::Nycr::Test::TNode *that, const char *as_member)
 }
 
 void TErrorKwd::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1071,7 +1039,6 @@ TAnonymousMember::~TAnonymousMember() = default;
 
 
 void TAnonymousMember::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1104,7 +1071,6 @@ TOperRef::~TOperRef() = default;
 
 
 void TOperRef::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1142,7 +1108,6 @@ bool TOperRef::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) con
 }
 
 void TNoOperRef::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1166,7 +1131,6 @@ TNoRhs::~TNoRhs() = default;
 
 
 void TNoRhs::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1204,7 +1168,6 @@ bool TNoRhs::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) const
 }
 
 void TEmptyKwd::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1225,7 +1188,6 @@ bool TEmptyKwd::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) co
 }
 
 void TOpenAngle::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1249,7 +1211,6 @@ TPath::~TPath() = default;
 
 
 void TPath::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1290,7 +1251,6 @@ TPathTail::~TPathTail() = default;
 
 
 void TPathTail::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1328,7 +1288,6 @@ bool TPathTail::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) co
 }
 
 void TSlash::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1349,7 +1308,6 @@ bool TSlash::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) const
 }
 
 void TNoPathTail::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1370,7 +1328,6 @@ bool TNoPathTail::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) 
 }
 
 void TNoPath::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1391,7 +1348,6 @@ bool TNoPath::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) cons
 }
 
 void TCloseAngle::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1412,7 +1368,6 @@ bool TCloseAngle::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) 
 }
 
 void TNoExpectedSr::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1436,7 +1391,6 @@ TExpectedSr::~TExpectedSr() = default;
 
 
 void TExpectedSr::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1474,7 +1428,6 @@ bool TExpectedSr::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) 
 }
 
 void TSrKwd::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1495,7 +1448,6 @@ bool TSrKwd::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) const
 }
 
 void TNoExpectedRr::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1519,7 +1471,6 @@ TExpectedRr::~TExpectedRr() = default;
 
 
 void TExpectedRr::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1557,7 +1508,6 @@ bool TExpectedRr::Test(::Tools::Nycr::Test::TNode *that, const char *as_member) 
 }
 
 void TRrKwd::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1581,7 +1531,6 @@ TRule::~TRule() = default;
 
 
 void TRule::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1638,7 +1587,6 @@ TKeyword::~TKeyword() = default;
 
 
 void TKeyword::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1695,7 +1643,6 @@ TBase::~TBase() = default;
 
 
 void TBase::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";
@@ -1744,7 +1691,6 @@ TBadDecl::~TBadDecl() = default;
 
 
 void TBadDecl::Write(ostream &strm, size_t depth, const char *as_member) const {
-  assert(&strm);
   strm << ::Tools::Nycr::TIndent(depth);
   if (as_member) {
     strm << as_member << " -> ";

--- a/tools/nycr/syntax/nycr.cst.h
+++ b/tools/nycr/syntax/nycr.cst.h
@@ -136,7 +136,6 @@ class TNoDeclSeq : public TOptDeclSeq {
   public:
   TNoDeclSeq() {}
   virtual void Accept(const TOptDeclSeq::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   virtual void Write(std::ostream &strm, size_t depth, const char *as_member) const;
@@ -154,7 +153,6 @@ class TDeclSeq : public TOptDeclSeq {
   }
   virtual ~TDeclSeq();
   virtual void Accept(const TOptDeclSeq::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const TDecl *GetDecl() const {
@@ -207,7 +205,6 @@ class TPrecLevel : public TDecl {
   }
   virtual ~TPrecLevel();
   virtual void Accept(const TDecl::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const TPrecKwd *GetPrecKwd() const {
@@ -311,11 +308,9 @@ class TOper : public TKind {
   }
   virtual ~TOper();
   virtual void Accept(const TKind::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   virtual void Accept(const TDecl::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const TName *GetName() const {
@@ -378,7 +373,6 @@ class TSuper : public TOptSuper {
   }
   virtual ~TSuper();
   virtual void Accept(const TOptSuper::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const TColon *GetColon() const {
@@ -415,7 +409,6 @@ class TNoSuper : public TOptSuper {
   public:
   TNoSuper() {}
   virtual void Accept(const TOptSuper::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   virtual void Write(std::ostream &strm, size_t depth, const char *as_member) const;
@@ -494,7 +487,6 @@ class TSingleQuotedStrLiteral : public TStrLiteral {
   TSingleQuotedStrLiteral(int start_line, int start_col, int limit_line, int limit_col, const char *text, int len)
       : Lexeme(start_line, start_col, limit_line, limit_col, text, len) {}
   virtual void Accept(const TStrLiteral::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const ::Tools::Nycr::TLexeme &GetLexeme() const {
@@ -513,7 +505,6 @@ class TSingleQuotedRawStrLiteral : public TStrLiteral {
   TSingleQuotedRawStrLiteral(int start_line, int start_col, int limit_line, int limit_col, const char *text, int len)
       : Lexeme(start_line, start_col, limit_line, limit_col, text, len) {}
   virtual void Accept(const TStrLiteral::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const ::Tools::Nycr::TLexeme &GetLexeme() const {
@@ -532,7 +523,6 @@ class TDoubleQuotedStrLiteral : public TStrLiteral {
   TDoubleQuotedStrLiteral(int start_line, int start_col, int limit_line, int limit_col, const char *text, int len)
       : Lexeme(start_line, start_col, limit_line, limit_col, text, len) {}
   virtual void Accept(const TStrLiteral::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const ::Tools::Nycr::TLexeme &GetLexeme() const {
@@ -551,7 +541,6 @@ class TDoubleQuotedRawStrLiteral : public TStrLiteral {
   TDoubleQuotedRawStrLiteral(int start_line, int start_col, int limit_line, int limit_col, const char *text, int len)
       : Lexeme(start_line, start_col, limit_line, limit_col, text, len) {}
   virtual void Accept(const TStrLiteral::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const ::Tools::Nycr::TLexeme &GetLexeme() const {
@@ -594,7 +583,6 @@ class TPriLevel : public TOptPriLevel {
   }
   virtual ~TPriLevel();
   virtual void Accept(const TOptPriLevel::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const TPriKwd *GetPriKwd() const {
@@ -646,7 +634,6 @@ class TNoPriLevel : public TOptPriLevel {
   public:
   TNoPriLevel() {}
   virtual void Accept(const TOptPriLevel::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   virtual void Write(std::ostream &strm, size_t depth, const char *as_member) const;
@@ -681,7 +668,6 @@ class TRightKwd : public TAssoc {
   TRightKwd(int start_line, int start_col, int limit_line, int limit_col, const char *text, int len)
       : Lexeme(start_line, start_col, limit_line, limit_col, text, len) {}
   virtual void Accept(const TAssoc::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const ::Tools::Nycr::TLexeme &GetLexeme() const {
@@ -700,7 +686,6 @@ class TNonassocKwd : public TAssoc {
   TNonassocKwd(int start_line, int start_col, int limit_line, int limit_col, const char *text, int len)
       : Lexeme(start_line, start_col, limit_line, limit_col, text, len) {}
   virtual void Accept(const TAssoc::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const ::Tools::Nycr::TLexeme &GetLexeme() const {
@@ -719,7 +704,6 @@ class TLeftKwd : public TAssoc {
   TLeftKwd(int start_line, int start_col, int limit_line, int limit_col, const char *text, int len)
       : Lexeme(start_line, start_col, limit_line, limit_col, text, len) {}
   virtual void Accept(const TAssoc::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const ::Tools::Nycr::TLexeme &GetLexeme() const {
@@ -749,11 +733,9 @@ class TLanguage : public TKind {
   }
   virtual ~TLanguage();
   virtual void Accept(const TKind::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   virtual void Accept(const TDecl::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const TName *GetName() const {
@@ -829,7 +811,6 @@ class TRhs : public TOptRhs {
   }
   virtual ~TRhs();
   virtual void Accept(const TOptRhs::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const TArrow *GetArrow() const {
@@ -890,7 +871,6 @@ class TNoMemberSeq : public TOptMemberSeq {
   public:
   TNoMemberSeq() {}
   virtual void Accept(const TOptMemberSeq::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   virtual void Write(std::ostream &strm, size_t depth, const char *as_member) const;
@@ -908,7 +888,6 @@ class TMemberSeq : public TOptMemberSeq {
   }
   virtual ~TMemberSeq();
   virtual void Accept(const TOptMemberSeq::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const TMember *GetMember() const {
@@ -957,7 +936,6 @@ class TNamedMember : public TMember {
   }
   virtual ~TNamedMember();
   virtual void Accept(const TMember::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const TName *GetName() const {
@@ -987,7 +965,6 @@ class TErrorMember : public TMember {
   }
   virtual ~TErrorMember();
   virtual void Accept(const TMember::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const TErrorKwd *GetErrorKwd() const {
@@ -1024,7 +1001,6 @@ class TAnonymousMember : public TMember {
   }
   virtual ~TAnonymousMember();
   virtual void Accept(const TMember::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const TName *GetName() const {
@@ -1067,7 +1043,6 @@ class TOperRef : public TOptOperRef {
   }
   virtual ~TOperRef();
   virtual void Accept(const TOptOperRef::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const TPrecKwd *GetPrecKwd() const {
@@ -1089,7 +1064,6 @@ class TNoOperRef : public TOptOperRef {
   public:
   TNoOperRef() {}
   virtual void Accept(const TOptOperRef::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   virtual void Write(std::ostream &strm, size_t depth, const char *as_member) const;
@@ -1107,7 +1081,6 @@ class TNoRhs : public TOptRhs {
   }
   virtual ~TNoRhs();
   virtual void Accept(const TOptRhs::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const TArrow *GetArrow() const {
@@ -1184,7 +1157,6 @@ class TPath : public TOptPath {
   }
   virtual ~TPath();
   virtual void Accept(const TOptPath::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const TName *GetName() const {
@@ -1231,7 +1203,6 @@ class TPathTail : public TOptPathTail {
   }
   virtual ~TPathTail();
   virtual void Accept(const TOptPathTail::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const TSlash *GetSlash() const {
@@ -1268,7 +1239,6 @@ class TNoPathTail : public TOptPathTail {
   public:
   TNoPathTail() {}
   virtual void Accept(const TOptPathTail::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   virtual void Write(std::ostream &strm, size_t depth, const char *as_member) const;
@@ -1281,7 +1251,6 @@ class TNoPath : public TOptPath {
   public:
   TNoPath() {}
   virtual void Accept(const TOptPath::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   virtual void Write(std::ostream &strm, size_t depth, const char *as_member) const;
@@ -1329,7 +1298,6 @@ class TNoExpectedSr : public TOptExpectedSr {
   public:
   TNoExpectedSr() {}
   virtual void Accept(const TOptExpectedSr::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   virtual void Write(std::ostream &strm, size_t depth, const char *as_member) const;
@@ -1347,7 +1315,6 @@ class TExpectedSr : public TOptExpectedSr {
   }
   virtual ~TExpectedSr();
   virtual void Accept(const TOptExpectedSr::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const TSrKwd *GetSrKwd() const {
@@ -1404,7 +1371,6 @@ class TNoExpectedRr : public TOptExpectedRr {
   public:
   TNoExpectedRr() {}
   virtual void Accept(const TOptExpectedRr::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   virtual void Write(std::ostream &strm, size_t depth, const char *as_member) const;
@@ -1422,7 +1388,6 @@ class TExpectedRr : public TOptExpectedRr {
   }
   virtual ~TExpectedRr();
   virtual void Accept(const TOptExpectedRr::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const TRrKwd *GetRrKwd() const {
@@ -1466,11 +1431,9 @@ class TRule : public TKind {
   }
   virtual ~TRule();
   virtual void Accept(const TKind::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   virtual void Accept(const TDecl::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const TName *GetName() const {
@@ -1507,11 +1470,9 @@ class TKeyword : public TKind {
   }
   virtual ~TKeyword();
   virtual void Accept(const TKind::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   virtual void Accept(const TDecl::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const TName *GetName() const {
@@ -1547,11 +1508,9 @@ class TBase : public TKind {
   }
   virtual ~TBase();
   virtual void Accept(const TKind::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   virtual void Accept(const TDecl::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const TName *GetName() const {
@@ -1581,7 +1540,6 @@ class TBadDecl : public TDecl {
   }
   virtual ~TBadDecl();
   virtual void Accept(const TDecl::TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
   const TSemi *GetSemi() const {

--- a/tools/nycr/test.h
+++ b/tools/nycr/test.h
@@ -52,7 +52,6 @@ namespace Tools {
         void InsertIntoParent(TNode *parent, const std::string &kind) {
           assert(parent);
           assert(parent != this);
-          assert(&kind);
           RemoveFromParent();
           Kind = kind;
           Parent = parent;
@@ -112,12 +111,10 @@ namespace Tools {
       };  // TNode;
 
       static void SkipWhitespace(const char *&str) {
-        assert(&str);
         while (!isgraph(*str)) ++str;
       }
 
       static bool TryMatch(const char *&str, char expected) {
-        assert(&str);
         SkipWhitespace(str);
         bool result = *str == expected;
         if (result) ++str;
@@ -131,8 +128,6 @@ namespace Tools {
       }
 
       static void ParseString(const char *&str, std::string &out) {
-        assert(&str);
-        assert(&out);
         SkipWhitespace(str);
         const char *cur = str;
         while (isgraph(*cur) && !ispunct(*cur)) ++cur;

--- a/utf8/piece.cc
+++ b/utf8/piece.cc
@@ -33,7 +33,6 @@ TPiece::TPiece(const char *that) {
 }
 
 int TPiece::Compare(const TPiece &that) const {
-  assert(&that);
   TPiece
       lhs = *this,
       rhs = that;

--- a/utf8/piece.h
+++ b/utf8/piece.h
@@ -139,7 +139,6 @@ namespace Utf8 {
 
     /* True iff. this string piece and that one are pointing at the same memory. */
     bool Is(const TPiece &that) const {
-      assert(&that);
       return Start == that.Start && Limit == that.Limit;
     }
 
@@ -179,8 +178,6 @@ namespace Utf8 {
 
   /* A std stream inserter for Utf8::TPiece. */
   inline std::ostream &operator<<(std::ostream &strm, const TPiece &that) {
-    assert(&strm);
-    assert(&that);
     return strm.write(that.GetStart(), that.GetByteCount());
   }
 
@@ -192,7 +189,6 @@ namespace std {
   template <>
   struct hash<Utf8::TPiece> {
     inline size_t operator()(const Utf8::TPiece &that) const {
-      assert(&that);
       return that.GetHash();
     }
   };

--- a/utf8/pos.h
+++ b/utf8/pos.h
@@ -58,8 +58,6 @@ namespace Utf8 {
 
   /* A std stream inserter for Utf8::TPiece. */
   inline std::ostream &operator<<(std::ostream &strm, const TPos &that) {
-    assert(&strm);
-    assert(&that);
     return strm << that.GetLine() << ':' << that.GetCol();
   }
 

--- a/utf8/pos_map.cc
+++ b/utf8/pos_map.cc
@@ -24,7 +24,6 @@ using namespace std;
 using namespace Utf8;
 
 TPosMap::TPosMap(const TPiece &text) {
-  assert(&text);
   if (text) {
     Eols.push_back(text.GetStart() - 1);
     TPiece csr = text;

--- a/util/io.h
+++ b/util/io.h
@@ -32,7 +32,6 @@ namespace Util {
   template <typename TStrm>
   void OpenFile(TStrm &strm, const std::string &path) {
     //TODO: This should move out the stream, but we can't because libstdc++ 4.9 hasn't implemented move for at least ifstream
-    assert(&path);
 
     strm.exceptions(std::ios_base::failbit);
     try {

--- a/util/string.cc
+++ b/util/string.cc
@@ -69,7 +69,6 @@ string Util::ToString(const TWriter &writer) {
 }
 
 void Util::WriteBracketedJoin(ostream &strm, const TCStrGen &c_str_gen, char open_c, char close_c, const char *sep) {
-  assert(&strm);
   assert(c_str_gen);
   assert(sep);
   strm << open_c;
@@ -95,7 +94,6 @@ void Util::WriteBracketedJoin(ostream &strm, const TCStrGen &c_str_gen, char ope
 }
 
 void Util::WriteJoin(ostream &strm, const TCStrGen &c_str_gen, const char *sep) {
-  assert(&strm);
   assert(c_str_gen);
   assert(sep);
   bool sep_required = false;

--- a/visitor/applier.test.cc
+++ b/visitor/applier.test.cc
@@ -122,17 +122,14 @@ namespace Shape {
   using Double = Visitor::Alias::Double<TShape::TVisitor, TShape::TVisitor>;
 
   void TCircle::Accept(const TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
 
   void TSquare::Accept(const TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
 
   void TTriangle::Accept(const TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
 

--- a/visitor/auto.test.cc
+++ b/visitor/auto.test.cc
@@ -124,17 +124,14 @@ namespace Shape {
   /* 5. Finish the definitions for the final classes' Accept() functions. */
 
   void TCircle::Accept(const TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
 
   void TSquare::Accept(const TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
 
   void TTriangle::Accept(const TVisitor &visitor) const {
-    assert(&visitor);
     visitor(this);
   }
 

--- a/visitor/manual.test.cc
+++ b/visitor/manual.test.cc
@@ -51,19 +51,16 @@ namespace Shape {
 
     /* The sum of this point and that one. */
     TPoint operator+(const TPoint &that) const {
-      assert(&that);
       return TPoint(X + that.X, Y + that.Y);
     }
 
     /* The difference of this point and that one. */
     TPoint operator-(const TPoint &that) const {
-      assert(&that);
       return TPoint(X - that.X, Y - that.Y);
     }
 
     /* The dot-product of this point and that one. */
     double operator*(const TPoint &that) const {
-      assert(&that);
       return (X * that.X) + (Y * that.Y);
     }
 
@@ -80,7 +77,6 @@ namespace Shape {
 
     /* The distance between this point and that one. */
     double operator, (const TPoint &that) const {
-      assert(&that);
       TPoint diff = that - *this;
       return sqrt((diff.X * diff.X) + (diff.Y * diff.Y));
     }
@@ -181,7 +177,6 @@ namespace Shape {
 
     /* Call back for each edge of the rectangle. */
     bool ForEachEdge(const std::function<bool(const TLineSegment &)> &cb) const {
-      assert(&cb);
       return cb(GetTopEdge()) && cb(GetBottomEdge()) && cb(GetLeftEdge()) && cb(GetRightEdge());
     }
 
@@ -298,12 +293,10 @@ namespace Shape {
   /* 9. Finish the definitions for the final classes' Accept() functions. */
 
   void TCircle::Accept(const TVisitor &visitor) const {
-    assert(&visitor);
     visitor(*this);
   }
 
   void TRectangle::Accept(const TVisitor &visitor) const {
-    assert(&visitor);
     visitor(*this);
   }
 
@@ -324,7 +317,6 @@ double GetArea(const Shape::TShape &shape) {
       Result = that.GetWidth() * that.GetHeight();
     }
   };
-  assert(&shape);
   double result;
   Visitor::Single::Accept(shape, visitor_t(result));  /* 10. First method to Accept(). */
   return result;

--- a/visitor/shared.h
+++ b/visitor/shared.h
@@ -21,7 +21,6 @@
      // In this version, we computed a new value which needs to be managed, so
         fine, we'll give it to std::make_shared<> to get it managed.
      std::shared_ptr<std::string> ToString(const int &that) {
-       assert(&that);
        return std::make_shared<std::string>(std::to_string(that));
      }
 
@@ -29,7 +28,6 @@
         the string is already managed. We'd rather not make another copy of it
         and worse-yet, do an unnecessary heap-allocation.
      std::shared_ptr<std::string> ToString(const std::string &that) {
-       assert(&that);
        return std::make_shared<std::string>(that);
      }
 
@@ -38,7 +36,6 @@
      // ToString(const int &that) omitted.
 
      TShared<std::string> ToString(const std::string &that) {
-       assert(&that);
        return TShared<std::string>::Share(&that);
      }
 
@@ -381,7 +378,6 @@ namespace Visitor {
 
     /* Swap the pointers to the managed element. */
     TShared &Swap(TShared &that) noexcept {
-      assert(&that);
       if (this == &that) {
         return *this;
       }  // if
@@ -448,20 +444,16 @@ namespace Visitor {
   template <typename TLhsElem, typename TRhsElem>
   bool operator==(const TShared<TLhsElem> &lhs,
                   const TShared<TRhsElem> &rhs) noexcept {
-    assert(&lhs);
-    assert(&rhs);
     return lhs.Get() == rhs.Get();
   }
 
   template <typename TElem>
   bool operator==(const TShared<TElem> &lhs, std::nullptr_t rhs) noexcept {
-    assert(&lhs);
     return lhs.Get() == rhs;
   }
 
   template <typename TElem>
   bool operator==(std::nullptr_t lhs, const TShared<TElem> &rhs) noexcept {
-    assert(&rhs);
     return lhs == rhs.Get();
   }
 
@@ -486,15 +478,12 @@ namespace Visitor {
   template <typename TLhsElem, typename TRhsElem>
   bool operator<(const TShared<TLhsElem> &lhs,
                  const TShared<TRhsElem> &rhs) noexcept {
-    assert(&lhs);
-    assert(&rhs);
     using common_t = std::common_type_t<TLhsElem *, TRhsElem *>;
     return std::less<common_t>()(lhs.Get(), rhs.Get());
   }
 
   template <typename TElem>
   bool operator<(const TShared<TElem> &lhs, std::nullptr_t rhs) noexcept {
-    assert(&lhs);
     return std::less<TElem *>()(lhs.Get(), rhs);
   }
 
@@ -559,8 +548,6 @@ namespace Visitor {
   std::basic_ostream<TChar, TCharTraits> &operator<<(
       std::basic_ostream<TChar, TCharTraits> &strm,
       const TShared<TElem> &that) {
-    assert(&strm);
-    assert(&that);
     return strm << that.Get();
   }
 
@@ -645,7 +632,6 @@ namespace Visitor {
 
     /* Swap the pointers to the managed element. */
     TWeak &Swap(TWeak &that) noexcept {
-      assert(&that);
       if (this == &that) {
         return *this;
       }  // if
@@ -682,14 +668,12 @@ namespace Visitor {
   /* std::swap<> specialization. */
   template <typename TElem>
   void swap(Visitor::TShared<TElem> &lhs, Visitor::TShared<TElem> &rhs) noexcept {
-    assert(&lhs);
     lhs.Swap(rhs);
   }
 
   /* std::swap<> specialization. */
   template <typename TElem>
   void swap(Visitor::TWeak<TElem> &lhs, Visitor::TWeak<TElem> &rhs) noexcept {
-    assert(&lhs);
     lhs.Swap(rhs);
   }
 
@@ -706,7 +690,6 @@ namespace std {
     using result_type = std::size_t;
 
     result_type operator()(const argument_type &that) const {
-      assert(&that);
       return std::hash<TElem *>()(that.Get());
     }
 

--- a/visitor/variant.h
+++ b/visitor/variant.h
@@ -226,7 +226,6 @@ namespace Visitor {
        that we have a valid conversion, we conclude by moving the data. */
     template <typename ThatFamily>
     TVariant(TVariant<ThatFamily> &&that) : TVariant() {
-      assert(&that);
       if (!that) {
         return;
       }  // if
@@ -245,7 +244,6 @@ namespace Visitor {
        end rather than moving it. */
     template <typename ThatFamily>
     TVariant(const TVariant<ThatFamily> &that) : TVariant() {
-      assert(&that);
       if (!that) {
         return;
       }  // if
@@ -297,14 +295,12 @@ namespace Visitor {
     /* Accept a regular (non-mutating) visitor. */
     void Accept(const TVisitor &visitor) const {
       assert(*this);
-      assert(&visitor);
       (*Acceptor)(visitor, Data.Get());
     }
 
     /* Accept a mutating visitor. */
     void Accept(const TMutatingVisitor &visitor) {
       assert(*this);
-      assert(&visitor);
       if (!Data.IsUnique()) {
         Data = Single::Accept<TApplier<TMakeShared>>(*this);
       }  // if
@@ -319,7 +315,6 @@ namespace Visitor {
 
     /* Swap two variants. */
     TVariant &Swap(TVariant &that) noexcept {
-      assert(&that);
       if (this == &that) {
         return *this;
       }  // if
@@ -374,7 +369,6 @@ namespace Visitor {
          its correct type. */
       virtual void operator()(const TVisitor &visitor,
                               const void *data) const override {
-        assert(&visitor);
         assert(data);
         visitor(*static_cast<const TElem *>(data));
       }
@@ -386,7 +380,6 @@ namespace Visitor {
          instead. Fullfilling the COW (Copy-on-Write) feature of TVariant. */
       virtual void operator()(const TMutatingVisitor &visitor,
                               void *data) const override {
-        assert(&visitor);
         assert(data);
         visitor(*static_cast<TElem *>(data));
       }

--- a/visitor/variant.test.cc
+++ b/visitor/variant.test.cc
@@ -145,11 +145,9 @@ int GetInt(const TFoo &that);
 // get_int.cc
 int TGetInt::operator()(int that) const { return that; }
 int TGetInt::operator()(const std::string &that) const {
-  assert(&that);
   return stoi(that);
 }
 int TGetInt::operator()(const std::vector<TFoo> &that) const {
-  assert(&that);
   int result = 0;
   for (const auto &variant : that) {
     result += GetInt(variant);
@@ -286,7 +284,6 @@ int TGetIntAndWriteVector::operator()(int that,
 int TGetIntAndWriteVector::operator()(const std::string &that,
                                       std::ostream &strm,
                                       const std::vector<int> &ints) const {
-  assert(&that);
   for (const auto &i : ints) {
     strm << i;
   }
@@ -295,7 +292,6 @@ int TGetIntAndWriteVector::operator()(const std::string &that,
 int TGetIntAndWriteVector::operator()(const std::vector<TFoo> &that,
                                       std::ostream &strm,
                                       const std::vector<int> &ints) const {
-  assert(&that);
   for (const auto &i : ints) {
     strm << i;
   }
@@ -380,12 +376,10 @@ std::string TToString::operator()(int that) const {
 }
 
 std::string TToString::operator()(const std::string &that) const {
-  assert(&that);
   return "'" + that + "'";
 }
 
 std::string TToString::operator()(const std::vector<TFoo> &that) const {
-  assert(&that);
   std::ostringstream strm;
   strm << '[';
   bool sep = false;
@@ -398,7 +392,6 @@ std::string TToString::operator()(const std::vector<TFoo> &that) const {
 }
 
 std::string TToString::operator()(const std::list<TBar> &that) const {
-  assert(&that);
   std::ostringstream strm;
   strm << '[';
   bool sep = false;
@@ -493,17 +486,14 @@ void SetDefault(TFoo &that);
 
 // set_default.cc
 void TSetDefault::operator()(int &that) const {
-  assert(&that);
   that = 0;
 }
 
 void TSetDefault::operator()(std::string &that) const {
-  assert(&that);
   that.clear();
 }
 
 void TSetDefault::operator()(std::vector<TFoo> &that) const {
-  assert(&that);
   for (auto &variant : that) {
     SetDefault(variant);
   }
@@ -540,7 +530,6 @@ struct TSetDefaultTemplate {
 
   template <typename TMember>
   void operator()(TMember &that) const {
-    assert(&that);
     that = TMember{};
   }
 


### PR DESCRIPTION
## Background

Companion sweep to #29. Same reasoning, different pattern:

```cpp
void Foo(const TBar &that) {
  assert(&that);   // <-- this line, 1477 of them
  ...
}
```

Taking the address of a reference cannot produce nullptr in well-formed C++. If you had a null reference, you already invoked UB by binding to it -- the assert can't catch a case that didn't already happen. Modern gcc treats `&ref == nullptr` as unreachable and optimizes the check away. Under `-DNDEBUG` the assert is `((void)0)` regardless.

After #29 stripped the 4,729 `assert(this);` lines, this was the next-largest noise pile.

## What this PR does

Deletes lines matching exactly `^\s*assert\(&[ident]\);\s*$`. **1,477 lines across 423 files.**

## What this PR deliberately does NOT touch

Same exclusions as #29:
- string literals in code generators (`out << "assert(&ctx);" << Eol`)
- macro `\` continuations
- The one `assert(&test); // To keep GCC from warning about unused variables` -- correctly flagged as intentional by its own comment

## One surprise

Removing the assert broke 3 call sites with `-Werror=unused-parameter`. The `assert(&that);` was *incidentally* keeping the parameter "used." Fixed each by removing the parameter name -- the correct C++ idiom for "interface requires this argument but this implementation ignores it":

- `orly/rt/unknown.h` -- `bool operator==(const TUnknown &) const` (two operators)
- `orly/balancer/balancer.{cc,test.cc}` -- `ServeClient(TFd &fd, const TAddress &)`
- `orly/server/server.cc` -- `ServeMemcacheClient(TFd &&fd_original, const TAddress &)`

These are an improvement on the prior state -- the intent ("this implementation doesn't use client_address") is now explicit in the signature.

## Test plan

- [x] `make debug` -- clean (1707/1707)
- [x] `make test` -- passes

## Next

After this lands, ~2,800 asserts remain in the codebase. Those are the reviewable set where the actual question lives -- which ones protect runtime invariants that get silently stripped under `-DNDEBUG`. That's #29's promised follow-up.
