### PR TITLE
Fix `TFd::Pipe` silently ignoring `pipe2()` failures

### DIFF
--- a/base/fd.h
+++ b/base/fd.h
@@ -134,7 +134,7 @@ namespace Base {
     /* Construct the read- and write-only ends of a pipe. */
     static void Pipe(TFd &readable, TFd &writeable, int flags = 0) {
       int fds[2];
-      Util::IfLt0(pipe2(fds, flags) < 0);
+      Util::IfLt0(pipe2(fds, flags));
       readable = TFd(fds[0], NoThrow);
       writeable = TFd(fds[1], NoThrow);
     }

--- a/util/error.h
+++ b/util/error.h
@@ -37,7 +37,11 @@ namespace Util {
      Use this function to test the results of system I/O calls. */
   template <typename TRet>
   TRet IfLt0(TRet &&ret) {
-    if constexpr (std::is_signed_v<std::remove_reference_t<TRet>>) {
+    using TBare = std::remove_cv_t<std::remove_reference_t<TRet>>;
+    static_assert(!std::is_same_v<TBare, bool>,
+                  "IfLt0 called with bool -- did you accidentally write `IfLt0(syscall(...) < 0)`? "
+                  "Pass the raw syscall result; the < 0 check is internal.");
+    if constexpr (std::is_signed_v<TBare>) {
       if (ret < 0) {
         ThrowSystemError(errno);
       }


### PR DESCRIPTION
## The bug

`base/fd.h:137` had:

```cpp
Util::IfLt0(pipe2(fds, flags) < 0);
```

The `< 0` coerces the `int` return code to `bool` *before* `IfLt0` sees it. `IfLt0`'s body is:

```cpp
if constexpr (std::is_signed_v<TRet>) {
  if (ret < 0) { ThrowSystemError(errno); }
}
```

`is_signed_v<bool>` is `false`. So the entire error check is compiled out. If `pipe2()` returns `-1`, the bool is `true`, `IfLt0<bool>` does literally nothing, and `TFd::Pipe` returns "success" with two `TFd`s wrapping `-1`. Later use of those FDs blows up as `EBADF` -- or worse, gets paired with an unrelated FD that happens to be `-1`-adjacent. Exactly the silent-failure-then-cascade pattern from #24.

## How I found it

While surveying what the post-`Pipe()` asserts in `base/pump.cc:46-49` were defending against:

```cpp
TFd::Pipe(ReadFd, write);
SetNonBlocking(ReadFd);
TFd::Pipe(read, WriteFd);
SetNonBlocking(WriteFd);

assert(write);
assert(read);
assert(ReadFd);
assert(WriteFd);
```

These asserts were a manual backstop for the silently-skipped error check -- and useless under `-DNDEBUG`, which is when you most want them.

## The fix

Two parts:

1. **`base/fd.h`** -- drop the spurious `< 0`. `pipe2()` returns `int`; `IfLt0(int)` already does the right thing. One character... well, two characters removed.

2. **`util/error.h`** -- add a `static_assert` in `IfLt0` that rejects `bool` with a diagnostic pointing at the typical mistake. So this can't recur:

   ```
   error: static assertion failed: IfLt0 called with bool -- did you
   accidentally write `IfLt0(syscall(...) < 0)`? Pass the raw syscall
   result; the < 0 check is internal.
   ```

I checked every other `IfLt0` call site in the codebase -- `subprocess.cc`, `failover_test.cc`, `cold_start_test.cc` -- all pass `execv`/`execvp` results directly, no bool coercion. Only `fd.h:137` had the bug.

## Test plan

- [x] `make debug` clean
- [x] `make test` clean
- [x] `Util::IfLt0(true);` in a sample TU now fails compilation with the intended diagnostic
