### PR TITLE
Drop redundant asserts in `base/pump.cc`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ tools/clang
 tools/clang++
 third_party/llvm
 third_party/llvm_build
+.claude/
 

--- a/base/pump.cc
+++ b/base/pump.cc
@@ -42,11 +42,6 @@ class TPump::TPipe {
     // Pipe from where we write to where the user will read
     TFd::Pipe(read, WriteFd);
     SetNonBlocking(WriteFd);
-
-    assert(write);
-    assert(read);
-    assert(ReadFd);
-    assert(WriteFd);
   }
 
   ~TPipe() {
@@ -85,9 +80,6 @@ class TPump::TPipe {
       } else {  // Read data
         ReadOffset += read_size;
         StartWriting();
-
-        // NOTE: If we handle being at the end of the buffer / out of block space at the start of reading.
-        assert(ReadOffset <= ReadBufSize);
       }
     }
 
@@ -121,8 +113,6 @@ class TPump::TPipe {
           }
         } else {
           WriteOffset += write_size;
-
-          assert(WriteOffset <= ReadBufSize);
 
           // If we're at the same point in the buffer as the read head, release it to simplify things.
           if (Blocks.front() == Blocks.back() && ReadOffset == WriteOffset) {


### PR DESCRIPTION
## Background

Follow-on cleanup to #31. With `TFd::Pipe` now actually throwing on `pipe2()` failure, the asserts in `base/pump.cc` that were defending against the (silently-skipped) failure mode are dead, so let's delete them.

## What this PR does

Removes 6 asserts in two clusters:

**Constructor (lines 46-49)**
```cpp
assert(write); assert(read);
assert(ReadFd); assert(WriteFd);
```
These ran after the two `TFd::Pipe()` calls. Pre-#31, `TFd::Pipe` silently produced `TFd(-1)`s on failure and these asserts caught it in debug builds only. Post-#31, the `Pipe()` call throws, so by the time control reaches these lines all four fds are guaranteed open.

**`Service()` (lines 90, 125)**
```cpp
assert(ReadOffset <= ReadBufSize);
assert(WriteOffset <= ReadBufSize);
```
These restate the kernel's guarantee that `read(fd, buf, n)` returns `<= n` bytes (and same for `write`). The byte count is added to the offset on the line above. The asserts cannot fire unless the kernel breaks its contract -- and if that ever happens, the assert (stripped at release) is not what saves us.

## What stays

The comment block on `StopReading()` referencing "the historical `assert(ReadFd.IsOpen())` doesn't catch the double-call" stays intact -- it explains the runtime `if (ReadFd.IsOpen())` check that replaced that assert in #24, which is real and load-bearing.

## Bonus

`.gitignore` -- `.claude/` (per-session scheduler state from the Claude Code tool, leaked into a previous commit by accident in this branch).

## Test plan

- [x] `make debug` clean
- [x] `make test` clean
