### PR TITLE
Drop `-Werror` from root.jhm

### DIFF
--- a/root.jhm
+++ b/root.jhm
@@ -28,7 +28,6 @@
     "g++" : [
       "-std=c++17",
       "-Wall",
-      "-Werror",
       "-Wextra",
       "-Wold-style-cast",
       "-Wno-type-limits",
@@ -60,7 +59,6 @@
       "-Wno-format-overflow",
       "-Wno-nonnull-compare",
       "-Wno-nonnull",
-      "-Wno-error=cpp",
       "-Wno-cast-function-type",
       "-Wno-aligned-new",
       "-Wno-placement-new",
@@ -82,11 +80,8 @@
       "-Wno-multichar",
       "-Wno-int-to-pointer-cast",
       "-Wno-pointer-arith",
-      "-Wno-error=return-type",
-      "-Wno-error=switch",
       "-Wno-format",
       "-Wno-format-security",
-      "-Wno-error=format-security",
       "-Wno-ignored-qualifiers",
       "-msse2",
       "-pthread",
@@ -99,7 +94,6 @@
       "-isystem","third_party/websocketpp/"
     ],
     "gcc": [
-      "-Werror",
       "-Wall",
       "-Wextra",
       "-Wno-type-limits",


### PR DESCRIPTION
## What and why

PR #28 dropped `-Werror` from `orlyc`'s shell-out g++ flags with this argument: every gcc release that adds a new warning category breaks the compile until someone updates the hand-maintained `-Wno-*` list, and the warnings are almost always about *our* code (packed unions in `TCore`, deprecated patterns, etc.) -- things the user can't fix.

The exact same trap is wired into the in-tree build. `root.jhm` has accumulated 50+ `-Wno-*` flags over the years, plus a wave of ~30 added during the 2026 revival just to get `make debug` to compile on gcc 13. Every future gcc release will need more.

This PR drops `-Werror` from `root.jhm` (both the `g++` C++ block and the `gcc` C block), mirroring #28's fix on the in-tree path.

## What changed

- **`-Werror`** dropped from both `g++` and `gcc` flag blocks.
- **Now-meaningless `-Wno-error=*` lines** removed: `-Wno-error=cpp`, `-Wno-error=return-type`, `-Wno-error=switch`, `-Wno-error=format-security`. Without `-Werror`, these are no-ops. The underlying warning categories are either still suppressed by their `-Wno-*` siblings or downgraded to plain warnings, which is the same behavior they'd have had under `-Werror -Wno-error=*`.
- **`-Wno-*` set kept verbatim.** No culling -- they don't cost anything, and future gcc versions may re-emit any of these categories with new diagnostics worth keeping quiet.

## What this PR doesn't do

If a specific warning is dangerous enough to be a hard error, `-Werror=<specific>` is the surgical way -- e.g. `-Werror=return-type` (UB on fall-off-end) might be worth adding. Not added here; let's add them on demand if a real silent bug surfaces, rather than building another speculative suppression list.

## Test plan

- [x] `make debug` clean (1707/1707 targets)
- [x] `make test` clean
- [x] grepped build output for `warning:` -- none surfaced. Existing `-Wno-*` set is comprehensive enough that gcc 13 has nothing to say.
