### PR TITLE
Bump to `-std=c++23`

### DIFF
--- a/orly/compiler.cc
+++ b/orly/compiler.cc
@@ -214,7 +214,7 @@ Package::TVersionedName Orly::Compiler::Compile(
       out_strm << "MM_NOTICE: Compiling C++" << endl;
     }
 
-    vector<string> gcc_cmd{"g++", "-std=c++17", "-xc++", "-I" + GetSrcRoot(), "-fPIC", "-shared", "-o",
+    vector<string> gcc_cmd{"g++", "-std=c++23", "-xc++", "-I" + GetSrcRoot(), "-fPIC", "-shared", "-o",
                            AsStr(out_tree.GetAbsPath(SwapExtension(
                                TPath(core_rel.Path), {to_string(packages[core_rel]->GetVersion()), "so"}))),
                            "-iquote", AsStr(out_tree),

--- a/orly/indy/fiber/algorithm.test.cc
+++ b/orly/indy/fiber/algorithm.test.cc
@@ -19,6 +19,7 @@
 #include <orly/indy/fiber/algorithm.h>
 
 #include <algorithm>
+#include <random>
 #include <thread>
 
 #include <unistd.h>
@@ -184,6 +185,6 @@ FIXTURE(LargeParallelSort) {
     input_data.emplace_back(i, i * 10);
   }
   printf("DataSetSize = [%fMB]\n", static_cast<double>(num_elem * sizeof(TSortedObj)) / (1024 * 1024));
-  random_shuffle(input_data.begin(), input_data.end());
+  std::shuffle(input_data.begin(), input_data.end(), std::mt19937(std::random_device{}()));
   TestSort(input_data, num_workers);
 }

--- a/root.jhm
+++ b/root.jhm
@@ -26,7 +26,7 @@
     ],
   "cmd": {
     "g++" : [
-      "-std=c++17",
+      "-std=c++23",
       "-Wall",
       "-Wextra",
       "-Wold-style-cast",
@@ -117,14 +117,14 @@
     "flex": {
       "g++": [
         "-DTEST_OUTPUT_DIR=\"/tmp/\"",
-        "-std=c++17",
+        "-std=c++23",
         "-pthread"
       ]
     },
     "bison": {
       "g++": [
         "-DTEST_OUTPUT_DIR=\"/tmp/\"",
-        "-std=c++17",
+        "-std=c++23",
         "-pthread"
       ]
     },

--- a/test/expect.h
+++ b/test/expect.h
@@ -19,8 +19,11 @@
 #pragma once
 
 #include <cassert>
+#include <cstdint>
+#include <ios>
 #include <sstream>
 #include <string>
+#include <type_traits>
 #include <typeinfo>
 
 #include <base/class_traits.h>
@@ -255,6 +258,24 @@ namespace Test {
     }
 
     private:
+    /* C++20 deleted operator<<(ostream&, char16_t/char32_t/char8_t) since
+       there's no agreed encoding for writing a single unicode code unit to
+       a byte stream. We just want a readable diagnostic, so print the code
+       point as U+XXXX hex. */
+    template <typename TVal>
+    static void StreamValue(std::ostream &strm, const TVal &val) {
+      using TBare = std::decay_t<TVal>;
+      if constexpr (std::is_same_v<TBare, char16_t> ||
+                    std::is_same_v<TBare, char32_t> ||
+                    std::is_same_v<TBare, char8_t>) {
+        std::ios::fmtflags saved(strm.flags());
+        strm << "U+" << std::hex << static_cast<std::uint32_t>(val);
+        strm.flags(saved);
+      } else {
+        strm << val;
+      }
+    }
+
     template <typename TLhs, typename TRhs>
     void WriteInfixOp(const char *lhs_str, const TLhs &lhs, const char *op_str, const char *rhs_str, const TRhs &rhs) {
       assert(lhs_str);
@@ -268,7 +289,9 @@ namespace Test {
       strm << rhs_str;
       Source = strm.str();
       strm.str("");
-      strm << lhs << ' ' << op_str << ' ' << rhs;
+      StreamValue(strm, lhs);
+      strm << ' ' << op_str << ' ';
+      StreamValue(strm, rhs);
       Expression = strm.str();
     }
 

--- a/visitor/variant.h
+++ b/visitor/variant.h
@@ -110,7 +110,7 @@ namespace Visitor {
 
   //TODO: This belongs somewhere in <mpl/*>
   template <bool B, typename T>
-  using requires = typename std::enable_if<B, T>::type;
+  using Require = typename std::enable_if<B, T>::type;
 
   /* Defines a class that can change its type at runtime, but only among a
      finite set of possible types. */
@@ -418,7 +418,7 @@ namespace Visitor {
       /* The other variant's value is not supported by this family.
          Throw a std::bad_cast exception. */
       template <typename TElem>
-      requires<!IsMember<TElem>::value,
+      Require<!IsMember<TElem>::value,
       const TAnyAcceptor *> operator()(TElem &&) const {
         /*std::cerr
             << "Error attempting to copy- or move- construct variants across "
@@ -432,7 +432,7 @@ namespace Visitor {
       /* The other variant's value is not supported by this family.
          Return the corresponding type-erased acceptor. */
       template <typename TElem>
-      requires<IsMember<TElem>::value,
+      Require<IsMember<TElem>::value,
       const TAnyAcceptor *> operator()(TElem &&) const {
         return TAcceptor<std::decay_t<TElem>>::Get();
       }

--- a/visitor/variant.test.cc
+++ b/visitor/variant.test.cc
@@ -83,7 +83,7 @@ struct TPrintName {
 };  // TPrintName
 
 template <typename TMember>
-requires<IsFoo<TMember>::value,
+Require<IsFoo<TMember>::value,
 void> PrintName(TMember &&member) {
   TPrintName()(std::forward<TMember>(member));
 }
@@ -135,7 +135,7 @@ struct TGetInt {
 };  // TGetInt
 
 template <typename TMember>
-requires<IsFoo<TMember>::value,
+Require<IsFoo<TMember>::value,
 int> GetInt(TMember &&member) {
   return TGetInt()(std::forward<TMember>(member));
 }
@@ -192,7 +192,7 @@ struct TWriteName {
 };  // TWriteName
 
 template <typename TMember>
-requires<IsFoo<TMember>::value,
+Require<IsFoo<TMember>::value,
 std::ostream &> WriteName(TMember &&member, std::ostream &strm) {
   return TWriteName()(std::forward<TMember>(member), strm);
 }
@@ -261,7 +261,7 @@ struct TGetIntAndWriteVector {
 };  // TGetIntAndWriteVector
 
 template <typename TMember>
-requires<IsFoo<TMember>::value,
+Require<IsFoo<TMember>::value,
 int> GetIntAndWriteVector(TMember &&member,
                          std::ostream &strm,
                          const std::vector<int> &ints) {
@@ -359,7 +359,7 @@ struct TToString {
 };  // TToString
 
 template <typename TMember>
-requires<IsFooBar<TMember>::value,
+Require<IsFooBar<TMember>::value,
 std::string> ToString(TMember &&member) {
   return TToString()(std::forward<TMember>(member));
 }
@@ -477,7 +477,7 @@ struct TSetDefault {
 };  // TSetDefault
 
 template <typename TMember>
-requires<IsFoo<TMember>::value,
+Require<IsFoo<TMember>::value,
 void> SetDefault(TMember &&member) {
   TSetDefault()(std::forward<TMember>(member));
 }
@@ -536,7 +536,7 @@ struct TSetDefaultTemplate {
 };  // TSetDefaultTemplate
 
 template <typename TMember>
-requires<IsFoo<TMember>::value,
+Require<IsFoo<TMember>::value,
 void> SetDefaultTemplate(TMember &&member) {
   TSetDefaultTemplate()(std::forward<TMember>(member));
 }
@@ -623,7 +623,7 @@ struct TWriteNameDouble {
 };  // TWriteNameDouble
 
 template <typename TLhs, typename TRhs>
-requires<IsFooBar<TLhs>::value && IsFooBar<TRhs>::value,
+Require<IsFooBar<TLhs>::value && IsFooBar<TRhs>::value,
 void> WriteNameDouble(TLhs &&lhs, TRhs &&rhs, std::ostream &strm) {
   TWriteNameDouble()(std::forward<TLhs>(lhs), std::forward<TRhs>(rhs), strm);
 }
@@ -852,7 +852,7 @@ struct TMutate {
 };  // TMutate
 
 template <typename TMember>
-requires<IsFoo<TMember>::value,
+Require<IsFoo<TMember>::value,
 void> Mutate(TMember &&member) {
   TMutate()(std::forward<TMember>(member));
 }


### PR DESCRIPTION
## Background

The websocketpp removal in #34 unblocked the C++23 bump. This PR is purely the flag flip and the small fallout fixes -- not a big refactor that *uses* C++20/23 features. Reach for `std::expected`, `std::print`, ranges, etc. when they actually help; for now, just open the door.

## Changes

- **`root.jhm`** (x3 places: `g++`, `flex.g++`, `bison.g++`) + **`orly/compiler.cc`** (orlyc's shell-out flags): `-std=c++17` → `-std=c++23`.

- **`test/expect.h`** -- C++20 deleted `operator<<(ostream&, char16_t)` (and `char32_t`/`char8_t`) since there's no agreed encoding for writing a single unicode code unit to a byte stream. `EXPECT_EQ(piece.Peek(), u'a')` in `utf8/piece.test.cc` hits this. Fix is an `if constexpr` wrapper that prints these as `U+XXXX` hex for the diagnostic message, isolated to `WriteInfixOp`'s value-streaming path.

- **`visitor/variant.h` + `visitor/variant.test.cc`** -- renamed the SFINAE helper `Visitor::requires` (a `std::enable_if_t` alias) to `Visitor::Require`. The identifier clashed with the C++20 `requires` keyword. 11 call sites updated, all in `visitor/`.

- **`orly/indy/fiber/algorithm.test.cc`** -- `std::random_shuffle` (removed in C++17; gcc kept a deprecation stub through C++20, finally gone in C++23) → `std::shuffle(first, last, std::mt19937{std::random_device{}()})`. Added `<random>`.

## Test plan

- [x] `make debug` clean (1707/1707), **zero warnings**
- [x] `make test` clean
- [x] Standalone `orly/server/ws.test` passes -- confirms the beast WS surface from #34 works under C++23
- [x] `orlyi --mem_sim --create=true` boots without crash

## What this PR does NOT do

- No actual use of C++20/23 features yet. Future PRs can adopt `std::expected`, `<ranges>`, `consteval`, etc. where they actually help.
- `std::is_pod` in `visitor/pass.h:88` is deprecated in C++20 but currently suppressed by our `-Wno-deprecated-declarations`. Worth a future cleanup to `std::is_trivial_v<T> && std::is_standard_layout_v<T>`, but not blocking the bump.

## Diff size

6 files, +42 / -18. Cleanest bump I could have hoped for -- the noise sweeps in #29/#30 plus the websocketpp removal in #34 paid off here.
