### PR TITLE
Replace deprecated `std::is_pod` with `is_trivial && is_standard_layout`

### DIFF
--- a/visitor/pass.h
+++ b/visitor/pass.h
@@ -84,9 +84,9 @@ namespace Visitor {
      it or to just aggregate it directly. */
   template <typename T>
   using IsSmall =
-      std::integral_constant<bool,
-                             std::is_pod<std::decay_t<T>>::value &&
-                                 sizeof(std::decay_t<T>) <= sizeof(int *)>;
+      std::bool_constant<std::is_trivial_v<std::decay_t<T>> &&
+                         std::is_standard_layout_v<std::decay_t<T>> &&
+                         sizeof(std::decay_t<T>) <= sizeof(int *)>;
 
   /* Pass by T if T is POD and the size of T is less than or equal to a
      pointer (passing by value is more efficient or


### PR DESCRIPTION
## What and why

`std::is_pod` was deprecated in C++20 -- the "POD" concept was decomposed into two orthogonal traits:

- `std::is_trivial<T>` -- default ctor, copy, move, and dtor are all trivial
- `std::is_standard_layout<T>` -- memory layout is C-compatible

`is_pod<T>` was exactly the conjunction of these two. Future libstdc++ versions will remove it; our current `-Wno-deprecated-declarations` is just papering over the warning today.

## Change

One site: `Visitor::IsSmall<T>` in `visitor/pass.h`, used by the visitor scaffolding (`Visitor::TPass`, `Visitor::TVariant`) to pick pass-by-value vs pass-by-const-ref. Trivial + standard-layout types that fit in a pointer are passed by value.

Behavior preserved exactly. Also nudged `std::integral_constant<bool, ...>` to the C++17 `std::bool_constant<...>` alias while in the area -- not switching would have looked like an oversight.

## Test plan

- [x] `make debug` clean (1707/1707)
- [x] `make test` clean
