### PR TITLE
Fix `TDesc` ctor template shadowing the implicit copy ctor

### DIFF
--- a/orly/desc.h
+++ b/orly/desc.h
@@ -19,6 +19,8 @@
 #pragma once
 
 #include <cassert>
+#include <type_traits>
+#include <utility>
 
 namespace Orly {
 
@@ -30,10 +32,19 @@ namespace Orly {
     /* Do-little. */
     TDesc() {}
 
-    /* Do-little. */
-    template <typename TArg>
+    /* Construct from any value convertible to TVal.  SFINAE-excludes
+       TDesc itself so this template doesn't shadow the implicit
+       copy/move ctors -- without the exclusion, `TDesc<T> b(a)` with
+       `a` a non-const lvalue TDesc<T> picks this template (it's a
+       better overload than the implicit copy ctor's const-adjusting
+       reference bind), then tries to instantiate `TVal::TVal(TDesc<T>)`
+       which fails.  Latent in C++17, exposed by C++23 overload-
+       resolution tightening. */
+    template <typename TArg,
+              typename = std::enable_if_t<
+                  !std::is_same_v<std::decay_t<TArg>, TDesc>>>
     TDesc(TArg &&arg)
-        : Val(arg) {}
+        : Val(std::forward<TArg>(arg)) {}
 
     /* Behave like a smart pointer. */
     const TVal &operator*() const {


### PR DESCRIPTION
## Background

CI's `lang-tests` job regressed on master after #35 (the C++23 bump). Baseline was `124 passed / 3 failed / 0 changed` (3 always-fail snapshot tests); post-#35 it became `123 passed / 4 failed / 1 changed`. The new failure was `orly/lang_tests/general/misc.orly`, with orlyc's shell-out `g++ -std=c++23` reporting:

```
orly/desc.h:36:11: note: cannot convert 'arg' (type 'Orly::TDesc<std::string>')
                          to type 'const char*'
   36 |         : Val(arg) {}
```

CI run: https://github.com/orlyatomics/orly/actions/runs/26730245074

## Root cause

`TDesc<T>` had:

```cpp
TDesc() {}
template <typename TArg>
TDesc(TArg &&arg) : Val(arg) {}
// + the implicit TDesc(const TDesc&) / TDesc(TDesc&&)
```

For `TDesc<string> b(a);` with `a` a non-const lvalue `TDesc<string>`:

- The **template** matches with `TArg = TDesc<string>&` -- exact bind.
- The **implicit copy ctor** matches with `const TDesc&` -- needs const-adjusting reference bind.

C++ overload resolution prefers the exact bind, so the template wins. Its body then tries `Val(arg)` where `Val` is `string` and `arg` is `TDesc<string>&`. No `string` constructor accepts a `TDesc<string>`, hence the cascade of "candidate expects N arguments / cannot convert" notes.

Latent under C++17 -- some combination of mandatory copy elision and the specific patterns orlyc emits kept this overload from being instantiated on the bad path. Exposed under C++23, which tightens overload resolution around forwarding references competing with implicit ctors.

## Fix

SFINAE the template ctor out of the case where it would shadow the copy/move ctor:

```cpp
template <typename TArg,
          typename = std::enable_if_t<
              !std::is_same_v<std::decay_t<TArg>, TDesc>>>
TDesc(TArg &&arg) : Val(std::forward<TArg>(arg)) {}
```

Now `TDesc<T> b(a)` resolves to the implicit copy ctor; the template only kicks in for the genuinely-converting cases.

While in there, replaced the bare `arg` with `std::forward<TArg>(arg)`. The template is a forwarding reference; not forwarding means we always copy from an lvalue regardless of how the caller passed the argument. Behaviorally indistinguishable for snapshot purposes (all 124 passes match exactly), correctness improvement.

Added `<type_traits>` and `<utility>` includes.

## Test plan

- [x] `make debug` clean (1707/1707)
- [x] `python3 tools/lang_test.py -d orly/data orly/lang_tests` (same invocation CI uses): **124 passed / 3 failed / 0 changed** -- baseline restored
- [x] The 3 remaining fails are the pre-existing always-fail snapshot tests (`mutablefilter.orly`, `multiple_sequences.orly`, `sequence_in_effecting.orly`), unchanged by this PR
- [x] misc.orly: was the new fail, now passes

## Why this didn't catch in #35's pre-merge testing

`make debug` and `make test` cover the in-tree build; they don't run orlyc against each `.orly` file in `orly/lang_tests/`. lang_test.py is its own job in CI for that reason. I ran it during the websocketpp PR but skipped it for the c++23 bump on the assumption that the language-version change was purely defensive. That assumption was wrong; will run lang_test.py for any future flag-flip PR that touches orlyc's shell-out.
