### PR TITLE
bootstrap.sh: comment why we stay on `-std=c++17`

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -17,6 +17,12 @@
 set -e
 
 CC=g++
+# Bootstrap stays on -std=c++17. Only two binaries are built here --
+# tools/jhm and tools/make_dep_file -- and neither uses any post-C++17
+# language feature. The main build (root.jhm) runs -std=c++23. Keeping
+# bootstrap on the older standard means a contributor can build the
+# bootstrap binaries even on a host with an older gcc that doesn't fully
+# support C++23, which lowers the barrier to running jhm at all.
 common_flags=(
   -O3 -DNDEBUG -flto=auto
   -std=c++17


### PR DESCRIPTION
## What

Six-line comment in `bootstrap.sh` explaining why it stays on `-std=c++17` while the main build (`root.jhm`) is on `-std=c++23` since #35.

## Why

Without context, the version mismatch looks like a stale leftover. Two real reasons it's deliberate:

- Bootstrap only builds `tools/jhm` and `tools/make_dep_file`. Neither uses any post-C++17 feature.
- Keeping bootstrap on the older standard means contributors with older gcc (one that doesn't fully support C++23) can still produce `jhm` and start using it.

No functional change.
