### PR TITLE
orly/README.md: actually document what's in the directory

### DIFF
--- a/orly/README.md
+++ b/orly/README.md
@@ -1,13 +1,93 @@
-## orly
+# orly/
 
-Welcome to the world's most inadequate README file. To describe it as a "work in progress" is an understatement.
+The Orly database. Everything that makes Orly *Orly* lives under this
+directory: the storage engine, the Orlyscript compiler, the runtime,
+the server daemon, and the various wire protocols.
 
-Anyway, this directory contains the code for the Orly Database.
+For project-level orientation (build, test, install), see the
+[top-level README](../README.md). For a hands-on walkthrough of
+compiling and running a package, see [`docs/walkthrough.md`](../docs/walkthrough.md).
 
------
+## Layout
 
-README.md Copyright 2010-2026 Atomic Kismet Company
+The directory has a few top-level entry-point files (binary mains and
+broadly-shared types) and many subdirectories grouped by concern.
 
-README.md is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License.
+### Binary entry points
 
-You should have received a copy of the license along with this work. If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
+| File | Builds | Purpose |
+|---|---|---|
+| `orlyc.cc` | `orly/orlyc` | Orlyscript compiler -- takes a `.orly` source, emits a `.so` package |
+| `core_import.cc` | `orly/core_import` | Bulk data importer (`.bin` files into a package) |
+| `compile_import.cc` | -- | Helper used by `core_import` |
+| `manual.cc` | -- | Manual / interactive driver for experimentation |
+
+The other two production binaries live in subdirectories:
+[`server/orlyi`](server/) (the database daemon) and
+[`spa/spa`](spa/) (single-process app server).
+
+### Broadly-shared headers at the top level
+
+| File | What it is |
+|---|---|
+| `closure.h` / `.cc` | `TClosure`: a method name + bound arguments, the unit of call into the database |
+| `compiler.h` / `.cc` | Public entry point for the Orlyscript-to-`.so` pipeline; called by `orlyc` and by `server/ws.cc`'s `compile` statement |
+| `context_base.h` | Base type for compilation contexts (errors, position tracking) |
+| `desc.h` | `TDesc<T>`: wrapper providing descending ordering -- used in indexes that need reverse sort |
+| `error.h` | Base error class for the Orly subsystem |
+| `expr.h` | Forward declarations for the Orlyscript expression tree (real types in `expr/`) |
+| `key_generator.h` | UUID-based key generation utilities |
+| `method_request.{h,cc}` | `TMethodRequest`: pov + package + method + args, what the client sends |
+| `method_result.{h,cc}` | `TMethodResult`: the value returned + the arena that owns it |
+| `pos_range.h` | Source-position range type used in error reporting |
+| `protocol.{h,cc}` | Native (non-WS, non-memcached) wire protocol types |
+| `rt.h` | Umbrella include for the Orlyscript runtime (`rt/`) |
+| `orly.nycr` | Top-level Orlyscript grammar definition, fed to `tools/nycr` |
+| `orly.package.cst.h` | Generated CST header for the grammar above |
+| `indy_lives.orly` | Smoke-test Orlyscript package, kept here as a sample |
+
+### Subdirectories
+
+#### Storage engine
+
+| Dir | What it does |
+|---|---|
+| [`indy/`](indy/) | The Indy MVCC store: Points of View, the Flux Capacitor, the on-disk page/block format. The actual database engine |
+| [`durable/`](durable/) | Durable-handle primitives (`TDurable<T>`, manager) used by sessions and povs |
+| [`atom/`](atom/) | Atomic value primitives: `TCore`, `TKit2`, packed value layouts |
+| [`sabot/`](sabot/) | "State abstraction over binary": runtime type introspection over packed values. Used to walk a binary blob and discover its shape |
+| [`var/`](var/) | `TVar`: a discriminated-union value type used at the orlyscript boundary. Converters to/from JSON, sabot, native C++ |
+| [`native/`](native/) | Native (C++) representations of Orlyscript primitive types |
+
+#### Compiler
+
+| Dir | What it does |
+|---|---|
+| [`expr/`](expr/) | Orlyscript expression AST nodes (the e in `5 + x`, `[1, 2]`, `that.x`) |
+| [`symbol/`](symbol/) | Symbol table -- resolved names, scope, type binding |
+| [`synth/`](synth/) | Concrete-syntax-tree to semantic-symbol synthesis. The "parse tree → typed AST" pass |
+| [`type/`](type/) | The Orlyscript type system: type constructors, unification, subtyping |
+| [`code_gen/`](code_gen/) | C++ code generation from the typed AST -- produces the `.cc` files that get compiled into the package `.so` |
+| [`package/`](package/) | Package management: versioned names, on-disk package directory layout, installed-package registry |
+| [`rt/`](rt/) | Orlyscript runtime library: `TStr`, `TList`, `TDict`, `TSet`, all the built-ins generated code calls into |
+| [`csv_to_bin/`](csv_to_bin/) | Generator that produces the `data/*.cc` importer binaries from CSV schemas |
+
+#### Servers and protocols
+
+| Dir | What it does |
+|---|---|
+| [`server/`](server/) | The `orlyi` daemon: session manager, native protocol, WebSocket frontend (`ws.cc`), memcached frontend (`server.cc`) |
+| [`spa/`](spa/) | "Single-process app" -- alternative deployment with everything in one process, used for tests and small setups |
+| [`mynde/`](mynde/) | Memcached wire protocols (binary + text). Named for the protocol owner (a person), not "Mynde" the concept |
+| [`balancer/`](balancer/) | TCP-level load balancer that fronts an `orlyi` cluster |
+| [`client/`](client/) | The `orly_client` interactive shell + its statement grammar (`program/`) |
+| [`notification/`](notification/) | Pub/sub channel between server components |
+
+#### Data and tests
+
+| Dir | What it does |
+|---|---|
+| [`data/`](data/) | Sample Orlyscript packages for the bundled datasets (twitter, social_graph, etc.) plus their compile recipes |
+| [`perf/`](perf/) | Performance harness scaffolding |
+
+For the Orlyscript regression test suite see [`tests/lang_tests/`](../tests/lang_tests/) at the project root.


### PR DESCRIPTION
## What

Replace the one-liner placeholder in `orly/README.md` with an actual map of the directory.

The previous content:

> Welcome to the world's most inadequate README file. To describe it as a "work in progress" is an understatement. Anyway, this directory contains the code for the Orly Database.

After #39's layout reorg, `orly/` has ~22 subdirectories. The names alone (`sabot/`, `mynde/`, `synth/`, `indy/`, ...) don't make the storage-engine / compiler / server split obvious.

## Sections

- **Binary entry points** -- `orlyc.cc`, `core_import.cc`, etc., with the target each builds
- **Broadly-shared top-level headers** -- `closure`, `compiler`, `method_request`, `method_result`, `desc`, `pos_range`, etc. with a one-line role each
- **Subdirectories grouped by concern**:
  - Storage engine: `indy/`, `durable/`, `atom/`, `sabot/`, `var/`, `native/`
  - Compiler: `expr/`, `symbol/`, `synth/`, `type/`, `code_gen/`, `package/`, `rt/`, `csv_to_bin/`
  - Servers and protocols: `server/`, `spa/`, `mynde/`, `balancer/`, `client/`, `notification/`
  - Data and tests: `data/`, `perf/`

Cross-links to the top-level README, `docs/walkthrough.md`, and `tests/lang_tests/` so anyone landing on this page can navigate out.

## No code changes

Pure docs.
