### PR TITLE
examples/bitcoin-time-travel: time-travel + multiverse demo via key-encoded version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,11 @@
 # Build & test orly on Ubuntu 24.04 / gcc 13.
 #
-# Three jobs run on every push to master and every pull_request:
-#   1. debug-and-test  -- make debug + make test (188 binaries)
-#   2. release-build   -- jhm -c release direct + --help smoke on each binary
-#   3. lang-tests      -- make debug + python3 tools/lang_test.py
+# Four jobs run on every push to master and every pull_request:
+#   1. debug-and-test     -- make debug + make test (188 binaries)
+#   2. release-build      -- jhm -c release direct + --help smoke on each binary
+#   3. lang-tests         -- make debug + python3 tools/lang_test.py
+#   4. bitcoin-time-travel -- run the examples/bitcoin-time-travel demo
+#                            end-to-end (orlyc + orlyi + WS driver)
 #
 # Caching: both apt packages and the build output tree (../out_orly,
 # ../.jhm) are cached across runs. Incremental builds rely on jhm's own
@@ -146,3 +148,43 @@ jobs:
 
       - name: python3 tools/lang_test.py
         run: python3 tools/lang_test.py -d orly/data tests/lang_tests
+
+  bitcoin-time-travel:
+    name: examples/bitcoin-time-travel
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install system dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        with:
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind
+          version: 1.0
+
+      - name: Install python websocket-client
+        run: pip3 install --break-system-packages websocket-client
+
+      - name: Cache build outputs
+        if: github.event_name != 'schedule'
+        uses: actions/cache@v5
+        with:
+          path: |
+            ../out_orly
+            ../.jhm
+            tools/jhm
+            tools/make_dep_file
+          key: orly-debug-${{ runner.os }}-${{ hashFiles('root.jhm', 'debug.jhm', 'bootstrap.jhm', 'Makefile', 'bootstrap.sh') }}-${{ github.sha }}
+          restore-keys: |
+            orly-debug-${{ runner.os }}-${{ hashFiles('root.jhm', 'debug.jhm', 'bootstrap.jhm', 'Makefile', 'bootstrap.sh') }}-
+            orly-debug-${{ runner.os }}-
+
+      - name: make debug
+        run: make debug
+
+      # Smoke-tests the orlyc + orlyi + WebSocket protocol end to end.
+      # demo.py asserts the full expected balance trajectory across
+      # both branches; any divergence fails CI.
+      - name: examples/bitcoin-time-travel/run.sh
+        run: ./run.sh
+        working-directory: examples/bitcoin-time-travel

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is the repository for the Orly non-relational database. It's meant to be fa
 ## Orly features
 
 * **Points of View**: This is our version of optimistic locking or isolation. In traditional databases, clients have to lock the entire database (or at least large swaths of it) before updating it to ensure data remains consistent. In Orly, clients make changes in their own private points of view, which are like small sandboxes. Changes in private points of view eventually propagate into shared points of view and eventually reach the global point of view, which is the whole database. Updates to private points of view don't lock anything: Orly determines later whether, when, and how to reconcile changes from different points of view. We also encourage field calls rather than field changes (e.g., `x += 1` is better than `x = x + 1`).
-* **Time Travel**: We use something called the _Flux Capacitor_ to keep a history of changes made to the database and to resolve conflicts as they come into shared points of view and the global point of view. This permits us to perform consistent read for any point in time. Orly defines its "time line" by causality rather than clock time. Instead of manipulating timestamps, Orly records an ordering of events (e.g., update A affects update B, so A "happens before" B).
+* **Causal ordering (the _Flux Capacitor_)**: Orly's merge-conflict resolution defines its "time line" by causality rather than clock time. Instead of manipulating timestamps, it records an ordering of events (e.g., update A affects update B, so A "happens before" B), and uses that ordering to decide how concurrent writes from different POVs reconcile into global state. Note: the original 2014 README pitched this as user-facing "time travel" (consistent read at any point in time), but the implementation never exposed past-state queries — POV writes propagate to global rather than freezing snapshots. Time travel as a user-facing feature is achievable, but it lives in user-space; see [`examples/bitcoin-time-travel/`](examples/bitcoin-time-travel/) for a worked pattern (encode the version axis into the key tuple, fold on read) that gives you historical queries and branched-history multiverse queries without engine changes.
 * **Query Language**: Orly has its own high-level, compiled, type-safe, functional language called _Orlyscript_. Orlyscript is not just a query language: You can write general-purpose programs in it complete with compile-time unit tests. Orly comes with a compiler that transforms Orlyscript into shared libraries (.so files on Linux), which Orly servers load as packages.
 * **Scalability and Availability**: While we eventually plan to develop a sharded Orly machine (and actively design so that we can build such a machine), our current single-node server with fail-over/replication can handle hundreds of thousands of transactions per second. We like to say that Orly will function on a "planetary scale": Your data and computations will not only distribute across a data center, but also across many data centers across the globe. This means that no disaster short of nuking the planet fifty times over or colliding with a gigantic asteroid will destroy your data. (Even those might not be catastrophic: Maybe we'll have data centers running Orly with your replicated data on the moon or Mars.)
 
@@ -57,9 +57,8 @@ python3 tools/lang_test.py -d orly/data tests/lang_tests
 The revival pass uses:
 
 * gcc 13.3.0
-* `-std=c++17`
-* boost 1.83 (system)
-* websocketpp 0.8.2 (vendored)
+* `-std=c++23`
+* boost 1.83 (system, including `boost::beast` for the WebSocket surface)
 * Python 3.12 for `lang_test.py`
 
 Build flags live in `root.jhm` (per-target overrides in `debug.jhm` / `release.jhm` / `bootstrap.jhm`).
@@ -67,6 +66,10 @@ Build flags live in `root.jhm` (per-target overrides in `debug.jhm` / `release.j
 ## Walkthrough
 
 [`docs/walkthrough.md`](docs/walkthrough.md) walks through compiling an Orlyscript package with `orlyc`, loading it into a running `orlyi`, and invoking a method on it via `orly_client` — the full pipeline end-to-end.
+
+## Examples
+
+[`examples/bitcoin-time-travel/`](examples/bitcoin-time-travel/) — a Bitcoin-flavoured ledger that does **time-travel queries** ("balance at block 5") and **branched-history multiverse queries** ("balance on the fork vs the mainnet at block 7"). Uses one small Orlyscript package and a Python driver; smoke-tested in CI on every push.
 
 ## Contributing
 

--- a/examples/bitcoin-time-travel/README.md
+++ b/examples/bitcoin-time-travel/README.md
@@ -1,0 +1,164 @@
+# Bitcoin time-travel + multiverse
+
+A small example showing that Orly can serve **time-travel queries**
+("what was alice's balance at block 5?") and **branched-history
+multiverse queries** ("alice's balance on the fork vs the mainnet at
+block 7") entirely in user-space, without engine changes.
+
+The trick is to encode both the version axis (block height) and the
+branch axis into the **key tuple**, not into Points of View. Writes
+to different tuples never collide, so the past is structurally frozen
+— nothing ever overwrites it.
+
+## Run it
+
+```sh
+cd examples/bitcoin-time-travel
+./run.sh
+```
+
+Requires `make debug` to have produced `orlyi` and `orlyc`, and
+`python3 -c 'import websocket'` to work. The wrapper kills any prior
+demo instance and runs against a fresh `orlyi`, so it's reproducible.
+
+## What the demo does
+
+1. Applies 8 blocks of mainnet activity (credits, transfers).
+2. At height 6, forks a `fork` branch from the mainnet — modelling
+   a Bitcoin chain reorg where a different miner won the block 6
+   race and gave the coinbase to bob instead of alice.
+3. Applies 3 alternate blocks on the fork.
+4. Queries balances on both branches at every height, prints both
+   chains side by side, and self-checks every value.
+
+Truncated sample output:
+
+```
+=== mainnet vs fork, per height (* = post-fork) ===
+  h     mainnet alice  fork alice    mainnet bob   fork bob
+  ----------------------------------------------------------
+     0         0.00           0.00           0.00           0.00
+     1        50.00          50.00           0.00           0.00
+     ...
+     5        35.00          35.00           7.00           7.00      (last common)
+   * 6        85.00          35.00           7.00          57.00      (diverge)
+   * 7        83.00          55.00           7.00          37.00
+   * 8        82.00          50.00           7.00          37.00
+```
+
+Rows 0–5 are bit-identical across the two branches because reads on
+`fork` for `h < 6` recurse through `<['parent', 'fork']>` into
+mainnet's keyspace. Rows 6–8 differ because they're reading
+fork-local writes.
+
+## How it works
+
+### Schema
+
+| Key | Value | Meaning |
+|---|---|---|
+| `<['delta', branch, addr, h]>` | int | The per-block delta to apply at this (branch, addr, height) tuple |
+| `<['parent', branch]>` | str | This branch's parent, if forked |
+| `<['fork_h', branch]>` | int | The height at which this branch forked from its parent |
+
+### Reads
+
+```orly
+delta_at(branch, addr, h) =
+  if branch has a parent AND h < fork_h(branch):
+    delta_at(parent(branch), addr, h)          # recurse into parent
+  else:
+    *<['delta', branch, addr, h]>::(int) ?? 0  # local lookup
+
+balance_at(branch, addr, h) =
+  [0..h] reduce start 0 + delta_at(branch, addr, that)
+```
+
+That's the whole engine. `balance_at` is a fold over the height axis;
+`delta_at` is a one-step recursion through the branch tree.
+
+### Why the past is frozen
+
+Each block writes to a unique key tuple `(branch, addr, h)`. Once
+written, the tuple is never written again — because future blocks
+have different `h`, and other branches have different `branch`. So a
+read at any historical `(branch, addr, h)` returns the same value
+forever, even after arbitrary later activity on any branch.
+
+This sidesteps Orly's actual POV semantics, where writes in a child
+POV propagate up to the parent / global immediately, making the
+POV chain useless as a snapshot mechanism.
+
+## Why this is interesting
+
+### One pattern, many domains
+
+The same fold-over-keyed-versions pattern works for any commutative
+monoid:
+
+| Domain | Fold op | Identity |
+|---|---|---|
+| Balances / counters | `+` | `0` |
+| Set membership | `union` | `{}` |
+| List append | `++` | `[]` |
+| Min / max | `min` / `max` | `+∞` / `-∞` |
+| Last-write-wins | take last | undefined |
+
+Swap the fold operator and the identity; you get historical queries
+on sets, lists, extrema, etc. for free.
+
+### What this exploits about Orly specifically
+
+- **Tuple-structured keys** as first-class indexes (`<['delta',
+  branch, addr, h]>`). Most KV stores would force you to mangle a
+  string.
+- **Per-key immutability via uniqueness.** Different tuples never
+  collide; nothing has to be "snapshotted" because nothing is ever
+  overwritten.
+- **Orlyscript recursion + short-circuit booleans** (`and_then`).
+  Lets `delta_at` defer to its parent branch in a single 4-line
+  function.
+
+### Comparison to a typical graph DB
+
+Modelling this in Cypher / Neo4j needs:
+
+- A `:Block` node per height with `(:Block)-[:NEXT]->(:Block)` edges.
+- A `:Branch {name}` node per timeline with a `[:HEAD]` edge.
+- Each transaction as a `(:Tx)-[:IN]->(:Block)` with `[:CREDITS]` /
+  `[:DEBITS]` rels to address nodes.
+- A path-walking Cypher query per question: "balance for alice on
+  fork at height 5" becomes a non-trivial chain traversal with
+  aggregation, redesigned for every domain (sets need a different
+  query than balances).
+
+In Orly the branch and height are just key coordinates, and the
+balance / set / list / min-max question is the choice of fold
+operator. One small Orlyscript helper per type, four-line read,
+domain-agnostic shape.
+
+## Caveats
+
+- **Write amplification.** Every state change costs a fresh key.
+  For a real Bitcoin-scale chain (~1B txns × N branches) you'd add
+  periodic snapshot keys (`<['snap', branch, addr, h_floor]>`
+  every N blocks) and fold from the nearest snapshot.
+- **Read amplification.** `balance_at(h)` folds over `[0..h]`.
+  Same fix: snapshot keys, then fold from the nearest one.
+- **Recursion depth.** A long fork chain (fork-of-fork-of-fork)
+  costs one recursive call per ancestor at pre-fork heights. For
+  shallow chains this is fine; for deep ones you'd flatten on
+  fork by copying ancestors' keys into the new branch's namespace.
+- **Not isomorphic to real Bitcoin.** This is account arithmetic,
+  not UTXO output consumption. The pattern generalizes (UTXOs would
+  be `<['utxo', branch, tx_id, idx]>` with a `spent` set keyed by
+  `<['spent', branch, tx_id, idx]>`), but the demo uses balances
+  for clarity.
+
+## Files
+
+| File | What |
+|---|---|
+| `bitcoin.orly` | The Orlyscript package: `delta_at`, `credit_at`, `balance_at`, `fork_from`, plus 13 inline tests |
+| `demo.py` | Python WebSocket driver: applies the scenario, prints both chains, self-checks |
+| `run.sh` | End-to-end wrapper: compiles, starts a fresh `orlyi`, runs `demo.py` |

--- a/examples/bitcoin-time-travel/bitcoin.orly
+++ b/examples/bitcoin-time-travel/bitcoin.orly
@@ -1,0 +1,128 @@
+/* <examples/bitcoin-time-travel/bitcoin.orly>
+
+   A multi-branch, time-travelling toy ledger -- inspired by Bitcoin
+   chain reorgs -- demonstrating that Orly can model historical
+   queries AND branched-history multiverse queries entirely in
+   user-space, with no engine changes.
+
+   The trick: encode the version (block height) AND the branch into
+   the key tuple. Writes to different (branch, addr, height) tuples
+   never collide, so the past is structurally frozen. Reads at a
+   given height are a fold; cross-branch inheritance is a recursion
+   through a parent pointer.
+
+   Schema:
+
+     <['delta', branch, addr, h]>  : int   -- per-block delta
+     <['parent', branch]>          : str   -- the branch this branch forked from
+     <['fork_h', branch]>          : int   -- height at which we forked
+
+   The same fold pattern works for any commutative monoid; this demo
+   uses integer addition (balances), but `union` (sets), `++` (lists),
+   and `min`/`max` would all fit.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package #1;
+
+/* Look up the per-block delta in this branch's own keyspace; 0 if absent. */
+local_delta = (((*<['delta', branch, addr, h]>::(int)) if *<['delta', branch, addr, h]>::(int?) is known else 0)) where {
+  branch = given::(str);
+  addr   = given::(str);
+  h      = given::(int);
+};
+
+/* The per-block delta for (addr, h) on `branch`, recursing into the
+   parent branch when h is before the fork. Returns 0 if no write
+   exists anywhere in the chain. */
+delta_at = ((
+  delta_at(.branch: *<['parent', branch]>::(str), .addr: addr, .h: h)
+  if *<['parent', branch]>::(str?) is known and_then h < *<['fork_h', branch]>::(int)
+  else local_delta(.branch: branch, .addr: addr, .h: h)
+)) where {
+  branch = given::(str);
+  addr   = given::(str);
+  h      = given::(int);
+};
+
+/* Add `amount` to the (branch, addr, h) delta. First write creates;
+   subsequent writes at the same tuple accumulate -- so multiple ops
+   inside one block compose. Returns 1 if we accumulated, 0 if we
+   created. */
+credit_at = (((1) effecting {
+  *<['delta', branch, addr, h]>::(int) += amount;
+} if *<['delta', branch, addr, h]>::(int?) is known else (0) effecting {
+  new <['delta', branch, addr, h]> <- amount;
+})) where {
+  branch = given::(str);
+  addr   = given::(str);
+  amount = given::(int);
+  h      = given::(int);
+};
+
+/* Declare that `branch` is forked from `parent` at height `fork_h`.
+   Reads on `branch` at heights < fork_h will recurse into parent;
+   at heights >= fork_h they see only what's been written into
+   `branch` itself. Each branch can only be forked once. */
+fork_from = ((1) effecting {
+  new <['parent', branch]> <- parent;
+  new <['fork_h', branch]> <- fork_h;
+}) where {
+  branch = given::(str);
+  parent = given::(str);
+  fork_h = given::(int);
+};
+
+/* The headline read: balance for `addr` on `branch` at height `h`.
+   Sums delta_at across the full causal prefix up to (and including) h. */
+balance_at = ([0..h] reduce start 0 + delta_at(.branch: branch, .addr: addr, .h: that)) where {
+  branch = given::(str);
+  addr   = given::(str);
+  h      = given::(int);
+};
+
+/* Inline tests -- 'orlyc -d bitcoin.orly' runs these. */
+test {
+  /* --- MAINNET --- */
+  t1: credit_at(.branch: "mainnet", .addr: "alice", .amount: 100, .h: 1) == 0 {
+    t2: credit_at(.branch: "mainnet", .addr: "alice", .amount: 50, .h: 3) == 0 {
+      t3: balance_at(.branch: "mainnet", .addr: "alice", .h: 3) == 150;
+
+      /* --- FORK from mainnet at h=2 --- */
+      t4: fork_from(.branch: "fork", .parent: "mainnet", .fork_h: 2) == 1 {
+        /* Pre-fork: fork inherits mainnet's state via recursion. */
+        t5: balance_at(.branch: "fork", .addr: "alice", .h: 1) == 100;
+
+        /* At and after the fork: fork is independent. No fork-local
+           writes yet, so balance stays at the pre-fork value. */
+        t6: balance_at(.branch: "fork", .addr: "alice", .h: 2) == 100;
+        t7: balance_at(.branch: "fork", .addr: "alice", .h: 3) == 100;
+
+        /* Mainnet is unaffected by the fork's existence. */
+        t8: balance_at(.branch: "mainnet", .addr: "alice", .h: 3) == 150;
+
+        /* Now write something different on the fork at h=3. */
+        t9: credit_at(.branch: "fork", .addr: "alice", .amount: 999, .h: 3) == 0 {
+          t10: balance_at(.branch: "fork", .addr: "alice", .h: 3) == 1099;
+          t11: balance_at(.branch: "mainnet", .addr: "alice", .h: 3) == 150;
+
+          /* Pre-fork heights remain identical across branches. */
+          t12: balance_at(.branch: "fork", .addr: "alice", .h: 1) == 100;
+          t13: balance_at(.branch: "mainnet", .addr: "alice", .h: 1) == 100;
+        };
+      };
+    };
+  };
+};

--- a/examples/bitcoin-time-travel/demo.py
+++ b/examples/bitcoin-time-travel/demo.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""
+Time-travel + multiverse demo against a running `orlyi`.
+
+Builds a `mainnet` chain of 8 blocks, forks at h=6 into a `fork`
+branch (modelling a Bitcoin chain reorg), then queries balances on
+both branches at every height. The version axis is encoded in the
+key tuple `<['delta', branch, addr, h]>`; cross-branch inheritance
+is the `delta_at` recursion in `bitcoin.orly`.
+
+Run via the wrapper:
+
+    ./run.sh
+
+Or directly, after starting `orlyi` separately:
+
+    python3 demo.py
+
+This script also self-checks: it asserts the entire expected balance
+trajectory for both branches. CI uses this as a smoke test for the
+WebSocket protocol and the Orlyscript package together.
+"""
+
+import json
+import sys
+import websocket
+
+WS_URL = "ws://127.0.0.1:8082/"
+SAT_PER_BTC = 100_000_000
+
+# --- The scenario ---------------------------------------------------------
+
+# Mainnet activity, one entry per block. Each entry is a list of
+# (address, delta) ops; positive credits, negative debits.
+MAINNET_BLOCKS = [
+    [("alice", 50_00000000)],                                               # h=1 coinbase
+    [("alice", -10_00000000), ("bob", 10_00000000)],                        # h=2
+    [("carol", 50_00000000)],                                               # h=3 coinbase
+    [("alice", -5_00000000), ("bob", 5_00000000)],                          # h=4
+    [("bob", -8_00000000), ("dave", 8_00000000)],                           # h=5 (last common block)
+    [("alice", 50_00000000)],                                               # h=6 mainnet: coinbase to alice
+    [("alice", -2_00000000), ("carol", 2_00000000)],                        # h=7
+    [("alice", -1_00000000), ("dave", 1_00000000)],                         # h=8
+]
+
+# Fork: branches at fork_h=6, then has different activity.
+FORK_BLOCKS = [
+    [("bob", 50_00000000)],                                                 # h=6 fork: coinbase to BOB instead
+    [("bob", -20_00000000), ("alice", 20_00000000)],                        # h=7
+    [("alice", -5_00000000), ("carol", 5_00000000)],                        # h=8
+]
+FORK_H = 6
+
+WATCH = ["alice", "bob", "carol", "dave"]
+
+# --- Expected output, for the self-check ---------------------------------
+
+# Balance in BTC for [alice, bob, carol, dave] at each height h on mainnet.
+EXPECT_MAINNET = [
+    (0, [ 0,  0,  0, 0]),
+    (1, [50,  0,  0, 0]),
+    (2, [40, 10,  0, 0]),
+    (3, [40, 10, 50, 0]),
+    (4, [35, 15, 50, 0]),
+    (5, [35,  7, 50, 8]),
+    (6, [85,  7, 50, 8]),
+    (7, [83,  7, 52, 8]),
+    (8, [82,  7, 52, 9]),
+]
+
+# Same on the fork. Heights 0..5 (pre-fork) must match mainnet exactly.
+EXPECT_FORK = [
+    (0, [ 0,  0,  0, 0]),
+    (1, [50,  0,  0, 0]),
+    (2, [40, 10,  0, 0]),
+    (3, [40, 10, 50, 0]),
+    (4, [35, 15, 50, 0]),
+    (5, [35,  7, 50, 8]),
+    (6, [35, 57, 50, 8]),
+    (7, [55, 37, 50, 8]),
+    (8, [50, 37, 55, 8]),
+]
+
+
+# --- WebSocket plumbing ---------------------------------------------------
+
+def send(ws, stmt):
+    """Send one Orlyscript statement; raise on non-OK reply."""
+    ws.send(stmt)
+    reply = json.loads(ws.recv())
+    if reply.get("status") != "ok":
+        raise RuntimeError(f"{stmt!r}\n  -> {reply}")
+    return reply.get("result")
+
+
+def credit_at(ws, pov, branch, addr, amount, h):
+    send(ws, f'try {{{pov}}} bitcoin credit_at '
+             f'<{{.branch: "{branch}", .addr: "{addr}", .amount: {amount}, .h: {h}}}>;')
+
+
+def balance_at(ws, pov, branch, addr, h):
+    return send(ws, f'try {{{pov}}} bitcoin balance_at '
+                    f'<{{.branch: "{branch}", .addr: "{addr}", .h: {h}}}>;')
+
+
+def fork_from(ws, pov, branch, parent, fork_h):
+    send(ws, f'try {{{pov}}} bitcoin fork_from '
+             f'<{{.branch: "{branch}", .parent: "{parent}", .fork_h: {fork_h}}}>;')
+
+
+# --- Output formatting ----------------------------------------------------
+
+def fmt(satoshi):
+    return f"{satoshi / SAT_PER_BTC:>7,.2f}"
+
+
+def print_chain(ws, pov, branch, max_h):
+    header = "  h    " + "  ".join(f"{a:>7}" for a in WATCH)
+    print(header)
+    print("  " + "-" * (len(header) - 2))
+    for h in range(0, max_h + 1):
+        bals = [balance_at(ws, pov, branch, addr, h) for addr in WATCH]
+        print(f"  {h:>2}   " + "  ".join(fmt(b) for b in bals))
+
+
+# --- Main -----------------------------------------------------------------
+
+def main():
+    ws = websocket.create_connection(WS_URL)
+    send(ws, "new session;")
+    send(ws, "install bitcoin.1;")
+    pov = send(ws, "new safe shared pov;")
+    print(f"pov: {pov}\n")
+
+    print(f"applying mainnet ({len(MAINNET_BLOCKS)} blocks)...")
+    for h, ops in enumerate(MAINNET_BLOCKS, start=1):
+        for addr, delta in ops:
+            credit_at(ws, pov, "mainnet", addr, delta, h)
+
+    print(f"forking at h={FORK_H}, applying {len(FORK_BLOCKS)} fork blocks...")
+    fork_from(ws, pov, "fork", "mainnet", FORK_H)
+    for i, ops in enumerate(FORK_BLOCKS):
+        h = FORK_H + i
+        for addr, delta in ops:
+            credit_at(ws, pov, "fork", addr, delta, h)
+
+    total_h = len(MAINNET_BLOCKS)
+
+    print("\n=== MAINNET ===")
+    print_chain(ws, pov, "mainnet", total_h)
+
+    print(f"\n=== FORK (forked from mainnet at h={FORK_H}) ===")
+    print_chain(ws, pov, "fork", total_h)
+
+    print("\n=== mainnet vs fork, per height (* = post-fork) ===")
+    print("  h     mainnet alice  fork alice    mainnet bob   fork bob")
+    print("  " + "-" * 58)
+    for h in range(0, total_h + 1):
+        ma = balance_at(ws, pov, "mainnet", "alice", h)
+        fa = balance_at(ws, pov, "fork", "alice", h)
+        mb = balance_at(ws, pov, "mainnet", "bob", h)
+        fb = balance_at(ws, pov, "fork", "bob", h)
+        marker = "  " if h < FORK_H else " *"
+        print(f" {marker}{h:>2}   {fmt(ma):>10}     {fmt(fa):>10}     {fmt(mb):>10}     {fmt(fb):>10}")
+    print(f"\n  rows 0..{FORK_H - 1} are identical: reads on `fork` recurse through `<['parent', 'fork']>` into mainnet's keyspace")
+
+    # --- Self-check ------------------------------------------------------
+    failures = []
+    for h, expected_btc in EXPECT_MAINNET:
+        for addr, want_btc in zip(WATCH, expected_btc):
+            got = balance_at(ws, pov, "mainnet", addr, h)
+            if got != want_btc * SAT_PER_BTC:
+                failures.append(f"mainnet h={h} {addr}: got {got}, want {want_btc * SAT_PER_BTC}")
+    for h, expected_btc in EXPECT_FORK:
+        for addr, want_btc in zip(WATCH, expected_btc):
+            got = balance_at(ws, pov, "fork", addr, h)
+            if got != want_btc * SAT_PER_BTC:
+                failures.append(f"fork h={h} {addr}: got {got}, want {want_btc * SAT_PER_BTC}")
+
+    send(ws, "exit;")
+    ws.close()
+
+    if failures:
+        print("\n=== self-check FAILED ===")
+        for f in failures:
+            print(f"  {f}")
+        sys.exit(1)
+    print("\n=== self-check OK ===")
+    print(f"  verified {len(EXPECT_MAINNET) * len(WATCH) * 2} balance values across both branches")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/bitcoin-time-travel/run.sh
+++ b/examples/bitcoin-time-travel/run.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Drives the end-to-end demo:
+#   1. Compile bitcoin.orly with orlyc (also runs its inline tests).
+#   2. Lay out a package directory orlyi can install from.
+#   3. Start a fresh orlyi (killing any prior `bitcoin_demo` instance).
+#   4. Run demo.py, which connects via WebSocket, applies the chain,
+#      queries balances, and self-checks against expected values.
+#   5. Kill orlyi on exit.
+#
+# Run from any working directory; binaries are found relative to the
+# repo, which is two levels up from this script. Override with the
+# ORLY_OUT environment variable if your build went elsewhere.
+
+set -e
+
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../.. && pwd)"
+ORLY_OUT="${ORLY_OUT:-$REPO_ROOT/../out_orly/debug}"
+ORLYI="$ORLY_OUT/orly/server/orlyi"
+ORLYC="$ORLY_OUT/orly/orlyc"
+
+for bin in "$ORLYI" "$ORLYC"; do
+  if [ ! -x "$bin" ]; then
+    echo "missing: $bin"
+    echo ""
+    echo "Build the project first (from $REPO_ROOT):"
+    echo "  make debug"
+    echo ""
+    echo "Or set ORLY_OUT to point at your debug-build output tree."
+    exit 1
+  fi
+done
+
+WORK="$(mktemp -d)"
+trap 'kill -9 $ORLYI_PID 2>/dev/null || true; rm -rf "$WORK"' EXIT
+
+echo "[1/5] compile bitcoin.orly (also runs inline tests)"
+"$ORLYC" -o "$WORK" bitcoin.orly
+
+echo "[2/5] populate packages/"
+mkdir "$WORK/packages"
+touch "$WORK/packages/__orly__"
+cp "$WORK/bitcoin.1.so" "$WORK/packages/"
+
+# Stop anything that might already be using port 8082 or the instance name.
+pkill -9 -f 'instance_name=bitcoin_time_travel_demo' 2>/dev/null || true
+sleep 1
+
+echo "[3/5] start fresh orlyi (logs -> $WORK/orlyi.log)"
+"$ORLYI" --mem_sim --create=true \
+         --port_number=19400 --slave_port_number=19401 \
+         --connection_backlog=10 \
+         --instance_name=bitcoin_time_travel_demo \
+         --starting_state=SOLO \
+         --package_dir="$WORK/packages" \
+         > "$WORK/orlyi.log" 2>&1 &
+ORLYI_PID=$!
+
+echo "[4/5] wait for WebSocket port 8082"
+for _ in $(seq 1 60); do
+  if ss -tln 2>/dev/null | grep -q ':8082'; then
+    break
+  fi
+  sleep 1
+done
+if ! ss -tln 2>/dev/null | grep -q ':8082'; then
+  echo "orlyi failed to come up; last log lines:"
+  tail -20 "$WORK/orlyi.log"
+  exit 1
+fi
+
+echo "[5/5] run demo.py"
+python3 demo.py


### PR DESCRIPTION
## What this PR does

Adds a worked example showing how Orly can do **user-facing time-travel queries** AND **branched-history multiverse queries** entirely in user-space, with no engine changes. Also fixes a misleading README claim that pointed people at a feature the engine never grew.

## The trick

Orly's POVs aren't snapshots — writes in a child POV propagate to ancestors immediately. That kills the obvious "POV chain = git commits" approach. But Orly's keys *are* tuples, and writes to different tuples never collide. So the example encodes the version (block height) and branch into the **key tuple**:

```
<['delta', branch, addr, h]> : int    -- per-block delta
<['parent', branch]>         : str    -- this branch's parent, if forked
<['fork_h', branch]>         : int    -- height at which we forked

delta_at(branch, addr, h):
  if parent exists AND h < fork_h: delta_at(parent, addr, h)   -- recurse
  else: lookup <['delta', branch, addr, h]> (or 0)

balance_at(branch, addr, h):
  [0..h] reduce start 0 + delta_at(branch, addr, that)
```

That's the whole "engine." Past entries are immutable because their tuple coordinates are unique. Time travel becomes a fold; multiverse becomes a recursion.

## What lands

### `examples/bitcoin-time-travel/`

| File | What |
|---|---|
| `bitcoin.orly` | Orlyscript package: 4 helpers + 13 inline tests, all passing under `orlyc -d` |
| `demo.py` | Python WebSocket driver: applies 8 mainnet blocks, forks at h=6 (chain reorg), applies 3 fork blocks, prints both chains, **self-checks 72 balance values across both branches** |
| `run.sh` | End-to-end wrapper — builds into a tmp dir, starts a fresh `orlyi`, runs `demo.py` |
| `README.md` | Pattern writeup, schema, monoid generalisation, vs-graph-DB comparison, honest caveats |

### `.github/workflows/ci.yml`

New `bitcoin-time-travel` job, fourth in the workflow. `make debug` then `run.sh`. `demo.py`'s self-check asserts the full balance trajectory, so any drift in `orlyc`, `orlyi`, the WS protocol, or the Orlyscript semantics surfaces in CI on every push.

### `README.md` (top level)

Rewrote the "Time Travel" bullet. The original 2014 phrasing — *"This permits us to perform consistent read for any point in time"* — promised a feature the implementation never grew. Replaced with an honest description of the Flux Capacitor (causal ordering for merge conflict resolution) plus a pointer at the example as the actual answer.

Bumped two other stale facts caught while in there:
- `-std=c++17` → `-std=c++23` (#35)
- Removed the `websocketpp 0.8.2 (vendored)` line — that was replaced with `boost::beast` in #34

Also added an `Examples` section linking the new directory.

## Sample output

```
=== mainnet vs fork, per height (* = post-fork) ===
  h     mainnet alice  fork alice    mainnet bob   fork bob
  ----------------------------------------------------------
    0         0.00           0.00           0.00           0.00
    1        50.00          50.00           0.00           0.00
    ...
    5        35.00          35.00           7.00           7.00       (last common)
  * 6        85.00          35.00           7.00          57.00       (diverge)
  * 7        83.00          55.00           7.00          37.00
  * 8        82.00          50.00           7.00          37.00

  rows 0..5 are identical: reads on `fork` recurse through `<['parent', 'fork']>` into mainnet's keyspace

=== self-check OK ===
  verified 72 balance values across both branches
```

## Why this matters

The previous README implied a feature the implementation never grew. Anyone exploring Orly for "time-travel queries" would find the claim, try a POV-chain demo, watch it not work, and bounce. (Speaking from experience — that's how I started.)

This PR shows the *capability* is achievable using Orly's actual primitives: tuple-structured keys + per-key uniqueness immutability + Orlyscript recursion + short-circuit booleans + `reduce`. The same fold-over-keyed-versions pattern works for any commutative monoid; the demo uses integer balances, but sets / lists / extrema / last-write-wins all fit the same shape.

## Test plan

- [x] `orlyc -d bitcoin.orly` — 13/13 inline tests pass
- [x] `./run.sh` — end-to-end, `demo.py` asserts the full 72-value trajectory across both branches, all pass
- [x] `yaml.safe_load` on `.github/workflows/ci.yml` parses clean
