### PR TITLE
examples/bitcoin-time-travel: add a Go driver alongside the Python one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,11 @@ jobs:
       - name: Install python websocket-client
         run: pip3 install --break-system-packages websocket-client
 
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
       - name: Cache build outputs
         if: github.event_name != 'schedule'
         uses: actions/cache@v5
@@ -183,8 +188,13 @@ jobs:
         run: make debug
 
       # Smoke-tests the orlyc + orlyi + WebSocket protocol end to end.
-      # demo.py asserts the full expected balance trajectory across
-      # both branches; any divergence fails CI.
-      - name: examples/bitcoin-time-travel/run.sh
+      # Both drivers (Python + Go) exercise the same scenario and
+      # self-check the full 72-value balance trajectory across both
+      # branches; any divergence fails CI.
+      - name: run.sh (python driver)
         run: ./run.sh
+        working-directory: examples/bitcoin-time-travel
+
+      - name: run-go.sh (go driver)
+        run: ./run-go.sh
         working-directory: examples/bitcoin-time-travel

--- a/examples/bitcoin-time-travel/.gitignore
+++ b/examples/bitcoin-time-travel/.gitignore
@@ -1,0 +1,2 @@
+# Stray go-build output from `go build ./...` in this dir.
+bitcoin-time-travel

--- a/examples/bitcoin-time-travel/README.md
+++ b/examples/bitcoin-time-travel/README.md
@@ -12,14 +12,21 @@ to different tuples never collide, so the past is structurally frozen
 
 ## Run it
 
+Two equivalent drivers ship -- Python and Go. Both do the same
+scenario and self-check the same 72 balance values; pick whichever
+your environment has.
+
 ```sh
 cd examples/bitcoin-time-travel
-./run.sh
+./run.sh       # python driver (requires `pip install websocket-client`)
+./run-go.sh    # go driver    (requires the `go` toolchain on PATH)
 ```
 
-Requires `make debug` to have produced `orlyi` and `orlyc`, and
-`python3 -c 'import websocket'` to work. The wrapper kills any prior
-demo instance and runs against a fresh `orlyi`, so it's reproducible.
+Either wrapper requires `make debug` to have produced `orlyi` and
+`orlyc`. Both kill any prior demo instance and run against a fresh
+`orlyi`, so they're reproducible end to end.
+
+Both drivers are exercised in CI on every push.
 
 ## What the demo does
 
@@ -161,4 +168,6 @@ domain-agnostic shape.
 |---|---|
 | `bitcoin.orly` | The Orlyscript package: `delta_at`, `credit_at`, `balance_at`, `fork_from`, plus 13 inline tests |
 | `demo.py` | Python WebSocket driver: applies the scenario, prints both chains, self-checks |
+| `demo.go` + `go.mod` + `go.sum` | Go WebSocket driver, equivalent to the Python one; single dep on `github.com/gorilla/websocket` |
 | `run.sh` | End-to-end wrapper: compiles, starts a fresh `orlyi`, runs `demo.py` |
+| `run-go.sh` | Same wrapper, but runs `demo.go` instead |

--- a/examples/bitcoin-time-travel/demo.go
+++ b/examples/bitcoin-time-travel/demo.go
@@ -1,0 +1,279 @@
+// Time-travel + multiverse demo against a running orlyi, in Go.
+//
+// Equivalent to demo.py -- same scenario (8 mainnet blocks, fork at h=6,
+// 3 fork blocks), same expected output, same self-check. The Python and
+// Go drivers are paired so reviewers can diff them in spirit.
+//
+// Run via the wrapper:
+//
+//	./run-go.sh
+//
+// Or directly, after starting orlyi separately:
+//
+//	go run demo.go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	wsURL      = "ws://127.0.0.1:8082/"
+	satPerBTC  = 100_000_000
+	forkHeight = 6
+)
+
+// One operation inside a block: a credit (or debit, if amount < 0) to addr.
+type op struct {
+	addr   string
+	amount int64
+}
+
+var (
+	mainnetBlocks = [][]op{
+		{{"alice", 50_00000000}},                                                   // h=1 coinbase
+		{{"alice", -10_00000000}, {"bob", 10_00000000}},                            // h=2
+		{{"carol", 50_00000000}},                                                   // h=3 coinbase
+		{{"alice", -5_00000000}, {"bob", 5_00000000}},                              // h=4
+		{{"bob", -8_00000000}, {"dave", 8_00000000}},                               // h=5 (last common)
+		{{"alice", 50_00000000}},                                                   // h=6 mainnet coinbase to alice
+		{{"alice", -2_00000000}, {"carol", 2_00000000}},                            // h=7
+		{{"alice", -1_00000000}, {"dave", 1_00000000}},                             // h=8
+	}
+
+	forkBlocks = [][]op{
+		{{"bob", 50_00000000}},                                                     // h=6 fork: coinbase to bob
+		{{"bob", -20_00000000}, {"alice", 20_00000000}},                            // h=7
+		{{"alice", -5_00000000}, {"carol", 5_00000000}},                            // h=8
+	}
+
+	watch = []string{"alice", "bob", "carol", "dave"}
+
+	// Expected balances in BTC for [alice, bob, carol, dave] at each height.
+	expectMainnet = []struct {
+		h    int
+		bals [4]int64
+	}{
+		{0, [4]int64{0, 0, 0, 0}},
+		{1, [4]int64{50, 0, 0, 0}},
+		{2, [4]int64{40, 10, 0, 0}},
+		{3, [4]int64{40, 10, 50, 0}},
+		{4, [4]int64{35, 15, 50, 0}},
+		{5, [4]int64{35, 7, 50, 8}},
+		{6, [4]int64{85, 7, 50, 8}},
+		{7, [4]int64{83, 7, 52, 8}},
+		{8, [4]int64{82, 7, 52, 9}},
+	}
+	expectFork = []struct {
+		h    int
+		bals [4]int64
+	}{
+		{0, [4]int64{0, 0, 0, 0}},
+		{1, [4]int64{50, 0, 0, 0}},
+		{2, [4]int64{40, 10, 0, 0}},
+		{3, [4]int64{40, 10, 50, 0}},
+		{4, [4]int64{35, 15, 50, 0}},
+		{5, [4]int64{35, 7, 50, 8}},
+		{6, [4]int64{35, 57, 50, 8}},
+		{7, [4]int64{55, 37, 50, 8}},
+		{8, [4]int64{50, 37, 55, 8}},
+	}
+)
+
+// One orlyi reply -- {"status": "ok|...", "result": ...}. result varies
+// (string for `new pov`, number for `balance_at`, null for void methods).
+type reply struct {
+	Status string          `json:"status"`
+	Result json.RawMessage `json:"result"`
+	Pos    string          `json:"pos,omitempty"`
+}
+
+// send a statement and return the raw result JSON; bail on non-OK.
+func send(c *websocket.Conn, stmt string) json.RawMessage {
+	if err := c.WriteMessage(websocket.TextMessage, []byte(stmt)); err != nil {
+		die(fmt.Sprintf("write %q: %v", stmt, err))
+	}
+	_, msg, err := c.ReadMessage()
+	if err != nil {
+		die(fmt.Sprintf("read after %q: %v", stmt, err))
+	}
+	var r reply
+	if err := json.Unmarshal(msg, &r); err != nil {
+		die(fmt.Sprintf("parse reply to %q: %v\n  raw: %s", stmt, err, msg))
+	}
+	if r.Status != "ok" {
+		die(fmt.Sprintf("%s: %s", stmt, string(msg)))
+	}
+	return r.Result
+}
+
+func sendString(c *websocket.Conn, stmt string) string {
+	raw := send(c, stmt)
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		die(fmt.Sprintf("expected string result, got %s", raw))
+	}
+	return s
+}
+
+func sendInt(c *websocket.Conn, stmt string) int64 {
+	// orlyi serialises numbers as JSON floats (e.g. `5000000000.0`), so we
+	// unmarshal into float64 and cast. Our domain is integer satoshi well
+	// inside float64's exact-integer range (2^53), so no precision loss.
+	raw := send(c, stmt)
+	var n float64
+	if err := json.Unmarshal(raw, &n); err != nil {
+		die(fmt.Sprintf("expected number result, got %s", raw))
+	}
+	return int64(n)
+}
+
+// Convenience wrappers that build the right `try {pov} bitcoin <method> <{args}>;`.
+func creditAt(c *websocket.Conn, pov, branch, addr string, amount int64, h int) {
+	stmt := fmt.Sprintf(
+		`try {%s} bitcoin credit_at <{.branch: "%s", .addr: "%s", .amount: %d, .h: %d}>;`,
+		pov, branch, addr, amount, h)
+	send(c, stmt)
+}
+
+func balanceAt(c *websocket.Conn, pov, branch, addr string, h int) int64 {
+	stmt := fmt.Sprintf(
+		`try {%s} bitcoin balance_at <{.branch: "%s", .addr: "%s", .h: %d}>;`,
+		pov, branch, addr, h)
+	return sendInt(c, stmt)
+}
+
+func forkFrom(c *websocket.Conn, pov, branch, parent string, h int) {
+	stmt := fmt.Sprintf(
+		`try {%s} bitcoin fork_from <{.branch: "%s", .parent: "%s", .fork_h: %d}>;`,
+		pov, branch, parent, h)
+	send(c, stmt)
+}
+
+func die(msg string) {
+	fmt.Fprintln(os.Stderr, msg)
+	os.Exit(1)
+}
+
+func fmtBTC(satoshi int64) string {
+	return fmt.Sprintf("%7.2f", float64(satoshi)/satPerBTC)
+}
+
+func printChain(c *websocket.Conn, pov, branch string, maxH int) {
+	fmt.Printf("  %-3s  ", "h")
+	for _, a := range watch {
+		fmt.Printf("%7s  ", a)
+	}
+	fmt.Println()
+	fmt.Println("  " + dashes(8+9*len(watch)))
+	for h := 0; h <= maxH; h++ {
+		fmt.Printf("  %2d   ", h)
+		for _, addr := range watch {
+			fmt.Printf("%s  ", fmtBTC(balanceAt(c, pov, branch, addr, h)))
+		}
+		fmt.Println()
+	}
+}
+
+func dashes(n int) string {
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = '-'
+	}
+	return string(out)
+}
+
+func main() {
+	u, _ := url.Parse(wsURL)
+	c, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	if err != nil {
+		die(fmt.Sprintf("dial %s: %v", wsURL, err))
+	}
+	defer c.Close()
+
+	sendString(c, "new session;")
+	send(c, "install bitcoin.1;")
+	pov := sendString(c, "new safe shared pov;")
+	fmt.Printf("pov: %s\n\n", pov)
+
+	fmt.Printf("applying mainnet (%d blocks)...\n", len(mainnetBlocks))
+	for hIdx, ops := range mainnetBlocks {
+		h := hIdx + 1
+		for _, o := range ops {
+			creditAt(c, pov, "mainnet", o.addr, o.amount, h)
+		}
+	}
+
+	fmt.Printf("forking at h=%d, applying %d fork blocks...\n", forkHeight, len(forkBlocks))
+	forkFrom(c, pov, "fork", "mainnet", forkHeight)
+	for i, ops := range forkBlocks {
+		h := forkHeight + i
+		for _, o := range ops {
+			creditAt(c, pov, "fork", o.addr, o.amount, h)
+		}
+	}
+
+	totalH := len(mainnetBlocks)
+
+	fmt.Println("\n=== MAINNET ===")
+	printChain(c, pov, "mainnet", totalH)
+
+	fmt.Printf("\n=== FORK (forked from mainnet at h=%d) ===\n", forkHeight)
+	printChain(c, pov, "fork", totalH)
+
+	fmt.Println("\n=== mainnet vs fork, per height (* = post-fork) ===")
+	fmt.Println("  h     mainnet alice  fork alice    mainnet bob   fork bob")
+	fmt.Println("  " + dashes(58))
+	for h := 0; h <= totalH; h++ {
+		ma := balanceAt(c, pov, "mainnet", "alice", h)
+		fa := balanceAt(c, pov, "fork", "alice", h)
+		mb := balanceAt(c, pov, "mainnet", "bob", h)
+		fb := balanceAt(c, pov, "fork", "bob", h)
+		marker := "  "
+		if h >= forkHeight {
+			marker = " *"
+		}
+		fmt.Printf(" %s%2d   %10s     %10s     %10s     %10s\n",
+			marker, h, fmtBTC(ma), fmtBTC(fa), fmtBTC(mb), fmtBTC(fb))
+	}
+	fmt.Printf("\n  rows 0..%d are identical: reads on `fork` recurse through `<['parent', 'fork']>` into mainnet's keyspace\n", forkHeight-1)
+
+	// Self-check, same as Python.
+	var failures []string
+	for _, want := range expectMainnet {
+		for i, addr := range watch {
+			got := balanceAt(c, pov, "mainnet", addr, want.h)
+			expected := want.bals[i] * satPerBTC
+			if got != expected {
+				failures = append(failures, fmt.Sprintf("mainnet h=%d %s: got %d, want %d", want.h, addr, got, expected))
+			}
+		}
+	}
+	for _, want := range expectFork {
+		for i, addr := range watch {
+			got := balanceAt(c, pov, "fork", addr, want.h)
+			expected := want.bals[i] * satPerBTC
+			if got != expected {
+				failures = append(failures, fmt.Sprintf("fork h=%d %s: got %d, want %d", want.h, addr, got, expected))
+			}
+		}
+	}
+
+	send(c, "exit;")
+
+	if len(failures) > 0 {
+		fmt.Println("\n=== self-check FAILED ===")
+		for _, f := range failures {
+			fmt.Println("  " + f)
+		}
+		os.Exit(1)
+	}
+	fmt.Println("\n=== self-check OK ===")
+	checked := (len(expectMainnet) + len(expectFork)) * len(watch)
+	fmt.Printf("  verified %d balance values across both branches\n", checked)
+}

--- a/examples/bitcoin-time-travel/go.mod
+++ b/examples/bitcoin-time-travel/go.mod
@@ -1,0 +1,5 @@
+module github.com/orlyatomics/orly/examples/bitcoin-time-travel
+
+go 1.22
+
+require github.com/gorilla/websocket v1.5.3

--- a/examples/bitcoin-time-travel/go.sum
+++ b/examples/bitcoin-time-travel/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/examples/bitcoin-time-travel/run-go.sh
+++ b/examples/bitcoin-time-travel/run-go.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Same end-to-end pipeline as run.sh, but driven by demo.go instead
+# of demo.py. The Go driver does the same scenario and self-check; it
+# exists for readers who'd rather see this in Go than Python.
+#
+# Requires the `go` toolchain on PATH.
+
+set -e
+
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../.. && pwd)"
+ORLY_OUT="${ORLY_OUT:-$REPO_ROOT/../out_orly/debug}"
+ORLYI="$ORLY_OUT/orly/server/orlyi"
+ORLYC="$ORLY_OUT/orly/orlyc"
+
+for bin in "$ORLYI" "$ORLYC"; do
+  if [ ! -x "$bin" ]; then
+    echo "missing: $bin"
+    echo ""
+    echo "Build the project first (from $REPO_ROOT):"
+    echo "  make debug"
+    echo ""
+    echo "Or set ORLY_OUT to point at your debug-build output tree."
+    exit 1
+  fi
+done
+
+if ! command -v go >/dev/null 2>&1; then
+  echo "missing: go (install golang-go or download from go.dev)"
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'kill -9 $ORLYI_PID 2>/dev/null || true; rm -rf "$WORK"' EXIT
+
+echo "[1/5] compile bitcoin.orly (also runs inline tests)"
+"$ORLYC" -o "$WORK" bitcoin.orly
+
+echo "[2/5] populate packages/"
+mkdir "$WORK/packages"
+touch "$WORK/packages/__orly__"
+cp "$WORK/bitcoin.1.so" "$WORK/packages/"
+
+pkill -9 -f 'instance_name=bitcoin_time_travel_demo' 2>/dev/null || true
+sleep 1
+
+echo "[3/5] start fresh orlyi (logs -> $WORK/orlyi.log)"
+"$ORLYI" --mem_sim --create=true \
+         --port_number=19400 --slave_port_number=19401 \
+         --connection_backlog=10 \
+         --instance_name=bitcoin_time_travel_demo \
+         --starting_state=SOLO \
+         --package_dir="$WORK/packages" \
+         > "$WORK/orlyi.log" 2>&1 &
+ORLYI_PID=$!
+
+echo "[4/5] wait for WebSocket port 8082"
+for _ in $(seq 1 60); do
+  if ss -tln 2>/dev/null | grep -q ':8082'; then
+    break
+  fi
+  sleep 1
+done
+if ! ss -tln 2>/dev/null | grep -q ':8082'; then
+  echo "orlyi failed to come up; last log lines:"
+  tail -20 "$WORK/orlyi.log"
+  exit 1
+fi
+
+echo "[5/5] go run demo.go"
+go run demo.go


### PR DESCRIPTION
## What this PR does

Adds `demo.go` as a Go-language equivalent of `demo.py`, alongside it (not replacing). Same scenario (8 mainnet blocks, fork at h=6, 3 fork blocks), same expected output, same 72-value self-check.

Why both: pairs the drivers so readers can diff them in spirit and pick whichever language matches their environment. Engineering-leaning audiences often prefer Go; the cost of the second driver is small and the CI gate prevents either from rotting.

## Files

| File | What |
|---|---|
| `demo.go` | 279-line Go driver, structurally a mirror of `demo.py` |
| `go.mod` + `go.sum` | Single dep: `github.com/gorilla/websocket` v1.5.3 (MIT, the de-facto Go WS client) |
| `run-go.sh` | End-to-end wrapper, same shape as `run.sh` — last step is `go run demo.go` |
| `.gitignore` | Ignores the stray `bitcoin-time-travel` binary that `go build ./...` drops here |
| `README.md` | Documents both drivers |
| `.github/workflows/ci.yml` | The `bitcoin-time-travel` job now installs Go via `actions/setup-go@v5` and runs both wrappers in sequence |

## Implementation note worth recording

`orlyi` returns numbers in its JSON replies as floats (`5000000000.0`), not as JSON integers — Go's `json.Unmarshal` won't accept that into `int64`. The driver unmarshals into `float64` and casts. Our domain (integer satoshi up to ~10^11) is well inside `float64`'s exact-integer range (2^53), so no precision loss. There's an in-code comment to that effect.

## Test plan

- [x] `go run demo.go` — self-check passes, 72 balance values verified
- [x] `./run-go.sh` — end-to-end wrapper, same result
- [x] `./run.sh` — Python driver still passes (no regression)
- [x] `yaml.safe_load` on `.github/workflows/ci.yml` validates clean

## Caveat for reviewers

This adds a Go toolchain to one CI job. The job is independent (doesn't share a cache key with the other three), so worst case it just adds ~30 seconds for `actions/setup-go` and the dep download. If you'd rather keep Go off CI and ship `demo.go` as untested example code, I can split that out — let me know.
