### PR TITLE
jhm: emit compile_commands.json for clangd / clang-tidy / IDE tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ __pycache__/
 tools/jhm
 tools/make_dep_file
 .claude/
+# jhm emits this on every successful build; rebuild-derivable, not committed.
+compile_commands.json
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Build flags live in `root.jhm` (per-target overrides in `debug.jhm` / `release.j
 
 The build system (`jhm`) lives in `jhm/`; the bootstrap path is documented in `bootstrap.sh`. There's no formal style guide; match the surrounding code.
 
+### IDE / clangd
+
+Every successful `make debug` (or any `jhm` invocation that compiles C/C++) writes a [JSON Compilation Database](https://clang.llvm.org/docs/JSONCompilationDatabase.html) to `compile_commands.json` at the repo root. clangd, clang-tidy, IWYU, and most C++-aware editors pick this up automatically. The file is regenerated on every build, so it's `.gitignore`d.
+
 -----
 
 README.md Copyright 2010-2026 Atomic Kismet Company

--- a/jhm/jhm.cc
+++ b/jhm/jhm.cc
@@ -24,6 +24,7 @@
    limitations under the License. */
 
 #include <csignal>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <string>
@@ -31,6 +32,8 @@
 
 #include <base/backtrace.h>
 #include <base/cmd.h>
+#include <base/dir_walker.h>
+#include <base/json.h>
 #include <base/path.h>
 #include <base/split.h>
 #include <base/thrower.h>
@@ -45,6 +48,59 @@ using namespace Jhm;
 using namespace std;
 using namespace std::placeholders;
 using namespace Util;
+
+/* Walks the build output tree collecting per-compile JSON Compilation
+   Database snippets (written by TCompileCFamily::GetCmd) into one
+   `<src_root>/compile_commands.json` file, the format clangd /
+   clang-tidy / IDE tooling expect.
+
+   Per-snippet rather than in-memory accumulation: an incremental build
+   that only recompiles a handful of files preserves the entries for
+   everything that didn't change. The snippet files live next to their
+   .o output and get re-emitted whenever the file is recompiled. */
+namespace {
+
+class TCompdbCollector final : public TDirWalker {
+  public:
+  explicit TCompdbCollector(TJson::TArray *entries) : Entries(entries) {}
+  bool OnFile(const TEntry &entry) override {
+    const std::string name(entry.Name);
+    static const std::string kSuffix = ".compdb.json";
+    if (name.size() <= kSuffix.size() ||
+        name.compare(name.size() - kSuffix.size(), kSuffix.size(), kSuffix) != 0) {
+      return true;
+    }
+    try {
+      Entries->push_back(TJson::Read(entry.AccessPath));
+    } catch (const std::exception &ex) {
+      // A malformed snippet shouldn't kill the build; just skip it.
+      std::cerr << "warning: skipping " << entry.AccessPath << ": " << ex.what() << '\n';
+    }
+    return true;
+  }
+  private:
+  TJson::TArray *Entries;
+};
+
+void WriteCompileCommandsJson(const TEnv &env) {
+  const std::string out_root = AsStr(*env.GetOut());
+  const std::string src_root = AsStr(*env.GetSrc());
+  TJson::TArray entries;
+  TCompdbCollector collector(&entries);
+  collector.Walk(out_root.c_str());
+  if (entries.empty()) {
+    return;  // nothing to write (e.g. test-only invocation, or first-ever bootstrap)
+  }
+  const std::string compdb_path = src_root + "/compile_commands.json";
+  std::ofstream out(compdb_path);
+  if (!out.is_open()) {
+    std::cerr << "warning: could not open " << compdb_path << " for write\n";
+    return;
+  }
+  out << TJson(std::move(entries));
+}
+
+}  // namespace
 
 /* Converts relative file to absolute path if needed, then has the environment find/make the actual file object. */
 TFile *FindFile(const string &cwd, TEnv &env, TWorkFinder &work_finder, const string &name) {
@@ -201,6 +257,10 @@ class TJhm : public TCmd {
     if (!work_finder.FinishAll()) {
       return 1;
     }
+
+    // All compile jobs done -- collect the per-target compile-database
+    // snippets they emitted into <src>/compile_commands.json.
+    WriteCompileCommandsJson(env);
 
     // Run all the tests if requested
     if (!RunTests) {

--- a/jhm/jobs/compile_c_family.cc
+++ b/jhm/jobs/compile_c_family.cc
@@ -16,6 +16,10 @@
 
 #include <jhm/jobs/compile_c_family.h>
 
+#include <filesystem>
+#include <fstream>
+
+#include <base/json.h>
 #include <base/split.h>
 #include <jhm/env.h>
 #include <jhm/file.h>
@@ -114,6 +118,34 @@ vector<string> TCompileCFamily::GetCmd() {
       cmd.push_back(move(arg));
     }
 
+  }
+
+  // Emit a JSON Compilation Database entry next to the .o output. The
+  // collector at jhm.cc end-of-build walks the out tree, reads every
+  // *.compdb.json, and unions them into <src>/compile_commands.json
+  // for clangd / clang-tidy / IDE consumption. We write per-job rather
+  // than accumulating in memory so incremental builds preserve entries
+  // for files that weren't touched this run.
+  /* compdb entry */ {
+    TJson::TArray args;
+    args.reserve(cmd.size());
+    for (const auto &a : cmd) {
+      args.emplace_back(a);
+    }
+    TJson::TObject entry;
+    entry.emplace("directory", AsStr(*Env.GetSrc()));
+    entry.emplace("file", GetInput()->GetPath());
+    entry.emplace("arguments", TJson(std::move(args)));
+
+    const string out_root = AsStr(*Env.GetOut());
+    const std::filesystem::path entry_path =
+        std::filesystem::path(out_root) / (GetSoleOutput()->GetPath() + ".compdb.json");
+    // GetCmd() runs at queue time, before gcc creates the .o's directory,
+    // so we have to ensure the parent exists ourselves.
+    std::error_code ec;
+    std::filesystem::create_directories(entry_path.parent_path(), ec);
+    std::ofstream out(entry_path);
+    out << TJson(std::move(entry));
   }
 
   return cmd;


### PR DESCRIPTION
## What

`jhm` now emits a JSON Compilation Database to `compile_commands.json` at the repo root on every successful build. Unblocks the day-to-day C++ tooling surface that's historically been the biggest QoL gap in jhm:

- **clangd** — language server, used by VS Code / Neovim / CLion / Emacs / Vim / Sublime
- **clang-tidy** — linting / refactoring
- **IWYU**, **include-what-you-use**
- **clang-format** invocation with project flag context
- Any sanitiser / coverage tool that needs to know "how was this file compiled?"

No build-system migration needed — jhm already knows every compile invocation.

## Architecture

**Per-job emission + end-of-build union.**

Each C/C++ compile job writes its single JSON entry `{directory, file, arguments}` to `<out>/<target>.o.compdb.json` at the same time it materialises the gcc command. After all jobs finish, jhm walks the out tree, reads every `*.compdb.json`, and concatenates them into one `compile_commands.json`.

Why per-job rather than in-memory accumulation: an incremental build that only recompiles a handful of files preserves the entries for everything that didn't change. The snippets live in the out tree alongside the `.o`s they describe; both get regenerated together.

## Files touched

| File | Change |
|---|---|
| `jhm/jobs/compile_c_family.cc` | `GetCmd()` now also serialises an entry next to the `.o`. Uses `std::filesystem::create_directories` because `GetCmd()` runs at job-queue time (before gcc creates the .o's parent dir) |
| `jhm/jhm.cc` | New `TCompdbCollector` (a `TDirWalker` subclass); `WriteCompileCommandsJson` called right after `work_finder.FinishAll()` returns success. Doesn't clobber an existing file if no compiles ran |
| `.gitignore` | `compile_commands.json` is build-derivable |
| `README.md` | New IDE / clangd subsection under Contributing |

## Test plan

- [x] Clean rebuild from scratch: **736 entries** written, one per C/C++ source jhm builds
- [x] Every entry has the required `{directory, file, arguments}` fields
- [x] Sample entry sanity check (`base/pump.cc`): `directory=/home/.../orly`, `arguments` includes `-std=c++23` and the full `-Wno-*` set — matches what gcc actually runs
- [x] `make debug` clean (1707/1707)
- [x] `make test` clean

## Caveats for reviewers

- The compdb only covers C/C++ jobs (the `compile_c_family` job class). Bison/flex generators and nycr aren't included — that's correct; clangd doesn't want to lint `.bison.cc` files or generated nycr output.
- A test-only or `--help` jhm invocation that doesn't compile anything will skip the write (rather than clobber an existing `compile_commands.json` with an empty array). 
- The `orlyc` shell-out path (which generates per-package `.cc` files and compiles them with a separate g++ command in `orly/compiler.cc`) isn't covered. Those are transient; their `.cc`s aren't usually what someone wants clangd to see.

## Why now / why this approach

I argued in the prior conversation that jhm is fine for this project but the IDE-tooling gap is the single biggest friction. This is the smallest change that closes that gap — ~98 lines, no architectural shift, doesn't lock in any future direction. If someone later migrates jhm → CMake/Bazel, this code goes away cleanly.
