### PR TITLE
examples/wikipedia-categories: same trick, different monoid (set union)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,8 @@
 #   1. debug-and-test     -- make debug + make test (188 binaries)
 #   2. release-build      -- jhm -c release direct + --help smoke on each binary
 #   3. lang-tests         -- make debug + python3 tools/lang_test.py
-#   4. bitcoin-time-travel -- run the examples/bitcoin-time-travel demo
-#                            end-to-end (orlyc + orlyi + WS driver)
+#   4. examples           -- run each examples/* end-to-end with both
+#                            its Python and Go drivers (orlyc + orlyi + WS)
 #
 # Caching: both apt packages and the build output tree (../out_orly,
 # ../.jhm) are cached across runs. Incremental builds rely on jhm's own
@@ -149,8 +149,8 @@ jobs:
       - name: python3 tools/lang_test.py
         run: python3 tools/lang_test.py -d orly/data tests/lang_tests
 
-  bitcoin-time-travel:
-    name: examples/bitcoin-time-travel
+  examples:
+    name: examples/* end-to-end
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
@@ -198,3 +198,14 @@ jobs:
       - name: run-go.sh (go driver)
         run: ./run-go.sh
         working-directory: examples/bitcoin-time-travel
+
+      # Same scenario as bitcoin-time-travel but uses set union instead
+      # of integer addition. Demonstrates the polymorphic-monoid claim
+      # from that demo's README: same fold pattern, different operator.
+      - name: wikipedia-categories run.sh (python driver)
+        run: ./run.sh
+        working-directory: examples/wikipedia-categories
+
+      - name: wikipedia-categories run-go.sh (go driver)
+        run: ./run-go.sh
+        working-directory: examples/wikipedia-categories

--- a/README.md
+++ b/README.md
@@ -72,12 +72,13 @@ python3 tools/lang_test.py -d orly/data tests/lang_tests
 
 A Bitcoin-flavoured ledger that does **historical queries** ("balance at block 5") and **branched-history multiverse queries** ("balance on the fork vs the mainnet at block 7"). The trick: encode the version axis (block height) AND the branch into the key tuple, fold over the height axis on read.
 
-| Driver | File | Notes |
-| --- | --- | --- |
-| Python | [`demo.py`](examples/bitcoin-time-travel/demo.py) | `pip install websocket-client`, then `./run.sh` |
-| Go | [`demo.go`](examples/bitcoin-time-travel/demo.go) | `gorilla/websocket` dep, then `./run-go.sh` |
+### [`examples/wikipedia-categories/`](examples/wikipedia-categories/) — same trick, different monoid
 
-Both drivers exercise the identical scenario, print the same balance trajectory, and self-check 72 balance values across both branches. Smoke-tested in CI on every push.
+A Wikipedia-flavoured demo that does the same fold-over-keyed-versions trick, but with **set union** as the operator instead of integer addition. Watch the "Programming languages" set grow from `{FORTRAN}` in 1957 through `{...35 entries...}` in 2024 — `members_at(cat, year)` is one four-line Orlyscript function.
+
+Together the two examples prove the polymorphic-monoid claim: pick the operator (`+`, `|`, `++`, `min`, …) and the identity, get historical queries for that domain.
+
+Both examples ship two equivalent drivers — Python (`./run.sh`) and Go (`./run-go.sh`) — and are smoke-tested in CI on every push.
 
 ## Walkthrough
 

--- a/examples/wikipedia-categories/.gitignore
+++ b/examples/wikipedia-categories/.gitignore
@@ -1,0 +1,2 @@
+# Stray go-build output from `go build ./...` in this dir.
+wikipedia-categories

--- a/examples/wikipedia-categories/README.md
+++ b/examples/wikipedia-categories/README.md
@@ -1,0 +1,132 @@
+# Wikipedia categories: same trick, different monoid
+
+A second worked example proving the polymorphic-monoid claim from
+[`examples/bitcoin-time-travel/`](../bitcoin-time-travel/): the same
+fold-over-keyed-versions pattern works for any commutative monoid.
+The bitcoin demo used **integer addition** (balances). This one uses
+**set union** (category membership).
+
+## The point
+
+> "Pick the operator and identity, get time travel for that domain. For free."
+
+This demo is the receipt for that claim.
+
+```
+bitcoin:     [0..h]            reduce start 0               + delta_at(addr, that)
+this demo:   [since..target]   reduce start (empty {str})   | growth_in(cat, that)
+```
+
+Same fold. Same key-encoded version axis. Same "the past is structurally
+frozen because nobody writes the same tuple twice." Different type, different
+operator.
+
+## Run it
+
+```sh
+cd examples/wikipedia-categories
+./run.sh       # python driver
+./run-go.sh    # go driver
+```
+
+Both drivers exercise the same scenario and self-check the same snapshot
+queries.
+
+## What you'll see
+
+The driver ingests a hand-curated timeline of when various programming
+languages and cryptocurrencies first appeared (sourced from Wikipedia's
+"first appeared" fields, rounded to year), then queries the category
+membership *as of* a range of historical years. Truncated output:
+
+```
+=== Programming languages ===
+  1957  ( 1): FORTRAN
+  1965  ( 5): ALGOL, BASIC, COBOL, FORTRAN, Lisp
+  1975  ( 8): ALGOL, BASIC, C, COBOL, FORTRAN, Lisp, Pascal, Smalltalk
+  1985  (11): + Ada, C++, Objective-C
+  1995  (21): + Erlang, Haskell, Java, JavaScript, Lua, PHP, Perl, Python, Ruby, Visual Basic
+  2005  (24): + C#, Scala, Groovy
+  2015  (33): + Clojure, Dart, Elixir, Go, Julia, Kotlin, Rust, Swift, TypeScript
+  2024  (35): + Mojo, Zig
+```
+
+You can literally watch the set grow over time. The bitcoin demo prints a
+number trajectory; this one prints a set trajectory. Same shape.
+
+## Schema
+
+| Key | Value |
+|---|---|
+| `<['cat_growth', cat, year]>` | `{str}` — the set of articles added to `cat` in `year` |
+
+## Read function (the headline)
+
+```orly
+members_at = (
+  [since..target] reduce start (empty {str}) | growth_in(.cat: cat, .year: that)
+) where {
+  cat    = given::(str);
+  since  = given::(int);
+  target = given::(int);
+};
+```
+
+That's the entire engine. Compare to the bitcoin demo's `balance_at`:
+
+```orly
+balance_at = (
+  [0..h] reduce start 0 + delta_at(.branch: branch, .addr: addr, .h: that)
+) where { ... };
+```
+
+Identical structure; the `start` value and the binary operator are the only
+differences.
+
+## Why the past is frozen
+
+Each `(cat, year)` tuple is written at most once by the driver (the driver
+pre-aggregates if multiple events land in the same bucket). Once written,
+the entry is immutable: future writes target different `(cat, year)`
+tuples. Reading at any historical year returns the same answer forever.
+
+This is the same property the bitcoin demo exploits, applied to a different
+domain.
+
+## Other monoids that fit this shape
+
+| Domain | Value type | Operator | Identity |
+|---|---|---|---|
+| Counters (this is bitcoin) | `int` | `+` | `0` |
+| **Set membership (this demo)** | `{T}` | `\|` | `empty {T}` |
+| List append | `[T]` | `++` | `[]` |
+| Min / max | `T` | `min` / `max` | `+∞` / `-∞` |
+| Last-write-wins | `T?` | take the latest | unknown |
+
+Implement each variant in ~80 lines of Orlyscript and you get historical
+queries for that domain.
+
+## Caveats
+
+- **Add-only.** Real Wikipedia categories churn (articles get removed
+  too). A removal-aware version would track a parallel `cat_removed`
+  set and do `members_added - members_removed` at read time. Out of
+  scope for the v1 demo, which is showing the polymorphic-monoid point,
+  not modeling Wikipedia in full fidelity.
+- **Year-resolution.** Wikipedia revision data is hour-resolution; this
+  demo rounds to year for clarity. The pattern doesn't care about the
+  resolution of the time axis -- substitute `(unix_epoch_hour)` for
+  `(year)` and you get hourly precision at the cost of much more
+  per-key overhead.
+- **Hand-curated dataset.** Real timing comes from `dumps.wikimedia.org`
+  category-link tables; the demo uses a small illustrative slice
+  hand-typed in `demo.py` / `demo.go` for ease of reading.
+
+## Files
+
+| File | What |
+|---|---|
+| `wiki.orly` | The Orlyscript package: `growth_in`, `add_growth`, `members_at`, `count_at`, plus 20 inline tests |
+| `demo.py` | Python WebSocket driver, ~150 lines |
+| `demo.go` + `go.mod` + `go.sum` | Go WebSocket driver, equivalent to Python |
+| `run.sh` / `run-go.sh` | End-to-end wrappers |

--- a/examples/wikipedia-categories/demo.go
+++ b/examples/wikipedia-categories/demo.go
@@ -1,0 +1,265 @@
+// Wikipedia-style category-membership demo, in Go.
+//
+// Mirrors demo.py: same scenario, same expected output, same self-check.
+// Provided so readers can pick whichever language matches their environment.
+//
+// Run via the wrapper:
+//
+//	./run-go.sh
+//
+// Or directly, after starting orlyi separately:
+//
+//	go run demo.go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/gorilla/websocket"
+)
+
+const wsURL = "ws://127.0.0.1:8082/"
+
+type growth struct {
+	cat     string
+	year    int
+	members []string
+}
+
+var events = []growth{
+	// --- Programming languages ---
+	{"languages", 1957, []string{"FORTRAN"}},
+	{"languages", 1958, []string{"Lisp", "ALGOL"}},
+	{"languages", 1959, []string{"COBOL"}},
+	{"languages", 1964, []string{"BASIC"}},
+	{"languages", 1970, []string{"Pascal"}},
+	{"languages", 1972, []string{"C", "Smalltalk"}},
+	{"languages", 1980, []string{"Ada"}},
+	{"languages", 1983, []string{"C++", "Objective-C"}},
+	{"languages", 1986, []string{"Erlang"}},
+	{"languages", 1987, []string{"Perl"}},
+	{"languages", 1990, []string{"Haskell"}},
+	{"languages", 1991, []string{"Python", "Visual Basic"}},
+	{"languages", 1993, []string{"Lua"}},
+	{"languages", 1995, []string{"Java", "JavaScript", "PHP", "Ruby"}},
+	{"languages", 2000, []string{"C#"}},
+	{"languages", 2003, []string{"Scala", "Groovy"}},
+	{"languages", 2007, []string{"Clojure"}},
+	{"languages", 2009, []string{"Go"}},
+	{"languages", 2010, []string{"Rust"}},
+	{"languages", 2011, []string{"Dart", "Elixir", "Kotlin"}},
+	{"languages", 2012, []string{"Julia", "TypeScript"}},
+	{"languages", 2014, []string{"Swift"}},
+	{"languages", 2016, []string{"Zig"}},
+	{"languages", 2023, []string{"Mojo"}},
+
+	// --- Cryptocurrencies ---
+	{"crypto", 2009, []string{"Bitcoin"}},
+	{"crypto", 2011, []string{"Litecoin", "Namecoin"}},
+	{"crypto", 2012, []string{"Ripple"}},
+	{"crypto", 2013, []string{"Dogecoin"}},
+	{"crypto", 2014, []string{"Monero"}},
+	{"crypto", 2015, []string{"Ethereum"}},
+	{"crypto", 2017, []string{"Bitcoin Cash", "Cardano"}},
+	{"crypto", 2020, []string{"Solana"}},
+}
+
+var snapshots = []struct {
+	cat   string
+	years []int
+}{
+	{"languages", []int{1957, 1965, 1975, 1985, 1995, 2005, 2015, 2024}},
+	{"crypto", []int{2008, 2010, 2012, 2014, 2016, 2018, 2020, 2024}},
+}
+
+type reply struct {
+	Status string          `json:"status"`
+	Result json.RawMessage `json:"result"`
+}
+
+func die(msg string) {
+	fmt.Fprintln(os.Stderr, msg)
+	os.Exit(1)
+}
+
+func send(c *websocket.Conn, stmt string) json.RawMessage {
+	if err := c.WriteMessage(websocket.TextMessage, []byte(stmt)); err != nil {
+		die(fmt.Sprintf("write %q: %v", stmt, err))
+	}
+	_, msg, err := c.ReadMessage()
+	if err != nil {
+		die(fmt.Sprintf("read after %q: %v", stmt, err))
+	}
+	var r reply
+	if err := json.Unmarshal(msg, &r); err != nil {
+		die(fmt.Sprintf("parse reply: %v\n  raw: %s", err, msg))
+	}
+	if r.Status != "ok" {
+		die(fmt.Sprintf("%s: %s", stmt, string(msg)))
+	}
+	return r.Result
+}
+
+func sendString(c *websocket.Conn, stmt string) string {
+	raw := send(c, stmt)
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		die(fmt.Sprintf("expected string result, got %s", raw))
+	}
+	return s
+}
+
+// orlyi serialises numbers as JSON floats; cast to int via float64.
+func sendInt(c *websocket.Conn, stmt string) int {
+	raw := send(c, stmt)
+	var n float64
+	if err := json.Unmarshal(raw, &n); err != nil {
+		die(fmt.Sprintf("expected number result, got %s", raw))
+	}
+	return int(n)
+}
+
+// orlyi serialises sets as JSON arrays.
+func sendStringSet(c *websocket.Conn, stmt string) []string {
+	raw := send(c, stmt)
+	var out []string
+	if string(raw) == "null" {
+		return out
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		die(fmt.Sprintf("expected array result, got %s", raw))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func setLiteral(members []string) string {
+	parts := make([]string, len(members))
+	for i, m := range members {
+		parts[i] = `"` + m + `"`
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}
+
+func addGrowth(c *websocket.Conn, pov, cat string, year int, members []string) {
+	stmt := fmt.Sprintf(
+		`try {%s} wiki add_growth <{.cat: "%s", .year: %d, .members: %s}>;`,
+		pov, cat, year, setLiteral(members))
+	send(c, stmt)
+}
+
+func membersAt(c *websocket.Conn, pov, cat string, since, target int) []string {
+	stmt := fmt.Sprintf(
+		`try {%s} wiki members_at <{.cat: "%s", .since: %d, .target: %d}>;`,
+		pov, cat, since, target)
+	return sendStringSet(c, stmt)
+}
+
+func main() {
+	c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		die(fmt.Sprintf("dial %s: %v", wsURL, err))
+	}
+	defer c.Close()
+
+	sendString(c, "new session;")
+	send(c, "install wiki.1;")
+	pov := sendString(c, "new safe shared pov;")
+	fmt.Printf("pov: %s\n\n", pov)
+
+	catSet := map[string]struct{}{}
+	for _, e := range events {
+		catSet[e.cat] = struct{}{}
+	}
+	fmt.Printf("ingesting %d growth events across %d categories...\n", len(events), len(catSet))
+	for _, e := range events {
+		addGrowth(c, pov, e.cat, e.year, e.members)
+	}
+
+	pretty := map[string]string{
+		"languages": "Programming languages",
+		"crypto":    "Cryptocurrencies",
+	}
+	for _, snap := range snapshots {
+		fmt.Println()
+		fmt.Printf("=== %s ===\n", pretty[snap.cat])
+		for _, y := range snap.years {
+			ms := membersAt(c, pov, snap.cat, 0, y)
+			body := strings.Join(ms, ", ")
+			if body == "" {
+				body = "(empty)"
+			}
+			fmt.Printf("  %d  (%2d): %s\n", y, len(ms), body)
+		}
+	}
+
+	// Cross-category sanity.
+	fmt.Println()
+	fmt.Println("=== cross-category isolation ===")
+	lang2024 := membersAt(c, pov, "languages", 0, 2024)
+	crypto2024 := membersAt(c, pov, "crypto", 0, 2024)
+	overlap := []string{}
+	cryptoSet := map[string]struct{}{}
+	for _, x := range crypto2024 {
+		cryptoSet[x] = struct{}{}
+	}
+	for _, x := range lang2024 {
+		if _, ok := cryptoSet[x]; ok {
+			overlap = append(overlap, x)
+		}
+	}
+	overlapStr := strings.Join(overlap, ", ")
+	if overlapStr == "" {
+		overlapStr = "empty (good — different keyspaces)"
+	}
+	fmt.Printf("  |languages 2024| = %d\n", len(lang2024))
+	fmt.Printf("  |crypto 2024|    = %d\n", len(crypto2024))
+	fmt.Printf("  overlap          = %s\n", overlapStr)
+
+	fmt.Println()
+	fmt.Println("=== the trick ===")
+	fmt.Println("  bitcoin demo:  [0..h] reduce start 0 + delta_at(addr, that)")
+	fmt.Println("  this demo:     [since..target] reduce start (empty {str}) | growth_in(cat, that)")
+	fmt.Println("  same pattern, different commutative monoid.")
+
+	// Self-check (mirrors demo.py).
+	type want struct {
+		cat      string
+		year     int
+		expected []string
+	}
+	wants := []want{
+		{"languages", 1957, []string{"FORTRAN"}},
+		{"languages", 1958, []string{"ALGOL", "FORTRAN", "Lisp"}},
+		{"languages", 1995, []string{"ALGOL", "Ada", "BASIC", "C", "C++", "COBOL", "Erlang",
+			"FORTRAN", "Haskell", "Java", "JavaScript", "Lisp", "Lua",
+			"Objective-C", "PHP", "Pascal", "Perl", "Python", "Ruby",
+			"Smalltalk", "Visual Basic"}},
+		{"crypto", 2009, []string{"Bitcoin"}},
+		{"crypto", 2024, []string{"Bitcoin", "Bitcoin Cash", "Cardano", "Dogecoin", "Ethereum",
+			"Litecoin", "Monero", "Namecoin", "Ripple", "Solana"}},
+	}
+	var failures []string
+	for _, w := range wants {
+		got := membersAt(c, pov, w.cat, 0, w.year)
+		if !reflect.DeepEqual(got, w.expected) {
+			failures = append(failures, fmt.Sprintf("%s at %d: got %v, want %v", w.cat, w.year, got, w.expected))
+		}
+	}
+
+	send(c, "exit;")
+
+	if len(failures) > 0 {
+		fmt.Println("\n=== self-check FAILED ===")
+		for _, f := range failures {
+			fmt.Println("  " + f)
+		}
+		os.Exit(1)
+	}
+	fmt.Printf("\n=== self-check OK ===\n  verified %d snapshot queries\n", len(wants))
+}

--- a/examples/wikipedia-categories/demo.py
+++ b/examples/wikipedia-categories/demo.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Wikipedia-style category-membership demo, in Python.
+
+Same fold-over-keyed-versions pattern as the bitcoin time-travel demo,
+but with set union instead of integer addition. Proves the polymorphic-
+monoid claim from the bitcoin README: swap the operator (`|` for sets,
+`+` for ints), keep the structure, get historical queries for free.
+
+The dataset is a hand-curated timeline of when various programming
+languages and cryptocurrencies came into being, by year of first
+release. Real Wikipedia categorization is richer (full hour-resolution
+revision history, removals, renames), but the demo's point is the
+pattern, not the data.
+
+Run via the wrapper:
+
+    ./run.sh
+
+Or directly, after starting orlyi separately:
+
+    python3 demo.py
+"""
+
+import json
+import sys
+import websocket
+
+WS_URL = "ws://127.0.0.1:8082/"
+
+
+# Each entry: (category, year, [articles added that year])
+# Sourced from Wikipedia's "first appeared" fields, rounded to year.
+# This is illustrative; treat the data as approximate.
+EVENTS = [
+    # --- Programming languages ---
+    ("languages", 1957, ["FORTRAN"]),
+    ("languages", 1958, ["Lisp", "ALGOL"]),
+    ("languages", 1959, ["COBOL"]),
+    ("languages", 1964, ["BASIC"]),
+    ("languages", 1970, ["Pascal"]),
+    ("languages", 1972, ["C", "Smalltalk"]),
+    ("languages", 1980, ["Ada"]),
+    ("languages", 1983, ["C++", "Objective-C"]),
+    ("languages", 1986, ["Erlang"]),
+    ("languages", 1987, ["Perl"]),
+    ("languages", 1990, ["Haskell"]),
+    ("languages", 1991, ["Python", "Visual Basic"]),
+    ("languages", 1993, ["Lua"]),
+    ("languages", 1995, ["Java", "JavaScript", "PHP", "Ruby"]),
+    ("languages", 2000, ["C#"]),
+    ("languages", 2003, ["Scala", "Groovy"]),
+    ("languages", 2007, ["Clojure"]),
+    ("languages", 2009, ["Go"]),
+    ("languages", 2010, ["Rust"]),
+    ("languages", 2011, ["Dart", "Elixir", "Kotlin"]),
+    ("languages", 2012, ["Julia", "TypeScript"]),
+    ("languages", 2014, ["Swift"]),
+    ("languages", 2016, ["Zig"]),
+    ("languages", 2023, ["Mojo"]),
+
+    # --- Cryptocurrencies ---
+    ("crypto", 2009, ["Bitcoin"]),
+    ("crypto", 2011, ["Litecoin", "Namecoin"]),
+    ("crypto", 2012, ["Ripple"]),
+    ("crypto", 2013, ["Dogecoin"]),
+    ("crypto", 2014, ["Monero"]),
+    ("crypto", 2015, ["Ethereum"]),
+    ("crypto", 2017, ["Bitcoin Cash", "Cardano"]),
+    ("crypto", 2020, ["Solana"]),
+]
+
+# Snapshot years to display, per category.
+SNAPSHOTS = {
+    "languages": [1957, 1965, 1975, 1985, 1995, 2005, 2015, 2024],
+    "crypto":    [2008, 2010, 2012, 2014, 2016, 2018, 2020, 2024],
+}
+
+
+def send(ws, stmt):
+    ws.send(stmt)
+    reply = json.loads(ws.recv())
+    if reply.get("status") != "ok":
+        raise RuntimeError(f"{stmt!r}\n  -> {reply}")
+    return reply.get("result")
+
+
+def set_literal(members):
+    """Format a Python iterable as an Orlyscript string-set literal."""
+    return "{" + ", ".join(f'"{m}"' for m in members) + "}"
+
+
+def add_growth(ws, pov, cat, year, members):
+    stmt = (f'try {{{pov}}} wiki add_growth '
+            f'<{{.cat: "{cat}", .year: {year}, .members: {set_literal(members)}}}>;')
+    send(ws, stmt)
+
+
+def members_at(ws, pov, cat, since, target):
+    """Returns a sorted list of articles in `cat` from `since` through `target`."""
+    stmt = (f'try {{{pov}}} wiki members_at '
+            f'<{{.cat: "{cat}", .since: {since}, .target: {target}}}>;')
+    result = send(ws, stmt)
+    # Orlyi serialises sets as JSON arrays.
+    return sorted(result) if result else []
+
+
+def count_at(ws, pov, cat, since, target):
+    stmt = (f'try {{{pov}}} wiki count_at '
+            f'<{{.cat: "{cat}", .since: {since}, .target: {target}}}>;')
+    result = send(ws, stmt)
+    return int(result) if result is not None else 0
+
+
+def main():
+    ws = websocket.create_connection(WS_URL)
+    send(ws, "new session;")
+    send(ws, "install wiki.1;")
+    pov = send(ws, "new safe shared pov;")
+    print(f"pov: {pov}\n")
+
+    # Ingest the timeline.
+    print(f"ingesting {len(EVENTS)} growth events across "
+          f"{len({e[0] for e in EVENTS})} categories...")
+    for cat, year, members in EVENTS:
+        add_growth(ws, pov, cat, year, members)
+
+    # The headline output: snapshots of each category at chosen years.
+    cat_pretty = {"languages": "Programming languages", "crypto": "Cryptocurrencies"}
+    for cat, years in SNAPSHOTS.items():
+        print()
+        print(f"=== {cat_pretty[cat]} ===")
+        for y in years:
+            members = members_at(ws, pov, cat, 0, y)
+            count = len(members)
+            print(f"  {y}  ({count:>2}): {', '.join(members) if members else '(empty)'}")
+
+    # Cross-category sanity: at the same year, the two sets are disjoint
+    # and querying one doesn't bleed into the other.
+    print()
+    print("=== cross-category isolation ===")
+    lang_2024 = set(members_at(ws, pov, "languages", 0, 2024))
+    crypto_2024 = set(members_at(ws, pov, "crypto", 0, 2024))
+    overlap = lang_2024 & crypto_2024
+    print(f"  |languages 2024| = {len(lang_2024)}")
+    print(f"  |crypto 2024|    = {len(crypto_2024)}")
+    print(f"  overlap          = {overlap or 'empty (good — different keyspaces)'}")
+
+    # The polymorphic-monoid demo: same fold pattern, different operator
+    # than the bitcoin demo.
+    print()
+    print("=== the trick ===")
+    print("  bitcoin demo:  [0..h] reduce start 0 + delta_at(addr, that)")
+    print("  this demo:     [since..target] reduce start (empty {str}) | growth_in(cat, that)")
+    print("  same pattern, different commutative monoid.")
+
+    # Self-check.
+    failures = []
+    expectations = [
+        ("languages", 1957, ["FORTRAN"]),
+        ("languages", 1958, ["ALGOL", "FORTRAN", "Lisp"]),
+        ("languages", 1995, ["ALGOL", "Ada", "BASIC", "C", "C++", "COBOL", "Erlang",
+                             "FORTRAN", "Haskell", "Java", "JavaScript", "Lisp", "Lua",
+                             "Objective-C", "PHP", "Pascal", "Perl", "Python", "Ruby",
+                             "Smalltalk", "Visual Basic"]),
+        ("crypto", 2009, ["Bitcoin"]),
+        ("crypto", 2024, ["Bitcoin", "Bitcoin Cash", "Cardano", "Dogecoin", "Ethereum",
+                          "Litecoin", "Monero", "Namecoin", "Ripple", "Solana"]),
+    ]
+    for cat, year, expected in expectations:
+        got = members_at(ws, pov, cat, 0, year)
+        if got != expected:
+            failures.append(f"{cat} at {year}: got {got!r}, want {expected!r}")
+
+    send(ws, "exit;")
+    ws.close()
+
+    if failures:
+        print("\n=== self-check FAILED ===")
+        for f in failures:
+            print(f"  {f}")
+        sys.exit(1)
+    print(f"\n=== self-check OK ===\n  verified {len(expectations)} snapshot queries")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/wikipedia-categories/go.mod
+++ b/examples/wikipedia-categories/go.mod
@@ -1,0 +1,5 @@
+module github.com/orlyatomics/orly/examples/wikipedia-categories
+
+go 1.22
+
+require github.com/gorilla/websocket v1.5.3

--- a/examples/wikipedia-categories/go.sum
+++ b/examples/wikipedia-categories/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/examples/wikipedia-categories/run-go.sh
+++ b/examples/wikipedia-categories/run-go.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Same end-to-end pipeline as run.sh, but driven by demo.go.
+# Requires the `go` toolchain on PATH.
+
+set -e
+
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../.. && pwd)"
+ORLY_OUT="${ORLY_OUT:-$REPO_ROOT/../out_orly/debug}"
+ORLYI="$ORLY_OUT/orly/server/orlyi"
+ORLYC="$ORLY_OUT/orly/orlyc"
+
+for bin in "$ORLYI" "$ORLYC"; do
+  if [ ! -x "$bin" ]; then
+    echo "missing: $bin"
+    exit 1
+  fi
+done
+
+if ! command -v go >/dev/null 2>&1; then
+  echo "missing: go (install golang-go or download from go.dev)"
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'kill -9 $ORLYI_PID 2>/dev/null || true; rm -rf "$WORK"' EXIT
+
+echo "[1/5] compile wiki.orly"
+"$ORLYC" -o "$WORK" wiki.orly
+
+echo "[2/5] populate packages/"
+mkdir "$WORK/packages"
+touch "$WORK/packages/__orly__"
+cp "$WORK/wiki.1.so" "$WORK/packages/"
+
+pkill -9 -f 'instance_name=wiki_categories_demo' 2>/dev/null || true
+sleep 1
+
+echo "[3/5] start fresh orlyi"
+"$ORLYI" --mem_sim --create=true \
+         --port_number=19400 --slave_port_number=19401 \
+         --connection_backlog=10 \
+         --instance_name=wiki_categories_demo \
+         --starting_state=SOLO \
+         --package_dir="$WORK/packages" \
+         > "$WORK/orlyi.log" 2>&1 &
+ORLYI_PID=$!
+
+echo "[4/5] wait for WebSocket port 8082"
+for _ in $(seq 1 60); do
+  if ss -tln 2>/dev/null | grep -q ':8082'; then
+    break
+  fi
+  sleep 1
+done
+if ! ss -tln 2>/dev/null | grep -q ':8082'; then
+  echo "orlyi failed to come up; last log lines:"
+  tail -20 "$WORK/orlyi.log"
+  exit 1
+fi
+
+echo "[5/5] go run demo.go"
+go run demo.go

--- a/examples/wikipedia-categories/run.sh
+++ b/examples/wikipedia-categories/run.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# End-to-end driver: compile wiki.orly, start a fresh orlyi, run demo.py.
+# Mirrors examples/bitcoin-time-travel/run.sh's shape.
+
+set -e
+
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../.. && pwd)"
+ORLY_OUT="${ORLY_OUT:-$REPO_ROOT/../out_orly/debug}"
+ORLYI="$ORLY_OUT/orly/server/orlyi"
+ORLYC="$ORLY_OUT/orly/orlyc"
+
+for bin in "$ORLYI" "$ORLYC"; do
+  if [ ! -x "$bin" ]; then
+    echo "missing: $bin"
+    echo ""
+    echo "Build the project first (from $REPO_ROOT):"
+    echo "  make debug"
+    echo ""
+    echo "Or set ORLY_OUT to point at your debug-build output tree."
+    exit 1
+  fi
+done
+
+WORK="$(mktemp -d)"
+trap 'kill -9 $ORLYI_PID 2>/dev/null || true; rm -rf "$WORK"' EXIT
+
+echo "[1/5] compile wiki.orly (also runs inline tests)"
+"$ORLYC" -o "$WORK" wiki.orly
+
+echo "[2/5] populate packages/"
+mkdir "$WORK/packages"
+touch "$WORK/packages/__orly__"
+cp "$WORK/wiki.1.so" "$WORK/packages/"
+
+pkill -9 -f 'instance_name=wiki_categories_demo' 2>/dev/null || true
+sleep 1
+
+echo "[3/5] start fresh orlyi (logs -> $WORK/orlyi.log)"
+"$ORLYI" --mem_sim --create=true \
+         --port_number=19400 --slave_port_number=19401 \
+         --connection_backlog=10 \
+         --instance_name=wiki_categories_demo \
+         --starting_state=SOLO \
+         --package_dir="$WORK/packages" \
+         > "$WORK/orlyi.log" 2>&1 &
+ORLYI_PID=$!
+
+echo "[4/5] wait for WebSocket port 8082"
+for _ in $(seq 1 60); do
+  if ss -tln 2>/dev/null | grep -q ':8082'; then
+    break
+  fi
+  sleep 1
+done
+if ! ss -tln 2>/dev/null | grep -q ':8082'; then
+  echo "orlyi failed to come up; last log lines:"
+  tail -20 "$WORK/orlyi.log"
+  exit 1
+fi
+
+echo "[5/5] run demo.py"
+python3 demo.py

--- a/examples/wikipedia-categories/wiki.orly
+++ b/examples/wikipedia-categories/wiki.orly
@@ -1,0 +1,110 @@
+/* <examples/wikipedia-categories/wiki.orly>
+
+   Wikipedia-style category membership over time. A demonstration that
+   the same fold-over-keyed-versions pattern from the bitcoin time-
+   travel demo works for any commutative monoid -- here, set union
+   instead of integer addition.
+
+   Schema:
+
+     <['cat_growth', cat, year]>  : {str}    -- articles added to `cat` in `year`
+
+   Reads:
+
+     members_at(cat, since, target) =
+         [since..target] reduce start (empty {str}) | growth_in(cat, that)
+
+   The version axis is the year coordinate in the key tuple, exactly
+   as in the bitcoin demo. Only the fold operator changes: `+` for
+   integer balances became `|` for sets.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package #1;
+
+/* Members added to `cat` in `year`; empty set if no growth that year. */
+growth_in = (((*<['cat_growth', cat, year]>::({str})) if *<['cat_growth', cat, year]>::({str}?) is known else empty {str})) where {
+  cat  = given::(str);
+  year = given::(int);
+};
+
+/* Record the set of new members added to `cat` in `year`.
+   One write per (cat, year) tuple; the driver pre-aggregates if
+   multiple events land in the same bucket. */
+add_growth = ((1) effecting {
+  new <['cat_growth', cat, year]> <- members;
+}) where {
+  cat     = given::(str);
+  year    = given::(int);
+  members = given::({str});
+};
+
+/* The headline read: members of `cat` as of `target` year, accumulating
+   from `since`. Fold across the year axis with set union. Pre-fork
+   pattern in spirit -- everything that was added by the target year
+   is in the result; nothing later. */
+members_at = ([since..target] reduce start (empty {str}) | growth_in(.cat: cat, .year: that)) where {
+  cat    = given::(str);
+  since = given::(int);
+  target = given::(int);
+};
+
+/* Convenience: size of the set at `target`. */
+count_at = (length_of members_at(.cat: cat, .since: since, .target: target)) where {
+  cat    = given::(str);
+  since  = given::(int);
+  target = given::(int);
+};
+
+test {
+  /* "Programming languages" minimal scenario: a couple of years, a couple of additions per year. */
+  t1: add_growth(.cat: "lang", .year: 1957, .members: {"FORTRAN"}) == 1 {
+    t2: add_growth(.cat: "lang", .year: 1958, .members: {"Lisp"}) == 1 {
+      t3: add_growth(.cat: "lang", .year: 1991, .members: {"Python", "Visual Basic"}) == 1 {
+        t4: add_growth(.cat: "lang", .year: 2010, .members: {"Rust"}) == 1 {
+
+          /* Point lookups: what was added each year? */
+          t5: growth_in(.cat: "lang", .year: 1957) == {"FORTRAN"};
+          t6: growth_in(.cat: "lang", .year: 1958) == {"Lisp"};
+          t7: growth_in(.cat: "lang", .year: 1991) == {"Python", "Visual Basic"};
+          t8: growth_in(.cat: "lang", .year: 1992) == empty {str};   /* nothing this year */
+
+          /* The fold: snapshot of the category at each year. */
+          t9:  members_at(.cat: "lang", .since: 1950, .target: 1956) == empty {str};
+          t10: members_at(.cat: "lang", .since: 1950, .target: 1957) == {"FORTRAN"};
+          t11: members_at(.cat: "lang", .since: 1950, .target: 1958) == {"FORTRAN", "Lisp"};
+          t12: members_at(.cat: "lang", .since: 1950, .target: 1991) == {"FORTRAN", "Lisp", "Python", "Visual Basic"};
+          t13: members_at(.cat: "lang", .since: 1950, .target: 2024) == {"FORTRAN", "Lisp", "Python", "Visual Basic", "Rust"};
+
+          /* Cross-category isolation: a separate `cat` keeps its own keyspace. */
+          t14: add_growth(.cat: "crypto", .year: 2009, .members: {"Bitcoin"}) == 1 {
+            t15: members_at(.cat: "crypto", .since: 2000, .target: 2024) == {"Bitcoin"};
+            /* `since: 2000` correctly excludes Python and Visual Basic (added 1991). */
+            t16: members_at(.cat: "lang",   .since: 2000, .target: 2024) == {"Rust"};
+          };
+
+          /* Count fold: |members_at(...)|. */
+          t17: count_at(.cat: "lang", .since: 1950, .target: 1957) == 1;
+          t18: count_at(.cat: "lang", .since: 1950, .target: 1991) == 4;
+          t19: count_at(.cat: "lang", .since: 1950, .target: 2024) == 5;
+
+          /* Time-travel stability: querying an old year returns the same
+             answer no matter what's been written for later years. */
+          t20: members_at(.cat: "lang", .since: 1950, .target: 1958) == {"FORTRAN", "Lisp"};
+        };
+      };
+    };
+  };
+};


### PR DESCRIPTION
## What

A second worked example proving the polymorphic-monoid claim from `examples/bitcoin-time-travel/`: the same fold-over-keyed-versions pattern works for any commutative monoid.

The bitcoin demo used **integer addition** (balances). This one uses **set union** (Wikipedia category membership).

```
bitcoin:    [0..h]          reduce start 0             + delta_at(addr, that)
this demo:  [since..target] reduce start (empty {str}) | growth_in(cat, that)
```

Same fold. Same key-encoded version axis. Different type, different operator. Receipt for the bitcoin README's claim that the trick generalises.

## Sample output

Watch the "Programming languages" set grow over time — one Orlyscript function, queried at successive years:

```
=== Programming languages ===
  1957  ( 1): FORTRAN
  1965  ( 5): ALGOL, BASIC, COBOL, FORTRAN, Lisp
  1975  ( 8): + C, Pascal, Smalltalk
  1985  (11): + Ada, C++, Objective-C
  1995  (21): + Erlang, Haskell, Java, JavaScript, Lua, PHP, Perl, Python, Ruby, Visual Basic
  2005  (24): + C#, Scala, Groovy
  2015  (33): + Clojure, Dart, Elixir, Go, Julia, Kotlin, Rust, Swift, TypeScript
  2024  (35): + Mojo, Zig
```

## What lands

| File | What |
|---|---|
| `examples/wikipedia-categories/wiki.orly` | Orlyscript package: `growth_in`, `add_growth`, `members_at`, `count_at`. **20 inline tests, all pass** |
| `examples/wikipedia-categories/demo.py` | Python WS driver, ~150 lines |
| `examples/wikipedia-categories/demo.go` + `go.mod`/`go.sum` | Go driver, equivalent |
| `examples/wikipedia-categories/run.sh` + `run-go.sh` | End-to-end wrappers, mirror bitcoin-time-travel's |
| `examples/wikipedia-categories/README.md` | Pattern writeup, schema, monoid table |
| `.github/workflows/ci.yml` | The existing `bitcoin-time-travel` CI job is renamed `examples` and generalised to run both demos |
| `README.md` (top level) | New Examples entry; the polymorphic-monoid claim now has two backing examples |

## Implementation gotchas worth recording

1. **`start` is a reserved keyword in Orlyscript** (used in `reduce start <init>`). Function parameter is named `since` to avoid the clash.
2. **orlyi serialises sets as JSON arrays** over the WebSocket protocol. Both drivers `[]string` and sort for stable output.
3. **`length_of` works on sets** (not just sequences), so `count_at` is one line.

## Test plan

- [x] `orlyc -d wiki.orly` — 20/20 inline tests pass
- [x] `./run.sh` (Python) — end-to-end, self-check OK, 5 snapshot queries verified
- [x] `./run-go.sh` (Go) — end-to-end, self-check OK
- [x] `bitcoin-time-travel` regression — both wrappers still pass (72/72 balance values)
- [x] yaml syntax of `.github/workflows/ci.yml` validates clean

## Net diff

11 files, +850 / -9.
