### PR TITLE
Phase 1 of #49: carry TMutator through TUpdate::TEntry

### DIFF
--- a/orly/indy/disk/data_file.cc
+++ b/orly/indy/disk/data_file.cc
@@ -242,6 +242,10 @@ class TIndexFile
 
   void PushKey(TUpdate::TEntry *entry);
   Base::TOpt<Indy::TKey> PrevKeyWritten;
+  /* Mutator of the previous current-key entry. Set when PrevKeyWritten is
+     set; emitted as the trailing portion of the on-disk TKeyItem when the
+     NEXT key arrives (or in FlushHistory for the final one). */
+  TMutator PrevKeyMutator = TMutator::Assign;
   std::unordered_map<size_t, shared_ptr<const TBufBlock>> KeyCollisionMap;
   std::unique_ptr<TDataFile::TDataOutStream> KeyStream;
   size_t CurKeyOffset;
@@ -478,12 +482,18 @@ void TIndexFile::PushKey(TUpdate::TEntry *entry) {
     TDataFile::TDataOutStream &stream = *KeyStream;
     if (PrevKeyWritten) {
       stream << NumHistoryElem << ByteOffsetOfHistory;
+      /* Emit the trailing TMutator (+ 4 bytes padding) for the previous
+         current key. Layout must match TKeyItem in read_file.h. */
+      stream.Write(&PrevKeyMutator, sizeof(TMutator));
+      const uint32_t mutator_padding = 0;
+      stream.Write(&mutator_padding, sizeof(mutator_padding));
       ByteOffsetOfHistory += NumHistoryElem * TDataFile::KeyHistorySize;
       NumHistoryElem = 0UL;
     }
     const TSequenceNumber seq_num = entry->GetSequenceNumber();
     const TCore &val = entry->GetOp();
     PrevKeyWritten = key;
+    PrevKeyMutator = entry->GetMutator();
     CurKeyOffset = stream.GetOffset();
     stream << seq_num;
     TCore key_core = key.GetCore();
@@ -547,8 +557,13 @@ void TIndexFile::FlushHistory() {
   TDataFile::TDataOutStream &stream = *KeyStream;
   if (PrevKeyWritten) {
     stream << NumHistoryElem << ByteOffsetOfHistory;
+    /* Final current key's trailing TMutator (+ padding). See PushKey. */
+    stream.Write(&PrevKeyMutator, sizeof(TMutator));
+    const uint32_t mutator_padding = 0;
+    stream.Write(&mutator_padding, sizeof(mutator_padding));
   }
   ByteOffsetOfHistory = stream.GetOffset();
+  const uint32_t mutator_padding = 0;
   for (const TUpdate::TEntry *entry : HistKeys) {
     const TSequenceNumber seq_num = entry->GetSequenceNumber();
     const TKey &key = entry->GetKey();
@@ -561,6 +576,10 @@ void TIndexFile::FlushHistory() {
     val_core.Remap(ValRemapper);
     stream.Write(&key_core, sizeof(key_core));
     stream.Write(&val_core, sizeof(val_core));
+    /* Trailing TMutator (+ padding) per THistoryKeyItem in read_file.h. */
+    TMutator mutator = entry->GetMutator();
+    stream.Write(&mutator, sizeof(TMutator));
+    stream.Write(&mutator_padding, sizeof(mutator_padding));
   }
   EndOfHistoryStream = stream.GetOffset();
 }

--- a/orly/indy/disk/data_file.h
+++ b/orly/indy/disk/data_file.h
@@ -151,10 +151,13 @@ namespace Orly {
         typedef Indy::Util::TBlockVec TBlockVec;
         typedef std::vector<size_t> TTypeBoundaryOffsetVec;
 
-        /* SequenceNumber, Key, Value, Num History Keys, Offset of History Keys */
-        static const size_t KeyEntrySize = sizeof(TSequenceNumber) + sizeof(Atom::TCore) + sizeof(Atom::TCore) + sizeof(size_t) + sizeof(size_t);
-        /* SequenceNumber, Key, Value */
-        static const size_t KeyHistorySize = sizeof(TSequenceNumber) + sizeof(Atom::TCore) + sizeof(Atom::TCore);
+        /* SequenceNumber, Key, Value, Num History Keys, Offset of History Keys,
+           Mutator (+ trailing alignment padding to 8 bytes).
+           Kept in sync with TKeyItem in read_file.h via static_assert there. */
+        static const size_t KeyEntrySize = sizeof(TSequenceNumber) + sizeof(Atom::TCore) + sizeof(Atom::TCore) + sizeof(size_t) + sizeof(size_t) + sizeof(uint64_t);
+        /* SequenceNumber, Key, Value, Mutator (+ trailing alignment padding to 8 bytes).
+           Kept in sync with THistoryKeyItem in read_file.h via static_assert there. */
+        static const size_t KeyHistorySize = sizeof(TSequenceNumber) + sizeof(Atom::TCore) + sizeof(Atom::TCore) + sizeof(uint64_t);
         /* Key, offset */
         static const size_t HashEntrySize = sizeof(Atom::TCore) + sizeof(size_t);
         /* sequence number, metadata, id, bucket offset, num in bucket */

--- a/orly/indy/disk/in_file.h
+++ b/orly/indy/disk/in_file.h
@@ -38,11 +38,14 @@ namespace Orly {
         NO_CONSTRUCTION(TData);
         public:
 
-        /* TODO */
-        static const size_t KeyEntrySize = sizeof(TSequenceNumber) + sizeof(Atom::TCore) + sizeof(Atom::TCore) + sizeof(size_t) + sizeof(size_t);
+        /* SequenceNumber, Key, Value, Num History Keys, Offset of History Keys,
+           Mutator (+ trailing alignment padding to 8 bytes).
+           Kept in sync with TKeyItem in read_file.h via static_assert there. */
+        static const size_t KeyEntrySize = sizeof(TSequenceNumber) + sizeof(Atom::TCore) + sizeof(Atom::TCore) + sizeof(size_t) + sizeof(size_t) + sizeof(uint64_t);
 
-        /* TODO */
-        static const size_t KeyHistorySize = sizeof(TSequenceNumber) + sizeof(Atom::TCore) + sizeof(Atom::TCore);
+        /* SequenceNumber, Key, Value, Mutator (+ trailing alignment padding to 8 bytes).
+           Kept in sync with THistoryKeyItem in read_file.h via static_assert there. */
+        static const size_t KeyHistorySize = sizeof(TSequenceNumber) + sizeof(Atom::TCore) + sizeof(Atom::TCore) + sizeof(uint64_t);
 
         /* TODO */
         static const size_t HashEntrySize = sizeof(Atom::TCore) + sizeof(size_t);

--- a/orly/indy/disk/merge_data_file.cc
+++ b/orly/indy/disk/merge_data_file.cc
@@ -487,7 +487,7 @@ class TMergeDataFileImpl {
                 Atom::TCore val_core = cur_item.Value;
                 key_core.Remap(idx_file.KeyRemapper);
                 val_core.Remap(idx_file.ValRemapper);
-                idx_file.PushCurKey(cur_item.SeqNum, key_core, val_core);
+                idx_file.PushCurKey(cur_item.SeqNum, key_core, val_core, cur_item.Mutator);
                 last_written = cur_key;
               } else { /* history key */
                 idx_file.MyPos = pos;
@@ -495,7 +495,7 @@ class TMergeDataFileImpl {
                 Atom::TCore val_core = cur_item.Value;
                 key_core.Remap(idx_file.KeyRemapper);
                 val_core.Remap(idx_file.ValRemapper);
-                idx_file.PushHistKey(cur_item.SeqNum, key_core, val_core);
+                idx_file.PushHistKey(cur_item.SeqNum, key_core, val_core, cur_item.Mutator);
               }
               ++cur_csr;
               if (CanTail) {
@@ -529,7 +529,7 @@ class TMergeDataFileImpl {
               Atom::TCore val_core = cur_item.Value;
               key_core.Remap(idx_file.KeyRemapper);
               val_core.Remap(idx_file.ValRemapper);
-              idx_file.PushHistKey(cur_item.SeqNum, key_core, val_core);
+              idx_file.PushHistKey(cur_item.SeqNum, key_core, val_core, cur_item.Mutator);
               ++hist_csr;
               if (CanTail) {
                 size_t &cur_hist_offset = history_key_cur_idx_vec[pos / 2];
@@ -2220,16 +2220,22 @@ class TMergeDataFileImpl {
                                         WasPrepared = true;
     }
 
-    void PushCurKey(TSequenceNumber seq_num, const Atom::TCore &key, const Atom::TCore &val) {
+    void PushCurKey(TSequenceNumber seq_num, const Atom::TCore &key, const Atom::TCore &val, TMutator mutator) {
       ++NumCurKeys;
       TDataOutStream &stream = *KeyStream;
       if (!FirstKey) {
         stream << NumCurHistoryElem << ByteOffsetOfCurHistory;
+        /* Trailing TMutator (+ 4 bytes padding) for the previous current
+           key. Layout must match TKeyItem in read_file.h. */
+        stream.Write(&PrevKeyMutator, sizeof(TMutator));
+        const uint32_t mutator_padding = 0;
+        stream.Write(&mutator_padding, sizeof(mutator_padding));
         ByteOffsetOfCurHistory += NumCurHistoryElem * TData::KeyHistorySize;
         NumCurHistoryElem = 0UL;
       } else {
         FirstKey = false;
       }
+      PrevKeyMutator = mutator;
       CurKeyOffset = stream.GetOffset();
       stream << seq_num;
       stream.Write(&key, sizeof(key));
@@ -2269,23 +2275,31 @@ class TMergeDataFileImpl {
       UpdateCollector->Emplace(seq_num, CurKeyOffset, true, IndexId);
     }
 
-    void PushHistKey(TSequenceNumber seq_num, const Atom::TCore &key, const Atom::TCore &val) {
+    void PushHistKey(TSequenceNumber seq_num, const Atom::TCore &key, const Atom::TCore &val, TMutator mutator) {
       ++NumHistKeys;
-      HistKeyVec.emplace_back(seq_num, key, val);
+      HistKeyVec.emplace_back(seq_num, key, val, mutator);
       UpdateCollector->Emplace(seq_num, ByteOffsetOfCurHistory + NumCurHistoryElem * TData::KeyHistorySize, false, IndexId);
       ++NumCurHistoryElem;
     }
 
     void FlushHistory() {
       TDataOutStream &stream = *KeyStream;
+      const uint32_t mutator_padding = 0;
       if (!FirstKey) {
         stream << NumCurHistoryElem << ByteOffsetOfCurHistory;
+        /* Final current key's trailing TMutator (+ padding). See PushCurKey. */
+        stream.Write(&PrevKeyMutator, sizeof(TMutator));
+        stream.Write(&mutator_padding, sizeof(mutator_padding));
       }
       ByteOffsetOfHistory = stream.GetOffset();
       for (const auto &hist : HistKeyVec) {
         stream << hist.SeqNum;
         stream.Write(&hist.Key, sizeof(hist.Key));
         stream.Write(&hist.Val, sizeof(hist.Val));
+        /* Trailing TMutator (+ padding) per THistoryKeyItem in read_file.h. */
+        TMutator hist_mutator = hist.Mutator;
+        stream.Write(&hist_mutator, sizeof(TMutator));
+        stream.Write(&mutator_padding, sizeof(mutator_padding));
         assert(stream.GetOffset() <= MaxByteOffsetOfKeyStream);
       }
       EndOfHistoryStream = stream.GetOffset();
@@ -2476,14 +2490,16 @@ class TMergeDataFileImpl {
     class THistKey {
       public:
 
-      THistKey(TSequenceNumber seq_num, const Atom::TCore &key, const Atom::TCore &val)
+      THistKey(TSequenceNumber seq_num, const Atom::TCore &key, const Atom::TCore &val, TMutator mutator)
           : SeqNum(seq_num),
             Key(key),
-            Val(val) {}
+            Val(val),
+            Mutator(mutator) {}
 
       TSequenceNumber SeqNum;
       Atom::TCore Key;
       Atom::TCore Val;
+      TMutator Mutator;
 
     };
 
@@ -2550,6 +2566,10 @@ class TMergeDataFileImpl {
     size_t NumHashTables;
 
     bool FirstKey;
+    /* Mutator of the previous current key. Emitted as the trailing
+       portion of the on-disk TKeyItem when the next key arrives (or in
+       FlushHistory for the final one). */
+    TMutator PrevKeyMutator = TMutator::Assign;
     size_t CurKeyOffset;
     std::unique_ptr<TDataOutStream> KeyStream;
     TCompletionTrigger KeyTrigger;

--- a/orly/indy/disk/present_walk_file.h
+++ b/orly/indy/disk/present_walk_file.h
@@ -240,7 +240,12 @@ namespace Orly {
             for (;Stream.GetOffset() < IndexFile->GetByteOffsetOfHistoryIndex();) {
               assert(Valid);
               Stream.Read(&Item.SequenceNumber, sizeof(TSequenceNumber) + sizeof(Atom::TCore) * 2);
-              Stream.Skip(sizeof(size_t) * 2U);
+              /* Skip NumHistKeys + OffsetOfHistKeys (2 size_t) then the
+                 trailing TMutator + 4 bytes padding (= sizeof(uint64_t)).
+                 Layout matches TKeyItem in read_file.h. Phase 1 of #49
+                 doesn't surface the mutator on TPresentWalker::TItem
+                 yet; phase 3 will. */
+              Stream.Skip(sizeof(size_t) * 2U + sizeof(uint64_t));
               Cached = true;
               switch (SearchKind) {
                 case Match: {

--- a/orly/indy/disk/read_file.h
+++ b/orly/indy/disk/read_file.h
@@ -542,7 +542,11 @@ namespace Orly {
           /* TODO */
           using TInStream = TStream<CachePageSize, BlockSize, PhysicalBlockSize, BufKind, 0UL /* local cache size */>;
 
-          /* TODO */
+          /* On-disk current-key entry. Read/written verbatim via
+             InStream.Read(&Item, sizeof(Item)) and the equivalent write
+             path, so layout MUST stay in sync with TData::KeyEntrySize
+             in in_file.h / TDataFile::KeyEntrySize in data_file.h
+             (validated by the static_assert below). */
           class TKeyItem {
             public:
 
@@ -552,10 +556,14 @@ namespace Orly {
             Atom::TCore Value;
             size_t NumHistKeys;
             size_t OffsetOfHistKeys;
+            /* Phase 1 of #49: default-Assign for every in-tree write
+               path. 4 bytes; trailing alignment padding pushes the
+               struct size up by 8 (see size constants in in_file.h). */
+            TMutator Mutator;
 
           };  // TKeyItem
 
-          /* TODO */
+          /* On-disk history-key entry. See note on TKeyItem above. */
           class THistoryKeyItem {
             public:
 
@@ -563,6 +571,8 @@ namespace Orly {
             TSequenceNumber SeqNum;
             Atom::TCore Key;
             Atom::TCore Value;
+            /* See TKeyItem::Mutator. */
+            TMutator Mutator;
 
           };  // THistoryKeyItem
 

--- a/orly/indy/memory_layer.test.cc
+++ b/orly/indy/memory_layer.test.cc
@@ -152,6 +152,62 @@ FIXTURE(Free) {
   }
 }
 
+/* Phase 1 of #49: TUpdate::TEntry carries a TMutator field. Verify that
+   the field defaults to Assign for the existing TOpByKey-based API and
+   round-trips when set explicitly via the new AddEntry overload. The
+   deep-copy ctor (TUpdate::CopyUpdate) must also preserve it -- that's
+   the path the merge engine uses. */
+FIXTURE(MutatorRoundTrip) {
+  Base::TUuid int_idx(Base::TUuid::Twister);
+  TSuprena arena;
+  void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
+
+  auto update = TUpdate::NewUpdate(
+      TUpdate::TOpByKey{
+        { TIndexKey(int_idx, TKey(std::make_tuple(int64_t(1)), &arena, state_alloc)),
+          TKey(int64_t(10), &arena, state_alloc) }
+      },
+      TKey(&arena),
+      TKey(Base::TUuid(Base::TUuid::Best), &arena, state_alloc));
+
+  /* The TOpByKey path defaults every entry's mutator to Assign. */ {
+    size_t seen = 0;
+    for (TUpdate::TEntryCollection::TCursor csr(update->GetEntryCollection(), InvCon::TOrient::Fwd); csr; ++csr) {
+      EXPECT_EQ(static_cast<int>(csr->GetMutator()), static_cast<int>(TMutator::Assign));
+      ++seen;
+    }
+    EXPECT_EQ(seen, 1UL);
+  }
+
+  /* The new AddEntry(...,mutator) overload stores the mutator verbatim. */
+  update->AddEntry(
+      TIndexKey(int_idx, TKey(std::make_tuple(int64_t(2)), &arena, state_alloc)),
+      TKey(int64_t(5), &arena, state_alloc),
+      TMutator::Add);
+  /* And so does the default-mutator overload (still Assign). */
+  update->AddEntry(
+      TIndexKey(int_idx, TKey(std::make_tuple(int64_t(3)), &arena, state_alloc)),
+      TKey(int64_t(7), &arena, state_alloc));
+  size_t assign_count = 0, add_count = 0;
+  for (TUpdate::TEntryCollection::TCursor csr(update->GetEntryCollection(), InvCon::TOrient::Fwd); csr; ++csr) {
+    if (csr->GetMutator() == TMutator::Add) ++add_count;
+    else if (csr->GetMutator() == TMutator::Assign) ++assign_count;
+  }
+  EXPECT_EQ(add_count, 1UL);
+  EXPECT_EQ(assign_count, 2UL);
+
+  /* CopyUpdate (deep copy used by the merge engine) must preserve the mutator. */
+  TUpdate *copy = TUpdate::CopyUpdate(update.get(), state_alloc);
+  size_t copy_assign = 0, copy_add = 0;
+  for (TUpdate::TEntryCollection::TCursor csr(copy->GetEntryCollection(), InvCon::TOrient::Fwd); csr; ++csr) {
+    if (csr->GetMutator() == TMutator::Add) ++copy_add;
+    else if (csr->GetMutator() == TMutator::Assign) ++copy_assign;
+  }
+  EXPECT_EQ(copy_add, 1UL);
+  EXPECT_EQ(copy_assign, 2UL);
+  delete copy;
+}
+
 #if 0
 FIXTURE(Range) {
   TMemoryLayer layer(nullptr);

--- a/orly/indy/update.cc
+++ b/orly/indy/update.cc
@@ -97,11 +97,12 @@ bool TUpdate::TEntry::TEntryKey::operator>(const TUpdate::TEntry::TEntryKey &tha
 TUpdate::TEntry::TEntryKey::TEntryKey(const TEntry *entry)
     : Entry(entry) {}
 
-TUpdate::TEntry::TEntry(TUpdate *update, const TIndexKey &index_key, const TKey &op, void *state_alloc)
+TUpdate::TEntry::TEntry(TUpdate *update, const TIndexKey &index_key, const TKey &op, void *state_alloc, TMutator mutator)
     : IndexKey(index_key.GetIndexId(), TKey(&update->Suprena, state_alloc, index_key.GetKey())),
       UpdateMembership(this, IndexKey.GetKey(), InvCon::TOrient::Rev, &update->EntryCollection),
       MemoryLayerMembership(this, TEntryKey(this)),
-      Op(&update->Suprena, Sabot::State::TAny::TWrapper(op.GetCore().NewState(op.GetArena(), state_alloc))) {
+      Op(&update->Suprena, Sabot::State::TAny::TWrapper(op.GetCore().NewState(op.GetArena(), state_alloc))),
+      Mutator(mutator) {
   void *type_alloc = alloca(Sabot::Type::GetMaxTypeSize());
   #ifndef NDEBUG
   Sabot::AssertTuple(*Sabot::Type::TAny::TWrapper(GetKey().GetCore().GetType(&update->Suprena, type_alloc)));
@@ -132,7 +133,7 @@ TUpdate::TUpdate(const TUpdate *that, void *state_alloc)
       PersistenceNotification(that->PersistenceNotification) {
   try {
     for (TEntryCollection::TCursor csr(&that->EntryCollection, InvCon::TOrient::Fwd /*Rev*/); csr; ++csr) {
-      new TEntry(this, csr->GetIndexKey(), TKey(csr->GetOp(), static_cast<TCore::TArena *>(&that->Suprena)), state_alloc);
+      new TEntry(this, csr->GetIndexKey(), TKey(csr->GetOp(), static_cast<TCore::TArena *>(&that->Suprena)), state_alloc, csr->GetMutator());
     }
   } catch (...) {
     EntryCollection.DeleteEachMember();

--- a/orly/indy/update.h
+++ b/orly/indy/update.h
@@ -27,6 +27,7 @@
 #include <orly/indy/util/pool.h>
 #include <orly/sabot/all.h>
 #include <orly/sabot/assert_tuple.h>
+#include <orly/shared_enum.h>
 
 namespace Orly {
 
@@ -107,6 +108,19 @@ namespace Orly {
         /* TODO */
         inline const Atom::TCore &GetOp() const;
 
+        /* The mutator used to produce Op. For assignments (the historical
+           default and current observable behavior for all in-tree code
+           paths) this is TMutator::Assign and Op is the resolved value.
+           For commutative ops (Add, Mult, Or, And, Xor, Union, Intersection,
+           SymmetricDiff) this is the mutator that produced the entry and
+           Op is the right-hand side -- the read path will then accumulate
+           same-mutator entries on the same key.
+
+           Phase 1 of #49 added this field but every in-tree write site
+           still passes Assign by default, so observable behavior is
+           unchanged until phase 2 (session.cc emits the real mutator). */
+        inline TMutator GetMutator() const;
+
         /* TODO */
         inline TSequenceNumber GetSequenceNumber() const;
 
@@ -164,8 +178,12 @@ namespace Orly {
         typedef InvCon::OrderedList::TMembership<TEntry, TUpdate, TKey> TUpdateMembership;
         typedef InvCon::OrderedList::TMembership<TEntry, TMemoryLayer, TEntryKey> TMemoryLayerMembership;
 
-        /* TODO */
-        TEntry(TUpdate *update, const TIndexKey &key, const TKey &op, void *state_alloc);
+        /* Construct an entry. The mutator defaults to TMutator::Assign,
+           which is the historical / current behavior for every in-tree
+           write path. Phase 2 of #49 (session.cc) is where non-Assign
+           mutators start flowing through. */
+        TEntry(TUpdate *update, const TIndexKey &key, const TKey &op, void *state_alloc,
+               TMutator mutator = TMutator::Assign);
 
         /* TODO */
         inline const TEntryKey &GetEntryKey() const;
@@ -181,6 +199,10 @@ namespace Orly {
 
         /* TODO */
         Atom::TCore Op;
+
+        /* See GetMutator(). Defaults to TMutator::Assign for every
+           in-tree write path until phase 2 of #49 lands. */
+        TMutator Mutator;
 
         /* TODO */
         static Util::TPool Pool;
@@ -226,6 +248,11 @@ namespace Orly {
 
       /* TODO */
       inline TEntry *AddEntry(const TIndexKey &key, const TKey &op);
+
+      /* Add an entry that carries a mutator. The default-mutator
+         overload above forwards to this with TMutator::Assign so all
+         existing call sites stay behaviorally identical. */
+      inline TEntry *AddEntry(const TIndexKey &key, const TKey &op, TMutator mutator);
 
       /* TODO */
       static std::shared_ptr<TUpdate> NewUpdate(const TOpByKey &op_by_key, const TKey &metadata, const TKey &id);
@@ -371,6 +398,11 @@ namespace Orly {
       return new TEntry(this, index_key, op, state_alloc);
     }
 
+    inline TUpdate::TEntry *TUpdate::AddEntry(const TIndexKey &index_key, const TKey &op, TMutator mutator) {
+      void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
+      return new TEntry(this, index_key, op, state_alloc, mutator);
+    }
+
     /* TODO */
     inline const TKey &TUpdate::TEntry::GetKey() const {
       return IndexKey.GetKey();
@@ -384,6 +416,10 @@ namespace Orly {
     /* TODO */
     inline const Atom::TCore &TUpdate::TEntry::GetOp() const {
       return Op;
+    }
+
+    inline TMutator TUpdate::TEntry::GetMutator() const {
+      return Mutator;
     }
 
     /* TODO */


### PR DESCRIPTION
## Summary

First of five phases for fixing #49 (concurrent `+=` loses updates because `session.cc:174-181` resolves commutative mutations to values before storage). This phase is **purely structural** — no observable behavior change — and is the load-bearing foundation that lets later phases actually defer the resolution.

- `TUpdate::TEntry` gains a `TMutator Mutator` field defaulting to `TMutator::Assign`, plus a `GetMutator()` accessor. Constructor takes a defaulted mutator argument so every existing call site is unchanged behaviorally.
- `TUpdate::AddEntry(...)` gets a new overload that accepts a mutator. Phase 2 (session.cc) will use this to start emitting real non-Assign mutators for commutative ops.
- `TUpdate::CopyUpdate`'s deep-copy ctor propagates the source mutator — otherwise the merge engine would silently drop it once phase 2 produces non-defaults.
- On-disk `TKeyItem` / `THistoryKeyItem` each grow a trailing `TMutator` + 4 bytes alignment padding. `KeyEntrySize` / `KeyHistorySize` bump by `sizeof(uint64_t)` in both `data_file.h` and `in_file.h`; the existing `static_assert`s in `read_file.h` validate the layout.
- `data_file.cc` and `merge_data_file.cc` write paths emit the trailing mutator+padding for current-key and history-key entries.
- `present_walk_file.h`'s hand-rolled streamer (which duplicates the `TKeyItem` layout rather than using `sizeof(Item)`) is updated to skip the new 8 trailing bytes.

`TOpByKey` is intentionally **not** widened — every test file uses brace-initializer syntax against it, and a signature change there would be invasive churn. Phase 2 introduces non-Assign mutators via the new `AddEntry` overload instead.

## Phased plan (this PR is phase 1 only)

1. **This PR** — TEntry gains the field; no behavior change.
2. session.cc emits non-Assign mutators for commutative ops (replaces the read-then-Apply at #L174-181).
3. Read path accumulates same-mutator commutative entries on the same key — **this is where the bug actually goes away**.
4. Compaction (`TMutation::Augment` from #48) folds same-mutator runs.
5. End-to-end test + restore the `examples/wikipedia-pageviews/` demo that originally surfaced the issue.

## Test plan

- [x] `make debug` clean from `rm -rf ../out_orly ../.jhm` — 1707/1707 succeed.
- [x] `make test` — 192/192 pass.
- [x] New `MutatorRoundTrip` fixture in `orly/indy/memory_layer.test.cc` covers default-Assign (existing API) → Assign, new `AddEntry(...,mutator)` overload → mutator preserved, and `CopyUpdate` deep-copy → mutator preserved.
- [x] `lang_test.py tests/lang_tests/{general,samples}/...` — 119 pass / 3 fail; the 3 fails (`mutablefilter`, `multiple_sequences`, `sequence_in_effecting`) are the known pre-existing snapshot mismatches, not regressions.
- [x] Caught one regression during testing: `present_walk_file.h:242-243` was hand-rolling stream offsets and missed the new trailing bytes — `present_walk_file.test` aborted. Fixed in this PR before commit.

Refs #49.