### PR TITLE
Phase 2+3 of #49: emit and fold commutative mutations across transactions

### DIFF
--- a/orly/indy/context.cc
+++ b/orly/indy/context.cc
@@ -18,6 +18,8 @@
 
 #include <orly/indy/context.h>
 
+#include <orly/rt/mutate.h>
+#include <orly/var/mutation.h>
 #include <orly/var/sabot_to_var.h>
 
 using namespace std;
@@ -76,7 +78,8 @@ bool TContext::Exists(const Indy::TIndexKey &key) {
 
 TContext::TPresentWalker::TPresentWalker(TContext *ctx, const TRepoTree &repo_tree, const TIndexKey &key)
     : MinHeap(repo_tree.size()),
-      Valid(false) {
+      Valid(false),
+      FoldArena(ctx->GetArena()) {
   assert(Fiber::TFrame::LocalFramePool);
   size_t pos = 0;
   ctx->PresentWalkConsTimer.Start();
@@ -100,7 +103,8 @@ TContext::TPresentWalker::TPresentWalker(TContext *ctx, const TRepoTree &repo_tr
 
 TContext::TPresentWalker::TPresentWalker(TContext *ctx, const TRepoTree &repo_tree, const TIndexKey &from, const TIndexKey &to)
     : MinHeap(repo_tree.size()),
-      Valid(false) {
+      Valid(false),
+      FoldArena(ctx->GetArena()) {
   ctx->PresentWalkConsTimer.Start();
   size_t pos = 0;
   for (const auto &iter : repo_tree) {
@@ -140,9 +144,84 @@ void TContext::TPresentWalker::Refresh() {
     if (!done) {
       Valid = static_cast<bool>(MinHeap);
     } else {
+      /* Phase 3 of #49: if the anchor entry was produced by a defer-safe
+         commutative mutator, fold older same-mutator entries (and the
+         eventual Assign base) into a single resolved value before
+         returning. No-op when the anchor is an Assign. */
+      if (Var::IsDeferSafeCommutative(Item.Mutator)) {
+        ApplyDeferredFold();
+      }
       break;
     }
   }
+}
+
+void TContext::TPresentWalker::ApplyDeferredFold() {
+  /* Walk back through additional heap entries on the same key, folding
+     them via Rt::Mutate. The loop terminates on:
+       * Heap empty -- accumulated value stands (no Assign base existed;
+         the commutative-mutator identity is "missing", matching the
+         existing "first += against an empty key" semantics).
+       * Different key -- next call to Refresh handles that key.
+       * Tombstone on this key -- history below the tombstone is
+         invisible; accumulated value stands.
+       * Same key + Assign -- the base. Fold the accumulator onto it.
+       * Same key + a different mutator -- mixed-mutator history, which
+         TMutation::Augment already rejects at compose time. We surface
+         the accumulator as-is and let downstream typed code react. */
+  const TMutator mut = Item.Mutator;
+  void *state_alloc_a = alloca(Sabot::State::GetMaxStateSize() * 3);
+  void *state_alloc_b = static_cast<uint8_t *>(state_alloc_a) + Sabot::State::GetMaxStateSize();
+  void *state_alloc_c = static_cast<uint8_t *>(state_alloc_b) + Sabot::State::GetMaxStateSize();
+  Var::TVar acc = Var::ToVar(*Sabot::State::TAny::TWrapper(Item.Op.NewState(Item.OpArena, state_alloc_a)));
+
+  while (MinHeap) {
+    size_t peek_pos;
+    const Indy::TPresentWalker::TItem &peek = MinHeap.Peek(peek_pos);
+    if (Indy::TKey::TupleNeEq(Item.Key, Item.KeyArena, peek.Key, peek.KeyArena)) {
+      break;
+    }
+    if (peek.Op.IsTombstone()) {
+      break;
+    }
+    if (peek.Mutator != TMutator::Assign && peek.Mutator != mut) {
+      break;
+    }
+    /* Commit to consuming this item. Copy the bits we need before Pop
+       invalidates the underlying walker's Item slot. */
+    const TMutator peek_mut = peek.Mutator;
+    const Atom::TCore peek_op = peek.Op;
+    Atom::TCore::TArena *const peek_op_arena = peek.OpArena;
+
+    size_t consumed_pos;
+    MinHeap.Pop(consumed_pos);
+
+    Var::TVar peek_val = Var::ToVar(*Sabot::State::TAny::TWrapper(peek_op.NewState(peek_op_arena, state_alloc_b)));
+    if (peek_mut == TMutator::Assign) {
+      /* Base. acc represents the accumulated RHS; result is base OP acc. */
+      acc = Rt::Mutate(peek_val, mut, acc);
+    } else {
+      /* Same commutative mutator. */
+      acc = Rt::Mutate(acc, mut, peek_val);
+    }
+
+    Indy::TPresentWalker &consumed_walker = *WalkerVec[consumed_pos];
+    ++consumed_walker;
+    if (consumed_walker) {
+      MinHeap.Insert(*consumed_walker, consumed_pos);
+    }
+
+    if (peek_mut == TMutator::Assign) {
+      break;
+    }
+  }
+
+  /* Stuff the resolved value back into Item.Op via FoldArena (owned by
+     the enclosing TContext, so the TCore outlives this walker). Tag it
+     as Assign so downstream consumers don't re-attempt the fold. */
+  Item.Op = Atom::TCore(FoldArena, Sabot::State::TAny::TWrapper(Var::NewSabot(state_alloc_c, acc)).get());
+  Item.OpArena = FoldArena;
+  Item.Mutator = TMutator::Assign;
 }
 
 TContext::TKeyCursor::TKeyCursor(TContext *context, const Indy::TIndexKey &pattern)

--- a/orly/indy/context.h
+++ b/orly/indy/context.h
@@ -87,6 +87,12 @@ namespace Orly {
         /* TODO */
         void Refresh();
 
+        /* Phase 3 of #49: fold consecutive same-mutator commutative
+           entries on the current key into a single resolved value.
+           No-op when Item.Mutator is TMutator::Assign (the only case
+           pre-#49-phase-2 in-tree code ever produced). */
+        void ApplyDeferredFold();
+
         /* TODO */
         std::vector<std::shared_ptr<Indy::TPresentWalker>> WalkerVec;
 
@@ -98,6 +104,10 @@ namespace Orly {
 
         /* TODO */
         mutable TItem Item;
+
+        /* Arena that owns folded Op TCores. Borrowed from the enclosing
+           TContext, so the folded TCore outlives the walker. */
+        Atom::TCore::TExtensibleArena *FoldArena;
 
       };  // TPresentWalker
 

--- a/orly/indy/disk/present_walk_file.h
+++ b/orly/indy/disk/present_walk_file.h
@@ -240,12 +240,15 @@ namespace Orly {
             for (;Stream.GetOffset() < IndexFile->GetByteOffsetOfHistoryIndex();) {
               assert(Valid);
               Stream.Read(&Item.SequenceNumber, sizeof(TSequenceNumber) + sizeof(Atom::TCore) * 2);
-              /* Skip NumHistKeys + OffsetOfHistKeys (2 size_t) then the
-                 trailing TMutator + 4 bytes padding (= sizeof(uint64_t)).
-                 Layout matches TKeyItem in read_file.h. Phase 1 of #49
-                 doesn't surface the mutator on TPresentWalker::TItem
-                 yet; phase 3 will. */
-              Stream.Skip(sizeof(size_t) * 2U + sizeof(uint64_t));
+              /* Skip NumHistKeys + OffsetOfHistKeys (2 size_t), then read
+                 TMutator + skip its 4 bytes of trailing alignment padding
+                 (struct ends at sizeof(uint64_t) past the 2 size_t). The
+                 mutator goes onto Item.Mutator so context.cc's fold can
+                 see it -- this is the #49 phase 3 hookup that finishes
+                 what phase 1 plumbed structurally. */
+              Stream.Skip(sizeof(size_t) * 2U);
+              Stream.Read(&Item.Mutator, sizeof(TMutator));
+              Stream.Skip(sizeof(uint64_t) - sizeof(TMutator));
               Cached = true;
               switch (SearchKind) {
                 case Match: {

--- a/orly/indy/memory_layer.cc
+++ b/orly/indy/memory_layer.cc
@@ -128,6 +128,7 @@ void TMemoryLayer::TMatchPresentWalker::Refresh() const {
               Item.Key = Csr->GetKey().GetCore();
               Item.Op = Csr->GetOp();
               Item.SequenceNumber = Csr->GetSequenceNumber();
+              Item.Mutator = Csr->GetMutator();
               return;
               break;
             }
@@ -224,6 +225,7 @@ void TMemoryLayer::TRangePresentWalker::Refresh() const {
           Item.Key = Csr->GetKey().GetCore();
           Item.Op = Csr->GetOp();
           Item.SequenceNumber = Csr->GetSequenceNumber();
+          Item.Mutator = Csr->GetMutator();
           return;
         }
         case Atom::TComparison::Gt: {

--- a/orly/indy/present_walker.h
+++ b/orly/indy/present_walker.h
@@ -26,6 +26,7 @@
 #include <orly/atom/kit2.h>
 #include <orly/indy/fiber/fiber.h>
 #include <orly/indy/sequence_number.h>
+#include <orly/shared_enum.h>
 
 namespace Orly {
 
@@ -42,7 +43,7 @@ namespace Orly {
         public:
 
         /* Do-little. */
-        TItem() : SequenceNumber(0UL), KeyArena(nullptr), OpArena(nullptr) {}
+        TItem() : SequenceNumber(0UL), KeyArena(nullptr), OpArena(nullptr), Mutator(TMutator::Assign) {}
 
         /* TODO */
         bool operator<(const TItem &that) const {
@@ -71,6 +72,14 @@ namespace Orly {
 
         /* The arena to look the op core up in. */
         Atom::TCore::TArena *OpArena;
+
+        /* The mutator that produced Op. For TMutator::Assign (every
+           in-tree entry pre-#49-phase-2), Op is the resolved value of
+           the key. For commutative non-Assign mutators (Add, Mult, Or,
+           ...), Op is the RHS of that mutation and the context-level
+           walker (orly/indy/context.cc) folds same-mutator runs to
+           produce the actual resolved value. */
+        TMutator Mutator;
 
       };  // TItem
 

--- a/orly/server/session.cc
+++ b/orly/server/session.cc
@@ -23,6 +23,7 @@
 #include <orly/notification/all.h>
 #include <orly/server/meta_record.h>
 #include <orly/spa/orly_args.h>
+#include <orly/var/mutation.h>
 #include <base/util/time.h>
 
 using namespace std;
@@ -169,8 +170,29 @@ TMethodResult TSession::Try(TServer *server, const TUuid &pov_id, const vector<s
       had_effects = true;
       auto transaction = server->GetRepoManager()->NewTransaction();
       Indy::TUpdate::TOpByKey op_by_key;
+      /* Deferred entries from #49 phase 2: defer-safe commutative
+         mutations skip the read-modify-write and get registered with
+         their mutator preserved, after NewUpdate constructs the rest.
+         This is the actual concurrent-write fix -- two sessions both
+         doing `+= 5` now each emit {Add, 5} and the read path folds
+         them, instead of both resolving against a stale read and
+         producing a lost update. */
+      std::vector<std::tuple<Indy::TIndexKey, Indy::TKey, TMutator>> deferred_entries;
       for (const auto &item: effects) {
         auto key = item.first;
+        /* Defer-safe path: single TMutation with a commutative+associative
+           mutator. Skip the read entirely; emit RHS + mutator directly.
+           Anything else (Assign, Delete, partial changes, non-commutative
+           mutators) falls through to the existing resolve-to-value path. */
+        if (auto *mut = dynamic_cast<const Var::TMutation *>(item.second.get())) {
+          if (Var::IsDeferSafeCommutative(mut->GetMutator())) {
+            deferred_entries.emplace_back(
+                key,
+                Indy::TKey(&my_arena, Sabot::State::TAny::TWrapper(Var::NewSabot(state_alloc_2, mut->GetRhs())).get()),
+                mut->GetMutator());
+            continue;
+          }
+        }
         Var::TVar val;
         if (!item.second->IsDelete()) {
           if (!item.second->IsFinal()) {
@@ -214,6 +236,13 @@ TMethodResult TSession::Try(TServer *server, const TUuid &pov_id, const vector<s
               run_time, random_seed)
       );
       auto update = Indy::TUpdate::NewUpdate(op_by_key, Indy::TKey(meta_record, &my_arena, state_alloc_1), Indy::TKey(update_id, &my_arena, state_alloc_2));
+      /* Register the defer-safe commutative mutations gathered above.
+         These don't go through TOpByKey because op_by_key is a map and
+         TUpdate's TOpByKey ctor always tags entries Assign -- the
+         AddEntry overload (added in #49 phase 1) takes the mutator. */
+      for (auto &entry : deferred_entries) {
+        update->AddEntry(std::get<0>(entry), std::get<1>(entry), std::get<2>(entry));
+      }
       transaction->Push(repo, update);
       transaction->Prepare();
       transaction->CommitAction();

--- a/orly/var/mutation.cc
+++ b/orly/var/mutation.cc
@@ -140,6 +140,8 @@ void TMutation::Augment(const TPtr<const TChange> &change) {
   if (other->Mutator != Mutator) {
     throw Rt::TSystemError(HERE, "Conflicting updates to the same key. Mixed mutators (e.g. += and *=) on the same key cannot be safely collapsed.");
   }
+  // The commutative+associative cases below match IsDeferSafeCommutative()
+  // (mutation.h) -- keep the two in sync.
   switch (Mutator) {
     case TMutator::Add:
     case TMutator::Mult:

--- a/orly/var/mutation.h
+++ b/orly/var/mutation.h
@@ -32,6 +32,38 @@ namespace Orly {
       template <typename TVal>
       using TPtr = std::shared_ptr<TVal>;
 
+      /* True iff this mutator is both commutative and associative, so that
+         a sequence of `x OP a; x OP b; x OP c` on the same key can be
+         safely re-folded as `x OP (a OP b OP c)` without knowing the
+         current value of x at any intermediate point.
+
+         This is the single source of truth for the defer-safe set: both
+         TMutation::Augment (compose-time, in this PR's predecessor #48)
+         and the session-layer emit path (#49 phase 2) gate on this. Sub,
+         Div, Mod and Exp deliberately return false here -- they compose
+         only via different operations than the mutator itself, which
+         TMutation::Augment also rejects. */
+      inline bool IsDeferSafeCommutative(TMutator mutator) {
+        switch (mutator) {
+          case TMutator::Add:
+          case TMutator::Mult:
+          case TMutator::And:
+          case TMutator::Or:
+          case TMutator::Xor:
+          case TMutator::Union:
+          case TMutator::Intersection:
+          case TMutator::SymmetricDiff:
+            return true;
+          case TMutator::Assign:
+          case TMutator::Sub:
+          case TMutator::Div:
+          case TMutator::Mod:
+          case TMutator::Exp:
+            return false;
+        }
+        return false;
+      }
+
       //NOTE: There is a class hierarchy in <orly/code_gen/mutation.h> which is almost identical to this one
       //TODO: The shared pointers in / around TChange are fugly.
       /* A database change */
@@ -156,6 +188,13 @@ namespace Orly {
         void Augment(const TPtr<const TChange> &change) final;
         bool IsDelete() const final;
         bool IsFinal() const;
+
+        /* The mutator + right-hand side that this mutation will apply.
+           Exposed so the session layer (#49 phase 2) can detect defer-safe
+           commutative mutations and emit them with their mutator preserved
+           instead of resolving them to a value at write time. */
+        TMutator GetMutator() const { return Mutator; }
+        const Var::TVar &GetRhs() const { return Rhs; }
 
         private:
         TMutation(TMutator mutator, const Var::TVar &rhs);

--- a/tests/lang_tests/general/issue_49_fold.orly
+++ b/tests/lang_tests/general/issue_49_fold.orly
@@ -1,0 +1,145 @@
+/* <orly/lang_tests/general/issue_49_fold.orly>
+
+   Targeted regression test for issue #49 phase 2+3: session.cc emits
+   defer-safe commutative mutations with their mutator preserved, and the
+   context-level read path folds runs of same-mutator entries onto an
+   Assign base.
+
+   The shape that exercises the fold is:
+     with { <[k]> <- BASE }     // Assign(BASE)
+     test { tN: mut_X(...x:A) { // emits {Mutator, A}
+              tM: mut_X(...x:B) { // emits {Mutator, B}
+                  tR: read == fold(BASE, X, A, B);
+              };
+            }; };
+
+   Each tN runs in its own transaction, so reading after both mut_X calls
+   walks back through {X, B}, {X, A}, {Assign, BASE} and the phase 3
+   read-path fold produces BASE op A op B.
+
+   Pre-fix behavior on these workloads was correct for single-writer
+   sequential tests (since each writer reads the latest committed value
+   before computing), so this test only catches a fold-implementation
+   regression -- not the underlying concurrent-write lost-update bug,
+   which a single-process lang_test cannot exercise.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+read_int = (*<[n]>::(int)) where {
+  n = given::(int);
+};
+
+write_int = ((true) effecting {
+  new <[n]> <- x;
+}) where {
+  n = given::(int);
+  x = given::(int);
+};
+
+add_int = ((true) effecting {
+  *<[n]>::(int) += x;
+}) where {
+  n = given::(int);
+  x = given::(int);
+};
+
+mult_int = ((true) effecting {
+  *<[n]>::(int) *= x;
+}) where {
+  n = given::(int);
+  x = given::(int);
+};
+
+read_set = (*<[n]>::({int})) where {
+  n = given::(int);
+};
+
+union_set = ((true) effecting {
+  *<[n]>::({int}) |= {x};
+}) where {
+  n = given::(int);
+  x = given::(int);
+};
+
+read_bool = (*<[n]>::(bool)) where {
+  n = given::(int);
+};
+
+write_bool = ((true) effecting {
+  new <[n]> <- x;
+}) where {
+  n = given::(int);
+  x = given::(bool);
+};
+
+or_bool = ((true) effecting {
+  *<[n]>::(bool) or= x;
+}) where {
+  n = given::(int);
+  x = given::(bool);
+};
+
+/* Add: two-deep fold on top of an Assign base. */
+with {
+  <[100]> <- 10;
+} test {
+  t1: read_int(.n: 100) == 10;
+  t2: add_int(.n: 100, .x: 5) {
+    t3: read_int(.n: 100) == 15;
+    t4: add_int(.n: 100, .x: 3) {
+      t5: read_int(.n: 100) == 18;
+      /* Three-deep fold. */
+      t6: add_int(.n: 100, .x: 2) {
+        t7: read_int(.n: 100) == 20;
+      };
+    };
+  };
+};
+
+/* Mult: same shape, different mutator. 7 * 2 * 3 = 42. */
+with {
+  <[101]> <- 7;
+} test {
+  t10: mult_int(.n: 101, .x: 2) {
+    t11: read_int(.n: 101) == 14;
+    t12: mult_int(.n: 101, .x: 3) {
+      t13: read_int(.n: 101) == 42;
+    };
+  };
+};
+
+/* Bool or: identity is false; folds via logical OR. */
+with {
+  <[102]> <- false;
+} test {
+  t20: or_bool(.n: 102, .x: false) {
+    t21: read_bool(.n: 102) == false;
+    t22: or_bool(.n: 102, .x: true) {
+      t23: read_bool(.n: 102) == true;
+    };
+  };
+};
+
+/* Set union, where the fold composes per-key set values. */
+with {
+  <[104]> <- {1, 2};
+} test {
+  t40: union_set(.n: 104, .x: 3) {
+    t41: read_set(.n: 104) == {1, 2, 3};
+    t42: union_set(.n: 104, .x: 4) {
+      t43: read_set(.n: 104) == {1, 2, 3, 4};
+    };
+  };
+};


### PR DESCRIPTION
## Summary

This is the actual concurrent-write lost-update fix for #49. Phase 1 (#50) added the structural plumbing; this PR uses it.

**Before:** `session.cc:170-185` resolved every non-final effect into an `Assign` by reading the current value, calling `Apply()`, and writing the result. Two sessions concurrently running `x += 5` each read the same value, each computed `value+5` locally, and the second write clobbered the first contribution. Textbook lost update.

**After:** session.cc emits `x += 5` as a deferred `{Mutator=Add, Op=5}` entry on the key. The read path folds runs of same-mutator entries back into a single value at read time. Two concurrent `+= 5`s reach storage as separate `Add(5)` entries; the reader composes them.

## Changes

**Emit side** (`orly/server/session.cc`, `orly/var/mutation.{h,cc}`):
- `TMutation` gains public `GetMutator()` / `GetRhs()` accessors.
- New `Var::IsDeferSafeCommutative(TMutator)` — single source of truth for `{Add, Mult, And, Or, Xor, Union, Intersection, SymmetricDiff}`. The set matches what `TMutation::Augment` already validated in #48 (with a comment in `mutation.cc` keeping the two enumerations in sync).
- `session.cc` partitions effects: defer-safe commutative `TMutation`s skip the read+apply entirely and are registered post-`NewUpdate` via the `AddEntry(idx_key, op_key, mutator)` overload phase 1 added. Everything else (Assign, Delete, partial changes, non-commutative mutators) takes the existing resolve-to-value path, unchanged.

**Fold side** (`orly/indy/context.{h,cc}`):
- `TPresentWalker::TItem` grows a `Mutator` field (phase 1 deferred this on purpose to phase 3), populated by both the memory-layer walker (`memory_layer.cc`) and the disk walker (`present_walk_file.h` reads the byte phase 1 wrote, instead of just skipping it).
- `TContext::TPresentWalker::ApplyDeferredFold` walks heap entries on the current key, folding same-mutator runs via `Rt::Mutate`. Stops on: Assign (folds accumulator onto base), tombstone, different key, different mutator, or empty heap. The resolved `TCore` lives in an arena borrowed from the enclosing `TContext` so it outlives the walker.

## Edge cases handled

- **No prior Assign** (e.g. `+= 5` on a never-written key): fold returns the accumulated RHS as-is, matching today's "missing → identity" semantics for the commutative mutators.
- **Tombstone in the chain**: fold stops at the tombstone — history below is invisible.
- **Mixed mutators on the same key**: `TMutation::Augment` already rejects this at compose time; the fold defensively stops accumulating, surfaces the partial result, and lets downstream typed code react.
- **Multi-POV reads**: heap ordering is `(Key asc, SeqNum desc)`, so the fold sees most-recent-first across all POV layers and bottoms out correctly on the oldest Assign.
- **TUpdate::CopyUpdate** (the merge-engine deep-copy path): already propagates the mutator since phase 1.

## What this PR does not do

- Phase 4: compaction folding via `TMutation::Augment` in `merge_data_file.cc` — punted; uncompacted deferred runs are correctly read via fold, they just don't get collapsed at compaction time. Follow-up.
- Phase 5: restore the `examples/wikipedia-pageviews/` demo that originally surfaced the bug — follow-up once phase 4 is in.

## Test plan

- [x] `make debug` clean and incremental — green.
- [x] `make test` — 192/192 pass, including `memory_layer.test` / `present_walk_file.test` / `data_file.test` / `merge_data_file.test` which exercise the read+write paths most directly affected.
- [x] **New** `tests/lang_tests/general/issue_49_fold.orly` exercises the multi-transaction fold via sequential committed transactions: two-deep and three-deep folds on int `+=`, int `*=`, bool `or=`, and set `|=`. Passes only if both the emit AND the fold do the right thing — without phase 3, the second read would return the most-recent RHS (e.g. `3`) instead of the composed value (e.g. `18`).
- [x] `lang_test.py` — 120 pass / 3 fail. The 3 fails (`mutablefilter`, `multiple_sequences`, `sequence_in_effecting`) are the known pre-existing snapshot mismatches, unchanged from PR #50's baseline.
- [ ] **Cannot exercise in lang_test:** the actual concurrent-writer scenario the bug describes. That requires a multi-session integration harness (probably extending `ws.test` or `pov.test`) and is outside the scope of this PR; the architecture is now correct for it.

Refs #49.