### PR TITLE
Phase 5 of #49: restore wikipedia-pageviews demo + fix two remaining lost-update sites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,3 +209,11 @@ jobs:
       - name: wikipedia-categories run-go.sh (go driver)
         run: ./run-go.sh
         working-directory: examples/wikipedia-categories
+
+      # The concurrent-writers demo: 8 sessions all `+= n` into the same
+      # hot keys. Self-checks that every increment lands (no lost updates).
+      # This is the integration validation for the issue #49 fix --
+      # without phases 2+3, only ~1/8 of the writes survive.
+      - name: wikipedia-pageviews run.sh (python driver, concurrent +=)
+        run: ./run.sh
+        working-directory: examples/wikipedia-pageviews

--- a/examples/wikipedia-pageviews/README.md
+++ b/examples/wikipedia-pageviews/README.md
@@ -1,0 +1,39 @@
+# Wikipedia hourly pageviews — concurrent `+=` demo
+
+The motivating workload for [issue #49](https://github.com/orlyatomics/orly/issues/49). 8 concurrent WebSocket writers all do `*<['views', lang, page, hour]>::(int) += n` into the same hot keys; the demo self-checks that every increment lands.
+
+## The trick
+
+Orly's `+= n` is a field **call**, not a read-then-write. Two sessions concurrently doing `x += 5` against the same key each emit a deferred `{Add, 5}` mutation at the storage layer; the read path folds them via `Rt::Mutate` back into the correct sum. No row lock, no read-modify-write race, no lost updates.
+
+Equivalent operations in other databases:
+
+| Database | Statement | Notes |
+|---|---|---|
+| Postgres | `UPDATE views SET n = n + 1 WHERE page = ?` | Row lock; N writers serialize on hot pages. |
+| Redis | `INCR views:<page>` | Atomic but single-threaded server. |
+| Cassandra | `UPDATE views SET n = n + 1 WHERE ...` | Counter columns, with consistency caveats. |
+| Orly | `*<['views', lang, page, hour]>::(int) += n` | Field call; lock-free; N writers in N sessions all land their increments. |
+
+## Run it
+
+```sh
+cd examples/wikipedia-pageviews
+./run.sh
+```
+
+The wrapper requires `make debug` to have produced `orlyi` and `orlyc`. It kills any prior demo instance, starts a fresh `orlyi`, and runs `demo.py` which spawns 8 concurrent WebSocket writers (250 events each = 2000 events total) hammering 96 hot keys (4 pages × 24 hours).
+
+Exit code is non-zero if the verifier finds any per-key counter that disagrees with the independently-tracked ground truth.
+
+## What the demo proves
+
+- **No lost updates under contention.** Without the issue-#49 fix (phases 1–3), this demo recovers ~1/8 of the writes — each writer's reads against a stale view clobber the others when resolved-as-Assign writes hit storage. With the fix, all 5,938 events are accounted for.
+- **The fold composes commutatively across POVs.** Concurrent writes go through Tetris merge from the shared POV to the global repo; the read path walks both layers and folds same-mutator runs back into a value.
+
+## Related demos
+
+- [`bitcoin-time-travel/`](../bitcoin-time-travel/) — same fold pattern over integer addition with multi-branch (multiverse) keys. Demonstrates user-space time-travel.
+- [`wikipedia-categories/`](../wikipedia-categories/) — same fold pattern over set union. Demonstrates the polymorphic-monoid claim: the fold trick works for any commutative+associative operator.
+
+This one demonstrates the third leg of that story: **the same `+= n` field-call works under concurrent writers**, which is the assumption the other two demos make about Orly's `+=` semantics but don't themselves exercise.

--- a/examples/wikipedia-pageviews/demo.py
+++ b/examples/wikipedia-pageviews/demo.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Wikimedia hourly pageviews demo, in Python.
+
+Spawns N concurrent WebSocket writers that hammer per-(page, hour)
+counters via Orly's `+=` field calls. Demonstrates:
+
+  - All increments land correctly even with many concurrent writers
+    on the same hot key (Orly's `+=` is commutative and lock-free)
+  - Throughput doesn't degrade catastrophically with more writers
+  - The recorded counts match an independent ground-truth sum
+
+The dataset is synthetic but shaped after real Wikimedia pageview
+dumps: each event is `(lang, page, hour, count)`. We deliberately
+target a small set of hot pages so the writers contend on the same
+keys.
+
+Run via the wrapper:
+
+    ./run.sh
+
+Or directly, after starting orlyi separately:
+
+    python3 demo.py
+"""
+
+import json
+import random
+import sys
+import threading
+import time
+import websocket
+
+WS_URL = "ws://127.0.0.1:8082/"
+
+NUM_WRITERS = 8
+EVENTS_PER_WRITER = 250
+PAGES = ["Donald_Trump", "Taylor_Swift", "ChatGPT", "Wikipedia"]
+HOURS = list(range(2026_06_01_00, 2026_06_01_24))  # 24 "hour" buckets (using a YYYYMMDDHH-shaped int for readability)
+
+
+def send(ws, stmt):
+    ws.send(stmt)
+    reply = json.loads(ws.recv())
+    if reply.get("status") != "ok":
+        raise RuntimeError(f"{stmt!r}\n  -> {reply}")
+    return reply.get("result")
+
+
+def increment_view(ws, pov, page, hour, n):
+    stmt = (f'try {{{pov}}} views increment_view '
+            f'<{{.lang: "en", .page: "{page}", .hour: {hour}, .n: {n}}}>;')
+    send(ws, stmt)
+
+
+def views_in_hour(ws, pov, page, hour):
+    stmt = (f'try {{{pov}}} views views_in_hour '
+            f'<{{.lang: "en", .page: "{page}", .hour: {hour}}}>;')
+    return int(send(ws, stmt))
+
+
+def views_total(ws, pov, page, h_start, h_end):
+    stmt = (f'try {{{pov}}} views views_total '
+            f'<{{.lang: "en", .page: "{page}", .h_start: {h_start}, .h_end: {h_end}}}>;')
+    return int(send(ws, stmt))
+
+
+def generate_events(seed, count):
+    """Generate `count` (page, hour, n) events. Deterministic given seed."""
+    rng = random.Random(seed)
+    out = []
+    for _ in range(count):
+        page = rng.choice(PAGES)
+        hour = rng.choice(HOURS)
+        n = rng.randint(1, 5)
+        out.append((page, hour, n))
+    return out
+
+
+def writer(writer_id, pov, events):
+    """One writer: open a fresh WebSocket connection, open a session,
+    ingest its slice of events using the shared POV."""
+    ws = websocket.create_connection(WS_URL)
+    try:
+        send(ws, "new session;")
+        for page, hour, n in events:
+            increment_view(ws, pov, page, hour, n)
+    finally:
+        ws.close()
+
+
+def main():
+    # Generate all events deterministically, then split per writer.
+    all_events = []
+    for w in range(NUM_WRITERS):
+        all_events.append(generate_events(seed=w * 17 + 3, count=EVENTS_PER_WRITER))
+    total_events = sum(len(es) for es in all_events)
+
+    # Ground truth: what *should* each (page, hour) count be after ingest?
+    ground_truth = {}
+    for batch in all_events:
+        for page, hour, n in batch:
+            ground_truth[(page, hour)] = ground_truth.get((page, hour), 0) + n
+
+    # Open one bootstrap connection to create the shared POV and install the package.
+    boot = websocket.create_connection(WS_URL)
+    send(boot, "new session;")
+    send(boot, "install views.1;")
+    pov = send(boot, "new safe shared pov;")
+    print(f"pov: {pov}")
+    print(f"writers: {NUM_WRITERS}, events per writer: {EVENTS_PER_WRITER}, "
+          f"total events: {total_events:,}")
+    print(f"hot keyspace: {len(PAGES)} pages × {len(HOURS)} hours = "
+          f"{len(PAGES) * len(HOURS)} keys")
+
+    # Pre-create every (page, hour) key with value 0 so the concurrent
+    # writers all take the `+=` branch (never the `new` create branch).
+    # Isolates whether lost updates come from the create-race vs from
+    # `+=` itself.
+    print("\npre-initialising all hot keys to 0...")
+    for page in PAGES:
+        for hour in HOURS:
+            increment_view(boot, pov, page, hour, 0)
+
+    # Ingest in parallel.
+    threads = []
+    t0 = time.monotonic()
+    for w in range(NUM_WRITERS):
+        t = threading.Thread(target=writer, args=(w, pov, all_events[w]))
+        t.start()
+        threads.append(t)
+    for t in threads:
+        t.join()
+    elapsed = time.monotonic() - t0
+    rate = total_events / elapsed
+    print(f"\ningest done in {elapsed:.2f}s "
+          f"({rate:,.0f} events/sec end-to-end with {NUM_WRITERS} writers)")
+
+    # Verify every (page, hour) counter matches ground truth.
+    print()
+    print("=== verifying counters ===")
+    failures = []
+    for (page, hour), expected in sorted(ground_truth.items()):
+        got = views_in_hour(boot, pov, page, hour)
+        marker = "✓" if got == expected else "✗"
+        if got != expected:
+            failures.append(f"{page} @ {hour}: got {got}, want {expected}")
+        if hour == HOURS[-1]:  # only print one line per page for brevity
+            pass
+    # Print a per-page summary instead of every (page, hour) line.
+    print(f"  {'page':<16}  {'24h total':>12}  {'expected':>12}")
+    print(f"  {'-'*16}  {'-'*12}  {'-'*12}")
+    grand_got = 0
+    grand_want = 0
+    for page in PAGES:
+        got_total = views_total(boot, pov, page, HOURS[0], HOURS[-1])
+        want_total = sum(v for (p, h), v in ground_truth.items() if p == page)
+        marker = "✓" if got_total == want_total else "✗"
+        print(f"  {page:<16}  {got_total:>12,}  {want_total:>12,}  {marker}")
+        if got_total != want_total:
+            failures.append(f"{page} total: got {got_total}, want {want_total}")
+        grand_got += got_total
+        grand_want += want_total
+    print(f"  {'-'*16}  {'-'*12}  {'-'*12}")
+    print(f"  {'TOTAL':<16}  {grand_got:>12,}  {grand_want:>12,}")
+
+    print()
+    print("=== the trick ===")
+    print(f"  {NUM_WRITERS} concurrent WebSocket writers all `+=` into the same")
+    print(f"  {len(PAGES) * len(HOURS)} hot keys, with zero locking. Field calls")
+    print(f"  commute; the merge machinery aggregates safely.")
+
+    send(boot, "exit;")
+    boot.close()
+
+    if failures:
+        print("\n=== self-check FAILED ===")
+        for f in failures[:20]:
+            print(f"  {f}")
+        sys.exit(1)
+    print(f"\n=== self-check OK ===")
+    print(f"  verified {len(ground_truth)} per-key counters + "
+          f"{len(PAGES)} per-page totals across {NUM_WRITERS} concurrent writers")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/wikipedia-pageviews/run.sh
+++ b/examples/wikipedia-pageviews/run.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# End-to-end driver for the wikipedia-pageviews demo.
+set -e
+
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../.. && pwd)"
+ORLY_OUT="${ORLY_OUT:-$REPO_ROOT/../out_orly/debug}"
+ORLYI="$ORLY_OUT/orly/server/orlyi"
+ORLYC="$ORLY_OUT/orly/orlyc"
+
+for bin in "$ORLYI" "$ORLYC"; do
+  if [ ! -x "$bin" ]; then
+    echo "missing: $bin"
+    exit 1
+  fi
+done
+
+WORK="$(mktemp -d)"
+trap 'kill -9 $ORLYI_PID 2>/dev/null || true; rm -rf "$WORK"' EXIT
+
+echo "[1/5] compile views.orly"
+"$ORLYC" -o "$WORK" views.orly
+
+echo "[2/5] populate packages/"
+mkdir "$WORK/packages"
+touch "$WORK/packages/__orly__"
+cp "$WORK/views.1.so" "$WORK/packages/"
+
+pkill -9 -f 'instance_name=wiki_pageviews_demo' 2>/dev/null || true
+sleep 1
+
+echo "[3/5] start fresh orlyi"
+"$ORLYI" --mem_sim --create=true \
+         --port_number=19400 --slave_port_number=19401 \
+         --connection_backlog=10 \
+         --instance_name=wiki_pageviews_demo \
+         --starting_state=SOLO \
+         --package_dir="$WORK/packages" \
+         > "$WORK/orlyi.log" 2>&1 &
+ORLYI_PID=$!
+
+echo "[4/5] wait for WebSocket port 8082"
+for _ in $(seq 1 60); do
+  if ss -tln 2>/dev/null | grep -q ':8082'; then
+    break
+  fi
+  sleep 1
+done
+if ! ss -tln 2>/dev/null | grep -q ':8082'; then
+  echo "orlyi failed to come up; last log lines:"
+  tail -20 "$WORK/orlyi.log"
+  exit 1
+fi
+
+echo "[5/5] run demo.py"
+python3 demo.py

--- a/examples/wikipedia-pageviews/views.orly
+++ b/examples/wikipedia-pageviews/views.orly
@@ -1,0 +1,114 @@
+/* <examples/wikipedia-pageviews/views.orly>
+
+   Wikimedia-style hourly pageview counters, accumulated under contention
+   via Orly's field-call semantics (`+=`).
+
+   This demo showcases a feature the bitcoin-time-travel and
+   wikipedia-categories demos didn't exercise:  ORLY DOESN'T LOCK on
+   concurrent writes to the same key.
+
+   Why that works: `+= n` is a field CALL, not a field change. It's
+   not "read the value, add n, write the value back" (which would race
+   and lose updates without a lock). It's an opaque increment that
+   commutes with itself and with any other concurrent increment. The
+   merge machinery aggregates increments from many POVs without needing
+   a per-key mutex.
+
+   Equivalent operations in other databases:
+
+     Postgres:   UPDATE views SET n = n + 1 WHERE page = ?
+                 -- row lock; N writers serialize on hot pages
+     Redis:      INCR views:<page>
+                 -- atomic but single-threaded server (no real concurrency)
+     Cassandra:  UPDATE views SET n = n + 1 WHERE ...
+                 -- counter columns, but with consistency caveats
+     Orly:       *<['views', lang, page, hour]>::(int) += n
+                 -- field call; lock-free; N writers in N sessions all
+                    land their increments, sum is correct
+
+   Schema:
+
+     <['views', lang, page, hour]>  : int
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package #1;
+
+/* Per-hour view count; 0 if no events landed in that hour. */
+views_in_hour = (((*<['views', lang, page, hour]>::(int)) if *<['views', lang, page, hour]>::(int?) is known else 0)) where {
+  lang = given::(str);
+  page = given::(str);
+  hour = given::(int);
+};
+
+/* The headline write -- a field-call increment. First write at this
+   tuple creates; subsequent writes accumulate. Multiple sessions
+   calling this concurrently on the same (lang, page, hour) all land
+   their increments correctly without locking. */
+increment_view = (((1) effecting {
+  *<['views', lang, page, hour]>::(int) += n;
+} if *<['views', lang, page, hour]>::(int?) is known else (0) effecting {
+  new <['views', lang, page, hour]> <- n;
+})) where {
+  lang = given::(str);
+  page = given::(str);
+  hour = given::(int);
+  n    = given::(int);
+};
+
+/* Sum of views across an inclusive hour range. */
+views_total = ([h_start..h_end] reduce start 0 + views_in_hour(.lang: lang, .page: page, .hour: that)) where {
+  lang    = given::(str);
+  page    = given::(str);
+  h_start = given::(int);
+  h_end   = given::(int);
+};
+
+test {
+  /* Unknown tuples return 0 at the top level. */
+  t1: views_in_hour(.lang: "en", .page: "ChatGPT", .hour: 100) == 0;
+  t2: views_total(.lang: "en", .page: "ChatGPT", .h_start: 0, .h_end: 1000) == 0;
+
+  /* First write creates (returns 0); subsequent writes at the same tuple
+     accumulate (return 1). The nested chain demonstrates field-call
+     accumulation: 1 + 4 + 10 = 15 visible inside the innermost block. */
+  t3: increment_view(.lang: "en", .page: "ChatGPT", .hour: 100, .n: 1) == 0 {
+    t4: views_in_hour(.lang: "en", .page: "ChatGPT", .hour: 100) == 1;
+    t5: increment_view(.lang: "en", .page: "ChatGPT", .hour: 100, .n: 4) == 1 {
+      t6: views_in_hour(.lang: "en", .page: "ChatGPT", .hour: 100) == 5;
+      t7: increment_view(.lang: "en", .page: "ChatGPT", .hour: 100, .n: 10) == 1 {
+        t8: views_in_hour(.lang: "en", .page: "ChatGPT", .hour: 100) == 15;
+
+        /* Different (page, hour) tuple, independent counter. */
+        t9: increment_view(.lang: "en", .page: "ChatGPT", .hour: 101, .n: 7) == 0 {
+          t10: views_in_hour(.lang: "en", .page: "ChatGPT", .hour: 101) == 7;
+          /* Hour 100 still 15 because hour 101 is a different key. */
+          t11: views_in_hour(.lang: "en", .page: "ChatGPT", .hour: 100) == 15;
+
+          /* The fold across the hour range. */
+          t12: views_total(.lang: "en", .page: "ChatGPT", .h_start: 100, .h_end: 101) == 22;
+          t13: views_total(.lang: "en", .page: "ChatGPT", .h_start: 100, .h_end: 100) == 15;
+          t14: views_total(.lang: "en", .page: "ChatGPT", .h_start: 50,  .h_end: 99)  == 0;
+
+          /* Different (lang, page) tuple, also independent. */
+          t15: increment_view(.lang: "es", .page: "ChatGPT", .hour: 100, .n: 3) == 0 {
+            t16: views_in_hour(.lang: "es", .page: "ChatGPT", .hour: 100) == 3;
+            t17: views_in_hour(.lang: "en", .page: "ChatGPT", .hour: 100) == 15;
+          };
+        };
+      };
+    };
+  };
+};

--- a/orly/indy/disk/update_walk_file.h
+++ b/orly/indy/disk/update_walk_file.h
@@ -128,6 +128,11 @@ namespace Orly {
                 EntryStream.GoTo(offset_of_key + sizeof(TSequenceNumber));
                 EntryStream.Read(&key, sizeof(Atom::TCore));
                 EntryStream.Read(&val, sizeof(Atom::TCore));
+                /* TODO(#49): disk EntryVec walker still emits Mutator=Assign
+                   because the entry type (current vs history) is opaque at
+                   this offset and the trailing-Mutator byte is at different
+                   offsets for the two layouts. The in-memory path (used by
+                   the --mem_sim demo) is correct via TMemoryLayer::TUpdateWalker. */
                 Item.EntryVec.emplace_back(TIndexKey(ret->second->GetIndexId(), TKey(key, key_arena)), val);
               }
               Cached = true;

--- a/orly/indy/disk/update_walk_file.test.cc
+++ b/orly/indy/disk/update_walk_file.test.cc
@@ -102,7 +102,7 @@ FIXTURE(Typical) {
         int64_t expected = (i / 2L * 2L);
         std::map<TIndexKey, TKey> entry_map;
         for (auto iter : (*walker).EntryVec) {
-          entry_map.insert(make_pair(iter.first, TKey(iter.second, (*walker).MainArena)));
+          entry_map.insert(make_pair(iter.IndexKey, TKey(iter.Op, (*walker).MainArena)));
         }
         EXPECT_EQ((*walker).SequenceNumber, i + 1UL);
         EXPECT_EQ(entry_map.size(), 2UL);
@@ -166,7 +166,7 @@ FIXTURE(WithMergeFile) {
         int64_t expected = ((i % 12) / 2L * 2L);
         std::map<TIndexKey, TKey> entry_map;
         for (auto iter : (*walker).EntryVec) {
-          entry_map.insert(make_pair(iter.first, TKey(iter.second, (*walker).MainArena)));
+          entry_map.insert(make_pair(iter.IndexKey, TKey(iter.Op, (*walker).MainArena)));
         }
         EXPECT_EQ((*walker).SequenceNumber, i + 1UL);
         EXPECT_EQ(entry_map.size(), 2UL);

--- a/orly/indy/memory_layer.cc
+++ b/orly/indy/memory_layer.cc
@@ -260,7 +260,7 @@ const TUpdateWalker::TItem &TMemoryLayer::TUpdateWalker::operator*() const {
   Item.Id = Csr->GetId();
   Item.EntryVec.clear();
   for (TUpdate::TEntryCollection::TCursor csr(Csr->GetEntryCollection()); csr; ++csr) {
-    Item.EntryVec.push_back(std::make_pair(csr->GetIndexKey(), csr->GetOp()));
+    Item.EntryVec.emplace_back(csr->GetIndexKey(), csr->GetOp(), csr->GetMutator());
   }
   return Item;
 }

--- a/orly/indy/repo.cc
+++ b/orly/indy/repo.cc
@@ -345,11 +345,25 @@ std::shared_ptr<TUpdate> TRepo::GetLowestUpdate() {
   assert(walker);
   if (walker) {
     const TUpdateWalker::TItem &item = *walker;
+    /* Split entries by mutator: Assign-tagged entries go through the
+       TOpByKey ctor (existing semantics); non-Assign entries go through
+       AddEntry post-construction so the mutator is preserved. This is
+       the #49 phase-2 plumbing on the Tetris-merge / GetLowestUpdate
+       path -- without it, deferred Add entries get rebuilt as Assigns
+       and concurrent `+= n` loses updates again. */
     TUpdate::TOpByKey op_by_key;
     for (const auto &iter : item.EntryVec) {
-      op_by_key.insert(make_pair(iter.first, TKey(iter.second, item.MainArena)));
+      if (iter.Mutator == TMutator::Assign) {
+        op_by_key.insert(make_pair(iter.IndexKey, TKey(iter.Op, item.MainArena)));
+      }
     }
-    return TUpdate::NewUpdate(op_by_key, TKey(item.Metadata, item.MainArena), TKey(item.Id, item.MainArena));
+    auto update = TUpdate::NewUpdate(op_by_key, TKey(item.Metadata, item.MainArena), TKey(item.Id, item.MainArena));
+    for (const auto &iter : item.EntryVec) {
+      if (iter.Mutator != TMutator::Assign) {
+        update->AddEntry(iter.IndexKey, TKey(iter.Op, item.MainArena), iter.Mutator);
+      }
+    }
+    return update;
   }
   return nullptr;
 }

--- a/orly/indy/repo.h
+++ b/orly/indy/repo.h
@@ -711,7 +711,16 @@ namespace Orly {
         assert((*walker).OpArena == cur_item.OpArena);
         assert((*walker).SequenceNumber == cur_item.SequenceNumber);
         assert(Item.KeyArena != nullptr);
-        if (cur_item.SequenceNumber >= Lower && cur_item.SequenceNumber <= Upper && Indy::TKey::TupleNeEq(Item.Key, Item.KeyArena, cur_item.Key, cur_item.KeyArena) && (!IgnoreTombstone || !cur_item.Op.IsTombstone())) {
+        /* #49: the historical filter dropped same-key entries on the
+           grounds that the newest one shadowed older ones (Assign
+           overwrite semantics). After phase 2 introduced commutative
+           non-Assign entries, the older same-key entries are NOT shadowed
+           -- the read-path fold in TContext::TPresentWalker needs them
+           to compose multiple `+= n` writes. We yield all entries here
+           and rely on the context-level fold + dedup for correctness;
+           Assign-only workloads keep the same observable behavior, they
+           just pop a few extra items at the context layer. */
+        if (cur_item.SequenceNumber >= Lower && cur_item.SequenceNumber <= Upper && (!IgnoreTombstone || !cur_item.Op.IsTombstone())) {
           done = true;
           Item = cur_item;
         }

--- a/orly/indy/update_walker.h
+++ b/orly/indy/update_walker.h
@@ -21,6 +21,7 @@
 #include <base/class_traits.h>
 #include <orly/atom/kit2.h>
 #include <orly/indy/sequence_number.h>
+#include <orly/shared_enum.h>
 
 namespace Orly {
 
@@ -44,8 +45,21 @@ namespace Orly {
         /* TODO */
         Atom::TCore Id;
 
-        /* TODO */
-        std::vector<std::pair<TIndexKey, Atom::TCore>> EntryVec;
+        /* Per-entry mutator + payload. Mutator defaults to Assign for
+           backwards-compat with paths that don't yet populate it (notably
+           the replication wire format in util/context_streamer.h and the
+           disk update walker). For #49 the in-memory TUpdateWalker
+           populates it correctly, which is what TRepo::GetLowestUpdate
+           uses for Tetris push-to-parent. */
+        struct TEntry {
+          TIndexKey IndexKey;
+          Atom::TCore Op;
+          TMutator Mutator;
+          TEntry() : Mutator(TMutator::Assign) {}
+          TEntry(const TIndexKey &k, const Atom::TCore &op) : IndexKey(k), Op(op), Mutator(TMutator::Assign) {}
+          TEntry(const TIndexKey &k, const Atom::TCore &op, TMutator m) : IndexKey(k), Op(op), Mutator(m) {}
+        };
+        std::vector<TEntry> EntryVec;
 
         /* TODO */
         Atom::TCore::TArena *MainArena;

--- a/orly/indy/util/context_streamer.h
+++ b/orly/indy/util/context_streamer.h
@@ -109,9 +109,12 @@ namespace Orly {
             void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
             Metadata = Atom::TCore(&new_arena, state_alloc, item.MainArena, item.Metadata);
             Id = Atom::TCore(&new_arena, state_alloc, item.MainArena, item.Id);
+            /* TODO(#49): wire format does not yet carry Mutator. Replication
+               currently loses defer-safe mutator info -- treat as
+               known followup; the demo uses --mem_sim so doesn't hit this. */
             for (const auto &iter : item.EntryVec) {
-              EntryVec.push_back(std::make_pair(TIndexKey(iter.first.GetIndexId(), TKey(Atom::TCore(&new_arena, state_alloc, iter.first.GetKey().GetArena(), iter.first.GetKey().GetCore()), &new_arena)),
-                                                Atom::TCore(&new_arena, state_alloc, item.MainArena, iter.second)));
+              EntryVec.push_back(std::make_pair(TIndexKey(iter.IndexKey.GetIndexId(), TKey(Atom::TCore(&new_arena, state_alloc, iter.IndexKey.GetKey().GetArena(), iter.IndexKey.GetKey().GetCore()), &new_arena)),
+                                                Atom::TCore(&new_arena, state_alloc, item.MainArena, iter.Op)));
             }
           }
 


### PR DESCRIPTION
## Summary

Restores the demo that originally surfaced #49 and fixes the two remaining sites in the storage stack that were still stripping the Mutator field — discovered when the restored demo failed end-to-end despite phases 1-3 having landed.

**Before this PR:** 8 concurrent writers, each `+= n` into one of 96 hot keys, 250 events each = 5938 total events. Demo recovered ~542 increments (~9%, basically last-writer-wins per key).

**After this PR:** 5938/5938. All concurrent writes preserved.

## The two remaining bugs phases 2+3 missed

**1. `TRepo::GetLowestUpdate` rebuilt updates without the Mutator.**

The Tetris merge from a child POV up to a parent POV peeks an update from the child, then pushes it to the parent. Peek goes through `TRepo::GetLowestUpdate`, which reconstructs the TUpdate from `TUpdateWalker::TItem::EntryVec`. That EntryVec was `vector<pair<TIndexKey, TCore>>` — no mutator field — so deferred `{Add, n}` entries were rebuilt as Assigns at the parent and the concurrent-writers race that phase 2 fixed at the session boundary reappeared at the Tetris boundary.

Fix: extend `TUpdateWalker::TItem::EntryVec` to a struct carrying the mutator; populate it in the in-memory walker; `GetLowestUpdate` splits entries into "Assign → TOpByKey ctor (existing path), non-Assign → `AddEntry(...,mutator)` overload (phase-1 API)".

**2. `TRepo::TPresentWalker::Refresh` dedup'd same-key items.**

After #1, entries arrived at the parent repo correctly tagged. But the repo-level read walker filtered same-key items via `TupleNeEq(Item.Key, cur_item.Key)` — designed for Assign overwrite semantics ("the newest one shadows older same-key entries"). Only the most-recent entry per key reached the context-level fold, so the fold only ever saw 1 item and a lone `Add(5)` got returned as `5` instead of the sum.

Fix: drop the same-key dedup at the repo walker. The context-level walker still dedups for Assign overwrite (existing behavior) and runs the phase-3 fold for non-Assign commutative entries. Assign-only workloads see no observable difference; they just pop a few extra items at the context layer.

## What landed

- `examples/wikipedia-pageviews/` restored (the original from before commit 7804bf0) + new README aligned with the other examples
- `.github/workflows/ci.yml`: wired the demo into the `examples/* end-to-end` job — this is now the integration test for the issue-#49 fix at the workload level
- `orly/indy/update_walker.h`: `TItem::EntryVec` element type changed from `pair` to a 3-field struct (IndexKey, Op, Mutator)
- `orly/indy/memory_layer.cc`: in-memory `TUpdateWalker` populates Mutator
- `orly/indy/repo.cc`: `GetLowestUpdate` preserves Mutator via AddEntry-with-mutator
- `orly/indy/repo.h`: `TPresentWalker::Refresh` no longer dedups same-key entries
- `orly/indy/disk/update_walk_file.h` + `orly/indy/util/context_streamer.h`: updated to compile against the new EntryVec element type. Both still default Mutator to Assign — documented with `TODO(#49)` comments for follow-up

## Test plan

- [x] `examples/wikipedia-pageviews/run.sh` — 5938/5938 events accounted for across 8 concurrent writers, 96 hot keys (was 542/5938 before this PR)
- [x] `make test` — 192/192 (unchanged)
- [x] `lang_test.py` — 120 pass / 3 fail (the 3 failures are the same pre-existing snapshot mismatches as #50/#51 baseline: `mutablefilter`, `multiple_sequences`, `sequence_in_effecting`)
- [x] Discovered + fixed in this PR before commit: removing the repo-walker dedup is the kind of behavior change that needed `make test` validation before claiming done. Did so, no regressions.

## What this PR does **not** do

- **Disk persistence path** (`disk/update_walk_file.h`): still defaults Mutator to Assign because the entry-type (current vs history) is opaque at the random-access offset and the trailing-Mutator byte lives at different offsets for the two on-disk layouts. The demo uses `--mem_sim` so doesn't hit this. Followup tracked on issue #49.
- **Master→slave replication wire format** (`util/context_streamer.h`): still doesn't carry Mutator. Same story; followup.
- **Phase 4** (compaction-time fold in `merge_data_file.cc`): deferred per the architectural investigation already documented on issue #49.

Refs #49.