### PR TITLE
chore: point #49 TODO comments at split-out followup issues

### DIFF
--- a/orly/indy/disk/update_walk_file.h
+++ b/orly/indy/disk/update_walk_file.h
@@ -128,7 +128,7 @@ namespace Orly {
                 EntryStream.GoTo(offset_of_key + sizeof(TSequenceNumber));
                 EntryStream.Read(&key, sizeof(Atom::TCore));
                 EntryStream.Read(&val, sizeof(Atom::TCore));
-                /* TODO(#49): disk EntryVec walker still emits Mutator=Assign
+                /* TODO(#53): disk EntryVec walker still emits Mutator=Assign
                    because the entry type (current vs history) is opaque at
                    this offset and the trailing-Mutator byte is at different
                    offsets for the two layouts. The in-memory path (used by

--- a/orly/indy/util/context_streamer.h
+++ b/orly/indy/util/context_streamer.h
@@ -109,7 +109,7 @@ namespace Orly {
             void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
             Metadata = Atom::TCore(&new_arena, state_alloc, item.MainArena, item.Metadata);
             Id = Atom::TCore(&new_arena, state_alloc, item.MainArena, item.Id);
-            /* TODO(#49): wire format does not yet carry Mutator. Replication
+            /* TODO(#54): wire format does not yet carry Mutator. Replication
                currently loses defer-safe mutator info -- treat as
                known followup; the demo uses --mem_sim so doesn't hit this. */
             for (const auto &iter : item.EntryVec) {


### PR DESCRIPTION
After #52 verified the issue-#49 fix end-to-end via the wikipedia-pageviews demo, #49 closed and the three remaining loose ends got split out into separate issues:

- #53 — disk update walker drops TMutator on read-back
- #54 — master→slave replication wire format doesn't carry TMutator
- #55 — phase 4 compaction-time fold via TMutation::Augment

Two TODO comments in the code still pointed at #49. This repoints them at the specific followup issue so a contributor grepping for either issue lands in the right place. No behavior change.