### PR TITLE
wikipedia-pageviews: DEMO_SCALE env var for local-showcase vs CI workload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,10 +210,15 @@ jobs:
         run: ./run-go.sh
         working-directory: examples/wikipedia-categories
 
-      # The concurrent-writers demo: 8 sessions all `+= n` into the same
+      # The concurrent-writers demo: N sessions all `+= n` into the same
       # hot keys. Self-checks that every increment lands (no lost updates).
       # This is the integration validation for the issue #49 fix --
-      # without phases 2+3, only ~1/8 of the writes survive.
+      # without phases 2+3, only ~1/N of the writes survive.
+      # DEMO_SCALE=small opts into the CI-tractable 4-writer / 800-event
+      # workload; the default (large) is the 8-writer / 2000-event
+      # local-showcase mode used in the README / tweet captures.
       - name: wikipedia-pageviews run.sh (python driver, concurrent +=)
         run: ./run.sh
         working-directory: examples/wikipedia-pageviews
+        env:
+          DEMO_SCALE: small

--- a/examples/wikipedia-pageviews/demo.py
+++ b/examples/wikipedia-pageviews/demo.py
@@ -25,6 +25,7 @@ Or directly, after starting orlyi separately:
 """
 
 import json
+import os
 import random
 import sys
 import threading
@@ -33,16 +34,31 @@ import websocket
 
 WS_URL = "ws://127.0.0.1:8082/"
 
-NUM_WRITERS = 4
-EVENTS_PER_WRITER = 200
-PAGES = ["Donald_Trump", "Taylor_Swift", "ChatGPT", "Wikipedia"]
-HOURS = list(range(2026_06_01_00, 2026_06_01_12))  # 12 "hour" buckets
+# Two workload sizes:
+#
+#   DEMO_SCALE=small  -- 4 writers x 200 events x 48 keys = 800 events.
+#                        Sized for the CI runner's fiber-pool headroom
+#                        (per-layer Fiber::TSync parallelism in
+#                        TRepo::TPresentWalker can burst large under
+#                        many concurrent reads on a 4-CPU box).
+#   anything else     -- 8 writers x 250 events x 96 keys = 2,000 events.
+#                        Local-showcase default. Matches the README
+#                        screenshots and the tweet's headline numbers.
+#
+# Both sizes demonstrate the same concurrent-`+=` property; the larger
+# one just makes the totals more impressive.
+_SCALE = os.environ.get("DEMO_SCALE", "large").lower()
+if _SCALE == "small":
+    NUM_WRITERS = 4
+    EVENTS_PER_WRITER = 200
+    _NUM_HOURS = 12
+else:
+    NUM_WRITERS = 8
+    EVENTS_PER_WRITER = 250
+    _NUM_HOURS = 24
 
-# Scaled down from 8 writers * 250 events * 96 keys so that the
-# per-layer fiber parallelism in TRepo::TPresentWalker's construction
-# doesn't exhaust orlyi's fiber pool on a 4-CPU GitHub Actions runner.
-# Still meaningfully concurrent (4 writers hammering 48 hot keys,
-# ~17 writes per key on average).
+PAGES = ["Donald_Trump", "Taylor_Swift", "ChatGPT", "Wikipedia"]
+HOURS = list(range(2026_06_01_00, 2026_06_01_00 + _NUM_HOURS))
 
 
 def send(ws, stmt):


### PR DESCRIPTION
Follow-on to PR #57: that PR (correctly) shrank the demo to 4 writers x 200 events x 48 hot keys to fit CI's fiber-pool budget. The side effect was that the local default also dropped to the small workload, which diverges from the README screenshots and the tweet's headline numbers (8 writers x 2,000 events x 96 keys = 5,938 events).

This PR reintroduces the larger workload as the default and keeps the CI-friendly version reachable via an env var:

- **demo.py**: reads \`DEMO_SCALE\` env var.
  - \`DEMO_SCALE=small\` -> 4 / 200 / 12 hours = 48 keys, 800 events.
  - anything else (incl. unset) -> 8 / 250 / 24 hours = 96 keys, 2,000 events.
- **.github/workflows/ci.yml**: passes \`DEMO_SCALE: small\` on the wikipedia-pageviews step.

Same concurrent-\`+=\` property demonstrated at either scale; the larger one just makes the totals more impressive for showcase/tweet purposes.

Both modes verified locally: large produces \`96 per-key counters + 4 per-page totals across 8 concurrent writers\`, small produces \`48 / 4 / 4\`. Neither leaks lost updates.

I'd intended for this to be the 3rd commit on PR #57 but pushed it 2 minutes after you merged that PR — orphan branch, so opening this as a clean follow-up.