### PR TITLE
fix: dedup cross-repo duplicate entries in context-walker fold

### DIFF
--- a/orly/indy/context.cc
+++ b/orly/indy/context.cc
@@ -168,12 +168,27 @@ void TContext::TPresentWalker::ApplyDeferredFold() {
        * Same key + Assign -- the base. Fold the accumulator onto it.
        * Same key + a different mutator -- mixed-mutator history, which
          TMutation::Augment already rejects at compose time. We surface
-         the accumulator as-is and let downstream typed code react. */
+         the accumulator as-is and let downstream typed code react.
+
+     Dedup: the SAME logical update can appear in two repos briefly
+     during a Tetris push-to-parent / pop-from-child window. Both copies
+     have the same UpdateId (the per-transaction TUuid from session.cc)
+     but different per-repo SeqNums. We track seen UpdateIds and skip
+     duplicates -- without this, the Wikipedia-pageviews demo's Go
+     driver (which hammers tighter than the Python one) reproducibly
+     double-counted ~1 per ~5,000 increments under contention. Entries
+     with a zero UpdateId (e.g. the disk walker, which never hits the
+     cross-repo Tetris window) are passed through without dedup. */
   const TMutator mut = Item.Mutator;
   void *state_alloc_a = alloca(Sabot::State::GetMaxStateSize() * 3);
   void *state_alloc_b = static_cast<uint8_t *>(state_alloc_a) + Sabot::State::GetMaxStateSize();
   void *state_alloc_c = static_cast<uint8_t *>(state_alloc_b) + Sabot::State::GetMaxStateSize();
   Var::TVar acc = Var::ToVar(*Sabot::State::TAny::TWrapper(Item.Op.NewState(Item.OpArena, state_alloc_a)));
+  const Base::TUuid zero_uuid;
+  std::vector<Base::TUuid> seen_update_ids;
+  if (Item.UpdateId != zero_uuid) {
+    seen_update_ids.push_back(Item.UpdateId);
+  }
 
   while (MinHeap) {
     size_t peek_pos;
@@ -192,9 +207,36 @@ void TContext::TPresentWalker::ApplyDeferredFold() {
     const TMutator peek_mut = peek.Mutator;
     const Atom::TCore peek_op = peek.Op;
     Atom::TCore::TArena *const peek_op_arena = peek.OpArena;
+    const Base::TUuid peek_update_id = peek.UpdateId;
 
     size_t consumed_pos;
     MinHeap.Pop(consumed_pos);
+
+    /* Advance + reinsert the walker we just popped from regardless of
+       whether we fold this entry. */
+    Indy::TPresentWalker &consumed_walker = *WalkerVec[consumed_pos];
+    ++consumed_walker;
+    if (consumed_walker) {
+      MinHeap.Insert(*consumed_walker, consumed_pos);
+    }
+
+    /* Dedup by UpdateId. If we've already consumed this logical
+       update from another repo's walker in the same fold, drop it. */
+    bool is_duplicate = false;
+    if (peek_update_id != zero_uuid) {
+      for (const auto &seen : seen_update_ids) {
+        if (seen == peek_update_id) {
+          is_duplicate = true;
+          break;
+        }
+      }
+    }
+    if (is_duplicate) {
+      continue;
+    }
+    if (peek_update_id != zero_uuid) {
+      seen_update_ids.push_back(peek_update_id);
+    }
 
     Var::TVar peek_val = Var::ToVar(*Sabot::State::TAny::TWrapper(peek_op.NewState(peek_op_arena, state_alloc_b)));
     if (peek_mut == TMutator::Assign) {
@@ -203,12 +245,6 @@ void TContext::TPresentWalker::ApplyDeferredFold() {
     } else {
       /* Same commutative mutator. */
       acc = Rt::Mutate(acc, mut, peek_val);
-    }
-
-    Indy::TPresentWalker &consumed_walker = *WalkerVec[consumed_pos];
-    ++consumed_walker;
-    if (consumed_walker) {
-      MinHeap.Insert(*consumed_walker, consumed_pos);
     }
 
     if (peek_mut == TMutator::Assign) {

--- a/orly/indy/memory_layer.cc
+++ b/orly/indy/memory_layer.cc
@@ -18,6 +18,8 @@
 
 #include <orly/indy/memory_layer.h>
 
+#include <orly/sabot/to_native.h>
+
 using namespace std;
 using namespace Base;
 using namespace Orly::Indy;
@@ -129,6 +131,17 @@ void TMemoryLayer::TMatchPresentWalker::Refresh() const {
               Item.Op = Csr->GetOp();
               Item.SequenceNumber = Csr->GetSequenceNumber();
               Item.Mutator = Csr->GetMutator();
+              /* Logical update id -- the per-transaction TUuid set in
+                 session.cc. Survives Tetris renumbering across repos,
+                 used by the context-walker fold to dedup duplicates
+                 that exist briefly in both child + parent repos during
+                 a Tetris push/pop window. */ {
+                void *id_state_alloc = alloca(Sabot::State::GetMaxStateSize());
+                const TUpdate *update_ptr = Csr->GetUpdate();
+                Sabot::ToNative(
+                    *Sabot::State::TAny::TWrapper(update_ptr->GetId().NewState(&update_ptr->GetSuprena(), id_state_alloc)),
+                    Item.UpdateId);
+              }
               return;
               break;
             }
@@ -226,6 +239,13 @@ void TMemoryLayer::TRangePresentWalker::Refresh() const {
           Item.Op = Csr->GetOp();
           Item.SequenceNumber = Csr->GetSequenceNumber();
           Item.Mutator = Csr->GetMutator();
+          /* See TMatchPresentWalker; same plumbing for the Tetris-window dedup. */ {
+            void *id_state_alloc = alloca(Sabot::State::GetMaxStateSize());
+            const TUpdate *update_ptr = Csr->GetUpdate();
+            Sabot::ToNative(
+                *Sabot::State::TAny::TWrapper(update_ptr->GetId().NewState(&update_ptr->GetSuprena(), id_state_alloc)),
+                Item.UpdateId);
+          }
           return;
         }
         case Atom::TComparison::Gt: {

--- a/orly/indy/present_walker.h
+++ b/orly/indy/present_walker.h
@@ -43,7 +43,7 @@ namespace Orly {
         public:
 
         /* Do-little. */
-        TItem() : SequenceNumber(0UL), KeyArena(nullptr), OpArena(nullptr), Mutator(TMutator::Assign) {}
+        TItem() : SequenceNumber(0UL), KeyArena(nullptr), OpArena(nullptr), Mutator(TMutator::Assign), UpdateId() {}
 
         /* TODO */
         bool operator<(const TItem &that) const {
@@ -80,6 +80,18 @@ namespace Orly {
            walker (orly/indy/context.cc) folds same-mutator runs to
            produce the actual resolved value. */
         TMutator Mutator;
+
+        /* Logical update id (the per-transaction TUuid from session.cc's
+           TUpdate::NewUpdate(...)). Same logical update committed to a
+           child POV and then Tetris-pushed to a parent POV ends up
+           living in TWO TRepos with two different SequenceNumbers but
+           the SAME UpdateId. The fold in context.cc uses this to dedup:
+           without it, the brief window between Tetris push-to-parent
+           and pop-from-child causes a deferred {Add, n} to be visible
+           in both repos and double-counted. Populated by the in-memory
+           walker; defaults to a zero Uuid for disk-walker entries
+           (which can't hit the cross-repo duplication issue). */
+        Base::TUuid UpdateId;
 
       };  // TItem
 


### PR DESCRIPTION
## Diagnosis

A Go-driver port of the wikipedia-pageviews demo (~2× faster request cadence than the Python driver) reproducibly double-counted ~1 in 5,000 deferred-Add increments under contention. The Python driver doesn't surface this — its slower per-request overhead means verify reads happen after Tetris has settled across the POV chain.

Root cause: Tetris merge from a child POV to a parent POV is **not atomic across the two repos**. Specifically:

1. Writer commits an update with logical id `U` (e.g. `{Add, 5}` on key `K`) to the shared POV's repo. SeqNum=100 in that repo.
2. Tetris peeks it, deep-copies, then `AppendUpdate` on the parent assigns it a NEW SeqNum=N in the parent's seqnum space.
3. **Brief window**: the same logical entry now exists in BOTH repos with two different SeqNums.
4. Tetris pops from the child.

During step 3, the read-path's `TContext::TPresentWalker` (which merges across all repos in the tree) sees the entry from BOTH walkers. The phase-3 fold (#51) composes them via `Rt::Mutate`, double-counting the single logical increment.

## Fix

Track logical update identity end-to-end and dedup at fold time using the per-transaction `Base::TUuid` (the `update_id` from `session.cc`'s `TUpdate::NewUpdate(...)`).

- `TPresentWalker::TItem` gains a `Base::TUuid UpdateId` field. The Tetris push-copy in `update.cc`'s deep-copy ctor already preserves this id; only the per-repo SeqNum is renumbered.
- `memory_layer.cc`'s two walker variants populate `UpdateId` via `Sabot::ToNative` on `Csr->GetUpdate()->GetId()`.
- The disk walker leaves `UpdateId` at the zero default (disk entries can't hit the cross-repo Tetris window — they're persisted in exactly one location).
- `context.cc::ApplyDeferredFold` maintains a small vector of seen UpdateIds for the current fold. Entries with a non-zero UpdateId that match a seen one are popped + their walker advanced normally but **not** folded into the accumulator. Entries with zero UpdateId pass through without dedup.

## Test plan

- [x] Go driver of `examples/wikipedia-pageviews/` (8 writers, 96 hot keys, 5,937 events): **5/5 clean runs** at full showcase scale. Previously 2/2 failed with off-by-1/2 errors.
- [x] Python driver of same demo: still 100% (no regression).
- [x] `make test`: 192/192.
- [x] `lang_test.py`: 120 pass / 3 known pre-existing fails (`mutablefilter`, `multiple_sequences`, `sequence_in_effecting`). Unchanged from baseline.

## Out of scope

The Go driver itself + `run-go.sh` + ci.yml hookup + README revert to claim "Python + Go for pageviews too" land in a follow-up PR built on top of this. Held back so this PR has a single concern: the engine bugfix that makes the Go driver pass.

Refs #49.
