### PR TITLE
wikipedia-pageviews: add Go driver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,3 +222,9 @@ jobs:
         working-directory: examples/wikipedia-pageviews
         env:
           DEMO_SCALE: small
+
+      - name: wikipedia-pageviews run-go.sh (go driver, concurrent +=)
+        run: ./run-go.sh
+        working-directory: examples/wikipedia-pageviews
+        env:
+          DEMO_SCALE: small

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Most databases force a tradeoff on this workload:
 
 The mechanism: each `+=` emits an `{Add, n}` mutation at the storage layer instead of resolving to a value at write time, and the read path folds same-mutator runs back into the resolved value. CI runs this as the workload-level integration test for the property; pass `DEMO_SCALE=small` for the CI-friendly 4-writer / 800-event variant.
 
-All three examples ship a Python driver (`./run.sh`); the bitcoin and wikipedia-categories examples also ship an equivalent Go driver (`./run-go.sh`). All are smoke-tested in CI on every push.
+All three examples ship two equivalent drivers — Python (`./run.sh`) and Go (`./run-go.sh`) — and are smoke-tested in CI on every push.
 
 ## Walkthrough
 

--- a/examples/wikipedia-pageviews/demo.go
+++ b/examples/wikipedia-pageviews/demo.go
@@ -1,0 +1,288 @@
+// Wikimedia hourly pageviews demo, in Go.
+//
+// Mirrors demo.py: same scenario shape, same self-check, same output
+// layout. Provided so readers can pick whichever language matches
+// their environment. Because the two drivers seed their RNGs
+// differently, the per-page totals between Python and Go runs differ
+// in absolute value -- but each driver's self-check uses its own
+// derived ground truth, so both pass independently.
+//
+// Two workload sizes (controlled by DEMO_SCALE env var, mirroring
+// demo.py):
+//
+//	DEMO_SCALE=small  -- 4 writers x 200 events x 48 keys (CI-friendly).
+//	anything else     -- 8 writers x 250 events x 96 keys (showcase).
+//
+// Run via the wrapper:
+//
+//	./run-go.sh
+//
+// Or directly, after starting orlyi separately:
+//
+//	go run demo.go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const wsURL = "ws://127.0.0.1:8082/"
+
+var (
+	pages = []string{"Donald_Trump", "Taylor_Swift", "ChatGPT", "Wikipedia"}
+
+	// Populated from DEMO_SCALE in initScale().
+	numWriters      int
+	eventsPerWriter int
+	hours           []int
+)
+
+func initScale() {
+	numHours := 24
+	numWriters = 8
+	eventsPerWriter = 250
+	if strings.ToLower(os.Getenv("DEMO_SCALE")) == "small" {
+		numWriters = 4
+		eventsPerWriter = 200
+		numHours = 12
+	}
+	hours = make([]int, numHours)
+	for i := 0; i < numHours; i++ {
+		hours[i] = 2026060100 + i
+	}
+}
+
+type event struct {
+	page string
+	hour int
+	n    int
+}
+
+func send(c *websocket.Conn, stmt string) (interface{}, error) {
+	if err := c.WriteMessage(websocket.TextMessage, []byte(stmt)); err != nil {
+		return nil, err
+	}
+	_, raw, err := c.ReadMessage()
+	if err != nil {
+		return nil, err
+	}
+	var r struct {
+		Status string      `json:"status"`
+		Result interface{} `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return nil, fmt.Errorf("bad reply json: %w (raw: %s)", err, raw)
+	}
+	if r.Status != "ok" {
+		return nil, fmt.Errorf("%s\n  -> %s", stmt, raw)
+	}
+	return r.Result, nil
+}
+
+func mustSend(c *websocket.Conn, stmt string) interface{} {
+	r, err := send(c, stmt)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+func incrementView(c *websocket.Conn, pov, page string, hour, n int) {
+	mustSend(c, fmt.Sprintf(
+		`try {%s} views increment_view <{.lang: "en", .page: %q, .hour: %d, .n: %d}>;`,
+		pov, page, hour, n))
+}
+
+func viewsInHour(c *websocket.Conn, pov, page string, hour int) int {
+	r := mustSend(c, fmt.Sprintf(
+		`try {%s} views views_in_hour <{.lang: "en", .page: %q, .hour: %d}>;`,
+		pov, page, hour))
+	return int(r.(float64))
+}
+
+func viewsTotal(c *websocket.Conn, pov, page string, hStart, hEnd int) int {
+	r := mustSend(c, fmt.Sprintf(
+		`try {%s} views views_total <{.lang: "en", .page: %q, .h_start: %d, .h_end: %d}>;`,
+		pov, page, hStart, hEnd))
+	return int(r.(float64))
+}
+
+func generateEvents(seed int64, count int) []event {
+	rng := rand.New(rand.NewSource(seed))
+	out := make([]event, count)
+	for i := 0; i < count; i++ {
+		out[i] = event{
+			page: pages[rng.Intn(len(pages))],
+			hour: hours[rng.Intn(len(hours))],
+			n:    1 + rng.Intn(5),
+		}
+	}
+	return out
+}
+
+func writer(pov string, events []event, wg *sync.WaitGroup) {
+	defer wg.Done()
+	c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		panic(err)
+	}
+	defer c.Close()
+	mustSend(c, "new session;")
+	for _, e := range events {
+		incrementView(c, pov, e.page, e.hour, e.n)
+	}
+}
+
+// commaize prints non-negative ints with thousands separators (123 -> "123", 1234 -> "1,234").
+func commaize(n int) string {
+	s := fmt.Sprintf("%d", n)
+	if len(s) <= 3 {
+		return s
+	}
+	out := make([]byte, 0, len(s)+len(s)/3)
+	for i := 0; i < len(s); i++ {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			out = append(out, ',')
+		}
+		out = append(out, s[i])
+	}
+	return string(out)
+}
+
+func main() {
+	initScale()
+
+	// Generate all events deterministically, then split per writer.
+	allEvents := make([][]event, numWriters)
+	totalEvents := 0
+	for w := 0; w < numWriters; w++ {
+		allEvents[w] = generateEvents(int64(w)*17+3, eventsPerWriter)
+		totalEvents += len(allEvents[w])
+	}
+
+	// Ground truth: what each (page, hour) counter should be after ingest.
+	type key struct {
+		page string
+		hour int
+	}
+	ground := map[key]int{}
+	for _, batch := range allEvents {
+		for _, e := range batch {
+			ground[key{e.page, e.hour}] += e.n
+		}
+	}
+
+	// Bootstrap connection: install package + create the shared POV.
+	boot, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		panic(err)
+	}
+	mustSend(boot, "new session;")
+	mustSend(boot, "install views.1;")
+	pov := mustSend(boot, "new safe shared pov;").(string)
+	fmt.Printf("pov: %s\n", pov)
+	fmt.Printf("writers: %d, events per writer: %d, total events: %s\n",
+		numWriters, eventsPerWriter, commaize(totalEvents))
+	fmt.Printf("hot keyspace: %d pages × %d hours = %d keys\n",
+		len(pages), len(hours), len(pages)*len(hours))
+
+	// Pre-initialise every (page, hour) so writers all take the += branch.
+	fmt.Println("\npre-initialising all hot keys to 0...")
+	for _, p := range pages {
+		for _, h := range hours {
+			incrementView(boot, pov, p, h, 0)
+		}
+	}
+
+	// Ingest in parallel.
+	var wg sync.WaitGroup
+	t0 := time.Now()
+	for w := 0; w < numWriters; w++ {
+		wg.Add(1)
+		go writer(pov, allEvents[w], &wg)
+	}
+	wg.Wait()
+	elapsed := time.Since(t0)
+	rate := float64(totalEvents) / elapsed.Seconds()
+	fmt.Printf("\ningest done in %.2fs (%s events/sec end-to-end with %d writers)\n",
+		elapsed.Seconds(), commaize(int(rate)), numWriters)
+
+	// Per-key verification.
+	fmt.Println()
+	fmt.Println("=== verifying counters ===")
+	var failures []string
+	keys := make([]key, 0, len(ground))
+	for k := range ground {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].page != keys[j].page {
+			return keys[i].page < keys[j].page
+		}
+		return keys[i].hour < keys[j].hour
+	})
+	for _, k := range keys {
+		got := viewsInHour(boot, pov, k.page, k.hour)
+		if got != ground[k] {
+			failures = append(failures, fmt.Sprintf("%s @ %d: got %d, want %d", k.page, k.hour, got, ground[k]))
+		}
+	}
+
+	// Per-page summary (one line per page instead of 96 lines).
+	dash16 := strings.Repeat("-", 16)
+	dash12 := strings.Repeat("-", 12)
+	fmt.Printf("  %-16s  %12s  %12s\n", "page", "total", "expected")
+	fmt.Printf("  %-16s  %12s  %12s\n", dash16, dash12, dash12)
+	grandGot, grandWant := 0, 0
+	for _, page := range pages {
+		gotTotal := viewsTotal(boot, pov, page, hours[0], hours[len(hours)-1])
+		wantTotal := 0
+		for k, v := range ground {
+			if k.page == page {
+				wantTotal += v
+			}
+		}
+		marker := "✓"
+		if gotTotal != wantTotal {
+			marker = "✗"
+			failures = append(failures, fmt.Sprintf("%s total: got %d, want %d", page, gotTotal, wantTotal))
+		}
+		fmt.Printf("  %-16s  %12s  %12s  %s\n", page, commaize(gotTotal), commaize(wantTotal), marker)
+		grandGot += gotTotal
+		grandWant += wantTotal
+	}
+	fmt.Printf("  %-16s  %12s  %12s\n", dash16, dash12, dash12)
+	fmt.Printf("  %-16s  %12s  %12s\n", "TOTAL", commaize(grandGot), commaize(grandWant))
+
+	fmt.Println()
+	fmt.Println("=== the trick ===")
+	fmt.Printf("  %d concurrent WebSocket writers all `+=` into the same\n", numWriters)
+	fmt.Printf("  %d hot keys, with zero locking. Field calls\n", len(pages)*len(hours))
+	fmt.Println("  commute; the merge machinery aggregates safely.")
+
+	mustSend(boot, "exit;")
+	boot.Close()
+
+	if len(failures) > 0 {
+		fmt.Println("\n=== self-check FAILED ===")
+		for i, f := range failures {
+			if i >= 20 {
+				break
+			}
+			fmt.Println("  " + f)
+		}
+		os.Exit(1)
+	}
+	fmt.Println("\n=== self-check OK ===")
+	fmt.Printf("  verified %d per-key counters + %d per-page totals across %d concurrent writers\n",
+		len(ground), len(pages), numWriters)
+}

--- a/examples/wikipedia-pageviews/go.mod
+++ b/examples/wikipedia-pageviews/go.mod
@@ -1,0 +1,5 @@
+module github.com/orlyatomics/orly/examples/wikipedia-pageviews
+
+go 1.22
+
+require github.com/gorilla/websocket v1.5.3

--- a/examples/wikipedia-pageviews/go.sum
+++ b/examples/wikipedia-pageviews/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/examples/wikipedia-pageviews/run-go.sh
+++ b/examples/wikipedia-pageviews/run-go.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Same end-to-end pipeline as run.sh, but driven by demo.go.
+# Requires the `go` toolchain on PATH.
+set -e
+
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../.. && pwd)"
+ORLY_OUT="${ORLY_OUT:-$REPO_ROOT/../out_orly/debug}"
+ORLYI="$ORLY_OUT/orly/server/orlyi"
+ORLYC="$ORLY_OUT/orly/orlyc"
+
+for bin in "$ORLYI" "$ORLYC"; do
+  if [ ! -x "$bin" ]; then
+    echo "missing: $bin"
+    exit 1
+  fi
+done
+
+if ! command -v go >/dev/null 2>&1; then
+  echo "missing: go (install golang-go or download from go.dev)"
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'kill -9 $ORLYI_PID 2>/dev/null || true; rm -rf "$WORK"' EXIT
+
+echo "[1/5] compile views.orly"
+"$ORLYC" -o "$WORK" views.orly
+
+echo "[2/5] populate packages/"
+mkdir "$WORK/packages"
+touch "$WORK/packages/__orly__"
+cp "$WORK/views.1.so" "$WORK/packages/"
+
+pkill -9 -f 'instance_name=wiki_pageviews_demo' 2>/dev/null || true
+sleep 1
+
+echo "[3/5] start fresh orlyi"
+# Same conservative resource caps as run.sh -- see comment there.
+"$ORLYI" --mem_sim --create=true \
+         --port_number=19400 --slave_port_number=19401 \
+         --connection_backlog=10 \
+         --instance_name=wiki_pageviews_demo \
+         --starting_state=SOLO \
+         --package_dir="$WORK/packages" \
+         --max_parallel_frames 4000 \
+         --page_cache_size 256 \
+         --block_cache_size 64 \
+         > "$WORK/orlyi.log" 2>&1 &
+ORLYI_PID=$!
+
+echo "[4/5] wait for WebSocket port 8082"
+for _ in $(seq 1 60); do
+  if ss -tln 2>/dev/null | grep -q ':8082'; then
+    break
+  fi
+  sleep 1
+done
+if ! ss -tln 2>/dev/null | grep -q ':8082'; then
+  echo "orlyi failed to come up; last log lines:"
+  tail -20 "$WORK/orlyi.log"
+  exit 1
+fi
+
+echo "[5/5] go run demo.go"
+if ! go run demo.go; then
+  echo ""
+  echo "demo.go failed; dumping orlyi.log for diagnosis:"
+  echo "=========================================================="
+  cat "$WORK/orlyi.log"
+  echo "=========================================================="
+  exit 1
+fi


### PR DESCRIPTION
Follow-up to #60 (the Tetris-window dedup fix that this depends on). Adds the Go driver for the wikipedia-pageviews demo, matching what the bitcoin-time-travel and wikipedia-categories examples already ship.

## What's in

- **`demo.go`** — parallel writer goroutines + ground-truth verification. Same shape as `demo.py`, same `DEMO_SCALE` env var (`small` for CI, default `large` for the local showcase). Because Go's `math/rand` and Python's `random` seed differently, the absolute per-page totals differ between drivers, but each driver's ground truth is self-consistent and the property under test (every concurrent `+=` increment lands) holds for both.
- **`go.mod` / `go.sum`** — `gorilla/websocket` v1.5.3, matching the other Go drivers.
- **`run-go.sh`** — same end-to-end pipeline as `run.sh`. Includes the same orlyi pool/cache tuning and the orlyi.log dump on failure.
- **`.github/workflows/ci.yml`** — adds the Go driver as a second CI step (`DEMO_SCALE=small`).
- **`README.md`** — reverts the now-stale "Python only for pageviews" line to "all three examples ship Python + Go" now that the Go driver is here.

## Why this PR sits on top of #60

The Go driver caught a real bug — the tighter goroutine request cadence (compared to Python's GIL + websocket-client overhead) reproducibly landed verify reads inside a Tetris push-to-parent / pop-from-child window, double-counting the deferred-Add entries. That's the issue #60 fixed. Without #60 merged, this PR's Go driver would fail CI 100% of the time.

## Test plan

- [x] Go driver (8 writers / 96 keys / showcase): **5/5 clean runs** locally after #60 merged.
- [x] Go driver with `DEMO_SCALE=small`: passes (48 / 4 / 4 verified).
- [x] Python driver: still passes, both scales.
- [x] No `make test` or `lang_test` change; this PR is purely driver-side.

Refs #49.
