### PR TITLE
wikipedia-pageviews: 30s WS recv timeout so hangs surface as failures

### DIFF
--- a/examples/wikipedia-pageviews/demo.go
+++ b/examples/wikipedia-pageviews/demo.go
@@ -37,6 +37,14 @@ import (
 
 const wsURL = "ws://127.0.0.1:8082/"
 
+// Per-call recv timeout. Mirrors demo.py: normal latency is well under
+// a second; 30s is generous-but-finite so a hung orlyi surfaces as a
+// failed read rather than a multi-minute CI timeout with no diagnostic.
+// The run-go.sh wrapper's on-failure orlyi.log dump only fires on
+// demo.go exit, so we want it to exit (failing) within a reasonable
+// window.
+const wsTimeout = 30 * time.Second
+
 var (
 	pages = []string{"Donald_Trump", "Taylor_Swift", "ChatGPT", "Wikipedia"}
 
@@ -68,7 +76,14 @@ type event struct {
 }
 
 func send(c *websocket.Conn, stmt string) (interface{}, error) {
+	deadline := time.Now().Add(wsTimeout)
+	if err := c.SetWriteDeadline(deadline); err != nil {
+		return nil, err
+	}
 	if err := c.WriteMessage(websocket.TextMessage, []byte(stmt)); err != nil {
+		return nil, err
+	}
+	if err := c.SetReadDeadline(deadline); err != nil {
 		return nil, err
 	}
 	_, raw, err := c.ReadMessage()
@@ -131,7 +146,9 @@ func generateEvents(seed int64, count int) []event {
 
 func writer(pov string, events []event, wg *sync.WaitGroup) {
 	defer wg.Done()
-	c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	dialer := *websocket.DefaultDialer
+	dialer.HandshakeTimeout = wsTimeout
+	c, _, err := dialer.Dial(wsURL, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -182,7 +199,9 @@ func main() {
 	}
 
 	// Bootstrap connection: install package + create the shared POV.
-	boot, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	bootDialer := *websocket.DefaultDialer
+	bootDialer.HandshakeTimeout = wsTimeout
+	boot, _, err := bootDialer.Dial(wsURL, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/wikipedia-pageviews/demo.py
+++ b/examples/wikipedia-pageviews/demo.py
@@ -34,6 +34,13 @@ import websocket
 
 WS_URL = "ws://127.0.0.1:8082/"
 
+# Per-call recv timeout. Normal request latency is well under a second;
+# 30s is generous-but-finite so a hung orlyi surfaces as a failed read
+# rather than a multi-minute CI timeout with no diagnostic. The run.sh
+# wrapper's on-failure orlyi.log dump only fires on demo.py exit, so
+# we want demo.py to exit (failing) within a reasonable window.
+WS_TIMEOUT_S = 30
+
 # Two workload sizes:
 #
 #   DEMO_SCALE=small  -- 4 writers x 200 events x 48 keys = 800 events.
@@ -102,7 +109,7 @@ def generate_events(seed, count):
 def writer(writer_id, pov, events):
     """One writer: open a fresh WebSocket connection, open a session,
     ingest its slice of events using the shared POV."""
-    ws = websocket.create_connection(WS_URL)
+    ws = websocket.create_connection(WS_URL, timeout=WS_TIMEOUT_S)
     try:
         send(ws, "new session;")
         for page, hour, n in events:
@@ -125,7 +132,7 @@ def main():
             ground_truth[(page, hour)] = ground_truth.get((page, hour), 0) + n
 
     # Open one bootstrap connection to create the shared POV and install the package.
-    boot = websocket.create_connection(WS_URL)
+    boot = websocket.create_connection(WS_URL, timeout=WS_TIMEOUT_S)
     send(boot, "new session;")
     send(boot, "install views.1;")
     pov = send(boot, "new safe shared pov;")


### PR DESCRIPTION
A CI run on master right after #61 merged was cancelled after 15 minutes of `demo.py` sitting at "[5/5] run demo.py" with no output. The rerun on the same SHA passed cleanly, so the immediate cause was almost certainly transient GitHub Actions runner contention — but the failure mode was maximally unhelpful: no `orlyi.log` dumped (the `run.sh` on-failure trap only fires when `demo.py` exits non-zero, not when it's hung), no diagnostic, and a 15-minute wait before manual cancellation.

Defensive fix: cap per-call WS latency at 30s on both drivers. Normal request latency is well under a second; 30s is generous-but-finite so a hung orlyi surfaces as a failed read inside ~30s and the existing `run.sh` / `run-go.sh` orlyi.log dump path actually fires.

## Changes

- **`demo.py`**: `WS_TIMEOUT_S = 30` passed to `websocket.create_connection(...)`. The websocket-client library applies this to both the connect handshake and subsequent recv operations on the resulting connection.
- **`demo.go`**: `wsTimeout = 30 * time.Second`. Per-call `SetReadDeadline` and `SetWriteDeadline` in `send()` so each request gets a fresh 30s window. Each `Dial` site gets a local copy of `websocket.DefaultDialer` with `HandshakeTimeout` set.

## Test plan

- [x] Python driver, `DEMO_SCALE=large` (default): passes.
- [x] Python driver, `DEMO_SCALE=small`: passes.
- [x] Go driver, `DEMO_SCALE=large`: passes.
- [x] Go driver, `DEMO_SCALE=small`: passes.
- [x] No behavior change on the happy path — only failure mode changes.

The next CI flake of this shape will surface as a 30s-later failure with orlyi.log in the job output, not a 15-minute hang.
