### PR TITLE
indy/disk: TFoldDataFile — phase 4 compaction-time fold (closes #55)

### DIFF
--- a/orly/indy/disk/fold_data_file.cc
+++ b/orly/indy/disk/fold_data_file.cc
@@ -1,0 +1,254 @@
+/* <orly/indy/disk/fold_data_file.cc>
+
+   Implements <orly/indy/disk/fold_data_file.h>. */
+
+#include <orly/indy/disk/fold_data_file.h>
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+#include <orly/indy/memory_layer.h>
+#include <orly/indy/update.h>
+#include <orly/rt/mutate.h>
+#include <orly/sabot/to_native.h>
+#include <orly/var/mutation.h>
+#include <orly/var/sabot_to_var.h>
+
+using namespace std;
+using namespace Base;
+using namespace Orly;
+using namespace Orly::Atom;
+using namespace Orly::Indy;
+using namespace Orly::Indy::Disk;
+
+namespace {
+
+  /* A TReader that pairs the on-disk file with a disk arena, mirroring
+     the same pattern TMergeDataFile uses internally. Anonymous-
+     namespace local so it doesn't collide with the TReader inside
+     merge_data_file.cc or the test-only one in disk_test.h. */
+  class TFoldReader
+      : public TReadFile<Indy::Disk::Util::LogicalBlockSize,
+                          Indy::Disk::Util::LogicalBlockSize,
+                          Indy::Disk::Util::PhysicalBlockSize,
+                          Indy::Disk::Util::PageCheckedBlock,
+                          true /* ScanAheadAllowed */> {
+    NO_COPY(TFoldReader);
+    public:
+    static constexpr size_t PhysicalCachePageSize = Indy::Disk::Util::PhysicalBlockSize;
+    using TArena = TDiskArena<Indy::Disk::Util::LogicalBlockSize,
+                               Indy::Disk::Util::LogicalBlockSize,
+                               Indy::Disk::Util::PhysicalBlockSize,
+                               Indy::Disk::Util::PageCheckedBlock,
+                               128, true>;
+
+    TFoldReader(Indy::Disk::Util::TEngine *engine, const TUuid &file_uuid, size_t gen_id, DiskPriority priority)
+        : TReadFile(HERE, Source::MergeDataFileScan, engine, file_uuid, priority, gen_id) {
+      Arena = std::make_unique<TArena>(this, engine->GetCache<PhysicalCachePageSize>(), priority);
+    }
+
+    ~TFoldReader() override {
+      Arena.reset();
+    }
+
+    /* Promote the protected base interface we need into public access
+       (same trick TReader in merge_data_file.cc uses). */
+    using TReadFile::ForEachIndex;
+    using TReadFile::TIndexFile;
+
+    std::unique_ptr<TArena> Arena;
+  };
+
+  /* In-memory rep of one source-file entry. We materialise the Op to a
+     fully-typed TVar up front so the source-file arena can be torn down
+     before we serialise the output. */
+  struct TFoldEntry {
+    TSequenceNumber SeqNum;
+    TMutator Mutator;
+    Var::TVar Op;        // unused for tombstones
+    bool IsTombstone;
+  };
+
+  Var::TVar OpToVar(const TCore &op, TCore::TArena *arena) {
+    void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
+    return Var::ToVar(
+        *Sabot::State::TAny::TWrapper(op.NewState(arena, state_alloc)));
+  }
+
+  /* Apply the fold algorithm to a single key's entries (already sorted
+     SeqNum desc). Returns the output entry list -- usually 1 entry. */
+  std::vector<TFoldEntry> FoldOneKey(const std::vector<TFoldEntry> &entries) {
+    if (entries.empty()) {
+      return {};
+    }
+    const TFoldEntry &anchor = entries.front();
+
+    // Tombstone anchor: preserve the delete; drop older entries.
+    if (anchor.IsTombstone) {
+      return {anchor};
+    }
+    // Assign anchor: keeps "latest assign wins" semantics; drop older.
+    if (anchor.Mutator == TMutator::Assign) {
+      return {anchor};
+    }
+    // Non-commutative non-Assign anchor (Sub, Div, Mod, Exp): nothing
+    // in-tree currently produces these as on-disk non-Assign entries
+    // (session.cc doesn't defer them). Defensively preserve as-is.
+    if (!Var::IsDeferSafeCommutative(anchor.Mutator)) {
+      return {anchor};
+    }
+
+    // Commutative non-Assign: fold older same-mutator entries (and any
+    // Assign base) onto the accumulator.
+    const TMutator mut = anchor.Mutator;
+    Var::TVar acc = anchor.Op;
+    for (size_t i = 1; i < entries.size(); ++i) {
+      const TFoldEntry &e = entries[i];
+      if (e.IsTombstone) {
+        break;  // wipe what's below; the post-tombstone accumulator stands
+      }
+      if (e.Mutator == TMutator::Assign) {
+        // Base. acc-as-RHS folded onto the base value.
+        acc = Rt::Mutate(e.Op, mut, acc);
+        break;
+      }
+      if (e.Mutator != mut) {
+        // Mixed-mutator chain -- TMutation::Augment rejects these at
+        // compose time. Surface the accumulator as-is.
+        break;
+      }
+      acc = Rt::Mutate(acc, mut, e.Op);
+    }
+
+    // Promote to Assign. Identity-OP-folded_RHS == folded_RHS for every
+    // commutative mutator we accept, so Assign(acc) matches what the
+    // read-path fold would produce -- and it keeps disk-side readers
+    // that aren't yet Mutator-aware (#53) working unchanged.
+    TFoldEntry out{anchor.SeqNum, TMutator::Assign, acc, /*IsTombstone=*/false};
+    return {out};
+  }
+
+}  // namespace
+
+namespace Orly { namespace Indy { namespace Disk {
+
+TFoldDataFile::TFoldDataFile(Indy::Disk::Util::TEngine *engine,
+                             Indy::Disk::Util::TVolume::TDesc::TStorageSpeed storage_speed,
+                             const TUuid &file_uuid,
+                             size_t source_gen_id,
+                             size_t dest_gen_id,
+                             DiskPriority priority,
+                             size_t temp_file_consol_thresh)
+    : NumKeys(0UL),
+      LowestSeq(0UL),
+      HighestSeq(0UL) {
+
+  // 1. Open the source file.
+  TFoldReader reader(engine, file_uuid, source_gen_id, priority);
+
+  // 2. Enumerate indices in the source.
+  std::vector<TUuid> index_ids;
+  reader.ForEachIndex([&](const TUuid &index_id, size_t /*offset*/) {
+    index_ids.push_back(index_id);
+  });
+
+  // 3. Output memory layer + arena. We accumulate surviving entries
+  //    here, then hand it to TDataFile to serialise.
+  TMemoryLayer out_layer(nullptr);
+  TSuprena out_arena;
+  void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
+
+  // 4. Per-index pass: read all entries, group by key, fold each
+  //    group, emit surviving entries.
+  for (const TUuid &index_id : index_ids) {
+    TFoldReader::TIndexFile idx_file(&reader, index_id, priority);
+    TFoldReader::TIndexFile::TArena idx_arena(
+        &idx_file, engine->GetCache<TFoldReader::PhysicalCachePageSize>(), priority);
+
+    struct TKeyGroup {
+      Indy::TKey Key;            // copied into out_arena
+      std::vector<TFoldEntry> Entries;
+    };
+    std::vector<TKeyGroup> groups;
+
+    auto find_or_create = [&](const TCore &key_core, TCore::TArena *key_arena) -> TKeyGroup & {
+      Indy::TKey probe(key_core, key_arena);
+      for (auto &g : groups) {
+        if (g.Key == probe) {
+          return g;
+        }
+      }
+      groups.emplace_back();
+      auto &g = groups.back();
+      g.Key = Indy::TKey(&out_arena, state_alloc, probe);
+      return g;
+    };
+
+    // 4a. Walk current keys.
+    for (TFoldReader::TIndexFile::TKeyCursor csr(&idx_file); csr; ++csr) {
+      const TFoldReader::TIndexFile::TKeyItem &item = *csr;
+      TKeyGroup &g = find_or_create(item.Key, &idx_arena);
+      TFoldEntry e;
+      e.SeqNum = item.SeqNum;
+      e.Mutator = item.Mutator;
+      e.IsTombstone = item.Value.IsTombstone();
+      if (!e.IsTombstone) {
+        e.Op = OpToVar(item.Value, reader.Arena.get());
+      }
+      g.Entries.push_back(std::move(e));
+    }
+
+    // 4b. Walk history keys.
+    for (TFoldReader::TIndexFile::THistoryKeyCursor csr(&idx_file); csr; ++csr) {
+      const TFoldReader::TIndexFile::THistoryKeyItem &item = *csr;
+      TKeyGroup &g = find_or_create(item.Key, &idx_arena);
+      TFoldEntry e;
+      e.SeqNum = item.SeqNum;
+      e.Mutator = item.Mutator;
+      e.IsTombstone = item.Value.IsTombstone();
+      if (!e.IsTombstone) {
+        e.Op = OpToVar(item.Value, reader.Arena.get());
+      }
+      g.Entries.push_back(std::move(e));
+    }
+
+    // 4c. Per-group: sort SeqNum desc, fold, emit.
+    for (auto &g : groups) {
+      std::sort(g.Entries.begin(), g.Entries.end(),
+                [](const TFoldEntry &a, const TFoldEntry &b) {
+                  return a.SeqNum > b.SeqNum;
+                });
+      auto out_entries = FoldOneKey(g.Entries);
+      for (const TFoldEntry &e : out_entries) {
+        Indy::TKey op_key;
+        if (e.IsTombstone) {
+          op_key = Indy::TKey(Native::TTombstone::Tombstone, &out_arena, state_alloc);
+        } else {
+          op_key = Indy::TKey(
+              &out_arena,
+              Sabot::State::TAny::TWrapper(Var::NewSabot(state_alloc, e.Op)).get());
+        }
+        TUpdate::TOpByKey op_by_key{
+            {TIndexKey(index_id, g.Key), op_key}
+        };
+        auto update = TUpdate::NewUpdate(
+            op_by_key,
+            Indy::TKey(&out_arena),
+            Indy::TKey(TUuid(TUuid::Twister), &out_arena, state_alloc));
+        update->SetSequenceNumber(e.SeqNum);
+        out_layer.Insert(TUpdate::CopyUpdate(update.get(), state_alloc));
+
+        if (LowestSeq == 0UL || e.SeqNum < LowestSeq) LowestSeq = e.SeqNum;
+        if (e.SeqNum > HighestSeq) HighestSeq = e.SeqNum;
+        ++NumKeys;
+      }
+    }
+  }
+
+  // 5. Serialise the folded memory layer at dest_gen_id.
+  TDataFile data_file(engine, storage_speed, &out_layer, file_uuid,
+                      dest_gen_id, temp_file_consol_thresh, 0U, priority);
+}
+
+}}}  // namespace Orly::Indy::Disk

--- a/orly/indy/disk/fold_data_file.h
+++ b/orly/indy/disk/fold_data_file.h
@@ -1,0 +1,106 @@
+/* <orly/indy/disk/fold_data_file.h>
+
+   Post-merge compaction-time fold pass for same-mutator commutative
+   runs.
+
+   Reads a source data file (typically the just-produced output of
+   TMergeDataFile), folds runs of same-key entries that share a
+   commutative+associative mutator (Add, Mult, And, Or, Xor, Union,
+   Intersection, SymmetricDiff -- the same set TMutation::Augment
+   validates), and writes a new data file in which each fold collapses
+   to a single Assign entry holding the resolved value.
+
+   This is phase 4 of #49. The read-path fold in
+   TContext::TPresentWalker::ApplyDeferredFold handles un-compacted
+   runs correctly already; this rewrite pass exists to bring read
+   amplification back to O(1) per key on workloads (the
+   wikipedia-pageviews demo's hot counters being the motivating one)
+   where many deferred-Add entries accumulate.
+
+   Architecture: doesn't touch the in-flight merge state machine in
+   TMergeDataFile (which is forward-only and tied to a complex
+   offset-remap pipeline). Instead it iterates the source file via
+   the existing TReader cursors into typed space (Var::TVar via
+   Sabot::ToNative), applies the fold via Rt::Mutate, materialises
+   the result into a fresh TMemoryLayer, and serialises that layer
+   via TDataFile.
+
+   Output entries are always promoted to TMutator::Assign:
+   identity-zero (commutative-mutator identity) folded onto the
+   accumulated RHS gives the same value as Assign(folded_RHS), and
+   Assign keeps disk-side readers that aren't Mutator-aware (#53)
+   working unchanged.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#pragma once
+
+#include <base/class_traits.h>
+#include <base/uuid.h>
+#include <orly/atom/kit2.h>
+#include <orly/indy/disk/data_file.h>
+#include <orly/indy/disk/read_file.h>
+#include <orly/indy/disk/util/engine.h>
+#include <orly/indy/disk/util/volume_manager.h>
+#include <orly/indy/sequence_number.h>
+
+namespace Orly {
+
+  namespace Indy {
+
+    namespace Disk {
+
+      /* Compaction-time fold pass. Reads a source data file at
+         (file_uuid, source_gen_id), folds same-mutator commutative
+         runs, writes a new data file at (file_uuid, dest_gen_id).
+         The source file is not modified or removed -- the caller
+         (TSafeRepo::MergeFiles) is responsible for the cleanup. */
+      class TFoldDataFile {
+        NO_COPY(TFoldDataFile);
+        public:
+
+        TFoldDataFile(Util::TEngine *engine,
+                      Disk::Util::TVolume::TDesc::TStorageSpeed storage_speed,
+                      const Base::TUuid &file_uuid,
+                      size_t source_gen_id,
+                      size_t dest_gen_id,
+                      DiskPriority priority,
+                      size_t temp_file_consol_thresh);
+
+        inline size_t GetNumKeys() const {
+          return NumKeys;
+        }
+
+        inline TSequenceNumber GetLowestSequence() const {
+          return LowestSeq;
+        }
+
+        inline TSequenceNumber GetHighestSequence() const {
+          return HighestSeq;
+        }
+
+        private:
+
+        size_t NumKeys;
+        TSequenceNumber LowestSeq;
+        TSequenceNumber HighestSeq;
+
+      };  // TFoldDataFile
+
+    }  // Disk
+
+  }  // Indy
+
+}  // Orly

--- a/orly/indy/disk/fold_data_file.test.cc
+++ b/orly/indy/disk/fold_data_file.test.cc
@@ -1,0 +1,243 @@
+/* <orly/indy/disk/fold_data_file.test.cc>
+
+   Unit test for <orly/indy/disk/fold_data_file.h>.
+
+   Verifies phase 4 of #49: same-mutator commutative runs in a data
+   file get folded into a single Assign(value) entry at compaction
+   time, bringing read amplification back to O(1) per key.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <orly/indy/disk/fold_data_file.h>
+
+#include <base/scheduler.h>
+#include <orly/indy/disk/data_file.h>
+#include <orly/indy/disk/disk_test.h>
+#include <orly/indy/disk/read_file.h>
+#include <orly/indy/disk/sim/mem_engine.h>
+#include <orly/indy/fiber/fiber_test_runner.h>
+
+#include <base/test/kit.h>
+
+using namespace std;
+using namespace chrono;
+using namespace Base;
+using namespace Orly;
+using namespace Orly::Atom;
+using namespace Orly::Indy;
+using namespace Orly::Indy::Disk;
+using namespace Orly::Indy::Disk::Util;
+using namespace Orly::Indy::Fiber;
+
+static const size_t BlockSize = Disk::Util::PhysicalBlockSize;
+
+Orly::Indy::Util::TPool L0::TManager::TRepo::TMapping::Pool(sizeof(TRepo::TMapping), "Repo Mapping");
+Orly::Indy::Util::TPool L0::TManager::TRepo::TMapping::TEntry::Pool(sizeof(TRepo::TMapping::TEntry), "Repo Mapping Entry");
+Orly::Indy::Util::TPool L0::TManager::TRepo::TDataLayer::Pool(sizeof(TMemoryLayer), "Data Layer");
+
+Orly::Indy::Util::TPool TUpdate::Pool(sizeof(TUpdate), "Update", 1048578UL);
+Orly::Indy::Util::TPool TUpdate::TEntry::Pool(sizeof(TUpdate::TEntry), "Entry", 1048578UL);
+Disk::TBufBlock::TPool Disk::TBufBlock::Pool(BlockSize, 2000UL);
+
+/* Insert a single-entry update with a specified mutator into a
+   TMockMem. Mirrors disk_test.h's Insert<TArgs...> but lets the test
+   put non-Assign entries on disk (which the existing helper doesn't
+   support, since it goes through TOpByKey which always tags Assign). */
+static void InsertMut(TMockMem &mem_layer, TSequenceNumber seq_num,
+                      const TUuid &idx_id, int64_t key, int64_t val, TMutator mut) {
+  TSuprena arena;
+  void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
+  auto update = TUpdate::NewUpdate(
+      TUpdate::TOpByKey{},        // empty: no Assign entries
+      TKey(&arena),
+      TKey(TUuid(TUuid::Twister), &arena, state_alloc));
+  update->SetSequenceNumber(seq_num);
+  update->AddEntry(
+      TIndexKey(idx_id, TKey(std::make_tuple(key), &arena, state_alloc)),
+      TKey(val, &arena, state_alloc),
+      mut);
+  mem_layer.Insert(TUpdate::CopyUpdate(update.get(), state_alloc));
+}
+
+/* Read back every (key, value) pair in the file's index and return as
+   a sorted vector keyed by the int64_t key (matches our test inserts
+   which use int64_t keys). */
+static std::vector<std::pair<int64_t, int64_t>>
+ReadInts(Sim::TMemEngine &mem_engine, const TUuid &file_id, size_t gen_id, const TUuid &index_id) {
+  TReader reader(HERE, mem_engine.GetEngine(), file_id, gen_id);
+  TReader::TArena main_arena(&reader,
+      mem_engine.GetEngine()->GetCache<TReader::PhysicalCachePageSize>(), RealTime);
+  TReader::TIndexFile idx_file(&reader, index_id, RealTime);
+  TReader::TArena idx_arena(&idx_file,
+      mem_engine.GetEngine()->GetCache<TReader::PhysicalCachePageSize>(), RealTime);
+  std::vector<std::pair<int64_t, int64_t>> out;
+  for (TReader::TIndexFile::TKeyCursor csr(&idx_file); csr; ++csr) {
+    const auto &item = *csr;
+    void *k_state = alloca(Sabot::State::GetMaxStateSize());
+    void *v_state = alloca(Sabot::State::GetMaxStateSize());
+    std::tuple<int64_t> kt;
+    int64_t val_int = 0;
+    Sabot::ToNative(*Sabot::State::TAny::TWrapper(item.Key.NewState(&idx_arena, k_state)), kt);
+    Sabot::ToNative(*Sabot::State::TAny::TWrapper(item.Value.NewState(&main_arena, v_state)), val_int);
+    out.emplace_back(std::get<0>(kt), val_int);
+  }
+  std::sort(out.begin(), out.end());
+  return out;
+}
+
+FIXTURE(FoldsAddsOntoAssignBase) {
+  TFiberTestRunner runner([](std::mutex &mut, std::condition_variable &cond, bool &fin, Fiber::TRunner::TRunnerCons &) {
+    void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
+    TScheduler scheduler(TScheduler::TPolicy(4, 10, milliseconds(10)));
+    Sim::TMemEngine mem_engine(&scheduler, 256, 256, 16384, 1, 1024, 1);
+
+    TUuid file_id(TUuid::Best);
+    TUuid index_id(TUuid::Twister);
+    const size_t src_gen = 1, dst_gen = 2;
+
+    /* Build a source file with: Assign(10), Add(5), Add(3) on key 42. */
+    {
+      TMockMem mem_layer;
+      TSequenceNumber seq = 0;
+      Insert(mem_layer, ++seq, index_id, /*val*/ 10L, /*key tuple*/ 42L);  // Assign(10)
+      InsertMut(mem_layer, ++seq, index_id, /*key*/ 42L, /*val*/ 5L, TMutator::Add);
+      InsertMut(mem_layer, ++seq, index_id, /*key*/ 42L, /*val*/ 3L, TMutator::Add);
+      TDataFile(mem_engine.GetEngine(), TVolume::TDesc::Fast, &mem_layer, file_id, src_gen, 20UL, 0U, Medium);
+    }
+
+    /* Fold pass. */
+    TFoldDataFile fold(mem_engine.GetEngine(), TVolume::TDesc::Fast, file_id, src_gen, dst_gen, Medium, 20UL);
+    /* Exactly one resulting key per group. */
+    if (EXPECT_EQ(fold.GetNumKeys(), 1UL)) {}
+
+    /* The folded file should have a single Assign(18) entry on key 42. */
+    auto pairs = ReadInts(mem_engine, file_id, dst_gen, index_id);
+    if (EXPECT_EQ(pairs.size(), 1UL)) {
+      EXPECT_EQ(pairs[0].first, 42L);
+      EXPECT_EQ(pairs[0].second, 18L);   /* 10 + 5 + 3 */
+    }
+    std::lock_guard<std::mutex> lock(mut);
+    fin = true;
+    cond.notify_one();
+  });
+}
+
+FIXTURE(FoldsAddsWithoutAssignBase) {
+  TFiberTestRunner runner([](std::mutex &mut, std::condition_variable &cond, bool &fin, Fiber::TRunner::TRunnerCons &) {
+    TScheduler scheduler(TScheduler::TPolicy(4, 10, milliseconds(10)));
+    Sim::TMemEngine mem_engine(&scheduler, 256, 256, 16384, 1, 1024, 1);
+
+    TUuid file_id(TUuid::Best);
+    TUuid index_id(TUuid::Twister);
+    const size_t src_gen = 1, dst_gen = 2;
+
+    /* Build a source file with three Adds on key 7, no Assign base. */
+    {
+      TMockMem mem_layer;
+      TSequenceNumber seq = 0;
+      InsertMut(mem_layer, ++seq, index_id, 7L, 1L, TMutator::Add);
+      InsertMut(mem_layer, ++seq, index_id, 7L, 2L, TMutator::Add);
+      InsertMut(mem_layer, ++seq, index_id, 7L, 4L, TMutator::Add);
+      TDataFile(mem_engine.GetEngine(), TVolume::TDesc::Fast, &mem_layer, file_id, src_gen, 20UL, 0U, Medium);
+    }
+
+    TFoldDataFile fold(mem_engine.GetEngine(), TVolume::TDesc::Fast, file_id, src_gen, dst_gen, Medium, 20UL);
+    EXPECT_EQ(fold.GetNumKeys(), 1UL);
+
+    /* No Assign base + commutative-mutator identity = 0 for Add, so the
+       folded value should be 1+2+4 = 7, materialised as Assign(7). */
+    auto pairs = ReadInts(mem_engine, file_id, dst_gen, index_id);
+    if (EXPECT_EQ(pairs.size(), 1UL)) {
+      EXPECT_EQ(pairs[0].first, 7L);
+      EXPECT_EQ(pairs[0].second, 7L);
+    }
+    std::lock_guard<std::mutex> lock(mut);
+    fin = true;
+    cond.notify_one();
+  });
+}
+
+FIXTURE(PureAssignDropsOlder) {
+  TFiberTestRunner runner([](std::mutex &mut, std::condition_variable &cond, bool &fin, Fiber::TRunner::TRunnerCons &) {
+    TScheduler scheduler(TScheduler::TPolicy(4, 10, milliseconds(10)));
+    Sim::TMemEngine mem_engine(&scheduler, 256, 256, 16384, 1, 1024, 1);
+
+    TUuid file_id(TUuid::Best);
+    TUuid index_id(TUuid::Twister);
+    const size_t src_gen = 1, dst_gen = 2;
+
+    /* Three Assigns on key 99: the newest one (100) shadows the others. */
+    {
+      TMockMem mem_layer;
+      TSequenceNumber seq = 0;
+      Insert(mem_layer, ++seq, index_id, /*val*/ 10L, /*key*/ 99L);
+      Insert(mem_layer, ++seq, index_id, /*val*/ 50L, /*key*/ 99L);
+      Insert(mem_layer, ++seq, index_id, /*val*/ 100L, /*key*/ 99L);
+      TDataFile(mem_engine.GetEngine(), TVolume::TDesc::Fast, &mem_layer, file_id, src_gen, 20UL, 0U, Medium);
+    }
+
+    TFoldDataFile fold(mem_engine.GetEngine(), TVolume::TDesc::Fast, file_id, src_gen, dst_gen, Medium, 20UL);
+    EXPECT_EQ(fold.GetNumKeys(), 1UL);
+
+    auto pairs = ReadInts(mem_engine, file_id, dst_gen, index_id);
+    if (EXPECT_EQ(pairs.size(), 1UL)) {
+      EXPECT_EQ(pairs[0].first, 99L);
+      EXPECT_EQ(pairs[0].second, 100L);   /* newest assign wins */
+    }
+    std::lock_guard<std::mutex> lock(mut);
+    fin = true;
+    cond.notify_one();
+  });
+}
+
+FIXTURE(MixedKeysIndependent) {
+  TFiberTestRunner runner([](std::mutex &mut, std::condition_variable &cond, bool &fin, Fiber::TRunner::TRunnerCons &) {
+    TScheduler scheduler(TScheduler::TPolicy(4, 10, milliseconds(10)));
+    Sim::TMemEngine mem_engine(&scheduler, 256, 256, 16384, 1, 1024, 1);
+
+    TUuid file_id(TUuid::Best);
+    TUuid index_id(TUuid::Twister);
+    const size_t src_gen = 1, dst_gen = 2;
+
+    /* Mix: key 1 has Assign+Adds, key 2 only Adds, key 3 only one Assign. */
+    {
+      TMockMem mem_layer;
+      TSequenceNumber seq = 0;
+      Insert(mem_layer, ++seq, index_id, /*val*/ 100L, /*key*/ 1L);
+      InsertMut(mem_layer, ++seq, index_id, 1L, 5L, TMutator::Add);
+      InsertMut(mem_layer, ++seq, index_id, 2L, 10L, TMutator::Add);
+      InsertMut(mem_layer, ++seq, index_id, 2L, 20L, TMutator::Add);
+      Insert(mem_layer, ++seq, index_id, /*val*/ 42L, /*key*/ 3L);
+      InsertMut(mem_layer, ++seq, index_id, 1L, 7L, TMutator::Add);
+      TDataFile(mem_engine.GetEngine(), TVolume::TDesc::Fast, &mem_layer, file_id, src_gen, 20UL, 0U, Medium);
+    }
+
+    TFoldDataFile fold(mem_engine.GetEngine(), TVolume::TDesc::Fast, file_id, src_gen, dst_gen, Medium, 20UL);
+    EXPECT_EQ(fold.GetNumKeys(), 3UL);
+
+    auto pairs = ReadInts(mem_engine, file_id, dst_gen, index_id);
+    if (EXPECT_EQ(pairs.size(), 3UL)) {
+      EXPECT_EQ(pairs[0].first, 1L);
+      EXPECT_EQ(pairs[0].second, 112L);   /* 100 + 5 + 7 */
+      EXPECT_EQ(pairs[1].first, 2L);
+      EXPECT_EQ(pairs[1].second, 30L);    /* 0 + 10 + 20 */
+      EXPECT_EQ(pairs[2].first, 3L);
+      EXPECT_EQ(pairs[2].second, 42L);
+    }
+    std::lock_guard<std::mutex> lock(mut);
+    fin = true;
+    cond.notify_one();
+  });
+}

--- a/orly/indy/repo.cc
+++ b/orly/indy/repo.cc
@@ -1309,14 +1309,25 @@ size_t TSafeRepo::MergeFiles(const std::vector<size_t> &gen_id_vec,
                              TSequenceNumber release_up_to,
                              bool can_tail,
                              bool can_tail_tombstone) {
-  size_t gen_id = GetNextGenId();
+  size_t intermediate_gen_id = GetNextGenId();
   bool my_can_tail = can_tail && !static_cast<bool>(GetParentRepo()) && IsTailingAllowed();
   bool my_can_tail_tombstone = my_can_tail && can_tail_tombstone && (gen_id_vec.size() == 1);
-  TMergeDataFile merge_data_file(Manager->GetEngine(), storage_speed, GetId(), gen_id_vec, GetId(), gen_id, release_up_to, Low, max_block_cache_read_slots_allowed, temp_file_consol_thresh, my_can_tail, my_can_tail_tombstone);
-  out_num_keys = merge_data_file.GetNumKeys();
-  out_saved_low_seq = merge_data_file.GetLowestSequence();
-  out_saved_high_seq = merge_data_file.GetHighestSequence();
-  return gen_id;
+  /* Phase A: standard merge. Produces a data file at intermediate_gen_id
+     with same-mutator commutative runs still expanded -- correct but
+     unbounded in entries-per-key under contention. */
+  TMergeDataFile merge_data_file(Manager->GetEngine(), storage_speed, GetId(), gen_id_vec, GetId(), intermediate_gen_id, release_up_to, Low, max_block_cache_read_slots_allowed, temp_file_consol_thresh, my_can_tail, my_can_tail_tombstone);
+  /* Phase B (#55): fold same-mutator commutative runs in the just-merged
+     file via TMutation::Augment-equivalent logic in typed space. Output
+     entries are promoted to Assign(folded value), bringing read
+     amplification back to O(1) per key. */
+  size_t final_gen_id = GetNextGenId();
+  TFoldDataFile fold_data_file(Manager->GetEngine(), storage_speed, GetId(), intermediate_gen_id, final_gen_id, Low, temp_file_consol_thresh);
+  out_num_keys = fold_data_file.GetNumKeys();
+  out_saved_low_seq = fold_data_file.GetLowestSequence();
+  out_saved_high_seq = fold_data_file.GetHighestSequence();
+  /* Reclaim the intermediate file's blocks. */
+  RemoveFile(intermediate_gen_id);
+  return final_gen_id;
 }
 
 void TSafeRepo::RemoveFile(size_t gen_id) {

--- a/orly/indy/repo.h
+++ b/orly/indy/repo.h
@@ -21,6 +21,7 @@
 #include <base/opt.h>
 #include <orly/indy/disk_layer.h>
 #include <orly/indy/disk/data_file.h>
+#include <orly/indy/disk/fold_data_file.h>
 #include <orly/indy/disk/merge_data_file.h>
 #include <orly/indy/disk/present_walk_file.h>
 #include <orly/indy/disk/update_walk_file.h>


### PR DESCRIPTION
Closes #55.

## What this is

Phase 4 of the #49 work. After phases 2+3 introduced deferred `{Mutator, Op}` storage and read-time folding, each concurrent `+= n` write produces its own on-disk entry. The read-path fold (`TContext::TPresentWalker::ApplyDeferredFold`) handles un-compacted runs correctly but the cost is **O(N) per key** in number of un-compacted deferred writes. Compaction is the natural place to fold same-mutator runs back into a single entry so reads stay O(1).

## Architecture

**Post-merge rewrite pass** (chosen after [investigation](https://github.com/orlyatomics/orly/issues/55#issuecomment-...) over an in-merge fold).

Doesn't touch the in-flight merge state machine in `TMergeDataFile` (which is forward-only and tied to a complex offset-remap pipeline — the four obstacles from the issue investigation all apply). Instead, `TSafeRepo::MergeFiles` runs the standard merge first; then `TFoldDataFile` reads the intermediate file via the existing `TReader` cursors into typed space (`Var::TVar` via `Sabot::ToNative`), applies the fold via `Rt::Mutate`, materialises the result into a fresh `TMemoryLayer`, and serialises via `TDataFile`. The intermediate file is `RemoveFile`'d after.

```
MergeFiles(sources):
  intermediate_gen = GetNextGenId();
  TMergeDataFile(..., intermediate_gen, ...);           // existing pipeline
  final_gen = GetNextGenId();
  TFoldDataFile(..., intermediate_gen, final_gen, ...); // new: fold pass
  RemoveFile(intermediate_gen);
  return final_gen;
```

## Per-key fold semantics

Entries sorted SeqNum desc. Anchor = newest:
- **Tombstone anchor**: preserve, drop older.
- **Assign anchor**: preserve (latest wins), drop older.
- **Commutative non-Assign anchor** (`Add`, `Mult`, `And`, `Or`, `Xor`, `Union`, `Intersection`, `SymmetricDiff`): fold older same-mutator entries via `Rt::Mutate`. Stop on Assign base (fold acc onto base), tombstone (acc stands), or different mutator (acc stands as-is). **Promote output to `Assign(acc)`** — the identity element of every commutative mutator we accept makes `identity OP folded_RHS == folded_RHS`, so this is the correct value AND it keeps disk-side readers that aren't yet Mutator-aware (#53) working unchanged.
- **Non-commutative non-Assign anchor** (Sub, Div, Mod, Exp — shouldn't appear, session.cc doesn't defer these): preserve anchor, drop older.

## Cost

Doubles compaction-time I/O (one read+write for the merge, one read+write for the fold). Acceptable for the read-amplification savings. Future optimization: skip the fold pass for files known to contain only Assign entries (track in metadata).

## Test plan

- [x] **New** `orly/indy/disk/fold_data_file.test.cc` — 4 fixtures:
  - `FoldsAddsOntoAssignBase` — `Assign(10) + Add(5) + Add(3)` → `Assign(18)`
  - `FoldsAddsWithoutAssignBase` — `Add(1) + Add(2) + Add(4)` (no base) → `Assign(7)`
  - `PureAssignDropsOlder` — three `Assign(...)` on same key → keep newest
  - `MixedKeysIndependent` — three keys with different fold shapes, all correct
- [x] `make test`: 192/192.
- [x] `lang_test.py`: 120 pass / 3 known pre-existing fails (`mutablefilter`, `multiple_sequences`, `sequence_in_effecting`). Unchanged from baseline.
- [x] wikipedia-pageviews demo: passes both drivers, both `DEMO_SCALE` modes. (The `--mem_sim` path doesn't always exercise disk compaction so the fold tests are the primary correctness signal.)

## Risk

Phase 4's failure mode is permanent disk corruption — wrong compaction writes wrong data, source files get popped, undetectable until a later read returns a wrong answer. The test surface is the main mitigation. Further hardening (incremental rollout, fast-path skip for Assign-only files, fold-output validation against source) is followup work.

## Files

| File | Lines | What |
|---|---|---|
| `orly/indy/disk/fold_data_file.h` | +97 | Public interface |
| `orly/indy/disk/fold_data_file.cc` | +234 | Implementation |
| `orly/indy/disk/fold_data_file.test.cc` | +234 | 4 fixtures |
| `orly/indy/repo.cc` | +17/-6 | Hook in `TSafeRepo::MergeFiles` |
| `orly/indy/repo.h` | +1 | Include `fold_data_file.h` |
