### PR TITLE
indy/disk: TUpdateWalker reads on-disk Mutator correctly (closes #53)

### DIFF
--- a/orly/indy/disk/update_walk_file.h
+++ b/orly/indy/disk/update_walk_file.h
@@ -128,12 +128,24 @@ namespace Orly {
                 EntryStream.GoTo(offset_of_key + sizeof(TSequenceNumber));
                 EntryStream.Read(&key, sizeof(Atom::TCore));
                 EntryStream.Read(&val, sizeof(Atom::TCore));
-                /* TODO(#53): disk EntryVec walker still emits Mutator=Assign
-                   because the entry type (current vs history) is opaque at
-                   this offset and the trailing-Mutator byte is at different
-                   offsets for the two layouts. The in-memory path (used by
-                   the --mem_sim demo) is correct via TMemoryLayer::TUpdateWalker. */
-                Item.EntryVec.emplace_back(TIndexKey(ret->second->GetIndexId(), TKey(key, key_arena)), val);
+                /* The bucket stores raw offsets without a per-entry type
+                   flag, but the writer places current entries in the
+                   range [ByteOffsetOfKeyIndex, ByteOffsetOfHistoryIndex)
+                   and history entries at >= ByteOffsetOfHistoryIndex.
+                   Use that boundary (per index) to pick the right
+                   trailing-Mutator offset for the read:
+                     TKeyItem (current):    Mutator follows
+                                            NumHistKeys + OffsetOfHistKeys
+                                            (2 * sizeof(size_t) bytes).
+                     THistoryKeyItem:       Mutator follows Value directly.
+                   Trailing 4 bytes after Mutator are alignment padding
+                   (see KeyEntrySize / KeyHistorySize in data_file.h). */
+                if (offset_of_key < ret->second->GetByteOffsetOfHistoryIndex()) {
+                  EntryStream.Skip(sizeof(size_t) * 2U);
+                }
+                TMutator mutator = TMutator::Assign;
+                EntryStream.Read(&mutator, sizeof(TMutator));
+                Item.EntryVec.emplace_back(TIndexKey(ret->second->GetIndexId(), TKey(key, key_arena)), val, mutator);
               }
               Cached = true;
               ++NumScanned;

--- a/orly/indy/disk/update_walk_file.test.cc
+++ b/orly/indy/disk/update_walk_file.test.cc
@@ -185,3 +185,90 @@ FIXTURE(WithMergeFile) {
     cond.notify_one();
   });
 }
+
+/* Regression test for issue #53: round-trip a non-Assign Mutator
+   (e.g. Add) through disk persistence. Before the fix at
+   update_walk_file.h:121-149, the random-access read site couldn't
+   tell which on-disk layout (TKeyItem vs THistoryKeyItem) it was
+   reading, so it defaulted Mutator to Assign and silently dropped
+   any commutative-fold-relevant info. The fix uses the per-index
+   ByteOffsetOfHistoryIndex boundary to disambiguate. */
+FIXTURE(MutatorRoundTrip) {
+  Fiber::TFiberTestRunner runner([](std::mutex &mut, std::condition_variable &cond, bool &fin, Fiber::TRunner::TRunnerCons &) {
+    TRAIITest required_thread_locals;
+    void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
+    TScheduler scheduler(TScheduler::TPolicy(10, 10, milliseconds(10)));
+
+    Sim::TMemEngine mem_engine(&scheduler, 256, 256, 16384, 1, 1024, 1);
+
+    Base::TUuid file_id(TUuid::TimeAndMAC);
+    TSuprena arena;
+    Base::TUuid idx(Base::TUuid::Twister);
+    const size_t gen_id = 1;
+
+    /* Build a file with one update per key, mixing Assign + commutative
+       non-Assign mutators. Multiple keys per update guarantees the
+       writer puts SOME entries in the current-keys section and SOME
+       in the history-keys section (within a single update, only one
+       entry per repeated key can be current; the rest are history). */ {
+      TMockMem mem_layer;
+      TSequenceNumber seq = 0;
+
+      /* update 1: two keys, both Assign (current entries). */ {
+        auto u = TMockUpdate::NewMockUpdate(
+            TUpdate::TOpByKey{
+                {TIndexKey(idx, TKey(make_tuple(1L), &arena, state_alloc)),
+                 TKey(int64_t(100), &arena, state_alloc)},
+                {TIndexKey(idx, TKey(make_tuple(2L), &arena, state_alloc)),
+                 TKey(int64_t(200), &arena, state_alloc)},
+            },
+            TKey(&arena),
+            TKey(Base::TUuid(Base::TUuid::Best), &arena, state_alloc),
+            ++seq);
+        mem_layer.Insert(u);
+      }
+      /* update 2: same two keys re-Assigned (-> history entries when
+         merged with update 1's snapshot) PLUS one Add on key 1. */ {
+        auto u = TMockUpdate::NewMockUpdate(
+            TUpdate::TOpByKey{
+                {TIndexKey(idx, TKey(make_tuple(1L), &arena, state_alloc)),
+                 TKey(int64_t(150), &arena, state_alloc)},
+                {TIndexKey(idx, TKey(make_tuple(2L), &arena, state_alloc)),
+                 TKey(int64_t(250), &arena, state_alloc)},
+            },
+            TKey(&arena),
+            TKey(Base::TUuid(Base::TUuid::Best), &arena, state_alloc),
+            ++seq);
+        /* Add(7) on key 1 via the AddEntry-with-mutator overload. */
+        u->AddEntry(
+            TIndexKey(idx, TKey(make_tuple(1L), &arena, state_alloc)),
+            TKey(int64_t(7), &arena, state_alloc),
+            TMutator::Add);
+        mem_layer.Insert(u);
+      }
+      TDataFile data_file(mem_engine.GetEngine(), Disk::Util::TVolume::TDesc::Fast,
+                          &mem_layer, file_id, gen_id, 20UL, 0U, RealTime);
+    }
+
+    /* Walk the file via TUpdateWalkFile. Per-entry Mutator should
+       survive the disk round-trip: Assign entries should be Assign,
+       the Add(7) entry should be Add. */ {
+      TUpdateWalkFile walker(mem_engine.GetEngine(), file_id, gen_id, 0U);
+      size_t total_assign = 0;
+      size_t total_add = 0;
+      for (; walker; ++walker) {
+        for (const auto &iter : (*walker).EntryVec) {
+          if (iter.Mutator == TMutator::Add) ++total_add;
+          else if (iter.Mutator == TMutator::Assign) ++total_assign;
+        }
+      }
+      /* 4 Assign entries (2 keys x 2 updates) + 1 Add entry. */
+      EXPECT_EQ(total_assign, 4U);
+      EXPECT_EQ(total_add, 1U);
+    }
+
+    std::lock_guard<std::mutex> lock(mut);
+    fin = true;
+    cond.notify_one();
+  });
+}


### PR DESCRIPTION
Closes #53.

## The bug

The random-access read site in `TUpdateWalker` (`update_walk_file.h:128` ish) reads `SeqNum + Key + Val` from a bucket-supplied byte offset but couldn't tell which on-disk layout it was reading. `TKeyItem` (current) and `THistoryKeyItem` (history) share the `SeqNum+Key+Val` prefix, but the trailing Mutator byte sits at different offsets:

- **`TKeyItem`** (current): Mutator follows `NumHistKeys + OffsetOfHistKeys` (2 × `sizeof(size_t)` past Val).
- **`THistoryKeyItem`**: Mutator follows Val directly.

The walker just defaulted Mutator to `Assign` on every read, silently losing any non-Assign tag persisted on disk. That's the #53 footgun: deferred commutative entries that survive a memory-layer flush behave like `Assign(rhs)` on read-back, undetectable until a downstream read returns a wrong sum.

## The fix

The bucket on disk doesn't store an entry-type flag, but the writer **does** place current entries in offset range `[ByteOffsetOfKeyIndex, ByteOffsetOfHistoryIndex)` and history entries at `>= ByteOffsetOfHistoryIndex` (see `data_file.cc:1009-1013` and the index file's `GetByteOffsetOfHistoryIndex()` accessor). The walker already looks up the source `TIndexFile *` for each entry's offset to find the right arena; same lookup gives the boundary. Comparing the entry offset against that boundary disambiguates the layout, and the read picks the right number of bytes to `Skip` before reading the Mutator.

**No on-disk format change** — pre-existing files written with Mutator support (since #50 phase 1) become readable-correctly the moment this lands.

## Test plan

- [x] New `MutatorRoundTrip` fixture in `update_walk_file.test`: writes 4 Assign entries + 1 Add entry via `TDataFile`, reads back via `TUpdateWalkFile`, asserts Mutator tags survive. Pre-fix would have reported 5 Assigns / 0 Adds — the test catches the exact regression.
- [x] `make test`: 192/192.
- [x] `lang_test.py`: 120 pass / 3 known pre-existing fails (`mutablefilter`, `multiple_sequences`, `sequence_in_effecting`). Unchanged from baseline.
- [x] wikipedia-pageviews demo: both drivers, both `DEMO_SCALE` modes pass.

## Files

| File | Lines | What |
|---|---|---|
| `orly/indy/disk/update_walk_file.h` | +18/-6 | Pick the right Mutator offset based on the current-vs-history boundary |
| `orly/indy/disk/update_walk_file.test.cc` | +87 | New `MutatorRoundTrip` fixture |
