### PR TITLE
indy: master->slave replication carries Mutator (closes #54)

### DIFF
--- a/orly/indy/manager.cc
+++ b/orly/indy/manager.cc
@@ -691,13 +691,28 @@ void TManager::TSlave::PullUpdateRange(const Base::TUuid &repo_id, TManager::TPt
 
       Atom::TSuprena arena;
       for (auto iter : context.UpdateVec) {
+        /* Split entries by mutator: Assign-tagged go through the TUpdate
+           TOpByKey ctor (existing semantics); non-Assign entries get
+           registered via update->AddEntry(...,mutator) so the deferred
+           commutative info survives the slave-replay path. Mirrors the
+           fix in TRepo::GetLowestUpdate (PR #52) for the Tetris peek
+           path. Without this, the slave reconstructs deferred {Add, n}
+           entries as Assign(n) and silently loses updates on
+           concurrent writes that landed on the master (#54). */
         TUpdate::TOpByKey op_by_key;
         for (auto entry : iter.EntryVec) {
-          op_by_key[entry.first] = TKey(entry.second, context.Suprena.get());
+          if (entry.Mutator == TMutator::Assign) {
+            op_by_key[entry.IndexKey] = TKey(entry.Op, context.Suprena.get());
+          }
           ++num_entry_inserted;
         }
         TUpdate *update = new TUpdate(op_by_key, TKey(iter.Metadata, context.Suprena.get()), TKey(iter.Id, context.Suprena.get()), lhs_state_alloc);
         update->SetSequenceNumber(iter.SequenceNumber);
+        for (auto entry : iter.EntryVec) {
+          if (entry.Mutator != TMutator::Assign) {
+            update->AddEntry(entry.IndexKey, TKey(entry.Op, context.Suprena.get()), entry.Mutator);
+          }
+        }
         mem_layer->ImporterAppendUpdate(update);
       }
       /* sort and fix the mem_layer */ {

--- a/orly/indy/util/context_streamer.h
+++ b/orly/indy/util/context_streamer.h
@@ -88,7 +88,11 @@ namespace Orly {
             // (Base::TUuid) Repo Id; (TSequenceNumber) Sequence Number of the update; (TCore) Metadata;  (TCore) Id; (size_t) number of key-value pairs to follow
             strm << iter.RepoId << iter.SequenceNumber << Atom::TCore(iter.Metadata, remapper) << Atom::TCore(iter.Id, remapper) << iter.EntryVec.size();
             for (auto entry : iter.EntryVec) {
-              strm << entry.first.GetIndexId() << Atom::TCore(entry.first.GetKey().GetCore(), remapper) << Atom::TCore(entry.second, remapper);  // (TUuid) index_id; (TCore) Key; (TCore) Op
+              // (TUuid) index_id; (TCore) Key; (TCore) Op; (uint32_t) Mutator
+              strm << entry.IndexKey.GetIndexId()
+                   << Atom::TCore(entry.IndexKey.GetKey().GetCore(), remapper)
+                   << Atom::TCore(entry.Op, remapper)
+                   << static_cast<uint32_t>(entry.Mutator);
             }
           }
         }
@@ -98,6 +102,20 @@ namespace Orly {
         /* TODO */
         class TUpdate {
           public:
+
+          /* Per-entry payload on the wire: (IndexKey, Op, Mutator). The
+             Mutator field was added in #54 -- before that the wire format
+             dropped it, causing slaves to reconstruct deferred {Add, n}
+             entries as Assign(n) and silently lose updates on concurrent
+             writes that landed on the master. */
+          struct TEntry {
+            TIndexKey IndexKey;
+            Atom::TCore Op;
+            TMutator Mutator;
+            TEntry() : Mutator(TMutator::Assign) {}
+            TEntry(const TIndexKey &k, const Atom::TCore &op) : IndexKey(k), Op(op), Mutator(TMutator::Assign) {}
+            TEntry(const TIndexKey &k, const Atom::TCore &op, TMutator m) : IndexKey(k), Op(op), Mutator(m) {}
+          };
 
           /* TODO */
           TUpdate() {}
@@ -109,12 +127,12 @@ namespace Orly {
             void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
             Metadata = Atom::TCore(&new_arena, state_alloc, item.MainArena, item.Metadata);
             Id = Atom::TCore(&new_arena, state_alloc, item.MainArena, item.Id);
-            /* TODO(#54): wire format does not yet carry Mutator. Replication
-               currently loses defer-safe mutator info -- treat as
-               known followup; the demo uses --mem_sim so doesn't hit this. */
             for (const auto &iter : item.EntryVec) {
-              EntryVec.push_back(std::make_pair(TIndexKey(iter.IndexKey.GetIndexId(), TKey(Atom::TCore(&new_arena, state_alloc, iter.IndexKey.GetKey().GetArena(), iter.IndexKey.GetKey().GetCore()), &new_arena)),
-                                                Atom::TCore(&new_arena, state_alloc, item.MainArena, iter.Op)));
+              EntryVec.emplace_back(
+                  TIndexKey(iter.IndexKey.GetIndexId(),
+                            TKey(Atom::TCore(&new_arena, state_alloc, iter.IndexKey.GetKey().GetArena(), iter.IndexKey.GetKey().GetCore()), &new_arena)),
+                  Atom::TCore(&new_arena, state_alloc, item.MainArena, iter.Op),
+                  iter.Mutator);
             }
           }
 
@@ -131,7 +149,7 @@ namespace Orly {
           Atom::TCore Id;
 
           /* TODO */
-          std::vector<std::pair<TIndexKey, Atom::TCore>> EntryVec;
+          std::vector<TEntry> EntryVec;
 
         };  // TUpdate
 
@@ -198,6 +216,7 @@ namespace Orly {
           Base::TUuid temp_index_id;
           Atom::TCore temp_key;
           Atom::TCore temp_op;
+          uint32_t temp_mutator;
           for (size_t i = 0; i < num_updates; ++i) {
             TUpdate update;
             size_t num_entry;
@@ -208,10 +227,13 @@ namespace Orly {
             update.EntryVec.reserve(num_entry);
             for (size_t j = 0; j < num_entry; ++j) {
               // (TUuid) index_id; (TCore) Key; (TCore) Op
-              strm >> temp_index_id >> temp_key >> temp_op;
+              strm >> temp_index_id >> temp_key >> temp_op >> temp_mutator;
               temp_key.Remap(remapper);
               temp_op.Remap(remapper);
-              update.EntryVec.push_back(std::make_pair(TIndexKey(temp_index_id, TKey(temp_key, Suprena.get())), temp_op));
+              update.EntryVec.emplace_back(
+                  TIndexKey(temp_index_id, TKey(temp_key, Suprena.get())),
+                  temp_op,
+                  static_cast<TMutator>(temp_mutator));
             }
             UpdateVec.push_back(std::move(update));
           }
@@ -255,7 +277,11 @@ namespace Orly {
             // (Base::TUuid) Repo Id; (TSequenceNumber) Sequence Number of the update; (TCore) Metadata;  (TCore) Id; (size_t) number of key-value pairs to follow
             strm << iter.RepoId << iter.SequenceNumber << Atom::TCore(iter.Metadata, remapper) << Atom::TCore(iter.Id, remapper) << iter.EntryVec.size();
             for (auto entry : iter.EntryVec) {
-              strm << entry.first.GetIndexId() << Atom::TCore(entry.first.GetKey().GetCore(), remapper) << Atom::TCore(entry.second, remapper);  // (TUuid) index_id; (TCore) Key; (TCore) Op
+              // (TUuid) index_id; (TCore) Key; (TCore) Op; (uint32_t) Mutator
+              strm << entry.IndexKey.GetIndexId()
+                   << Atom::TCore(entry.IndexKey.GetKey().GetCore(), remapper)
+                   << Atom::TCore(entry.Op, remapper)
+                   << static_cast<uint32_t>(entry.Mutator);
             }
           }
         }

--- a/orly/indy/util/context_streamer.test.cc
+++ b/orly/indy/util/context_streamer.test.cc
@@ -198,3 +198,56 @@ FIXTURE(RPCInputToInput) {
   std::cout << "Joining server runner.." << std::endl;
   svr_run.join();
 }
+
+/* Regression test for issue #54: wire format must carry the per-entry
+   Mutator field through serialization + deserialization, otherwise
+   deferred {Mutator!=Assign, Op} entries arrive at the slave as
+   Assign(Op) and concurrent-write composition silently breaks. */
+FIXTURE(MutatorRoundTrip) {
+  void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
+  Atom::TSuprena arena;
+  Base::TUuid repo_id(TUuid::Best);
+  Base::TUuid idx_id(TUuid::Twister);
+
+  TContextInputStreamer out_context;
+  TContextInputStreamer::TUpdate update;
+  update.RepoId = repo_id;
+  update.SequenceNumber = 42UL;
+  update.Metadata = Atom::TCore(int64_t(1), &arena, state_alloc);
+  update.Id = Atom::TCore(Base::TUuid(TUuid::Best), &arena, state_alloc);
+  /* Three entries: Assign, Add, Mult. All three mutators should survive
+     the round-trip; pre-fix the Mutator field was just dropped. */
+  update.EntryVec.emplace_back(
+      TIndexKey(idx_id, TKey(int64_t(1), &arena, state_alloc)),
+      Atom::TCore(int64_t(10), &arena, state_alloc),
+      TMutator::Assign);
+  update.EntryVec.emplace_back(
+      TIndexKey(idx_id, TKey(int64_t(2), &arena, state_alloc)),
+      Atom::TCore(int64_t(20), &arena, state_alloc),
+      TMutator::Add);
+  update.EntryVec.emplace_back(
+      TIndexKey(idx_id, TKey(int64_t(3), &arena, state_alloc)),
+      Atom::TCore(int64_t(30), &arena, state_alloc),
+      TMutator::Mult);
+  out_context.UpdateVec.push_back(std::move(update));
+
+  /* Round-trip via the recorder. */
+  TContextInputStreamer in_context;
+  auto recorder = make_shared<TRecorder>();
+  /* Write. */ {
+    TBinaryOutputOnlyStream strm(recorder);
+    strm << out_context;
+  }
+  /* Read. */ {
+    TBinaryInputOnlyStream strm(make_shared<TPlayer>(recorder));
+    strm >> in_context;
+  }
+  if (EXPECT_EQ(in_context.UpdateVec.size(), 1UL)) {
+    const auto &in_update = in_context.UpdateVec[0];
+    if (EXPECT_EQ(in_update.EntryVec.size(), 3UL)) {
+      EXPECT_EQ(static_cast<int>(in_update.EntryVec[0].Mutator), static_cast<int>(TMutator::Assign));
+      EXPECT_EQ(static_cast<int>(in_update.EntryVec[1].Mutator), static_cast<int>(TMutator::Add));
+      EXPECT_EQ(static_cast<int>(in_update.EntryVec[2].Mutator), static_cast<int>(TMutator::Mult));
+    }
+  }
+}


### PR DESCRIPTION
Closes #54.

## The gap

`TContextOutputStreamer::TUpdate::EntryVec` dropped the per-entry Mutator at serialization time. Slaves reconstructed deferred `{Add, n}` entries as `Assign(n)` and silently lost updates on concurrent writes that landed on the master. The on-disk format has carried Mutator since PR #50 phase 1; this PR closes the matching gap on the master→slave wire.

## Changes

- **`orly/indy/util/context_streamer.h`** — `TUpdate::EntryVec` element type goes from `pair<TIndexKey, TCore>` to a 3-field `TEntry` struct that also holds `Mutator`. Both `Write` paths (`TContextOutputStreamer` + `TContextInputStreamer` — the latter used for slave→slave forwarding) emit the Mutator as a `uint32_t` after the existing per-entry fields. The matching `Read` parses + stores it.
- **`orly/indy/manager.cc:693`** (slave-side replay) — split entries by mutator on the way to a new `TUpdate`. Assign-tagged entries go through the existing `TOpByKey` ctor path; non-Assign entries get registered via `update->AddEntry(idx_key, op, mutator)` so the deferred commutative info survives to the slave's memory layer. Mirrors the `TRepo::GetLowestUpdate` fix from PR #52 — same logical shape, different mechanism.

## Wire-format compatibility

There's no wire-format version handshake in this codebase, so master/slave are assumed to be the same build (which has always been the case). Same compatibility model as the on-disk format changes since PR #50.

## Test plan

- [x] New `MutatorRoundTrip` fixture in `context_streamer.test`: serialises a `TUpdate` with Assign + Add + Mult entries through the recorder→player path, asserts all three mutators survive. Pre-fix all three would have come back as Assign.
- [x] `make test`: 192/192.
- [x] `lang_test.py`: 120 pass / 3 known pre-existing fails. Unchanged from baseline.
- [x] wikipedia-pageviews demo: both drivers pass at large scale (the demo uses `--mem_sim` so doesn't go through the replication path, but a regression in the in-process path would also break it).

## Files

| File | Lines | What |
|---|---|---|
| `orly/indy/util/context_streamer.h` | +35/-11 | New `TEntry` struct; Mutator in both Write paths + Read |
| `orly/indy/util/context_streamer.test.cc` | +53 | `MutatorRoundTrip` fixture |
| `orly/indy/manager.cc` | +16/-1 | Slave-replay splits entries by mutator |
