### PR TITLE
indy/disk: skip TFoldDataFile pass when source has no non-Assign entries (closes #64)

### DIFF
--- a/orly/indy/disk/merge_data_file.cc
+++ b/orly/indy/disk/merge_data_file.cc
@@ -764,9 +764,11 @@ class TMergeDataFileImpl {
         }
 
       }
-      /* compute the total number of current keys */ {
+      /* compute the total number of current keys + non-Assign entries
+         across all indices */ {
         for (const auto &idx : index_map) {
           NumKeys += idx.second->NumCurKeys;
+          NumNonAssignEntries += idx.second->NumNonAssignEntries;
         }
       }
       completion_trigger.Wait();
@@ -1943,6 +1945,13 @@ class TMergeDataFileImpl {
     return NumKeys;
   }
 
+  /* Aggregate count of entries with Mutator != Assign across all
+     indices in this merge output. Used by TSafeRepo::MergeFiles to
+     skip the TFoldDataFile pass when there's nothing to fold (#64). */
+  inline size_t GetNumNonAssignEntries() const {
+    return NumNonAssignEntries;
+  }
+
   /* TODO */
   inline TSequenceNumber GetLowestSequence() const {
     return LowestSeq;
@@ -2222,6 +2231,7 @@ class TMergeDataFileImpl {
 
     void PushCurKey(TSequenceNumber seq_num, const Atom::TCore &key, const Atom::TCore &val, TMutator mutator) {
       ++NumCurKeys;
+      if (mutator != TMutator::Assign) ++NumNonAssignEntries;
       TDataOutStream &stream = *KeyStream;
       if (!FirstKey) {
         stream << NumCurHistoryElem << ByteOffsetOfCurHistory;
@@ -2277,6 +2287,7 @@ class TMergeDataFileImpl {
 
     void PushHistKey(TSequenceNumber seq_num, const Atom::TCore &key, const Atom::TCore &val, TMutator mutator) {
       ++NumHistKeys;
+      if (mutator != TMutator::Assign) ++NumNonAssignEntries;
       HistKeyVec.emplace_back(seq_num, key, val, mutator);
       UpdateCollector->Emplace(seq_num, ByteOffsetOfCurHistory + NumCurHistoryElem * TData::KeyHistorySize, false, IndexId);
       ++NumCurHistoryElem;
@@ -2555,6 +2566,12 @@ class TMergeDataFileImpl {
     std::vector<std::unique_ptr<typename TRemapResolvedSorter::TCursor>> ResolvedValSorterCursorVec;
     size_t NumCurKeys;
     size_t NumHistKeys;
+    /* Per-index count of entries with Mutator != Assign. Accumulated in
+       PushCurKey / PushHistKey. The aggregate (across indices) is
+       surfaced via TMergeDataFile::GetNumNonAssignEntries() and used by
+       TSafeRepo::MergeFiles to skip the TFoldDataFile pass on files
+       that have nothing to fold (#64). */
+    size_t NumNonAssignEntries = 0UL;
     size_t EndOfHistoryStream;
     std::vector<THistKey> HistKeyVec;
     size_t NumCurHistoryElem;
@@ -2663,6 +2680,7 @@ class TMergeDataFileImpl {
 
   /* TODO */
   size_t NumKeys;
+  size_t NumNonAssignEntries = 0UL;
   TSequenceNumber LowestSeq;
   TSequenceNumber HighestSeq;
 
@@ -2709,17 +2727,20 @@ TMergeDataFile::TMergeDataFile(Util::TEngine *engine,
     if (can_tail_tombstone) {
       TMergeDataFileImpl<true, true> merge_file(engine, storage_speed, file_uuid, gen_vec, file_uid, gen_id, release_up_to, priority, max_block_cache_read_slots_allowed, temp_file_consol_thresh);
       NumKeys = merge_file.GetNumKeys();
+      NumNonAssignEntries = merge_file.GetNumNonAssignEntries();
       LowestSeq = merge_file.GetLowestSequence();
       HighestSeq = merge_file.GetHighestSequence();
     } else {
       TMergeDataFileImpl<true, false> merge_file(engine, storage_speed, file_uuid, gen_vec, file_uid, gen_id, release_up_to, priority, max_block_cache_read_slots_allowed, temp_file_consol_thresh);
       NumKeys = merge_file.GetNumKeys();
+      NumNonAssignEntries = merge_file.GetNumNonAssignEntries();
       LowestSeq = merge_file.GetLowestSequence();
       HighestSeq = merge_file.GetHighestSequence();
     }
   } else {
     TMergeDataFileImpl<false, false> merge_file(engine, storage_speed, file_uuid, gen_vec, file_uid, gen_id, release_up_to, priority, max_block_cache_read_slots_allowed, temp_file_consol_thresh);
     NumKeys = merge_file.GetNumKeys();
+    NumNonAssignEntries = merge_file.GetNumNonAssignEntries();
     LowestSeq = merge_file.GetLowestSequence();
     HighestSeq = merge_file.GetHighestSequence();
     assert(!can_tail_tombstone);

--- a/orly/indy/disk/merge_data_file.h
+++ b/orly/indy/disk/merge_data_file.h
@@ -61,6 +61,13 @@ namespace Orly {
           return NumKeys;
         }
 
+        /* Aggregate count of entries written with Mutator != Assign.
+           Used by TSafeRepo::MergeFiles to skip the TFoldDataFile pass
+           when zero -- there's nothing to fold (#64). */
+        inline size_t GetNumNonAssignEntries() const {
+          return NumNonAssignEntries;
+        }
+
         /* TODO */
         inline TSequenceNumber GetLowestSequence() const {
           return LowestSeq;
@@ -74,6 +81,7 @@ namespace Orly {
         private:
 
         size_t NumKeys;
+        size_t NumNonAssignEntries = 0UL;
         TSequenceNumber LowestSeq;
         TSequenceNumber HighestSeq;
 

--- a/orly/indy/disk/merge_data_file.test.cc
+++ b/orly/indy/disk/merge_data_file.test.cc
@@ -558,3 +558,71 @@ FIXTURE(JumpGrowingMainArena) {
     cond.notify_one();
   });
 }
+
+/* #64: TMergeDataFile reports a count of entries written with
+   Mutator != Assign. The aggregate is used by TSafeRepo::MergeFiles
+   to skip the TFoldDataFile pass when nothing needs folding. */
+FIXTURE(NonAssignEntryCount) {
+  TFiberTestRunner runner([](std::mutex &mut, std::condition_variable &cond, bool &fin, Fiber::TRunner::TRunnerCons &) {
+    void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
+    TScheduler scheduler(TScheduler::TPolicy(4, 10, milliseconds(10)));
+    Sim::TMemEngine mem_engine(&scheduler, 256, 256, 16384, 1, 1024, 1);
+
+    Base::TUuid file_id(TUuid::Best);
+    Base::TUuid index_id(TUuid::Twister);
+    TSuprena arena;
+
+    /* Case A: pure-Assign source. Merge should report 0. */ {
+      TMockMem mem_layer;
+      TSequenceNumber seq = 0;
+      Insert(mem_layer, ++seq, index_id, /*val*/ 10L, /*key*/ 1L);
+      Insert(mem_layer, ++seq, index_id, /*val*/ 20L, /*key*/ 2L);
+      Insert(mem_layer, ++seq, index_id, /*val*/ 30L, /*key*/ 3L);
+      TDataFile data_file(mem_engine.GetEngine(), TVolume::TDesc::Fast,
+                          &mem_layer, file_id, 1UL, 20UL, 0U, Medium);
+      TMergeDataFile merge(mem_engine.GetEngine(), TVolume::TDesc::Fast,
+                           file_id, vector<size_t>{1UL}, file_id, 2UL,
+                           0U, Low, 16384, 20UL, false, false);
+      EXPECT_EQ(merge.GetNumNonAssignEntries(), 0UL);
+    }
+
+    /* Case B: source with two Add entries plus an Assign. Merge should
+       count the two Adds. */ {
+      TMockMem mem_layer;
+      TSequenceNumber seq = 0;
+      Insert(mem_layer, ++seq, index_id, /*val*/ 100L, /*key*/ 5L);  // Assign
+      /* Two Adds via the AddEntry-with-mutator overload. */
+      auto u1 = TMockUpdate::NewMockUpdate(
+          TUpdate::TOpByKey{},
+          TKey(&arena),
+          TKey(Base::TUuid(Base::TUuid::Twister), &arena, state_alloc),
+          ++seq);
+      u1->AddEntry(
+          TIndexKey(index_id, TKey(make_tuple(5L), &arena, state_alloc)),
+          TKey(int64_t(7), &arena, state_alloc),
+          TMutator::Add);
+      mem_layer.Insert(u1);
+      auto u2 = TMockUpdate::NewMockUpdate(
+          TUpdate::TOpByKey{},
+          TKey(&arena),
+          TKey(Base::TUuid(Base::TUuid::Twister), &arena, state_alloc),
+          ++seq);
+      u2->AddEntry(
+          TIndexKey(index_id, TKey(make_tuple(5L), &arena, state_alloc)),
+          TKey(int64_t(3), &arena, state_alloc),
+          TMutator::Add);
+      mem_layer.Insert(u2);
+      TDataFile data_file(mem_engine.GetEngine(), TVolume::TDesc::Fast,
+                          &mem_layer, file_id, 3UL, 20UL, 0U, Medium);
+      TMergeDataFile merge(mem_engine.GetEngine(), TVolume::TDesc::Fast,
+                           file_id, vector<size_t>{3UL}, file_id, 4UL,
+                           0U, Low, 16384, 20UL, false, false);
+      EXPECT_EQ(merge.GetNumNonAssignEntries(), 2UL);
+    }
+
+    std::lock_guard<std::mutex> lock(mut);
+    fin = true;
+    cond.notify_one();
+  });
+}
+

--- a/orly/indy/repo.cc
+++ b/orly/indy/repo.cc
@@ -1316,6 +1316,16 @@ size_t TSafeRepo::MergeFiles(const std::vector<size_t> &gen_id_vec,
      with same-mutator commutative runs still expanded -- correct but
      unbounded in entries-per-key under contention. */
   TMergeDataFile merge_data_file(Manager->GetEngine(), storage_speed, GetId(), gen_id_vec, GetId(), intermediate_gen_id, release_up_to, Low, max_block_cache_read_slots_allowed, temp_file_consol_thresh, my_can_tail, my_can_tail_tombstone);
+  /* Fast path (#64): if the merge produced no non-Assign entries,
+     there's nothing to fold and the intermediate file IS the final
+     output. Skip the TFoldDataFile read+write+remove cycle entirely.
+     Most workloads are Assign-only and hit this path. */
+  if (merge_data_file.GetNumNonAssignEntries() == 0UL) {
+    out_num_keys = merge_data_file.GetNumKeys();
+    out_saved_low_seq = merge_data_file.GetLowestSequence();
+    out_saved_high_seq = merge_data_file.GetHighestSequence();
+    return intermediate_gen_id;
+  }
   /* Phase B (#55): fold same-mutator commutative runs in the just-merged
      file via TMutation::Augment-equivalent logic in typed space. Output
      entries are promoted to Assign(folded value), bringing read


### PR DESCRIPTION
Closes #64.

## What it does

Phase 4's fold pass (PR #63) always ran after every merge, even for files that contained only Assign entries (most workloads). For those the fold pass is a no-op: read everything once, write everything once, remove the intermediate file. Pure I/O cost for no benefit.

This PR adds a fast-path skip: if the merge produced zero non-Assign entries, the intermediate file IS the final output, and `TSafeRepo::MergeFiles` returns its gen_id directly without going through `TFoldDataFile`.

## How

Of the three options sketched in the issue body, went with **(c) TMergeDataFile counts entries during write** — strictly better than (a) on-disk metadata flag (no format change) and (b) quick-scan at fold time (no extra read pass). `TMergeDataFile` already iterates every entry, so the count is free.

- `merge_data_file.cc` `TMergeIndexFile` gains `NumNonAssignEntries` member; `PushCurKey` / `PushHistKey` increment when `Mutator != Assign`.
- `TMergeDataFileImpl` aggregates across all indices when summing keys.
- `TMergeDataFile` (public class) exposes `GetNumNonAssignEntries()`, populated from the impl in all three template instantiations.
- `TSafeRepo::MergeFiles` (`repo.cc:1318`): early-return with `intermediate_gen_id` when the count is zero; skip the fold read+write+remove cycle entirely.

## Cost / benefit

- Cost: a single integer increment per `PushCurKey`/`PushHistKey` call. Zero I/O overhead.
- Benefit: saves one full read pass + one full write pass + one `RemoveFile` per compaction for pure-Assign workloads (which is most of them).

## Test plan

- [x] New `NonAssignEntryCount` fixture in `merge_data_file.test`: asserts the counter reports 0 for a pure-Assign source and 2 for a source with two Add entries plus an Assign.
- [x] `make test`: 192/192.
- [x] `lang_test.py`: 120 pass / 3 known pre-existing fails. Unchanged.
- [x] wikipedia-pageviews demo: both drivers still pass at large scale. (Uses `--mem_sim` so compaction doesn't fire, but a regression in the in-process path would also break it.)

## Files

| File | Lines | What |
|---|---|---|
| `orly/indy/disk/merge_data_file.cc` | +22/-1 | Counter in TMergeIndexFile + aggregation + getter in TMergeDataFileImpl + populate in TMergeDataFile ctor |
| `orly/indy/disk/merge_data_file.h` | +8 | `GetNumNonAssignEntries()` + member |
| `orly/indy/disk/merge_data_file.test.cc` | +68 | `NonAssignEntryCount` fixture |
| `orly/indy/repo.cc` | +10 | Fast-path skip in `TSafeRepo::MergeFiles` |
