### PR TITLE
examples: agent-swarm knowledge-graph demo (concurrent |= and +=)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,3 +228,23 @@ jobs:
         working-directory: examples/wikipedia-pageviews
         env:
           DEMO_SCALE: small
+
+      # Multi-agent knowledge-graph demo: N concurrent agents each
+      # extract from a disjoint slice of a corpus, writing tags
+      # (|= set-union), per-doc mentions (+= int), and per-pair
+      # cooccurrences (+= int) into one shared POV with zero
+      # coordination. Combines both commutative-write shapes from the
+      # demos above and runs them concurrently -- the shape multi-agent
+      # LLM-extraction pipelines need. DEMO_SCALE=small uses 4 agents
+      # over 20 docs for CI tractability.
+      - name: agent-swarm run.sh (python driver, concurrent |= and +=)
+        run: ./run.sh
+        working-directory: examples/agent-swarm
+        env:
+          DEMO_SCALE: small
+
+      - name: agent-swarm run-go.sh (go driver, concurrent |= and +=)
+        run: ./run-go.sh
+        working-directory: examples/agent-swarm
+        env:
+          DEMO_SCALE: small

--- a/README.md
+++ b/README.md
@@ -93,7 +93,28 @@ Most databases force a tradeoff on this workload:
 
 The mechanism: each `+=` emits an `{Add, n}` mutation at the storage layer instead of resolving to a value at write time, and the read path folds same-mutator runs back into the resolved value. CI runs this as the workload-level integration test for the property; pass `DEMO_SCALE=small` for the CI-friendly 4-writer / 800-event variant.
 
-All three examples ship two equivalent drivers — Python (`./run.sh`) and Go (`./run-go.sh`) — and are smoke-tested in CI on every push.
+### [`examples/agent-swarm/`](examples/agent-swarm/) — multi-agent knowledge-graph extraction without coordination
+
+The shape multi-agent LLM pipelines keep reinventing badly. N independent extractor "agents" each process a disjoint slice of a corpus and stream tags, mentions, and cooccurrences into one shared knowledge graph — **with zero coordination**. No locks, no per-agent partitioning, no driver-side merge logic. Combines both commutative-write shapes from the demos above and runs them concurrently:
+
+- `*<['entity', e]>::({str}) |= {tag}` — set-union per entity (the `wikipedia-categories` operator, but concurrent)
+- `*<['mention', e, d]>::(int) += 1` — per-(entity, doc) counter
+- `*<['cooccur', a, b]>::(int) += 1` — per-unordered-pair counter
+
+8 agents extract from 40 docs concurrently, with hot entities (`Python`, `OpenAI`, `Claude`, `GPT-4`, …) deliberately round-robined across agents so they collide on the same keys; the self-check confirms every tag set, mention counter, and cooccurrence counter matches the independently-derived ground truth (25 tag sets + 105 mention counters + 76 cooccurrence pairs, zero lost extractions).
+
+What this would normally require:
+
+| Approach | Problem under N concurrent agents |
+|---|---|
+| Per-agent local graph + post-hoc merge | Doubles storage; merge logic has to commute by hand |
+| Read-modify-write per fact (`UPDATE … SET tags = tags ∪ {…}`) | Row lock per write; agents serialize on hot entities |
+| Single-writer service in front of the store | Throughput ceiling = one writer; agents queue |
+| **Orly** | `\|=` and `+=` are field calls; lock-free; all N agents land their contributions and the engine aggregates |
+
+Why it matters: this is exactly the topology AI extraction pipelines have — many agents reading disjoint chunks, emitting overlapping facts into one graph — and every conventional database forces you to invent a coordination protocol on top. Orly gives it to you for free, as a direct consequence of how field calls work. The driver never reads-then-writes; it only ever calls the three commutative functions in [`graph.orly`](examples/agent-swarm/graph.orly).
+
+All four examples ship two equivalent drivers — Python (`./run.sh`) and Go (`./run-go.sh`) — and are smoke-tested in CI on every push.
 
 ## Walkthrough
 

--- a/examples/agent-swarm/README.md
+++ b/examples/agent-swarm/README.md
@@ -1,0 +1,59 @@
+# Multi-agent knowledge graph — concurrent extraction demo
+
+The shape multi-agent LLM systems keep reinventing badly: many extractor agents reading disjoint chunks of a corpus, each emitting facts about overlapping entities into one shared knowledge graph. N concurrent WebSocket "agents" all stream tags, mentions, and co-occurrences into the same Orly POV with **zero coordination** — no locks, no per-agent partitioning, no merge-on-read logic in the driver. The demo self-checks that every contribution lands.
+
+## The trick
+
+Three commutative field calls — no read-modify-write anywhere:
+
+```orly
+*<['entity', e]>::({str})    |= {tag}    # set union per entity
+*<['mention', e, d]>::(int)  += 1        # per (entity, doc) counter
+*<['cooccur', a, b]>::(int)  += 1        # per unordered-pair counter
+```
+
+`|=` and `+=` are field **calls**, not field changes. Two agents concurrently doing `add_tag("Python", "popular")` each emit a deferred `{Union, {"popular"}}` mutation at the storage layer; the read path folds them via `Rt::Mutate` back into the correct set. No lock, no race, no lost updates — the same mechanism powers [`wikipedia-pageviews/`](../wikipedia-pageviews/) (counters) and [`wikipedia-categories/`](../wikipedia-categories/) (set unions).
+
+What an LLM-extraction pipeline would normally need:
+
+| Approach | Problem |
+|---|---|
+| Per-agent local graph + post-hoc merge | Doubles storage; merge logic has to commute by hand. |
+| Read-modify-write per fact (Postgres `UPDATE ... SET tags = tags <> ...`) | Row lock per write; N agents serialize on hot entities. |
+| Single-writer service in front of the store | Throughput ceiling = one writer; agents wait on the queue. |
+| Orly: `*<['entity', e]>::({str}) \|= {tag}` | Field call; lock-free; N agents land their unions, the engine aggregates. |
+
+## Run it
+
+Python:
+
+```sh
+cd examples/agent-swarm
+./run.sh
+```
+
+Go:
+
+```sh
+cd examples/agent-swarm
+./run-go.sh
+```
+
+Both wrappers require `make debug` to have produced `orlyi` and `orlyc`. Each kills any prior demo instance, starts a fresh `orlyi`, and runs the driver.
+
+`DEMO_SCALE=small` runs 4 agents over the first 20 docs (CI default). The default (`DEMO_SCALE=large` or unset) runs 8 agents over all 40 docs.
+
+Exit code is non-zero if the verifier finds any tag set, mention counter, or cooccurrence counter that disagrees with the independently-derived ground truth.
+
+## What the demo proves
+
+- **No lost extractions under contention.** Hot entities (Python, OpenAI, Anthropic, Claude, GPT-4, Microsoft, Google) appear in many docs; agents are assigned docs round-robin so multiple agents hit the same entity concurrently. Every `add_tag` / `add_mention` / `add_cooccur` call lands.
+- **Tag sets converge.** Different docs assign different tags to the same entity (Python picks up `language` from some docs, `popular` from others). The on-disk tag set after ingest equals the union derived from the corpus.
+- **No driver-side merge logic.** The driver never reads-then-writes. It only ever calls the three field-call functions in [`graph.orly`](graph.orly). Aggregation is the engine's job.
+
+## Related demos
+
+- [`wikipedia-pageviews/`](../wikipedia-pageviews/) — the same `+= n` field call against integer counters under concurrent writers. The original issue-#49 motivating workload.
+- [`wikipedia-categories/`](../wikipedia-categories/) — the same `|= {x}` field call against set unions, but single-writer. This demo combines both shapes and runs them concurrently.
+
+This one demonstrates that the commutative-write story generalises directly to the shape AI builders care about: **many independent agents writing into one shared graph, without any coordination protocol**.

--- a/examples/agent-swarm/demo.go
+++ b/examples/agent-swarm/demo.go
@@ -1,0 +1,592 @@
+// Multi-agent knowledge-graph demo, in Go.
+//
+// Mirrors demo.py: same corpus, same scenario shape, same self-check,
+// same output layout. Provided so readers can pick whichever language
+// matches their environment. Each driver verifies its own derived
+// ground truth, so the two pass independently.
+//
+// Two workload sizes (controlled by DEMO_SCALE, mirroring demo.py):
+//
+//	DEMO_SCALE=small  -- 4 agents over the first 20 docs (CI-friendly).
+//	anything else     -- 8 agents over all 40 docs (showcase).
+//
+// Run via the wrapper:
+//
+//	./run-go.sh
+//
+// Or directly, after starting orlyi separately:
+//
+//	go run demo.go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const wsURL = "ws://127.0.0.1:8082/"
+
+// Per-call recv timeout. Mirrors wikipedia-pageviews/demo.go: normal
+// latency is well under a second; 30s is generous-but-finite so a hung
+// orlyi surfaces as a failed read rather than a multi-minute CI timeout.
+const wsTimeout = 30 * time.Second
+
+// doc represents one corpus entry: the human-readable text plus the
+// "extraction" the demo treats as ground truth (entity -> tag list).
+type doc struct {
+	text     string
+	entities map[string][]string
+}
+
+// corpus is the hand-written corpus shared with demo.py. Each entry's
+// {entity: [tags]} dict IS the structured extraction; the sentence
+// text is human-readable flavor only.
+//
+// Hot entities (Python, OpenAI, Anthropic, Claude, GPT-4, Microsoft,
+// Google) appear in many docs to drive real contention on the
+// counters and tag sets.
+var corpus = []doc{
+	{"Python and Rust dominate modern systems work at OpenAI.", map[string][]string{
+		"Python": {"language", "popular"}, "Rust": {"language"},
+		"OpenAI": {"company", "ai-lab"}}},
+	{"Anthropic trained Claude on a custom Transformer architecture.", map[string][]string{
+		"Anthropic": {"company", "ai-lab"}, "Claude": {"model", "llm"},
+		"Transformer": {"model"}}},
+	{"GitHub Copilot now offers Claude alongside GPT-4 for code.", map[string][]string{
+		"GitHub": {"company", "tool"}, "Claude": {"model", "llm"},
+		"GPT-4": {"model", "llm"}}},
+	{"Linus Torvalds still maintains Linux from a laptop running Git.", map[string][]string{
+		"Linus": {"person"}, "Linux": {"tool", "open-source"},
+		"Git": {"tool", "open-source"}}},
+	{"Guido van Rossum joined Microsoft to improve Python performance.", map[string][]string{
+		"Guido": {"person"}, "Microsoft": {"company"},
+		"Python": {"language", "popular"}}},
+	{"Kubernetes manages workloads at Google, Meta, and Microsoft.", map[string][]string{
+		"Kubernetes": {"tool"}, "Google": {"company"},
+		"Meta": {"company"}, "Microsoft": {"company"}}},
+	{"Docker simplified deployment for Python and JavaScript developers.", map[string][]string{
+		"Docker": {"tool"}, "Python": {"language", "popular"},
+		"JavaScript": {"language", "popular"}}},
+	{"Meta released Llama as a competitive open-source LLM.", map[string][]string{
+		"Meta":  {"company", "ai-lab"},
+		"Llama": {"model", "llm", "open-source"}}},
+	{"PostgreSQL remains the database of choice at OpenAI for analytics.", map[string][]string{
+		"PostgreSQL": {"tool", "database"}, "OpenAI": {"company", "ai-lab"}}},
+	{"Sam Altman discussed GPT-4 in a recent OpenAI announcement.", map[string][]string{
+		"Sam": {"person"}, "GPT-4": {"model", "llm"},
+		"OpenAI": {"company", "ai-lab"}}},
+	{"Rust is gaining traction at Microsoft for systems-level libraries.", map[string][]string{
+		"Rust": {"language"}, "Microsoft": {"company"}}},
+	{"TypeScript powers most modern JavaScript codebases at Google.", map[string][]string{
+		"TypeScript": {"language"}, "JavaScript": {"language", "popular"},
+		"Google": {"company"}}},
+	{"Java still dominates enterprise software at Microsoft and Google.", map[string][]string{
+		"Java": {"language", "enterprise"}, "Microsoft": {"company"},
+		"Google": {"company"}}},
+	{"Ruby on Rails was created by a Danish developer; GitHub uses it.", map[string][]string{
+		"Ruby": {"language"}, "GitHub": {"company", "tool"}}},
+	{"Go was designed at Google to simplify backend programming.", map[string][]string{
+		"Go": {"language"}, "Google": {"company"}}},
+	{"Kubernetes orchestrates Docker containers in production at Meta.", map[string][]string{
+		"Kubernetes": {"tool"}, "Docker": {"tool"},
+		"Meta": {"company", "ai-lab"}}},
+	{"Claude can analyze long documents with its large context window.", map[string][]string{
+		"Claude": {"model", "llm"}}},
+	{"GPT-4 powers many tools released by OpenAI in recent years.", map[string][]string{
+		"GPT-4": {"model", "llm"}, "OpenAI": {"company", "ai-lab"}}},
+	{"Linux servers run most of the infrastructure at Google.", map[string][]string{
+		"Linux": {"tool", "open-source"}, "Google": {"company"}}},
+	{"Git is the version control system at Microsoft, Google, and Anthropic.", map[string][]string{
+		"Git": {"tool", "open-source"}, "Microsoft": {"company"},
+		"Google": {"company"}, "Anthropic": {"company", "ai-lab"}}},
+	{"Llama runs locally on a laptop with sufficient RAM.", map[string][]string{
+		"Llama": {"model", "llm", "open-source"}}},
+	{"PostgreSQL backs most production systems at GitHub and Anthropic.", map[string][]string{
+		"PostgreSQL": {"tool", "database"}, "GitHub": {"company", "tool"},
+		"Anthropic": {"company", "ai-lab"}}},
+	{"Python's ecosystem includes scientific tools widely used at OpenAI.", map[string][]string{
+		"Python": {"language", "popular"}, "OpenAI": {"company", "ai-lab"}}},
+	{"Anthropic recently expanded the Claude API for enterprise customers.", map[string][]string{
+		"Anthropic": {"company", "ai-lab"}, "Claude": {"model", "llm"}}},
+	{"Guido and Linus both shaped modern open-source culture.", map[string][]string{
+		"Guido": {"person"}, "Linus": {"person"}}},
+	{"Sam Altman leads OpenAI through aggressive product launches.", map[string][]string{
+		"Sam": {"person"}, "OpenAI": {"company", "ai-lab"}}},
+	{"Transformers underpin both Claude and GPT-4 architectures.", map[string][]string{
+		"Transformer": {"model"}, "Claude": {"model", "llm"},
+		"GPT-4": {"model", "llm"}}},
+	{"Meta engineers contribute heavily to PyTorch and the Python ecosystem.", map[string][]string{
+		"Meta": {"company", "ai-lab"}, "Python": {"language", "popular"}}},
+	{"Rust adoption is rising at Microsoft, Google, and Meta.", map[string][]string{
+		"Rust": {"language"}, "Microsoft": {"company"},
+		"Google": {"company"}, "Meta": {"company"}}},
+	{"JavaScript remains the most-used language on GitHub by far.", map[string][]string{
+		"JavaScript": {"language", "popular"}, "GitHub": {"company", "tool"}}},
+	{"TypeScript brings type safety to JavaScript codebases at Microsoft.", map[string][]string{
+		"TypeScript": {"language"}, "JavaScript": {"language", "popular"},
+		"Microsoft": {"company"}}},
+	{"Go's concurrency model influenced design choices at Anthropic.", map[string][]string{
+		"Go": {"language"}, "Anthropic": {"company", "ai-lab"}}},
+	{"Linux Foundation projects include Kubernetes, Docker, and Git.", map[string][]string{
+		"Linux": {"tool", "open-source"}, "Kubernetes": {"tool"},
+		"Docker": {"tool"}, "Git": {"tool", "open-source"}}},
+	{"Java powers Android development; Google supports it heavily.", map[string][]string{
+		"Java": {"language", "enterprise"}, "Google": {"company"}}},
+	{"Ruby developers often migrate to Python or Go for performance.", map[string][]string{
+		"Ruby": {"language"}, "Python": {"language", "popular"},
+		"Go": {"language"}}},
+	{"Claude can write and review Python, JavaScript, and Go code.", map[string][]string{
+		"Claude": {"model", "llm"}, "Python": {"language", "popular"},
+		"JavaScript": {"language", "popular"}, "Go": {"language"}}},
+	{"GPT-4 fine-tunes are restricted compared to open Llama weights.", map[string][]string{
+		"GPT-4": {"model", "llm"},
+		"Llama": {"model", "llm", "open-source"}}},
+	{"OpenAI and Anthropic compete in the enterprise LLM market.", map[string][]string{
+		"OpenAI":    {"company", "ai-lab"},
+		"Anthropic": {"company", "ai-lab"}}},
+	{"Microsoft has invested heavily in OpenAI and integrated GPT-4.", map[string][]string{
+		"Microsoft": {"company"}, "OpenAI": {"company", "ai-lab"},
+		"GPT-4": {"model", "llm"}}},
+	{"Docker images at Anthropic typically ship Python and Rust binaries.", map[string][]string{
+		"Docker": {"tool"}, "Anthropic": {"company", "ai-lab"},
+		"Python": {"language", "popular"}, "Rust": {"language"}}},
+}
+
+// Populated from DEMO_SCALE in initScale().
+var (
+	numAgents int
+	numDocs   int
+)
+
+func initScale() {
+	numAgents = 8
+	numDocs = 40
+	if strings.ToLower(os.Getenv("DEMO_SCALE")) == "small" {
+		numAgents = 4
+		numDocs = 20
+	}
+}
+
+// canonicalPair returns (smaller, larger) so add_cooccur(A,B) and
+// add_cooccur(B,A) collapse to the same key.
+func canonicalPair(a, b string) (string, string) {
+	if a < b {
+		return a, b
+	}
+	return b, a
+}
+
+type mentionKey struct {
+	entity string
+	docID  int
+}
+
+type pairKey struct {
+	a, b string
+}
+
+func computeGroundTruth(docs []doc) (
+	expectedTags map[string]map[string]bool,
+	expectedMentions map[mentionKey]int,
+	expectedCooccur map[pairKey]int,
+) {
+	expectedTags = map[string]map[string]bool{}
+	expectedMentions = map[mentionKey]int{}
+	expectedCooccur = map[pairKey]int{}
+	for docID, d := range docs {
+		for entity, tags := range d.entities {
+			if expectedTags[entity] == nil {
+				expectedTags[entity] = map[string]bool{}
+			}
+			for _, t := range tags {
+				expectedTags[entity][t] = true
+			}
+			expectedMentions[mentionKey{entity, docID}] = 1
+		}
+		names := make([]string, 0, len(d.entities))
+		for n := range d.entities {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		for i, a := range names {
+			for _, b := range names[i+1:] {
+				ca, cb := canonicalPair(a, b)
+				expectedCooccur[pairKey{ca, cb}]++
+			}
+		}
+	}
+	return
+}
+
+func send(c *websocket.Conn, stmt string) (interface{}, error) {
+	deadline := time.Now().Add(wsTimeout)
+	if err := c.SetWriteDeadline(deadline); err != nil {
+		return nil, err
+	}
+	if err := c.WriteMessage(websocket.TextMessage, []byte(stmt)); err != nil {
+		return nil, err
+	}
+	if err := c.SetReadDeadline(deadline); err != nil {
+		return nil, err
+	}
+	_, raw, err := c.ReadMessage()
+	if err != nil {
+		return nil, err
+	}
+	var r struct {
+		Status string      `json:"status"`
+		Result interface{} `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return nil, fmt.Errorf("bad reply json: %w (raw: %s)", err, raw)
+	}
+	if r.Status != "ok" {
+		return nil, fmt.Errorf("%s\n  -> %s", stmt, raw)
+	}
+	return r.Result, nil
+}
+
+func mustSend(c *websocket.Conn, stmt string) interface{} {
+	r, err := send(c, stmt)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+func addTag(c *websocket.Conn, pov, entity, tag string) {
+	mustSend(c, fmt.Sprintf(
+		`try {%s} graph add_tag <{.e: %q, .t: %q}>;`,
+		pov, entity, tag))
+}
+
+func addMention(c *websocket.Conn, pov, entity string, docID int) {
+	mustSend(c, fmt.Sprintf(
+		`try {%s} graph add_mention <{.e: %q, .d: %d}>;`,
+		pov, entity, docID))
+}
+
+func addCooccur(c *websocket.Conn, pov, a, b string) {
+	mustSend(c, fmt.Sprintf(
+		`try {%s} graph add_cooccur <{.a: %q, .b: %q}>;`,
+		pov, a, b))
+}
+
+func tagsForEntity(c *websocket.Conn, pov, entity string) map[string]bool {
+	r := mustSend(c, fmt.Sprintf(
+		`try {%s} graph tags_for_entity <{.e: %q}>;`,
+		pov, entity))
+	out := map[string]bool{}
+	if r == nil {
+		return out
+	}
+	for _, v := range r.([]interface{}) {
+		out[v.(string)] = true
+	}
+	return out
+}
+
+func mentionCount(c *websocket.Conn, pov, entity string, docID int) int {
+	r := mustSend(c, fmt.Sprintf(
+		`try {%s} graph mention_count <{.e: %q, .d: %d}>;`,
+		pov, entity, docID))
+	return int(r.(float64))
+}
+
+func mentionsTotal(c *websocket.Conn, pov, entity string, dStart, dEnd int) int {
+	r := mustSend(c, fmt.Sprintf(
+		`try {%s} graph mentions_total <{.e: %q, .d_start: %d, .d_end: %d}>;`,
+		pov, entity, dStart, dEnd))
+	return int(r.(float64))
+}
+
+func cooccurCount(c *websocket.Conn, pov, a, b string) int {
+	r := mustSend(c, fmt.Sprintf(
+		`try {%s} graph cooccur_count <{.a: %q, .b: %q}>;`,
+		pov, a, b))
+	return int(r.(float64))
+}
+
+// agentDoc is one (docID, doc) pair assigned to an agent.
+type agentDoc struct {
+	id  int
+	doc doc
+}
+
+// agent runs one writer goroutine: opens a fresh WS, opens a session,
+// ingests its slice of (doc_id, extraction) pairs into the shared POV.
+func agent(pov string, docs []agentDoc, wg *sync.WaitGroup) {
+	defer wg.Done()
+	dialer := *websocket.DefaultDialer
+	dialer.HandshakeTimeout = wsTimeout
+	c, _, err := dialer.Dial(wsURL, nil)
+	if err != nil {
+		panic(err)
+	}
+	defer c.Close()
+	mustSend(c, "new session;")
+	for _, ad := range docs {
+		for entity, tags := range ad.doc.entities {
+			for _, t := range tags {
+				addTag(c, pov, entity, t)
+			}
+			addMention(c, pov, entity, ad.id)
+		}
+		names := make([]string, 0, len(ad.doc.entities))
+		for n := range ad.doc.entities {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		for i, a := range names {
+			for _, b := range names[i+1:] {
+				ca, cb := canonicalPair(a, b)
+				addCooccur(c, pov, ca, cb)
+			}
+		}
+	}
+}
+
+// commaize prints non-negative ints with thousands separators.
+func commaize(n int) string {
+	s := fmt.Sprintf("%d", n)
+	if len(s) <= 3 {
+		return s
+	}
+	out := make([]byte, 0, len(s)+len(s)/3)
+	for i := 0; i < len(s); i++ {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			out = append(out, ',')
+		}
+		out = append(out, s[i])
+	}
+	return string(out)
+}
+
+func sortedTagList(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func tagSetsEqual(a, b map[string]bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if !b[k] {
+			return false
+		}
+	}
+	return true
+}
+
+func main() {
+	initScale()
+
+	docs := corpus[:numDocs]
+	expectedTags, expectedMentions, expectedCooccur := computeGroundTruth(docs)
+
+	// Round-robin assignment so hot entities collide across agents.
+	perAgent := make([][]agentDoc, numAgents)
+	for id, d := range docs {
+		perAgent[id%numAgents] = append(perAgent[id%numAgents], agentDoc{id, d})
+	}
+
+	totalWrites := 0
+	for _, tags := range expectedTags {
+		totalWrites += len(tags) // add_tag calls
+	}
+	totalWrites += len(expectedMentions) // add_mention calls
+	for _, n := range expectedCooccur {
+		totalWrites += n // add_cooccur calls
+	}
+
+	// Bootstrap: install graph + create the shared POV.
+	bootDialer := *websocket.DefaultDialer
+	bootDialer.HandshakeTimeout = wsTimeout
+	boot, _, err := bootDialer.Dial(wsURL, nil)
+	if err != nil {
+		panic(err)
+	}
+	mustSend(boot, "new session;")
+	mustSend(boot, "install graph.1;")
+	pov := mustSend(boot, "new safe shared pov;").(string)
+	fmt.Printf("pov: %s\n", pov)
+	fmt.Printf("agents: %d, docs: %d, entities: %d, unordered pairs: %d\n",
+		numAgents, numDocs, len(expectedTags), len(expectedCooccur))
+	fmt.Printf("total writes from agents: %s\n", commaize(totalWrites))
+
+	// Pre-initialise every key so concurrent agents take the
+	// commutative |= / += branch (never the `new <-` create branch).
+	fmt.Println("\npre-initialising all keys via the bootstrap session...")
+	for entity, tags := range expectedTags {
+		// Seed with the lex-first tag for determinism; agents union the rest.
+		first := sortedTagList(tags)[0]
+		addTag(boot, pov, entity, first)
+	}
+	for mk := range expectedMentions {
+		addMention(boot, pov, mk.entity, mk.docID)
+	}
+	for pk := range expectedCooccur {
+		addCooccur(boot, pov, pk.a, pk.b)
+	}
+
+	// Pre-init seeded each key with one of the agent ops; adjust expectations.
+	expectedMentionCount := map[mentionKey]int{}
+	for k, v := range expectedMentions {
+		expectedMentionCount[k] = v + 1
+	}
+	expectedCooccurCount := map[pairKey]int{}
+	for k, v := range expectedCooccur {
+		expectedCooccurCount[k] = v + 1
+	}
+
+	// Fan out: each agent on its own WS, all concurrent.
+	var wg sync.WaitGroup
+	t0 := time.Now()
+	for i := 0; i < numAgents; i++ {
+		wg.Add(1)
+		go agent(pov, perAgent[i], &wg)
+	}
+	wg.Wait()
+	elapsed := time.Since(t0)
+	rate := float64(totalWrites) / elapsed.Seconds()
+	fmt.Printf("\ningest done in %.2fs (%s writes/sec end-to-end with %d agents)\n",
+		elapsed.Seconds(), commaize(int(rate)), numAgents)
+
+	// ------------------------------------------------------------------
+	// Verify against ground truth.
+	// ------------------------------------------------------------------
+	fmt.Println()
+	fmt.Println("=== verifying knowledge graph ===")
+	var failures []string
+
+	for entity, wantTags := range expectedTags {
+		gotTags := tagsForEntity(boot, pov, entity)
+		if !tagSetsEqual(gotTags, wantTags) {
+			failures = append(failures, fmt.Sprintf(
+				"tags(%s): got %v, want %v",
+				entity, sortedTagList(gotTags), sortedTagList(wantTags)))
+		}
+	}
+	for mk, want := range expectedMentionCount {
+		got := mentionCount(boot, pov, mk.entity, mk.docID)
+		if got != want {
+			failures = append(failures, fmt.Sprintf(
+				"mention(%s, %d): got %d, want %d",
+				mk.entity, mk.docID, got, want))
+		}
+	}
+	for pk, want := range expectedCooccurCount {
+		got := cooccurCount(boot, pov, pk.a, pk.b)
+		if got != want {
+			failures = append(failures, fmt.Sprintf(
+				"cooccur(%s, %s): got %d, want %d",
+				pk.a, pk.b, got, want))
+		}
+	}
+
+	// Per-entity rollup, sorted hottest-first.
+	perEntityMentions := map[string]int{}
+	for mk, v := range expectedMentionCount {
+		perEntityMentions[mk.entity] += v
+	}
+	entitiesByHeat := make([]string, 0, len(perEntityMentions))
+	for e := range perEntityMentions {
+		entitiesByHeat = append(entitiesByHeat, e)
+	}
+	sort.Slice(entitiesByHeat, func(i, j int) bool {
+		if perEntityMentions[entitiesByHeat[i]] != perEntityMentions[entitiesByHeat[j]] {
+			return perEntityMentions[entitiesByHeat[i]] > perEntityMentions[entitiesByHeat[j]]
+		}
+		return entitiesByHeat[i] < entitiesByHeat[j]
+	})
+
+	dash14 := strings.Repeat("-", 14)
+	dash9 := strings.Repeat("-", 9)
+	dash30 := strings.Repeat("-", 30)
+	fmt.Printf("  %-14s  %9s  %9s  %s\n", "entity", "mentions", "expected", "tags")
+	fmt.Printf("  %-14s  %9s  %9s  %s\n", dash14, dash9, dash9, dash30)
+	for _, entity := range entitiesByHeat {
+		gotTotal := mentionsTotal(boot, pov, entity, 0, numDocs-1)
+		wantTotal := perEntityMentions[entity]
+		marker := "✓"
+		if gotTotal != wantTotal {
+			marker = "✗"
+			failures = append(failures, fmt.Sprintf(
+				"mentions_total(%s): got %d, want %d",
+				entity, gotTotal, wantTotal))
+		}
+		tagStr := strings.Join(sortedTagList(expectedTags[entity]), ",")
+		fmt.Printf("  %-14s  %9d  %9d  %s  %s\n",
+			entity, gotTotal, wantTotal, tagStr, marker)
+	}
+
+	// Top-10 cooccurrence pairs (by expected count).
+	fmt.Println()
+	fmt.Println("=== top cooccurrence pairs ===")
+	pairsSorted := make([]pairKey, 0, len(expectedCooccurCount))
+	for pk := range expectedCooccurCount {
+		pairsSorted = append(pairsSorted, pk)
+	}
+	sort.Slice(pairsSorted, func(i, j int) bool {
+		if expectedCooccurCount[pairsSorted[i]] != expectedCooccurCount[pairsSorted[j]] {
+			return expectedCooccurCount[pairsSorted[i]] > expectedCooccurCount[pairsSorted[j]]
+		}
+		if pairsSorted[i].a != pairsSorted[j].a {
+			return pairsSorted[i].a < pairsSorted[j].a
+		}
+		return pairsSorted[i].b < pairsSorted[j].b
+	})
+	topN := 10
+	if len(pairsSorted) < topN {
+		topN = len(pairsSorted)
+	}
+	for _, pk := range pairsSorted[:topN] {
+		want := expectedCooccurCount[pk]
+		got := cooccurCount(boot, pov, pk.a, pk.b)
+		marker := "✓"
+		if got != want {
+			marker = "✗"
+		}
+		label := pk.a + " & " + pk.b
+		fmt.Printf("  %-32s  %4d  (want %d)  %s\n", label, got, want, marker)
+	}
+
+	fmt.Println()
+	fmt.Println("=== the trick ===")
+	fmt.Printf("  %d concurrent agents all wrote into the same knowledge\n", numAgents)
+	fmt.Println("  graph with zero coordination. Tag-set unions and per-entity")
+	fmt.Println("  / per-pair counters all aggregate correctly: this is the shape")
+	fmt.Println("  multi-agent LLM extraction pipelines keep reinventing badly.")
+
+	mustSend(boot, "exit;")
+	boot.Close()
+
+	if len(failures) > 0 {
+		fmt.Println("\n=== self-check FAILED ===")
+		for i, f := range failures {
+			if i >= 20 {
+				break
+			}
+			fmt.Println("  " + f)
+		}
+		if len(failures) > 20 {
+			fmt.Printf("  ... and %d more\n", len(failures)-20)
+		}
+		os.Exit(1)
+	}
+	fmt.Println("\n=== self-check OK ===")
+	fmt.Printf("  verified %d tag sets + %d mention counters + %d cooccurrence counters across %d concurrent agents\n",
+		len(expectedTags), len(expectedMentionCount), len(expectedCooccurCount), numAgents)
+}

--- a/examples/agent-swarm/demo.py
+++ b/examples/agent-swarm/demo.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""
+Multi-agent knowledge-graph demo, in Python.
+
+Spawns N concurrent WebSocket "agents" that each process a disjoint
+slice of a corpus, extracting entities + tags + cooccurrences and
+streaming them into a single shared POV via Orly's commutative field
+calls (`+=`, `|=`). No coordination between agents -- no locks, no
+per-agent partitioning, no merge-on-read in the driver.
+
+The demo's AI angle: this is exactly the shape of a multi-agent
+LLM-extraction pipeline. Many agents read disjoint chunks of a corpus,
+each emits structured facts about overlapping entities, and the
+naive approach (read-modify-write per fact) drops updates the moment
+two agents touch the same entity at the same time. Orly's field calls
+don't read-modify-write -- the database aggregates increments and
+set-unions correctly under any interleaving.
+
+For demo simplicity, the "extraction" is deterministic: each doc in
+the corpus comes pre-tagged with the entities and tags an extractor
+would produce. So the headline property (concurrent writes land
+correctly) is testable without an actual LLM in the loop.
+
+Run via the wrapper:
+
+    ./run.sh
+
+Or directly, after starting orlyi separately:
+
+    python3 demo.py
+"""
+
+import json
+import os
+import sys
+import threading
+import time
+import websocket
+
+WS_URL = "ws://127.0.0.1:8082/"
+
+# Per-call recv timeout. Mirrors wikipedia-pageviews/demo.py: normal
+# latency is well under a second; 30s is generous-but-finite so a hung
+# orlyi surfaces as a failed read rather than a multi-minute CI timeout.
+WS_TIMEOUT_S = 30
+
+# ----------------------------------------------------------------------
+# The corpus. Each entry is (sentence text, {entity: [tags]}).
+#
+# The sentence text is human-readable flavor only -- the structured
+# {entity: [tags]} dict IS the "extraction" the demo treats as ground
+# truth. An entity may carry multiple tags from a single doc (different
+# extractors infer different attributes); the same entity across many
+# docs accumulates a UNION of all tags it ever received.
+#
+# Hot entities (Python, OpenAI, Anthropic, Claude, GPT-4, Microsoft,
+# Google) appear in many docs to drive real contention on the
+# `+=` mention counters and the `|=` tag sets.
+# ----------------------------------------------------------------------
+CORPUS = [
+    ("Python and Rust dominate modern systems work at OpenAI.",
+     {"Python": ["language", "popular"], "Rust": ["language"],
+      "OpenAI": ["company", "ai-lab"]}),
+    ("Anthropic trained Claude on a custom Transformer architecture.",
+     {"Anthropic": ["company", "ai-lab"], "Claude": ["model", "llm"],
+      "Transformer": ["model"]}),
+    ("GitHub Copilot now offers Claude alongside GPT-4 for code.",
+     {"GitHub": ["company", "tool"], "Claude": ["model", "llm"],
+      "GPT-4": ["model", "llm"]}),
+    ("Linus Torvalds still maintains Linux from a laptop running Git.",
+     {"Linus": ["person"], "Linux": ["tool", "open-source"],
+      "Git": ["tool", "open-source"]}),
+    ("Guido van Rossum joined Microsoft to improve Python performance.",
+     {"Guido": ["person"], "Microsoft": ["company"],
+      "Python": ["language", "popular"]}),
+    ("Kubernetes manages workloads at Google, Meta, and Microsoft.",
+     {"Kubernetes": ["tool"], "Google": ["company"],
+      "Meta": ["company"], "Microsoft": ["company"]}),
+    ("Docker simplified deployment for Python and JavaScript developers.",
+     {"Docker": ["tool"], "Python": ["language", "popular"],
+      "JavaScript": ["language", "popular"]}),
+    ("Meta released Llama as a competitive open-source LLM.",
+     {"Meta": ["company", "ai-lab"],
+      "Llama": ["model", "llm", "open-source"]}),
+    ("PostgreSQL remains the database of choice at OpenAI for analytics.",
+     {"PostgreSQL": ["tool", "database"], "OpenAI": ["company", "ai-lab"]}),
+    ("Sam Altman discussed GPT-4 in a recent OpenAI announcement.",
+     {"Sam": ["person"], "GPT-4": ["model", "llm"],
+      "OpenAI": ["company", "ai-lab"]}),
+    ("Rust is gaining traction at Microsoft for systems-level libraries.",
+     {"Rust": ["language"], "Microsoft": ["company"]}),
+    ("TypeScript powers most modern JavaScript codebases at Google.",
+     {"TypeScript": ["language"], "JavaScript": ["language", "popular"],
+      "Google": ["company"]}),
+    ("Java still dominates enterprise software at Microsoft and Google.",
+     {"Java": ["language", "enterprise"], "Microsoft": ["company"],
+      "Google": ["company"]}),
+    ("Ruby on Rails was created by a Danish developer; GitHub uses it.",
+     {"Ruby": ["language"], "GitHub": ["company", "tool"]}),
+    ("Go was designed at Google to simplify backend programming.",
+     {"Go": ["language"], "Google": ["company"]}),
+    ("Kubernetes orchestrates Docker containers in production at Meta.",
+     {"Kubernetes": ["tool"], "Docker": ["tool"],
+      "Meta": ["company", "ai-lab"]}),
+    ("Claude can analyze long documents with its large context window.",
+     {"Claude": ["model", "llm"]}),
+    ("GPT-4 powers many tools released by OpenAI in recent years.",
+     {"GPT-4": ["model", "llm"], "OpenAI": ["company", "ai-lab"]}),
+    ("Linux servers run most of the infrastructure at Google.",
+     {"Linux": ["tool", "open-source"], "Google": ["company"]}),
+    ("Git is the version control system at Microsoft, Google, and Anthropic.",
+     {"Git": ["tool", "open-source"], "Microsoft": ["company"],
+      "Google": ["company"], "Anthropic": ["company", "ai-lab"]}),
+    ("Llama runs locally on a laptop with sufficient RAM.",
+     {"Llama": ["model", "llm", "open-source"]}),
+    ("PostgreSQL backs most production systems at GitHub and Anthropic.",
+     {"PostgreSQL": ["tool", "database"], "GitHub": ["company", "tool"],
+      "Anthropic": ["company", "ai-lab"]}),
+    ("Python's ecosystem includes scientific tools widely used at OpenAI.",
+     {"Python": ["language", "popular"], "OpenAI": ["company", "ai-lab"]}),
+    ("Anthropic recently expanded the Claude API for enterprise customers.",
+     {"Anthropic": ["company", "ai-lab"], "Claude": ["model", "llm"]}),
+    ("Guido and Linus both shaped modern open-source culture.",
+     {"Guido": ["person"], "Linus": ["person"]}),
+    ("Sam Altman leads OpenAI through aggressive product launches.",
+     {"Sam": ["person"], "OpenAI": ["company", "ai-lab"]}),
+    ("Transformers underpin both Claude and GPT-4 architectures.",
+     {"Transformer": ["model"], "Claude": ["model", "llm"],
+      "GPT-4": ["model", "llm"]}),
+    ("Meta engineers contribute heavily to PyTorch and the Python ecosystem.",
+     {"Meta": ["company", "ai-lab"], "Python": ["language", "popular"]}),
+    ("Rust adoption is rising at Microsoft, Google, and Meta.",
+     {"Rust": ["language"], "Microsoft": ["company"],
+      "Google": ["company"], "Meta": ["company"]}),
+    ("JavaScript remains the most-used language on GitHub by far.",
+     {"JavaScript": ["language", "popular"], "GitHub": ["company", "tool"]}),
+    ("TypeScript brings type safety to JavaScript codebases at Microsoft.",
+     {"TypeScript": ["language"], "JavaScript": ["language", "popular"],
+      "Microsoft": ["company"]}),
+    ("Go's concurrency model influenced design choices at Anthropic.",
+     {"Go": ["language"], "Anthropic": ["company", "ai-lab"]}),
+    ("Linux Foundation projects include Kubernetes, Docker, and Git.",
+     {"Linux": ["tool", "open-source"], "Kubernetes": ["tool"],
+      "Docker": ["tool"], "Git": ["tool", "open-source"]}),
+    ("Java powers Android development; Google supports it heavily.",
+     {"Java": ["language", "enterprise"], "Google": ["company"]}),
+    ("Ruby developers often migrate to Python or Go for performance.",
+     {"Ruby": ["language"], "Python": ["language", "popular"],
+      "Go": ["language"]}),
+    ("Claude can write and review Python, JavaScript, and Go code.",
+     {"Claude": ["model", "llm"], "Python": ["language", "popular"],
+      "JavaScript": ["language", "popular"], "Go": ["language"]}),
+    ("GPT-4 fine-tunes are restricted compared to open Llama weights.",
+     {"GPT-4": ["model", "llm"],
+      "Llama": ["model", "llm", "open-source"]}),
+    ("OpenAI and Anthropic compete in the enterprise LLM market.",
+     {"OpenAI": ["company", "ai-lab"],
+      "Anthropic": ["company", "ai-lab"]}),
+    ("Microsoft has invested heavily in OpenAI and integrated GPT-4.",
+     {"Microsoft": ["company"], "OpenAI": ["company", "ai-lab"],
+      "GPT-4": ["model", "llm"]}),
+    ("Docker images at Anthropic typically ship Python and Rust binaries.",
+     {"Docker": ["tool"], "Anthropic": ["company", "ai-lab"],
+      "Python": ["language", "popular"], "Rust": ["language"]}),
+]
+
+# Two workload sizes (mirroring wikipedia-pageviews).
+#
+#   DEMO_SCALE=small  -- 4 agents over the first 20 docs (CI-friendly).
+#   anything else     -- 8 agents over all 40 docs (local showcase).
+_SCALE = os.environ.get("DEMO_SCALE", "large").lower()
+if _SCALE == "small":
+    NUM_AGENTS = 4
+    NUM_DOCS = 20
+else:
+    NUM_AGENTS = 8
+    NUM_DOCS = 40
+
+
+def canonical_pair(a, b):
+    """Unordered pair as (smaller, larger) so add_cooccur(A,B) and
+    add_cooccur(B,A) collapse to the same key. Driver-side
+    canonicalisation matches the (a, b) tuple shape in graph.orly."""
+    return (a, b) if a < b else (b, a)
+
+
+def compute_ground_truth(docs):
+    """Derive the expected end-state from the corpus alone."""
+    expected_tags = {}        # entity -> set(tags)
+    expected_mentions = {}    # (entity, doc_id) -> 1
+    expected_cooccur = {}     # (a, b) -> count
+    for doc_id, (_text, entities) in enumerate(docs):
+        for entity, tags in entities.items():
+            expected_tags.setdefault(entity, set()).update(tags)
+            expected_mentions[(entity, doc_id)] = 1
+        names = sorted(entities.keys())
+        for i, a in enumerate(names):
+            for b in names[i + 1:]:
+                key = canonical_pair(a, b)
+                expected_cooccur[key] = expected_cooccur.get(key, 0) + 1
+    return expected_tags, expected_mentions, expected_cooccur
+
+
+def send(ws, stmt):
+    ws.send(stmt)
+    reply = json.loads(ws.recv())
+    if reply.get("status") != "ok":
+        raise RuntimeError(f"{stmt!r}\n  -> {reply}")
+    return reply.get("result")
+
+
+def add_tag(ws, pov, entity, tag):
+    send(ws, f'try {{{pov}}} graph add_tag '
+             f'<{{.e: "{entity}", .t: "{tag}"}}>;')
+
+
+def add_mention(ws, pov, entity, doc_id):
+    send(ws, f'try {{{pov}}} graph add_mention '
+             f'<{{.e: "{entity}", .d: {doc_id}}}>;')
+
+
+def add_cooccur(ws, pov, a, b):
+    send(ws, f'try {{{pov}}} graph add_cooccur '
+             f'<{{.a: "{a}", .b: "{b}"}}>;')
+
+
+def tags_for_entity(ws, pov, entity):
+    r = send(ws, f'try {{{pov}}} graph tags_for_entity <{{.e: "{entity}"}}>;')
+    # graph.orly returns a set; WS wire form is a JSON array.
+    return set(r or [])
+
+
+def mention_count(ws, pov, entity, doc_id):
+    r = send(ws, f'try {{{pov}}} graph mention_count '
+                 f'<{{.e: "{entity}", .d: {doc_id}}}>;')
+    return int(r)
+
+
+def mentions_total(ws, pov, entity, d_start, d_end):
+    r = send(ws, f'try {{{pov}}} graph mentions_total '
+                 f'<{{.e: "{entity}", .d_start: {d_start}, .d_end: {d_end}}}>;')
+    return int(r)
+
+
+def cooccur_count(ws, pov, a, b):
+    r = send(ws, f'try {{{pov}}} graph cooccur_count '
+                 f'<{{.a: "{a}", .b: "{b}"}}>;')
+    return int(r)
+
+
+def agent(agent_id, pov, docs):
+    """One agent: open a fresh WebSocket, open a session, ingest its
+    slice of (doc_id, extraction) pairs into the shared POV."""
+    ws = websocket.create_connection(WS_URL, timeout=WS_TIMEOUT_S)
+    try:
+        send(ws, "new session;")
+        for doc_id, (_text, entities) in docs:
+            # Per doc: tag every entity, mention every entity, and emit
+            # one cooccurrence per unordered pair.
+            for entity, tags in entities.items():
+                for tag in tags:
+                    add_tag(ws, pov, entity, tag)
+                add_mention(ws, pov, entity, doc_id)
+            names = sorted(entities.keys())
+            for i, a in enumerate(names):
+                for b in names[i + 1:]:
+                    pa, pb = canonical_pair(a, b)
+                    add_cooccur(ws, pov, pa, pb)
+    finally:
+        ws.close()
+
+
+def main():
+    docs = CORPUS[:NUM_DOCS]
+    expected_tags, expected_mentions, expected_cooccur = compute_ground_truth(docs)
+
+    # Split docs across agents round-robin so hot entities collide
+    # across multiple agents (real contention on shared keys).
+    per_agent_docs = [[] for _ in range(NUM_AGENTS)]
+    for doc_id, doc in enumerate(docs):
+        per_agent_docs[doc_id % NUM_AGENTS].append((doc_id, doc))
+
+    total_writes = (
+        sum(len(tags) for _e, tags in expected_tags.items())  # add_tag calls
+        + len(expected_mentions)                              # add_mention calls
+        + sum(expected_cooccur.values())                      # add_cooccur calls
+    )
+
+    # Bootstrap connection: install graph + create the shared POV.
+    boot = websocket.create_connection(WS_URL, timeout=WS_TIMEOUT_S)
+    send(boot, "new session;")
+    send(boot, "install graph.1;")
+    pov = send(boot, "new safe shared pov;")
+    print(f"pov: {pov}")
+    print(f"agents: {NUM_AGENTS}, docs: {NUM_DOCS}, "
+          f"entities: {len(expected_tags)}, "
+          f"unordered pairs: {len(expected_cooccur)}")
+    print(f"total writes from agents: {total_writes:,}")
+
+    # Pre-initialise every key so concurrent agents all take the
+    # commutative `+=` / `|=` branch (never the `new <-` create branch).
+    # Isolates whether lost updates come from the create-race or from
+    # the field-call itself -- if the demo passes, it's the field-call.
+    print("\npre-initialising all keys via the bootstrap session...")
+    for entity, tags in expected_tags.items():
+        # Seed with one arbitrary tag so the set exists; the agents
+        # union the rest. Pick the lexicographically first tag for
+        # determinism.
+        first_tag = sorted(tags)[0]
+        add_tag(boot, pov, entity, first_tag)
+    for (entity, doc_id) in expected_mentions:
+        # Seed with a count of 1, then the agent's add_mention bumps
+        # to the expected 2. Adjust ground truth accordingly.
+        add_mention(boot, pov, entity, doc_id)
+    for (a, b) in expected_cooccur:
+        add_cooccur(boot, pov, a, b)
+
+    # Pre-init seeded each key with exactly one of the agent ops, so
+    # the expected end-state per key bumps up by one.
+    expected_mention_count = {k: v + 1 for k, v in expected_mentions.items()}
+    expected_cooccur_count = {k: v + 1 for k, v in expected_cooccur.items()}
+
+    # Fan out: each agent opens its own WS and runs concurrently.
+    threads = []
+    t0 = time.monotonic()
+    for i in range(NUM_AGENTS):
+        t = threading.Thread(target=agent, args=(i, pov, per_agent_docs[i]))
+        t.start()
+        threads.append(t)
+    for t in threads:
+        t.join()
+    elapsed = time.monotonic() - t0
+    rate = total_writes / elapsed
+    print(f"\ningest done in {elapsed:.2f}s "
+          f"({rate:,.0f} writes/sec end-to-end with {NUM_AGENTS} agents)")
+
+    # ------------------------------------------------------------------
+    # Verify against ground truth.
+    # ------------------------------------------------------------------
+    print()
+    print("=== verifying knowledge graph ===")
+    failures = []
+
+    for entity, want_tags in expected_tags.items():
+        got_tags = tags_for_entity(boot, pov, entity)
+        if got_tags != want_tags:
+            failures.append(
+                f"tags({entity}): got {sorted(got_tags)}, want {sorted(want_tags)}")
+
+    for (entity, doc_id), want in expected_mention_count.items():
+        got = mention_count(boot, pov, entity, doc_id)
+        if got != want:
+            failures.append(
+                f"mention({entity}, {doc_id}): got {got}, want {want}")
+
+    for (a, b), want in expected_cooccur_count.items():
+        got = cooccur_count(boot, pov, a, b)
+        if got != want:
+            failures.append(
+                f"cooccur({a}, {b}): got {got}, want {want}")
+
+    # ------------------------------------------------------------------
+    # Per-entity rollup (one line per entity, sorted by total mentions
+    # so the hot entities surface at the top).
+    # ------------------------------------------------------------------
+    per_entity_mentions = {}
+    for (entity, _doc_id), v in expected_mention_count.items():
+        per_entity_mentions[entity] = per_entity_mentions.get(entity, 0) + v
+
+    print(f"  {'entity':<14}  {'mentions':>9}  {'expected':>9}  {'tags'}")
+    print(f"  {'-'*14}  {'-'*9}  {'-'*9}  {'-'*30}")
+    for entity in sorted(per_entity_mentions, key=lambda e: -per_entity_mentions[e]):
+        # Doc IDs in this corpus are 0..NUM_DOCS-1, all dense.
+        got_total = mentions_total(boot, pov, entity, 0, NUM_DOCS - 1)
+        want_total = per_entity_mentions[entity]
+        marker = "✓" if got_total == want_total else "✗"
+        tag_str = ",".join(sorted(expected_tags[entity]))
+        print(f"  {entity:<14}  {got_total:>9}  {want_total:>9}  "
+              f"{tag_str}  {marker}")
+        if got_total != want_total:
+            failures.append(
+                f"mentions_total({entity}): got {got_total}, want {want_total}")
+
+    print()
+    print("=== top cooccurrence pairs ===")
+    top_pairs = sorted(expected_cooccur_count.items(),
+                       key=lambda kv: -kv[1])[:10]
+    for (a, b), want in top_pairs:
+        got = cooccur_count(boot, pov, a, b)
+        marker = "✓" if got == want else "✗"
+        print(f"  {a + ' & ' + b:<32}  {got:>4}  (want {want})  {marker}")
+
+    print()
+    print("=== the trick ===")
+    print(f"  {NUM_AGENTS} concurrent agents all wrote into the same knowledge")
+    print(f"  graph with zero coordination. Tag-set unions and per-entity")
+    print(f"  / per-pair counters all aggregate correctly: this is the shape")
+    print(f"  multi-agent LLM extraction pipelines keep reinventing badly.")
+
+    send(boot, "exit;")
+    boot.close()
+
+    if failures:
+        print("\n=== self-check FAILED ===")
+        for f in failures[:20]:
+            print(f"  {f}")
+        if len(failures) > 20:
+            print(f"  ... and {len(failures) - 20} more")
+        sys.exit(1)
+    print("\n=== self-check OK ===")
+    print(f"  verified {len(expected_tags)} tag sets + "
+          f"{len(expected_mention_count)} mention counters + "
+          f"{len(expected_cooccur_count)} cooccurrence counters across "
+          f"{NUM_AGENTS} concurrent agents")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agent-swarm/go.mod
+++ b/examples/agent-swarm/go.mod
@@ -1,0 +1,5 @@
+module github.com/orlyatomics/orly/examples/agent-swarm
+
+go 1.22
+
+require github.com/gorilla/websocket v1.5.3

--- a/examples/agent-swarm/go.sum
+++ b/examples/agent-swarm/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/examples/agent-swarm/graph.orly
+++ b/examples/agent-swarm/graph.orly
@@ -1,0 +1,148 @@
+/* <examples/agent-swarm/graph.orly>
+
+   Multi-agent knowledge-graph schema. N independent "agent" processes
+   stream extractions from disjoint slices of a corpus into the SAME
+   shared POV. Every write is commutative -- there is zero coordination
+   between agents:
+
+     *<['entity', e]>::({str})    |= {tag}    set union per entity
+     *<['mention', e, d]>::(int)  += 1        per (entity, doc) counter
+     *<['cooccur', a, b]>::(int)  += 1        per unordered-pair counter
+
+   This is the shape AI builders keep reinventing badly: many extractors
+   need to roll up into one knowledge graph, and the naive "read, merge,
+   write back" loop drops updates the moment two extractors hit the
+   same entity at the same time. Orly's field calls (`|=`, `+=`) don't
+   read-modify-write -- they're opaque commutative ops, so concurrent
+   writers all land their contributions and the merge machinery
+   aggregates correctly.
+
+   Each function below mirrors the pattern from
+   examples/wikipedia-pageviews/views.orly: a single function that
+   takes the `is known` branch for subsequent writes and the `new <-`
+   branch for the very first write at a key. The driver pre-initialises
+   every key before agents fan out so all concurrent writers take the
+   commutative branch (we want to isolate the +=/|= property, not the
+   create-race).
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package #1;
+
+/* ---------- entity -> tag set ---------- */
+
+tags_for_entity = (((*<['entity', e]>::({str})) if *<['entity', e]>::({str}?) is known else (empty {str}))) where {
+  e = given::(str);
+};
+
+/* Union one tag into the entity's set. First call creates with {t};
+   subsequent calls union -- both shapes commute under concurrent
+   callers writing different tags at the same key. */
+add_tag = (((1) effecting {
+  *<['entity', e]>::({str}) |= {t};
+} if *<['entity', e]>::({str}?) is known else (0) effecting {
+  new <['entity', e]> <- {t};
+})) where {
+  e = given::(str);
+  t = given::(str);
+};
+
+/* ---------- per-(entity, doc) mention counter ---------- */
+
+mention_count = (((*<['mention', e, d]>::(int)) if *<['mention', e, d]>::(int?) is known else 0)) where {
+  e = given::(str);
+  d = given::(int);
+};
+
+add_mention = (((1) effecting {
+  *<['mention', e, d]>::(int) += 1;
+} if *<['mention', e, d]>::(int?) is known else (0) effecting {
+  new <['mention', e, d]> <- 1;
+})) where {
+  e = given::(str);
+  d = given::(int);
+};
+
+/* Sum mentions of one entity across an inclusive doc-id range -- a
+   per-entity total. The driver uses this for its self-check summary. */
+mentions_total = ([d_start..d_end] reduce start 0 + mention_count(.e: e, .d: that)) where {
+  e       = given::(str);
+  d_start = given::(int);
+  d_end   = given::(int);
+};
+
+/* ---------- per-unordered-pair cooccurrence counter ---------- */
+
+/* The driver canonicalises pair order (lexicographically smaller first)
+   so the database only stores one direction of each undirected edge. */
+cooccur_count = (((*<['cooccur', a, b]>::(int)) if *<['cooccur', a, b]>::(int?) is known else 0)) where {
+  a = given::(str);
+  b = given::(str);
+};
+
+add_cooccur = (((1) effecting {
+  *<['cooccur', a, b]>::(int) += 1;
+} if *<['cooccur', a, b]>::(int?) is known else (0) effecting {
+  new <['cooccur', a, b]> <- 1;
+})) where {
+  a = given::(str);
+  b = given::(str);
+};
+
+/* ---------- inline tests ---------- */
+
+test {
+  /* Unknown keys read as identity values (empty set / 0). */
+  t1: tags_for_entity(.e: "Python") == (empty {str});
+  t2: mention_count(.e: "Python", .d: 0) == 0;
+  t3: cooccur_count(.a: "Python", .b: "GPT-4") == 0;
+
+  /* First add_tag creates (returns 0); subsequent unions return 1. */
+  t4: add_tag(.e: "Python", .t: "language") == 0 {
+    t5: tags_for_entity(.e: "Python") == {"language"};
+    t6: add_tag(.e: "Python", .t: "popular") == 1 {
+      t7: tags_for_entity(.e: "Python") == {"language", "popular"};
+      /* Idempotent: re-adding doesn't grow the set. */
+      t8: add_tag(.e: "Python", .t: "popular") == 1 {
+        t9: tags_for_entity(.e: "Python") == {"language", "popular"};
+      };
+    };
+  };
+
+  /* Mention counter accumulates across calls; per-doc keys are
+     independent; the range-fold sums them all. */
+  t10: add_mention(.e: "GPT-4", .d: 0) == 0 {
+    t11: mention_count(.e: "GPT-4", .d: 0) == 1;
+    t12: add_mention(.e: "GPT-4", .d: 0) == 1 {
+      t13: mention_count(.e: "GPT-4", .d: 0) == 2;
+      t14: add_mention(.e: "GPT-4", .d: 1) == 0 {
+        t15: mention_count(.e: "GPT-4", .d: 0) == 2;
+        t16: mention_count(.e: "GPT-4", .d: 1) == 1;
+        t17: mentions_total(.e: "GPT-4", .d_start: 0, .d_end: 1) == 3;
+        t18: mentions_total(.e: "GPT-4", .d_start: 5, .d_end: 9) == 0;
+      };
+    };
+  };
+
+  /* Cooccurrence counter, same shape as mention. */
+  t19: add_cooccur(.a: "Python", .b: "GPT-4") == 0 {
+    t20: cooccur_count(.a: "Python", .b: "GPT-4") == 1;
+    t21: add_cooccur(.a: "Python", .b: "GPT-4") == 1 {
+      t22: cooccur_count(.a: "Python", .b: "GPT-4") == 2;
+      /* Reversed-order pair is a DIFFERENT key (driver canonicalises). */
+      t23: cooccur_count(.a: "GPT-4", .b: "Python") == 0;
+    };
+  };
+};

--- a/examples/agent-swarm/run-go.sh
+++ b/examples/agent-swarm/run-go.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Same end-to-end pipeline as run.sh, but driven by demo.go.
+# Requires the `go` toolchain on PATH.
+set -e
+
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../.. && pwd)"
+ORLY_OUT="${ORLY_OUT:-$REPO_ROOT/../out_orly/debug}"
+ORLYI="$ORLY_OUT/orly/server/orlyi"
+ORLYC="$ORLY_OUT/orly/orlyc"
+
+for bin in "$ORLYI" "$ORLYC"; do
+  if [ ! -x "$bin" ]; then
+    echo "missing: $bin"
+    exit 1
+  fi
+done
+
+if ! command -v go >/dev/null 2>&1; then
+  echo "missing: go (install golang-go or download from go.dev)"
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'kill -9 $ORLYI_PID 2>/dev/null || true; rm -rf "$WORK"' EXIT
+
+echo "[1/5] compile graph.orly"
+"$ORLYC" -o "$WORK" graph.orly
+
+echo "[2/5] populate packages/"
+mkdir "$WORK/packages"
+touch "$WORK/packages/__orly__"
+cp "$WORK/graph.1.so" "$WORK/packages/"
+
+pkill -9 -f 'instance_name=agent_swarm_demo' 2>/dev/null || true
+sleep 1
+
+echo "[3/5] start fresh orlyi"
+# Same conservative resource caps as run.sh -- see comment there.
+"$ORLYI" --mem_sim --create=true \
+         --port_number=19400 --slave_port_number=19401 \
+         --connection_backlog=10 \
+         --instance_name=agent_swarm_demo \
+         --starting_state=SOLO \
+         --package_dir="$WORK/packages" \
+         --max_parallel_frames 4000 \
+         --page_cache_size 256 \
+         --block_cache_size 64 \
+         > "$WORK/orlyi.log" 2>&1 &
+ORLYI_PID=$!
+
+echo "[4/5] wait for WebSocket port 8082"
+for _ in $(seq 1 60); do
+  if ss -tln 2>/dev/null | grep -q ':8082'; then
+    break
+  fi
+  sleep 1
+done
+if ! ss -tln 2>/dev/null | grep -q ':8082'; then
+  echo "orlyi failed to come up; last log lines:"
+  tail -20 "$WORK/orlyi.log"
+  exit 1
+fi
+
+echo "[5/5] go run demo.go"
+if ! go run demo.go; then
+  echo ""
+  echo "demo.go failed; dumping orlyi.log for diagnosis:"
+  echo "=========================================================="
+  cat "$WORK/orlyi.log"
+  echo "=========================================================="
+  exit 1
+fi

--- a/examples/agent-swarm/run.sh
+++ b/examples/agent-swarm/run.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# End-to-end driver for the agent-swarm knowledge-graph demo.
+set -e
+
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../.. && pwd)"
+ORLY_OUT="${ORLY_OUT:-$REPO_ROOT/../out_orly/debug}"
+ORLYI="$ORLY_OUT/orly/server/orlyi"
+ORLYC="$ORLY_OUT/orly/orlyc"
+
+for bin in "$ORLYI" "$ORLYC"; do
+  if [ ! -x "$bin" ]; then
+    echo "missing: $bin"
+    exit 1
+  fi
+done
+
+WORK="$(mktemp -d)"
+trap 'kill -9 $ORLYI_PID 2>/dev/null || true; rm -rf "$WORK"' EXIT
+
+echo "[1/5] compile graph.orly"
+"$ORLYC" -o "$WORK" graph.orly
+
+echo "[2/5] populate packages/"
+mkdir "$WORK/packages"
+touch "$WORK/packages/__orly__"
+cp "$WORK/graph.1.so" "$WORK/packages/"
+
+pkill -9 -f 'instance_name=agent_swarm_demo' 2>/dev/null || true
+sleep 1
+
+echo "[3/5] start fresh orlyi"
+# Conservative resource caps mirroring wikipedia-pageviews/run.sh.
+# The fiber pool needs headroom for per-layer Fiber::TSync parallelism
+# during reads under many concurrent agents.
+"$ORLYI" --mem_sim --create=true \
+         --port_number=19400 --slave_port_number=19401 \
+         --connection_backlog=10 \
+         --instance_name=agent_swarm_demo \
+         --starting_state=SOLO \
+         --package_dir="$WORK/packages" \
+         --max_parallel_frames 4000 \
+         --page_cache_size 256 \
+         --block_cache_size 64 \
+         > "$WORK/orlyi.log" 2>&1 &
+ORLYI_PID=$!
+
+echo "[4/5] wait for WebSocket port 8082"
+for _ in $(seq 1 60); do
+  if ss -tln 2>/dev/null | grep -q ':8082'; then
+    break
+  fi
+  sleep 1
+done
+if ! ss -tln 2>/dev/null | grep -q ':8082'; then
+  echo "orlyi failed to come up; last log lines:"
+  tail -20 "$WORK/orlyi.log"
+  exit 1
+fi
+
+echo "[5/5] run demo.py"
+if ! python3 demo.py; then
+  echo ""
+  echo "demo.py failed; dumping orlyi.log for diagnosis:"
+  echo "=========================================================="
+  cat "$WORK/orlyi.log"
+  echo "=========================================================="
+  exit 1
+fi


### PR DESCRIPTION
## Summary

A new `examples/agent-swarm/` demo showcasing Orly's commutative field calls (`|= {x}` and `+= 1`) under the **multi-agent extraction** workload pattern that LLM pipelines keep reinventing badly. N independent "agents" each process a disjoint slice of a corpus and stream tags, mentions, and cooccurrences into one shared POV with **zero coordination** — no locks, no per-agent partitioning, no merge-on-read in the driver.

This combines both commutative-write shapes from prior demos and runs them concurrently:

- `*<['entity', e]>::({str}) |= {tag}` — set-union per entity (from `wikipedia-categories/`)
- `*<['mention', e, d]>::(int) += 1` — per-(entity, doc) counter (from `wikipedia-pageviews/`)
- `*<['cooccur', a, b]>::(int) += 1` — per-unordered-pair counter

Hot entities (`Python`, `OpenAI`, `Anthropic`, `Claude`, `GPT-4`, `Microsoft`, `Google`) appear across many docs, with docs round-robined across agents so multiple agents collide on the same keys concurrently. The driver only ever calls the three field-call functions in `graph.orly` — it never reads-then-writes — and the self-check confirms every tag set, mention counter, and cooccurrence counter matches independently-derived ground truth.

The AI framing: this is the shape multi-agent LLM extraction pipelines need (many agents reading disjoint chunks, emitting overlapping facts into one graph). The naive read-modify-write loop drops updates the moment two agents hit the same entity; Orly's field calls don't read-modify-write so all contributions land regardless of interleaving.

## What landed

- `examples/agent-swarm/graph.orly` — schema with `add_tag` / `add_mention` / `add_cooccur` field-call functions, plus `tags_for_entity` / `mention_count` / `mentions_total` / `cooccur_count` readers. Inline tests cover the commutative shape end-to-end.
- `examples/agent-swarm/demo.py` and `demo.go` — mirrored drivers. Each carries the same 40-doc corpus (sentence text + structured `{entity: [tags]}` extraction). Each derives its own ground truth, pre-initialises all keys, fans out N agents over its own WebSocket connection, then verifies tag sets / mention counters / cooccurrence counters against the derived truth.
- `examples/agent-swarm/run.sh` / `run-go.sh` — wrappers mirroring `wikipedia-pageviews/`: 30s WS recv timeouts, conservative orlyi resource caps, on-failure `orlyi.log` dump for diagnosis.
- `examples/agent-swarm/README.md` — explains the AI framing, the schema, and the relationship to prior demos.
- `.github/workflows/ci.yml` — two new steps wiring both drivers at `DEMO_SCALE=small` (4 agents over 20 docs).

## Validation

Local runs, all green:

- `DEMO_SCALE=small ./run.sh` — 4 agents × 20 docs, verified 25 tag sets + 53 mention counters + 45 cooccurrence counters
- `DEMO_SCALE=small ./run-go.sh` — same shape, Go driver
- `DEMO_SCALE=large ./run.sh` — 8 agents × 40 docs, verified 25 tag sets + 105 mention counters + 76 cooccurrence counters
- `DEMO_SCALE=large ./run-go.sh` — same shape, Go driver
- `make test` — exit 0, no failures
- `python3 tools/lang_test.py -d orly/data tests/lang_tests` — 0 changed, 125 passed, 3 pre-existing failures (no regressions)

## Test plan

- [ ] CI passes all four added paths (`agent-swarm run.sh` + `agent-swarm run-go.sh`, both implicitly at `DEMO_SCALE=small`)
- [ ] Existing `wikipedia-pageviews` / `wikipedia-categories` / `bitcoin-time-travel` demos still pass
- [ ] `lang-tests` job stays at its baseline (125 passed, 3 pre-existing failures, 0 changed)
