### PR TITLE
orly/indy/disk: replace placeholder TODO file-level docstrings (refs #70)

### DIFF
--- a/orly/indy/disk/block_hit_counter.h
+++ b/orly/indy/disk/block_hit_counter.h
@@ -1,6 +1,10 @@
 /* <orly/indy/disk/block_hit_counter.h>
 
-   TODO
+   Per-block access counter used by the page cache for eviction decisions.
+   Stores one byte per block in a memory-aligned buffer, log-compressed
+   (`log(exp(*val) + n)`) so a single byte tracks unbounded counts with
+   diminishing precision. Two-buffer design (Workset + Flush) lets the
+   counter accumulate against one buffer while another is being read.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/buf_block.h
+++ b/orly/indy/disk/buf_block.h
@@ -1,6 +1,10 @@
 /* <orly/indy/disk/buf_block.h>
 
-   TODO
+   Page-aligned, mlock'd block allocator backing the disk-layer buffer cache.
+   `TBufBlock`'s `operator new` / `operator delete` route through the static
+   `TPool` free-list so block reuse never returns to the heap. When the pool
+   is exhausted, allocators block on a condition variable until another
+   block is freed.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/disk_test.h
+++ b/orly/indy/disk/disk_test.h
@@ -1,6 +1,10 @@
 /* <orly/indy/disk/disk_test.h>
 
-   TODO
+   Test scaffolding for the disk layer: `TMockMem` (an empty `TMemoryLayer`),
+   `TMockUpdate` (a `TUpdate` that takes the sequence number directly rather
+   than from the engine), `TReader` (a `TReadFile` with internal methods
+   re-exported for assertion), and templated `Insert` helpers. Included by
+   the various `*.test.cc` files under `orly/indy/disk/`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/durable_manager.h
+++ b/orly/indy/disk/durable_manager.h
@@ -1,6 +1,13 @@
 /* <orly/indy/disk/durable_manager.h>
 
-   TODO
+   Durable-state manager: tracks `Durable::TManager` objects that need
+   periodic flush-to-disk, batches their serialized form into one stream,
+   and replays them on startup. `TFlush` schedules the periodic flush
+   tick; `TDurableManager` owns the per-object layers and the runner loop
+   that processes them. Large header -- the public `TDurableManager`
+   class declaration lives well below the top.
+
+   Consumers: `orly/server/orlyi`, the replication path.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/file_service.h
+++ b/orly/indy/disk/file_service.h
@@ -1,6 +1,11 @@
 /* <orly/indy/disk/file_service.h>
 
-   TODO
+   On-disk file registry: maps `(file_uid, gen_id)` to a `TFileObj`
+   describing where the file's blocks live on the volume. Inserts and
+   removes are queued and applied by a runner fiber so the in-memory
+   map stays internally consistent without per-call locking. Reads the
+   `image_1`/`image_2`/`append_log` blocks at startup to recover the
+   map after a crash. Test counterpart: `test_file_service.h`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/file_service_base.h
+++ b/orly/indy/disk/file_service_base.h
@@ -1,6 +1,9 @@
 /* <orly/indy/disk/file_service_base.h>
 
-   TODO
+   Abstract base for `TFileService` (production) and `TTestFileService`
+   (tests). Defines the file-registry API -- `InsertFile`, `RemoveFile`,
+   `FindFile`, `AppendFileGenSet`, `ForEachFile` -- plus the `TFileObj`
+   value type that describes one (`DataFile` | `DurableFile`) on disk.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/in_file.h
+++ b/orly/indy/disk/in_file.h
@@ -1,6 +1,12 @@
 /* <orly/indy/disk/in_file.h>
 
-   TODO
+   The read side of the disk layer. `TInFile` is the minimal abstract
+   interface for "something we can read pages from"; `TStream<>` is the
+   templated cursor that does byte-by-byte reads against the page cache
+   (with optional read-ahead). `TData` collects the on-disk layout
+   constants (entry sizes, meta-field counts) consumed by readers and
+   writers in lockstep -- changes here ripple through `read_file.h`,
+   `data_file.cc`, and the merge/walker classes.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/indy_util_reporter.h
+++ b/orly/indy/disk/indy_util_reporter.h
@@ -1,6 +1,11 @@
 /* <orly/indy/disk/indy_util_reporter.h>
 
-   TODO
+   I/O accounting for the disk layer. `TIndyUtilReporter` implements
+   `TUtilizationReporter` by tallying bytes and operations per `Source`
+   (`DataFile`, `MergeDataFile`, `DurableSortFile`, `PresentWalk`,
+   `UpdateWalk`, ...) split by `SyncRead` / `AsyncRead` / `Write`.
+   `Report()` emits the accumulated counters into a stringstream for
+   status pages and oncall dashboards.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/loop_block_dev.h
+++ b/orly/indy/disk/loop_block_dev.h
@@ -1,6 +1,10 @@
 /* <orly/indy/disk/loop_block_dev.h>
 
-   TODO
+   Test helper that creates a loopback block device (`losetup`) backed
+   by a sparse file under `/tmp/`. Constructor shells out to `truncate`,
+   `chmod`, and `sudo losetup`; destructor tears it down. Used by
+   disk-layer tests that need a real block device but don't want to
+   assume any specific path is available.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/merge_data_file.h
+++ b/orly/indy/disk/merge_data_file.h
@@ -1,6 +1,11 @@
 /* <orly/indy/disk/merge_data_file.h>
 
-   TODO
+   Merges a list of data files (identified by `gen_vec`) into a single
+   output file. Sequence numbers and the `Mutator` byte are carried
+   through so commutative ops still compose at read time (#49 / #53).
+   `GetNumNonAssignEntries()` is consulted by `TSafeRepo::MergeFiles`
+   to skip the subsequent `TFoldDataFile` pass when the source has
+   nothing to fold (#64).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/meta_rewriter.h
+++ b/orly/indy/disk/meta_rewriter.h
@@ -1,6 +1,9 @@
 /* <orly/indy/disk/meta_rewriter.h>
 
-   TODO
+   One-shot utility that rewrites a data file's meta section in place.
+   Used during recovery / repair when the meta block needs updating
+   after the data blocks have been written. Returns the new meta
+   location as a `(starting_block, offset)` pair.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/out_stream.h
+++ b/orly/indy/disk/out_stream.h
@@ -1,6 +1,11 @@
 /* <orly/indy/disk/out_stream.h>
 
-   TODO
+   The write side of the disk layer. `TOutStream<>` is the templated
+   cursor that appends bytes into block-aligned buffers and queues them
+   as a `TWriteGroup`. `TBoundaryChecker<>` tracks page-in-block
+   transitions so the writer knows when to start a new buffered page;
+   the `PageSize == BlockSize` specialization collapses to a trivial
+   "always new" check.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/present_walk_file.h
+++ b/orly/indy/disk/present_walk_file.h
@@ -1,6 +1,11 @@
 /* <orly/indy/disk/present_walk_file.h>
 
-   TODO
+   Read-side walker for the "present" (current) state of a data file:
+   yields each (key, value) at its latest sequence number, skipping
+   superseded history entries. `TWalkerKey` identifies one walk's
+   position by `(file_id, gen_id, index_id)` for use as a cache or
+   registry key. Consumed by the `TPresentWalker` paths in
+   `orly/indy/repo.cc`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/priority.h
+++ b/orly/indy/disk/priority.h
@@ -1,6 +1,9 @@
 /* <orly/indy/disk/priority.h>
 
-   TODO
+   Three-tier I/O priority: `RealTime` (synchronous user reads),
+   `Medium`, and `Low` (background compaction, merge, walkers). Used
+   by `TReadFile`, `TMergeDataFile`, and the page cache to schedule
+   disk operations against shared queue space.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/read_file.h
+++ b/orly/indy/disk/read_file.h
@@ -1,6 +1,11 @@
 /* <orly/indy/disk/read_file.h>
 
-   TODO
+   The reader half of the data-file format: parses meta, key, history,
+   arena, hash, and update indexes off a `TInFile` cursor and exposes
+   them via `ForEachIndex`, `FindInHash`, the typed `T*Stream`s, and
+   the per-index `TDiskArena`. `TFileKey` is the `(file_id, gen_id)`
+   identity used by callers like the page cache. Large header; the
+   public template `TReadFile` starts past the helper declarations.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/test_file_service.h
+++ b/orly/indy/disk/test_file_service.h
@@ -1,6 +1,10 @@
 /* <orly/indy/disk/test_file_service.h>
 
-   TODO
+   In-memory `TFileServiceBase` implementation used by disk-layer tests.
+   No runner loop, no on-disk recovery -- just a `(file_uid, gen_id) ->
+   TFileObj` map guarded by a mutex. Insert / Remove / Find / ForEach
+   all operate against the map directly so tests can assert state
+   without waiting on the production service's queue.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/update_walk_file.h
+++ b/orly/indy/disk/update_walk_file.h
@@ -1,6 +1,10 @@
 /* <orly/indy/disk/update_walk_file.h>
 
-   TODO
+   Read-side walker that yields a data file's updates in sequence order
+   from a starting sequence number. Used by master->slave replication
+   and by the `TUpdateWalker` consumers in `orly/indy/repo.cc` to scan
+   changes. The recorded `Mutator` byte is preserved on read-back (#53)
+   so commutative ops remain commutative when replayed downstream.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/utilization_reporter.h
+++ b/orly/indy/disk/utilization_reporter.h
@@ -1,6 +1,11 @@
 /* <orly/indy/disk/utilization_reporter.h>
 
-   TODO
+   Abstract base for I/O utilization reporting. `Push(source, kind,
+   bytes, priority)` is called from the disk read/write paths;
+   `Report(ss)` emits a summary into a stringstream. Concrete impl is
+   `TIndyUtilReporter` (see `indy_util_reporter.h`); the base lives
+   separately so tests and non-orly callers can plug in their own
+   accounting.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/write_group.h
+++ b/orly/indy/disk/write_group.h
@@ -1,6 +1,11 @@
 /* <orly/indy/disk/write_group.h>
 
-   TODO
+   Batches sequential block writes into a single submitted operation.
+   `Append(block_id, buf)` extends a contiguous run; a non-sequential
+   `block_id` flushes the current run and starts fresh. `TBufferedWrite`
+   is the per-block entry in the batch. Consumers: `TOutStream` (the
+   writer), `TController` and `TService` (the I/O scheduler),
+   `TIndexSortFile` (sort-file emission).
 
    Copyright 2010-2026 Atomic Kismet Company
 


### PR DESCRIPTION
First per-subsystem pass on #70. The issue's grep:

```sh
grep -rln '^   TODO$' orly/   # was 339 files
```

Drops 339 → 320 after this PR.

## Why orly/indy/disk first

The issue explicitly named it as the starting target: "A good starting target: the ~30 public-API headers under `orly/indy/`, since that's the storage layer every contributor hits first." `orly/indy/disk/` had 19 of those 30+ — every header with a placeholder docstring, all of them load-bearing for the storage layer.

## What changed

Each of the 19 headers now opens with 4–7 lines describing what the module does, who consumes it, and any non-obvious responsibilities. Examples:

- `merge_data_file.h` / `update_walk_file.h` — now call out the `Mutator` byte propagation tied to #49 / #53 so the next contributor doesn't accidentally strip it
- `block_hit_counter.h` — explains the log-compression byte-per-block scheme used by the page cache
- `buf_block.h` — explains the `operator new`/`operator delete` routing through the static pool
- `in_file.h` — flags `TData` as the layout-constants module that must stay in sync with `read_file.h`
- `disk_test.h` / `test_file_service.h` / `loop_block_dev.h` — marked as test scaffolding so they're not mistaken for production interfaces

Full list:

```
block_hit_counter.h    file_service.h        meta_rewriter.h        read_file.h
buf_block.h            file_service_base.h   out_stream.h           test_file_service.h
disk_test.h            in_file.h             present_walk_file.h    update_walk_file.h
durable_manager.h      indy_util_reporter.h  priority.h             utilization_reporter.h
file_service.h         loop_block_dev.h      merge_data_file.h      write_group.h
```

## Validation

- `make debug` — passes (1712 / 1712 jobs)
- Comment-only diff: no behavioral impact, no test changes needed

## What's next

This is the first PR in a per-subsystem arc. The remaining 320 files break down as (rough survey from `find <dir> -maxdepth 1 ... | xargs grep -l`):

| Subsystem | TODO docstrings |
|---|---|
| `orly/synth/` | 71 |
| `orly/code_gen/` | 43 |
| `orly/type/` | 41 |
| `orly/rt/` | 17 |
| `orly/symbol/` | 10 |
| `orly/sabot/` | 8 |
| `orly/indy/disk/util/` | 8 |
| `base/` | 5 |
| ... | ... |

Each subsystem can be its own PR. If this format works, I'll continue with `orly/indy/disk/util/` (8 files, small) and `orly/symbol/` (10 files, manageable) next, then move into the larger ones.

## Test plan

- [ ] CI passes (this PR only touches header comments)
- [ ] `grep -rln '^   TODO\$' orly/ | wc -l` reports 320 on master after merge
