### PR TITLE
orly/indy/disk/util: replace placeholder TODO file-level docstrings (refs #70)

### DIFF
--- a/orly/indy/disk/util/cache.h
+++ b/orly/indy/disk/util/cache.h
@@ -1,6 +1,12 @@
 /* <orly/indy/disk/util/cache.h>
 
-   TODO
+   The disk layer's templated page cache. `TCache<PageSize>` holds a
+   fixed pool of page-sized slots keyed by `page_id` with an LRU
+   eviction list, and exposes a `Get` / `Release` API plus async / sync
+   read paths. `engine.h` wires it up under two specialisations:
+   `TPageCache = TCache<PhysicalPageSize>` and `TBlockCache =
+   TCache<PhysicalBlockSize>`. Consumed by every read path in the
+   disk layer (`TStream`, `TReadFile`, the walkers, the mergers).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/util/corruption_detector.h
+++ b/orly/indy/disk/util/corruption_detector.h
@@ -1,6 +1,11 @@
 /* <orly/indy/disk/util/corruption_detector.h>
 
-   TODO
+   Stateless helpers that put / check a Murmur64 hash in the trailing
+   8 bytes of a block-sized buffer. `WriteMurmur` is called before
+   flush; `TryReadMurmur` / `ReadMurmur` is called after read-back to
+   detect bit-rot or partial-write corruption. Used by the disk-layer
+   read paths when the block kind (e.g. `PageCheckedBlock`) asks for
+   end-of-block checking.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/util/disk_util.cc
+++ b/orly/indy/disk/util/disk_util.cc
@@ -1,6 +1,10 @@
 /* <orly/indy/disk/util/disk_util.cc>
 
-   TODO
+   Out-of-line member implementations for `TDiskUtil` (declared in
+   `disk_util.h`). The constructor probes every device under `/dev/`
+   via `TDeviceUtil`, groups them by `VolumeId`, and constructs the
+   right `TPersistentDevice` for each one. Used at `orlyi` startup
+   to assemble the volume topology before the engine boots.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/util/engine.h
+++ b/orly/indy/disk/util/engine.h
@@ -1,6 +1,11 @@
 /* <orly/indy/disk/util/engine.h>
 
-   TODO
+   The disk-layer's resource hub. `TEngine` bundles a `TVolumeManager`
+   (where blocks live), two `TCache`s (`TPageCache` / `TBlockCache`),
+   and a `TFileServiceBase` (the file registry) behind a single handle.
+   Passed around as `Util::TEngine *` to nearly every disk-layer
+   consumer -- readers, writers, walkers, mergers -- so they don't
+   each have to take five constructor arguments.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/util/index_manager.h
+++ b/orly/indy/disk/util/index_manager.h
@@ -1,6 +1,11 @@
 /* <orly/indy/disk/util/index_manager.h>
 
-   TODO
+   External-merge-sort coordinator. `TIndexManager<TVal, MemSize, ...>`
+   accumulates values in an in-memory sorter; when memory pressure or
+   explicit flush triggers, the contents spill to disk as a
+   `TIndexSortFile` (snappy-compressed sorted run). `TCursor` produces
+   a globally-sorted stream by min-heaping across every spilled file
+   plus the in-memory sorter -- classic k-way merge.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/util/index_sort_file.h
+++ b/orly/indy/disk/util/index_sort_file.h
@@ -1,6 +1,11 @@
 /* <orly/indy/disk/util/index_sort_file.h>
 
-   TODO
+   One on-disk run produced by `TIndexManager`. Snappy-compressed,
+   sorted, written through the page cache. `TCursor` subclasses the
+   generic `TSorter::TCursor` so the k-way merge in `TIndexManager`
+   can treat it uniformly with in-memory cursors. `TIndexSortFile`
+   itself implements `TInFile` so it plugs into the standard read-path
+   streams.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/util/snappy.h
+++ b/orly/indy/disk/util/snappy.h
@@ -1,6 +1,10 @@
 /* <orly/indy/disk/util/snappy.h>
 
-   TODO
+   Snappy compression wrapped around the disk layer's stream / block
+   interface. `TBlockSource` / `TBlockSink` adapt a `TBufBlock` to
+   `snappy::Source` / `snappy::Sink`; `TStreamSource` / `TStreamSink`
+   adapt the `TStream<>` / `TOutStream<>` cursors. Used wherever the
+   on-disk format wants compression (notably `TIndexSortFile`'s body).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/util/volume_manager.h
+++ b/orly/indy/disk/util/volume_manager.h
@@ -1,6 +1,12 @@
 /* <orly/indy/disk/util/volume_manager.h>
 
-   TODO
+   The bottom of the disk stack. `TVolumeManager` owns the set of
+   `TVolume`s (devices grouped by `VolumeId`) and dispatches block
+   reads / writes against the appropriate device(s) via Linux AIO.
+   `TLogicalExtent` / `TBlockRange` describe block ranges; `TBufKind`
+   enumerates the block formats (`SectorCheckedBlock`, `PageCheckedBlock`,
+   ...) that callers ask the engine to honor. Large header -- the
+   public class declarations are spread throughout.
 
    Copyright 2010-2026 Atomic Kismet Company
 


### PR DESCRIPTION
Second per-subsystem pass on #70. Follows #78 (`orly/indy/disk/`).

```sh
grep -rln '^   TODO$' orly/   # 320 -> 312
```

## What changed

8 files under `orly/indy/disk/util/` (7 headers + `disk_util.cc`) — each now opens with 5–8 lines describing the module's role and how it fits into the wider disk-layer topology:

| File | One-line summary |
|---|---|
| `cache.h` | Templated `TCache<PageSize>` page cache; backs both `TPageCache` and `TBlockCache` |
| `engine.h` | `TEngine` is the disk-layer resource hub (volume + cache + file service in one handle) |
| `corruption_detector.h` | Murmur64 trailing-bytes checksum for blocks |
| `volume_manager.h` | `TVolumeManager` dispatches AIO reads/writes against per-device volumes |
| `index_manager.h` | External-merge-sort coordinator; spills to `TIndexSortFile` runs |
| `index_sort_file.h` | One on-disk run from `TIndexManager`, snappy-compressed, sorted |
| `snappy.h` | Snappy `Source` / `Sink` adapters for the disk layer's stream/block interface |
| `disk_util.cc` | Out-of-line `TDiskUtil` implementations (constructor probes `/dev/`) |

## Validation

- `make debug` — 1712 / 1712 jobs, clean
- Comment-only diff: no behavioral impact

## What's next

| Subsystem | Remaining TODO docstrings |
|---|---|
| `orly/synth/` | 71 |
| `orly/code_gen/` | 43 |
| `orly/type/` | 41 |
| `orly/rt/` | 17 |
| `orly/symbol/` | 10 |
| `orly/sabot/` | 8 |
| `base/` | 5 |
| `orly/var/` | 3 |
| `orly/indy/` (outside disk/) | 2 |
| `orly/atom/` | 1 |
| `orly/server/` | 1 |

The remaining 312 across the rest of the tree. Smaller targets like `orly/symbol/`, `orly/sabot/`, and `base/` next. The large ones (`orly/synth/`, `orly/code_gen/`, `orly/type/`) deserve more careful per-file reading and will land as separate PRs.

## Test plan

- [ ] CI passes (comment-only)
- [ ] `grep -rln '^   TODO\$' orly/ | wc -l` reports 312 on master after merge
