### PR TITLE
docs: replace TODO file-level docstrings across 7 small subsystems (refs #70)

### DIFF
--- a/base/debug_log.h
+++ b/base/debug_log.h
@@ -1,6 +1,9 @@
 /* <base/debug_log.h>
 
-   TODO
+   `DEBUG_LOG(msg, ...)` macro: in debug builds it forwards to
+   `syslog(LOG_DEBUG, ...)`; in release builds (`NDEBUG` defined) it
+   compiles to nothing so per-call overhead is zero. Use sparingly --
+   debug builds still pay the syslog round-trip.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/event_semaphore.h
+++ b/base/event_semaphore.h
@@ -1,6 +1,10 @@
 /* <base/event_semaphore.h>
 
-   TODO
+   `TEventSemaphore` wraps Linux `eventfd` as a counted semaphore.
+   `Push(n)` increments the count, `Pop()` decrements by 1; the
+   blocking / non-blocking behaviour of `Pop` is selected at
+   construction. `GetFd()` returns the underlying file descriptor
+   for integration with `epoll` and friends.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/hash.h
+++ b/base/hash.h
@@ -1,6 +1,10 @@
 /* <base/hash.h>
 
-   TODO
+   Hash-combination helpers used throughout the codebase:
+   `TTupleHash` (per-element folder for `std::tuple`),
+   `CombineHashes(lhs, rhs)` (the boost-style two-hash mixer), and
+   the variadic `HashChainer` that composes any number of hashers
+   in sequence.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/interner.h
+++ b/base/interner.h
@@ -1,6 +1,11 @@
 /* <base/interner.h>
 
-   TODO
+   `TInterner<TObj, TArgs...>` interns immutable objects by their
+   constructor arguments. `Get(args...)` returns the existing
+   `shared_ptr<const TObj>` or constructs one; the map holds
+   `weak_ptr`s so unused entries die naturally. Used for type
+   objects, sabot type singletons, and other "same args -> same
+   object" invariants.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/thrower.h
+++ b/base/thrower.h
@@ -1,6 +1,10 @@
 /* <base/thrower.h>
 
-   TODO
+   Error-throwing scaffolding: `DEFINE_ERROR(TName, base_t, desc)`
+   declares a new exception class; `THROW_ERROR(TName) << "..."` and
+   `THROW << "..."` are the streaming throw macros. Each thrown
+   error carries the source `TCodeLocation` of the throw site for
+   inclusion in the message.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/atom/transport_arena2.h
+++ b/orly/atom/transport_arena2.h
@@ -1,6 +1,11 @@
 /* <orly/atom/transport_arena2.h>
 
-   TODO
+   `TTransportArena` is a `TCore::TArena` specialised for stream-
+   based transport: `Read(stream, core)` and `Write(stream, ...)`
+   serialise the arena's notes in merge order to / from a
+   `TBinaryInput/OutputStream`. Used by the WS protocol and
+   master->slave replication to ship sabot values across process
+   boundaries.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/context.h
+++ b/orly/indy/context.h
@@ -1,6 +1,10 @@
 /* <orly/indy/context.h>
 
-   TODO
+   `TContext` (subclass of `TContextBase`) -- the per-call execution
+   context inside an `orlyi` method invocation. Holds the POV / repo
+   tree the method walks, the key-cursor collection (for iterators
+   that survive across statements), the sabot arena, and the current
+   sequence numbers. Constructed per RPC and torn down at end-of-call.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/update_walker.h
+++ b/orly/indy/update_walker.h
@@ -1,6 +1,12 @@
 /* <orly/indy/update_walker.h>
 
-   TODO
+   Abstract base for "walk a sequence of updates in order." `TItem`
+   describes one update: sequence number, metadata, id, and a vector
+   of `(TIndexKey, Op, Mutator)` entries. The `Mutator` field defaults
+   to `Assign` for the few paths that don't yet populate it -- the
+   in-memory walker does, but historically the on-disk walker (#53)
+   and replication wire format (#54) didn't, which broke commutative
+   ops on read-back. Both are now fixed.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/sabot/compare_states.h
+++ b/orly/sabot/compare_states.h
@@ -1,6 +1,10 @@
 /* <orly/sabot/compare_states.h>
 
-   TODO
+   `TCompareStatesVisitor` performs three-way comparison
+   (`Atom::TComparison`: `Eq` / `Lt` / `Gt` / `Unordered`) over two
+   `State::TAny`s of the same type. Used wherever the runtime needs
+   value-equality / value-ordering without committing to a static
+   type.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/sabot/compare_types.h
+++ b/orly/sabot/compare_types.h
@@ -1,6 +1,9 @@
 /* <orly/sabot/compare_types.h>
 
-   TODO
+   `CompareTypes(lhs, rhs)` returns three-way comparison
+   (`Atom::TComparison`) over two `Type::TAny`s; `CompareStates`
+   (in `compare_states.h`) uses this for the dispatch step before
+   recursing into element-wise state comparison.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/sabot/get_hash.h
+++ b/orly/sabot/get_hash.h
@@ -1,6 +1,9 @@
 /* <orly/sabot/get_hash.h>
 
-   TODO
+   `GetHash(state)` produces a `size_t` digest of a `State::TAny` via
+   the `THashVisitor`. Used wherever the runtime needs to put dynamic
+   values into hash-based containers (key lookup, dedup of free-form
+   args, etc.).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/sabot/match_prefix_state.h
+++ b/orly/sabot/match_prefix_state.h
@@ -1,6 +1,10 @@
 /* <orly/sabot/match_prefix_state.h>
 
-   TODO
+   `MatchPrefixState(lhs, rhs)` checks whether `lhs`'s state is a
+   prefix of `rhs`'s (returns one of `TMatchResult::NoMatch`,
+   `PrefixMatch`, or `Unifies`). Used by the key-pattern matching path
+   when the runtime evaluates `keys <[pattern]>` with `free::(T)`
+   wildcards.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/sabot/match_prefix_type.h
+++ b/orly/sabot/match_prefix_type.h
@@ -1,6 +1,9 @@
 /* <orly/sabot/match_prefix_type.h>
 
-   TODO
+   The `TMatchResult` enum (`NoMatch` / `PrefixMatch` / `Unifies`)
+   and helpers; partner of `match_prefix_state.h` -- the type-level
+   prefix-match check that the state version recurses into during
+   key-pattern evaluation.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/sabot/order_states.h
+++ b/orly/sabot/order_states.h
@@ -1,6 +1,9 @@
 /* <orly/sabot/order_states.h>
 
-   TODO
+   `TOrderStatesVisitor` produces a total ordering over `State::TAny`
+   values (`OrderStates(lhs, rhs)`). Used as the on-disk key ordering
+   for sorted indexes -- distinct from `CompareStates` (three-way
+   compare) in that this never returns `Unordered`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/sabot/order_types.h
+++ b/orly/sabot/order_types.h
@@ -1,6 +1,9 @@
 /* <orly/sabot/order_types.h>
 
-   TODO
+   `OrderStates` and `OrderTypes` -- total orderings over sabot
+   states and types respectively. The pair is used wherever the
+   storage layer wants a deterministic key ordering (sorted indexes,
+   merge files), and never returns `Unordered`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/sabot/visitor_perf.cc
+++ b/orly/sabot/visitor_perf.cc
@@ -1,6 +1,9 @@
 /* <orly/sabot/visitor_perf.cc>
 
-   TODO
+   Standalone microbenchmark for the sabot visitor pattern.
+   Repeatedly compares an `int8_t` type to itself 100k times and
+   reports total / per-op latency. Useful when changing the
+   visitor-dispatch hot path; not part of any production binary.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/server/meta_record.h
+++ b/orly/server/meta_record.h
@@ -1,6 +1,12 @@
 /* <orly/server/meta_record.h>
 
-   TODO
+   Per-invocation metadata captured for every `orlyi` method call.
+   `TMetaRecord::TEntry` holds session id, optional user id,
+   fully-qualified package name, method name, the named arg map,
+   expected predicate results, timestamp, and random seed. Used for
+   replay and audit -- the random seed in particular lets a
+   deterministic replay reproduce side effects that depended on
+   `RandomInt`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/symbol/any_function.h
+++ b/orly/symbol/any_function.h
@@ -1,6 +1,9 @@
 /* <orly/symbol/any_function.h>
 
-   TODO
+   Abstract base for callable symbols. `TVisitor` dispatches over the
+   two concrete kinds: user-defined `TFunction` and compiler-provided
+   `TBuiltInFunction`. Used by the compiler frontend wherever a
+   "this could be either" callable is referenced.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/symbol/built_in_function.h
+++ b/orly/symbol/built_in_function.h
@@ -1,6 +1,9 @@
 /* <orly/symbol/built_in_function.h>
 
-   TODO
+   Compiler-provided callable: `TimeDiff`, `TimePnt`, `RandomInt`,
+   `Replace`. Each is a singleton accessed via the `Get...()` static
+   helpers. Distinct from `TFunction` (user-defined) but visible
+   through the shared `TAnyFunction` base.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/symbol/def.h
+++ b/orly/symbol/def.h
@@ -1,6 +1,10 @@
 /* <orly/symbol/def.h>
 
-   TODO
+   Abstract base for named definitions in a function's scope. The
+   visitor pattern dispatches to the two concrete kinds:
+   `TGivenParamDef` (a `given` parameter) and `TResultDef` (the symbol
+   a function expression binds). The compiler frontend uses these for
+   name resolution after parsing.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/symbol/function.h
+++ b/orly/symbol/function.h
@@ -1,6 +1,9 @@
 /* <orly/symbol/function.h>
 
-   TODO
+   User-defined orlyscript function. Lives in a `TScope`, owns its
+   `TParamDefSet`, holds the body expression via the inherited
+   `TRoot`. Distinct from `TBuiltInFunction` (compiler-provided) but
+   visible through the shared `TAnyFunction` base.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/symbol/given_param_def.h
+++ b/orly/symbol/given_param_def.h
@@ -1,6 +1,9 @@
 /* <orly/symbol/given_param_def.h>
 
-   TODO
+   A function parameter introduced by a `given` clause -- one
+   concrete subclass of the visitor-friendly `TDef`. Held weakly
+   by the owning `TFunction` (the function holds the param; the
+   param holds the function back).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/symbol/package.h
+++ b/orly/symbol/package.h
@@ -1,6 +1,9 @@
 /* <orly/symbol/package.h>
 
-   TODO
+   Top-level scope: one `TPackage` per orlyscript source file. Tagged
+   with a fully-qualified `Package::TName`, an index name, and an
+   integer `version` for the `package #N;` declaration. Inherits
+   `TScope` so it holds functions and tests like any nested scope.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/symbol/param_def.h
+++ b/orly/symbol/param_def.h
@@ -1,6 +1,9 @@
 /* <orly/symbol/param_def.h>
 
-   TODO
+   Concrete `TFunction::TParamDef` -- a typed parameter bound to a
+   specific `TFunction`. Carries the type and a `weak_ptr` back to
+   the owning function. Subclassed by `TGivenParamDef` for
+   `given`-clause parameters.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/symbol/result_def.h
+++ b/orly/symbol/result_def.h
@@ -1,6 +1,8 @@
 /* <orly/symbol/result_def.h>
 
-   TODO
+   The named symbol that a function's expression binds -- one of the
+   two concrete `TDef`s (alongside `TGivenParamDef`). Carries the type
+   and a `weak_ptr` to the owning `TAnyFunction`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/symbol/root.h
+++ b/orly/symbol/root.h
@@ -1,6 +1,9 @@
 /* <orly/symbol/root.h>
 
-   TODO
+   Holds the top-level expression of a callable. `TFunction` inherits
+   this to carry its body expression; `TRoot` itself is an
+   `Expr::TExprParent` so the expression tree can climb back to the
+   owning function.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/symbol/scope.h
+++ b/orly/symbol/scope.h
@@ -1,6 +1,9 @@
 /* <orly/symbol/scope.h>
 
-   TODO
+   Holds a set of functions and a list of tests. Base for `TPackage`
+   (the top-level scope) and any nested scope the compiler frontend
+   builds. `TypeCheck()` walks the contained functions for type
+   resolution; consumers call `Add` / `Remove` during construction.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/var/impl.h
+++ b/orly/var/impl.h
@@ -1,6 +1,11 @@
 /* <orly/var/impl.h>
 
-   TODO
+   Forward declarations for every concrete `TVar` subclass
+   (`TBool`, `TInt`, `TList`, `TSet`, `TDict`, `TObj`, ...). `TVar`
+   is the runtime's dynamic value type -- a tagged variant covering
+   every orlyscript value. Full class definitions live in
+   `orly/var/all.h` and friends; this header just declares the
+   forwards consumers need.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/var/mutation.h
+++ b/orly/var/mutation.h
@@ -1,6 +1,11 @@
 /* <orly/var/mutation.h>
 
-   TODO
+   The single source of truth for which mutators (`TMutator::Add`,
+   `Or`, `Union`, ...) are commutative-and-associative -- i.e. safe
+   to defer and re-fold. `IsDeferSafeCommutative` gates both
+   `TMutation::Augment` (compose-time, PR #48) and the session-layer
+   emit path (#49 phase 2). `Sub` / `Div` / `Mod` / `Exp` deliberately
+   return false here.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/var/util.h
+++ b/orly/var/util.h
@@ -1,6 +1,9 @@
 /* <orly/var/util.h>
 
-   TODO
+   Out-of-line template definitions for `TVar::As<T>`, `TVar::Is<T>`,
+   `TVar::TryAs<T>`. Lives in its own header (rather than `impl.h`)
+   because these templates need full visibility of the concrete
+   subclass types -- including from this header would create a cycle.
 
    Copyright 2010-2026 Atomic Kismet Company
 


### PR DESCRIPTION
Third pass on #70. Follows #78 (`orly/indy/disk/`) and #79 (`orly/indy/disk/util/`); batches the remaining small subsystems into one PR per your suggestion.

## What changed

30 files across 7 subsystem roots — each now opens with 4–7 lines describing the module's role and its consumers:

| Subsystem | Files | What it is |
|---|---|---|
| `orly/symbol/` | 10 | Compiler symbol-table layer: `TFunction`, `TScope`, `TPackage`, the `TDef` / `TAnyFunction` visitor hierarchies |
| `orly/sabot/` | 8 | Polymorphic state/type visitors for compare / order / hash / prefix-match (+ a `visitor_perf.cc` microbenchmark) |
| `base/` | 5 | General-purpose primitives: `debug_log`, `event_semaphore`, `hash`, `interner`, `thrower` (top-level only — subdirs are followups) |
| `orly/var/` | 3 | `TVar` runtime value forwards + the `IsDeferSafeCommutative` source-of-truth (#49 gate) |
| `orly/indy/` | 2 | `TContext` (per-call execution context) and `TUpdateWalker` (with the `Mutator`-defaults context that motivated #53/#54) |
| `orly/atom/` | 1 | `TTransportArena` (stream-based sabot serialisation for WS / replication) |
| `orly/server/` | 1 | `TMetaRecord` (per-invocation metadata for replay) |

A few of the docstrings explicitly call out the issue-#49 / #53 / #54 connection (`update_walker.h`, `mutation.h`) so the next contributor working those paths immediately sees the constraint.

## Validation

- `make debug` — 1712 / 1712 jobs, clean
- Comment-only diff: no behavioural impact

## What's next

After this PR lands:

| Subsystem | Remaining TODO docstrings | Notes |
|---|---|---|
| `orly/synth/` | 71 | The big one — compiler synthesis tree |
| `orly/code_gen/` | 43 | C++ code emission |
| `orly/type/` | 41 | Static type system |
| `orly/rt/` | 17 | Runtime helpers (built-in operators, containers) |
| `base/` subdirs | ~19 | `base/io/`, `base/inv_con/`, `base/util/`, ... |
| Remaining `orly/indy/` non-disk subdirs | small | A handful in `orly/indy/util/` and the like |

The three big ones (`synth`, `code_gen`, `type`) each warrant their own PR with careful per-file reading. I'd suggest tackling `orly/rt/` next (~17 files, manageable) and the remaining `base/` subdirs in another batched PR before going into the compiler subsystems.

## Test plan

- [ ] CI passes (comment-only)
- [ ] `grep -rln '^   TODO\$' orly/ | wc -l` reports 295 on master after merge
