### PR TITLE
base/{gz,mpl}: replace placeholder TODO file-level docstrings (refs #70)

### DIFF
--- a/base/gz/input_producer.h
+++ b/base/gz/input_producer.h
@@ -1,6 +1,10 @@
 /* <gz/input_producer.h>
 
-   TODO
+   Adapts a gzip-decoded `Gz::TFile` to `Io::TInputProducer` so
+   gzipped input flows through the same chunk-and-pool pipeline as
+   any other `Io` source. Construct with a path + mode or with a
+   moved-in `TFd`; the producer pulls chunks from `File` and hands
+   them up.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/gz/output_consumer.h
+++ b/base/gz/output_consumer.h
@@ -1,6 +1,9 @@
 /* <gz/output_consumer.h>
 
-   TODO
+   Adapts a gzip-encoded `Gz::TFile` to `Io::TOutputConsumer` so
+   chunks emitted by an `Io` producer get gzip-compressed on the way
+   out. Construct with a path + mode; `ConsumeOutput` writes each
+   chunk through `File`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/mpl/and.h
+++ b/base/mpl/and.h
@@ -1,6 +1,9 @@
 /* <mpl/and.h>
 
-   TODO
+   Variadic logical conjunction of predicate type-traits. `And<>` is
+   `std::true_type`; `And<P, More...>` short-circuits via
+   `Conditional<P, And<More...>, std::false_type>` -- mirrors how
+   `&&` short-circuits at runtime.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/mpl/compare.h
+++ b/base/mpl/compare.h
@@ -1,6 +1,9 @@
 /* <mpl/compare.h>
 
-   TODO
+   Type-level comparison operators on `::value` of integral-constant
+   types: `Lt`, `Gt`, `LtEq`, `GtEq`, `EqEq`, `Neq`. Composes with
+   `Mpl::And` / `Mpl::Not` so you can write `Or<Lt<A, B>, EqEq<A, B>>`
+   the way you'd write `a < b || a == b` at runtime.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/mpl/conditional.h
+++ b/base/mpl/conditional.h
@@ -1,6 +1,8 @@
 /* <mpl/conditional.h>
 
-   TODO
+   Compile-time ternary: `Conditional<Pred, T, F>` evaluates to `T`
+   if `Pred::value` is true, else `F`. Used internally by `Mpl::And`,
+   `Mpl::Or`, and most of the recursive list metafunctions.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/mpl/contains.h
+++ b/base/mpl/contains.h
@@ -1,6 +1,9 @@
 /* <mpl/contains.h>
 
-   TODO
+   Compile-time set membership: `Contains<TTypeList<...>, TElem>`
+   (or `TTypeSet`) is `std::true_type` iff `TElem` appears.
+   Implemented via `std::is_base_of<TNode<TElem>, ...>` against the
+   inverted-tree set representation built by `get_unique.h`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/mpl/enable_if.h
+++ b/base/mpl/enable_if.h
@@ -1,6 +1,10 @@
 /* <mpl/enable_if.h>
 
-   TODO
+   SFINAE helper: `EnableIf<P>` is a well-formed type only when
+   `P::value` is true; otherwise the substitution fails and the
+   overload is dropped. `DisableIf<P>` is `EnableIf<Not<P>>`.
+   Used as a template default argument or return type -- the unary
+   counterpart of `std::enable_if_t`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/mpl/extend.h
+++ b/base/mpl/extend.h
@@ -1,6 +1,9 @@
 /* <mpl/extend.h>
 
-   TODO
+   Concatenates two `TTypeList`s: `TExtend<TTypeList<A...>,
+   TTypeList<B...>>` is `TTypeList<A..., B...>`. Building block for
+   the recursive list constructors (`merge`, `get_union`,
+   `get_unique`, ...).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/mpl/get_at.h
+++ b/base/mpl/get_at.h
@@ -1,6 +1,9 @@
 /* <mpl/get_at.h>
 
-   TODO
+   `TGetAt<TList, Idx>` evaluates to the `Idx`-th element of a
+   `TTypeList`. Implemented via `TTypeListRecur`'s overload set --
+   pure compile-time work, no runtime indirection. Inverse of
+   `TGetIdx`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/mpl/get_difference.h
+++ b/base/mpl/get_difference.h
@@ -1,6 +1,8 @@
 /* <mpl/get_difference.h>
 
-   TODO
+   Type-level set difference: `GetDifference<L, R>` is a `TTypeList`
+   containing every element of `L` that is not in `R`. Pairs with
+   `get_union` and `get_intersection` for the full set algebra.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/mpl/get_idx.h
+++ b/base/mpl/get_idx.h
@@ -1,6 +1,8 @@
 /* <mpl/get_idx.h>
 
-   TODO
+   `TGetIdx<TList, TElem>` evaluates to the index at which `TElem`
+   appears in a `TTypeList`. Inverse of `TGetAt`; thin wrapper over
+   `TTypeListRecur::GetIdx`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/mpl/get_intersection.h
+++ b/base/mpl/get_intersection.h
@@ -1,6 +1,8 @@
 /* <mpl/get_intersection.h>
 
-   TODO
+   Type-level set intersection: `GetIntersection<L, R>` is a
+   `TTypeList` of elements in both `L` and `R`. Pairs with
+   `get_union` / `get_difference` for the full set algebra.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/mpl/get_size.h
+++ b/base/mpl/get_size.h
@@ -1,6 +1,9 @@
 /* <mpl/get_size.h>
 
-   TODO
+   `GetSize<TList>()` evaluates to the number of elements in a
+   `TTypeList` (or `TTypeSet`, which forwards to its underlying list)
+   as a `constexpr size_t`. Used by `IsSame`'s set-equality
+   specialisation and as a building block in slicing.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/mpl/get_slice.h
+++ b/base/mpl/get_slice.h
@@ -1,6 +1,9 @@
 /* <mpl/get_slice.h>
 
-   TODO
+   `TGetSlice<TList, Start, End>` evaluates to a `TTypeList` of the
+   half-open `[Start, End)` slice of `TList`. Implemented recursively
+   by stepping the list head until `Start == 0`, then collecting
+   until the end index.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/mpl/get_union.h
+++ b/base/mpl/get_union.h
@@ -1,6 +1,8 @@
 /* <mpl/get_union.h>
 
-   TODO
+   Type-level set union: `GetUnion<L, R>` is a `TTypeList` of every
+   distinct element from `L` and `R` combined. Pairs with
+   `get_intersection` and `get_difference`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/mpl/get_unique.h
+++ b/base/mpl/get_unique.h
@@ -1,6 +1,9 @@
 /* <mpl/get_unique.h>
 
-   TODO
+   `TGetUnique<TList>` dedups a `TTypeList`, preserving first-seen
+   order. Builds an inverted-tree `TRoot<TNode<T>...>` for O(1)
+   membership checks via `std::is_base_of` -- the same trick that
+   backs `Mpl::Contains` and the `TTypeSet` representation.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/mpl/is_same.h
+++ b/base/mpl/is_same.h
@@ -1,6 +1,10 @@
 /* <mpl/is_same.h>
 
-   TODO
+   Specialises `std::is_same` for `Mpl::TTypeSet<...>` so two sets
+   compare equal regardless of element order (`std::is_same` on the
+   underlying tuple would require positional match). Also defines
+   `Mpl::IsSame<L, R>` -- a `decay`-aware passthrough useful for
+   template-parameter matching.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/mpl/is_subset_of.h
+++ b/base/mpl/is_subset_of.h
@@ -1,6 +1,9 @@
 /* <mpl/is_subset_of.h>
 
-   TODO
+   Type-level subset check: `IsSubsetOf<L, R>` is `std::true_type`
+   iff every element of `L` appears in `R`. Used by `is_same.h`'s
+   set-equality specialisation -- two sets are equal iff each is a
+   subset of the other.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/mpl/merge.h
+++ b/base/mpl/merge.h
@@ -1,6 +1,10 @@
 /* <mpl/merge.h>
 
-   TODO
+   Sorted merge of two `TTypeList`s under a user-supplied template
+   comparator: `TMerge<TCompare, A, B>` zips A's and B's heads using
+   `TCompare<L, R>::value`, taking the smaller each step. Pairs
+   naturally with `Mpl::Lt` / `Mpl::Gt` from `compare.h` for the
+   comparator argument.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/mpl/not.h
+++ b/base/mpl/not.h
@@ -1,6 +1,8 @@
 /* <mpl/not.h>
 
-   TODO
+   Negates a predicate type-trait: `Not<P>` is `true` iff `P::value`
+   is `false`. Useful as a building block for `EnableIf` /
+   `DisableIf` and for combining with `And` / `Or`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/mpl/or.h
+++ b/base/mpl/or.h
@@ -1,6 +1,9 @@
 /* <mpl/or.h>
 
-   TODO
+   Variadic logical disjunction of predicate type-traits. Symmetric
+   counterpart of `Mpl::And` -- `Or<>` is `std::false_type`,
+   `Or<P, More...>` short-circuits via `Conditional<P, std::true_type,
+   Or<More...>>`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/mpl/reverse.h
+++ b/base/mpl/reverse.h
@@ -1,6 +1,8 @@
 /* <mpl/reverse.h>
 
-   TODO
+   `TReverse<TList>` is a `TTypeList` with `TList`'s elements in
+   reverse order. Useful when a metafunction is easier to express
+   walking right-to-left than left-to-right.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/mpl/type_list.h
+++ b/base/mpl/type_list.h
@@ -1,6 +1,9 @@
 /* <mpl/type_list.h>
 
-   TODO
+   The core container of the `Mpl::` metaprogramming library: a
+   variadic `TTypeList<TElems...>` with compile-time
+   `GetIdx<TElem>()` lookup and `GetSize()`. Almost every other
+   `Mpl::` metafunction is built on this.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/base/mpl/type_set.h
+++ b/base/mpl/type_set.h
@@ -1,6 +1,9 @@
 /* <mpl/type_set.h>
 
-   TODO
+   Order-independent type container built on `TTypeList` by passing
+   the elements through `TGetUnique`. Backs `Mpl::Contains`, the
+   `Mpl::IsSame` set-equality specialisation, and the set-ops
+   (`GetUnion`, `GetIntersection`, `GetDifference`).
 
    Copyright 2010-2026 Atomic Kismet Company
 


### PR DESCRIPTION
Fifth pass on #70. Follows #78 (`orly/indy/disk/`), #79 (`orly/indy/disk/util/`), #80 (7 small subsystems incl. top-level `base/`), #81 (`orly/rt/`).

## What changed

24 files across two `base/` subdirs — `base/gz/` (2 files) and `base/mpl/` (22 files). After this PR, **`base/` is entirely TODO-docstring-free**.

### `base/gz/` (2)

| File | One-line summary |
|---|---|
| `input_producer.h` | Adapts gzip-decoded `Gz::TFile` to `Io::TInputProducer` |
| `output_consumer.h` | Adapts `Io` chunks to gzip-encoded `Gz::TFile` writes |

### `base/mpl/` (22)

A small custom template-metaprogramming library. Each file is a single metafunction; docstrings name what it computes in plain English so readers don't have to puzzle out the recursive struct templates.

| File | Metafunction |
|---|---|
| `type_list.h` | The core `TTypeList<TElems...>` container — everything else builds on this |
| `type_set.h` | Order-independent set built atop `TTypeList` via `TGetUnique` |
| `and.h` / `or.h` / `not.h` | Variadic boolean composition, short-circuiting like the runtime operators |
| `conditional.h` | Compile-time ternary used internally by `And` / `Or` / list folds |
| `compare.h` | `Lt` / `Gt` / `LtEq` / `GtEq` / `EqEq` / `Neq` on `::value` |
| `enable_if.h` | Unary `EnableIf<P>` / `DisableIf<P>` SFINAE helpers |
| `contains.h` | Type membership via `std::is_base_of<TNode<T>, ...>` |
| `extend.h` | Concatenates two `TTypeList`s |
| `get_at.h` / `get_idx.h` | Nth-element / index-of-element (inverses) |
| `get_size.h` | Compile-time length |
| `get_slice.h` | Half-open `[Start, End)` slice |
| `get_union.h` / `get_intersection.h` / `get_difference.h` | Type-level set algebra |
| `get_unique.h` | Dedup, builds the inverted `TRoot<TNode<T>...>` tree |
| `is_same.h` | Order-independent set equality (`std::is_same` specialisation for `TTypeSet`) |
| `is_subset_of.h` | Subset relation — underpins `is_same.h`'s set-equality |
| `merge.h` | Sorted merge under a user-supplied template comparator |
| `reverse.h` | Reverse a `TTypeList` |

A few docstrings call out the reusable inverted-tree `TRoot<TNode<T>...>` trick (in `get_unique.h`) and where it gets reused (`contains.h`, `type_set.h`) so the design pattern is obvious from the file headers.

## Validation

- `make debug` — 1712 / 1712 jobs, clean
- Comment-only diff: no behavioural impact
- `grep -rln '^   TODO\$' base/` now reports `0`

## What's next

After this PR lands, the remaining file-level TODO docstrings are concentrated in the three big compiler subsystems:

| Subsystem | Remaining TODO docstrings |
|---|---|
| `orly/synth/` | 71 |
| `orly/code_gen/` | 43 |
| `orly/type/` | 41 |

Each warrants its own PR with careful per-file reading. A handful of smaller leftovers (subdirs of `orly/sabot/`, `orly/atom/`, etc.) might exist too — I'll survey them before deciding whether to batch them in with one of the big PRs or do another small batched cleanup.

## Test plan

- [ ] CI passes (comment-only)
- [ ] `grep -rln '^   TODO\$' base/ | wc -l` reports `0` on master after merge
