### PR TITLE
orly/code_gen: replace placeholder TODO file-level docstrings (refs #70)

### DIFF
--- a/orly/code_gen/basic_ctor.h
+++ b/orly/code_gen/basic_ctor.h
@@ -1,6 +1,11 @@
 /* <orly/code_gen/basic_ctor.h>
 
-   TODO
+   `TBasicCtor<TContainer>` emits a container literal: addr (vector
+   of `(dir, inline)`), dict (map of `inline -> inline`), set
+   (set of inlines), list (vector of inlines). `WriteCtorElem` is
+   the per-container element formatter (dict elements emit as
+   `{key, val}`, addr elements emit just the value because the dir
+   lives outside).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/binary.h
+++ b/orly/code_gen/binary.h
@@ -1,6 +1,12 @@
 /* <orly/code_gen/binary.h>
 
-   TODO
+   `TBinary` emits a two-operand operator. `TOp` enumerates them:
+   `Add`, `And`, `Atan2`, `Div`, `EqEq`, `Exponent`, `Gt`, `GtEq`,
+   `In`, `Intersection`, `IsKnownExpr`, `Lt`, `LtEq`, `Modulo`,
+   `Mult`, `Neq`, `Or`, `Sub`, `SymmetricDiff`, `Union`, `Xor`. Each
+   `TOp` selects one of `Template` / `Infix` / `Call` / `CallReverse`
+   emit shapes (e.g. `Add` is infix `+`, `Atan2` is a function call,
+   `In` reverses operand order before calling).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/binary_scoped_rhs.h
+++ b/orly/code_gen/binary_scoped_rhs.h
@@ -1,6 +1,11 @@
 /* <orly/code_gen/binary_scoped_rhs.h>
 
-   TODO
+   `TBinaryScopedRhs` is `TBinary`'s sibling for the two operators
+   whose rhs needs its own scope (so it can compute lazily and only
+   fire when the lhs decides): `AndThen` (`x and_then y` evaluates
+   `y` only if `x` is true) and `OrElse` (`x or_else y` evaluates
+   `y` only if `x` is false). The rhs is a `TInlineScope`, not a
+   plain `TInline`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/builder.h
+++ b/orly/code_gen/builder.h
@@ -1,6 +1,12 @@
 /* <orly/code_gen/builder.h>
 
-   TODO
+   The entry point for code-gen: turn an `Expr::TExpr` tree into a
+   `CodeGen::TInline`. `BuildInline` handles implicit maps (a
+   function applied to a sequence argument becomes an element-wise
+   map); `Build` is the raw recursive builder that the rest of the
+   code-gen machinery calls through. The "do not use directly"
+   comment on `Build` is a footgun warning -- calling it directly
+   skips the map-lowering pass.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/built_in_call.h
+++ b/orly/code_gen/built_in_call.h
@@ -1,6 +1,10 @@
 /* <orly/code_gen/built_in_call.h>
 
-   TODO
+   `TBuiltInCall` emits a call into one of the compiler-provided
+   builtins from `Symbol::TBuiltInFunction` (`TimeDiff`, `TimePnt`,
+   `RandomInt`, `Replace`). Distinct from `TCall` because the
+   target isn't a user-defined function with a body to recurse into;
+   it just emits the runtime helper name and forwards arguments.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/call.h
+++ b/orly/code_gen/call.h
@@ -1,6 +1,9 @@
 /* <orly/code_gen/call.h>
 
-   TODO
+   `TCall` emits a call to a user-defined function with named
+   arguments. The args vector is required to be ordered asciibetically
+   by name (matches the function's `TNamedArgs` order). Dependency
+   graph includes both each argument and the callee's body.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/collated_by.h
+++ b/orly/code_gen/collated_by.h
@@ -1,6 +1,10 @@
 /* <orly/code_gen/collated_by.h>
 
-   TODO
+   `TCollatedBy` emits a `collated_by ... having ...` expression:
+   groups elements of `Seq` from `Start`, reducing each group
+   through `ReduceFunc`, then filtering groups through `HavingFunc`.
+   Both functions are `TImplicitFunc`s synthesised over the inline
+   body.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/collected_by.h
+++ b/orly/code_gen/collected_by.h
@@ -1,6 +1,9 @@
 /* <orly/code_gen/collected_by.h>
 
-   TODO
+   `TCollectedBy` emits a `collected_by` expression: fold a
+   sequence of `(key, val)` pairs into a `TDict`. The `CollectFunc`
+   is a `TImplicitFunc` over the (existing, val) collision case --
+   appears in the wikipedia-categories demo, among others.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/context.h
+++ b/orly/code_gen/context.h
@@ -1,6 +1,11 @@
 /* <orly/code_gen/context.h>
 
-   TODO
+   Process-singleton stack of code-gen state. Many emit paths need
+   access to the "current" scope / function / `that` arg / reduce
+   `start` arg / lhs / rhs / stmt block, so `Context` exposes them
+   as static getters. The friend `T*Ctx` classes are RAII stack-
+   frame guards that push and pop entries. Pure namespace dressed
+   as a class (`NO_CONSTRUCTION`).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/cpp_printer.h
+++ b/orly/code_gen/cpp_printer.h
@@ -1,7 +1,12 @@
 
 /* <orly/code_gen/cpp_printer.h>
 
-   TODO
+   The C++ source-writing stream used by every code-gen node.
+   `TCppPrinter` wraps an output `ofstream` with indent tracking and
+   a tiny vocabulary (`TEol`, `TIndent`, `TNamespacePrinter`,
+   `TOrlyNamespacePrinter`). Construct with a target filename and
+   description; each `Write` call honours the current indent level
+   (set up by `TIndent` RAII guards).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/effect.h
+++ b/orly/code_gen/effect.h
@@ -1,6 +1,14 @@
 /* <orly/code_gen/effect.h>
 
-   TODO
+   The mutation-statement hierarchy emitted inside `effecting { ... }`
+   blocks. `TChange` is the abstract base for one change to one
+   addressable slot: `TMutation` (the `OP=` shape -- runs the
+   runtime mutator), `TDelete` (key removal), `TNew` (initial
+   assignment). `TStmt` is the abstract statement, `TStmtBlock` is
+   the container, `TPredicatedBlock` + `TIf` give conditional
+   mutation. Mirrors the runtime mutator hierarchy in
+   `orly/var/mutation.h` -- in-file note flags that they must
+   change in parallel.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/error.h
+++ b/orly/code_gen/error.h
@@ -1,6 +1,9 @@
 /* <orly/code_gen/error.h>
 
-   TODO
+   Single error class for the code-gen layer: `TCgError`. Defined via
+   the `DEFINE_ERROR` macro to inherit `std::runtime_error`. Thrown
+   by `TCppPrinter` when it can't open an output file, and by helpers
+   that hit unexpected state during emission.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/exists.h
+++ b/orly/code_gen/exists.h
@@ -1,6 +1,9 @@
 /* <orly/code_gen/exists.h>
 
-   TODO
+   `TExists` emits an `is_known` / `keys ... is known` shaped
+   check where the underlying expression may reach the storage
+   layer. Carries the read value-type (for runtime sabot dispatch)
+   and the inline whose presence is being tested.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/export_func.h
+++ b/orly/code_gen/export_func.h
@@ -1,6 +1,10 @@
 /* <orly/code_gen/export_func.h>
 
-   TODO
+   `TExportFunc` is a top-level package function visible to other
+   packages and to the database client interface. Multiply-inherits
+   `TTopFunc` (for the emit-as-top-level wiring) and `TSymbolFunc`
+   (for the symbol-to-code-gen map). `WriteName` / `WriteCcName`
+   produce the public C++ name.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/filter.h
+++ b/orly/code_gen/filter.h
@@ -1,6 +1,9 @@
 /* <orly/code_gen/filter.h>
 
-   TODO
+   `TFilter` emits a `seq if (...)` filter expression. The body is
+   a `TImplicitFunc` synthesised over the filter predicate; the
+   emitted code threads each element through the function and
+   yields those that return `true`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/function.h
+++ b/orly/code_gen/function.h
@@ -1,6 +1,12 @@
 /* <orly/code_gen/function.h>
 
-   TODO
+   Abstract base for every emitted C++ function. Leaf classes are
+   `TTopFunc` (instantiable at package scope), `TInnerFunc` (named
+   lambda inside a top-level function), and `TImplicitFunc` (the
+   synthesised callback for `map` / `filter` / `reduce` / `sort` /
+   `while`). `TArg` represents one named parameter with its `TRef`
+   (the inline reference used inside the body). Argument maps are
+   always ordered by name -- callers must pass args asciibetically.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/id.h
+++ b/orly/code_gen/id.h
@@ -1,6 +1,10 @@
 /* <orly/code_gen/id.h>
 
-   TODO
+   `TId<TIdKind>` is a unique per-scope identifier with a kind
+   prefix (`a` for args, `f` for functions, `t` for tests, `v` for
+   variables). `TGen` is the per-scope monotonic counter that hands
+   them out. The prefix lets the emitted C++ distinguish `a0` (an
+   arg) from `v0` (a local) at a glance.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/if_else.h
+++ b/orly/code_gen/if_else.h
@@ -1,6 +1,10 @@
 /* <orly/code_gen/if_else.h>
 
-   TODO
+   `TIfElse` emits a ternary `if pred then true_case else false_case`
+   expression. `True` and `False` are `TInlineScope`s (not flat
+   `TInline`s) because the branches can introduce local definitions.
+   `InDependsOn` is a recursion guard so the dependency walker
+   doesn't infinitely recurse when one branch references the other.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/implicit_func.h
+++ b/orly/code_gen/implicit_func.h
@@ -1,6 +1,11 @@
 /* <orly/code_gen/implicit_func.h>
 
-   TODO
+   `TImplicitFunc` is the auto-synthesised callback that orlyc emits
+   for the implicit-lambda operators: `collected_by`, `filter`,
+   `map`, `reduce`, `sorted_by`, `while`. `TCause` records which
+   operator caused the synthesis (mainly for debugging / naming).
+   Inherits `TInlineFunc` because the result is always a lambda
+   inside the surrounding function.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/inline.h
+++ b/orly/code_gen/inline.h
@@ -1,6 +1,13 @@
 /* <orly/code_gen/inline.h>
 
-   TODO
+   `TInline` is the abstract base for every code-gen expression node.
+   `WriteExpr` emits the C++ source for this expression;
+   `AppendDependsOn` declares which other inlines this one references
+   (for the common-subexpression eliminator and dependency-order
+   emission). `SetCommonSubexpressionId` is set by CSE when the same
+   `TInline` appears more than once -- subsequent `Write` calls then
+   emit the saved variable name instead of re-emitting the full
+   expression.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/inline_func.h
+++ b/orly/code_gen/inline_func.h
@@ -1,6 +1,10 @@
 /* <orly/code_gen/inline_func.h>
 
-   TODO
+   `TInlineFunc` is the base for functions emitted inside another
+   function (lambdas). Carries a `TId<TIdKind::Func>` for naming
+   and writes its definition / declaration via `WriteDecl` /
+   `WriteDef`. Counterpart of `TTopFunc` -- the two are virtual
+   bases that `TInnerFunc` multiply-inherits from.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/inline_scope.h
+++ b/orly/code_gen/inline_scope.h
@@ -1,6 +1,9 @@
 /* <orly/code_gen/inline_scope.h>
 
-   TODO
+   `TInlineScope` wraps a body inline together with the `TCodeScope`
+   that hosts its locals / assertions. Used wherever a
+   sub-expression needs its own scope (the branches of `TIfElse`,
+   the body of `TBinaryScopedRhs`, the bodies of test predicates).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/inner_func.h
+++ b/orly/code_gen/inner_func.h
@@ -1,6 +1,10 @@
 /* <orly/code_gen/inner_func.h>
 
-   TODO
+   `TInnerFunc` is a named lambda defined inside a top-level
+   function: inherits both `TInlineFunc` (so it emits inside another
+   function's body) and `TSymbolFunc` (so calls bind through the
+   symbol map). Used for orlyscript's `f = (...) where { ... }`
+   definitions inside function bodies.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/interner.h
+++ b/orly/code_gen/interner.h
@@ -1,6 +1,11 @@
 /* <orly/code_gen/interner.h>
 
-   TODO
+   Per-`TCodeScope` interner that deduplicates identical inlines so
+   two equivalent subexpressions in the same scope share one
+   `TInline` pointer. Holds one `Base::TInterner` per inline kind
+   (binary, call, literal, basic_ctor, member, range, slice, sort,
+   ...); `GetBinary(args)` etc. are thin wrappers that route through
+   them. Backs common-subexpression elimination.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/keys.h
+++ b/orly/code_gen/keys.h
@@ -1,6 +1,10 @@
 /* <orly/code_gen/keys.h>
 
-   TODO
+   `TKeys` emits a `keys <[pattern]>` expression: builds the
+   `TAddrElems` (same `(TAddrDir, TInline)` shape as
+   `TBasicCtor<TAddrContainer>`) plus the dereferenced value type
+   and emits the runtime call that walks the index for matching
+   keys.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/literal.h
+++ b/orly/code_gen/literal.h
@@ -1,6 +1,10 @@
 /* <orly/code_gen/literal.h>
 
-   TODO
+   `TLiteral` wraps a runtime `Var::TVar` and emits its C++ literal
+   form (via the `<< Var` stream overload). Used for compile-time-
+   known values appearing in expressions. The in-file comment about
+   not common-subexpression-eliminating literals is a planned tweak --
+   literals are cheap enough to inline freely.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/map.h
+++ b/orly/code_gen/map.h
@@ -1,6 +1,10 @@
 /* <orly/code_gen/map.h>
 
-   TODO
+   `TMap` emits an implicit-or-explicit map expression: zips one or
+   more `Seqs` element-wise through `Func` (a `TImplicitFunc`).
+   Implicit maps are the orlyc frontend's lowering of a function
+   applied to a sequence argument -- by the time code-gen runs,
+   they've all become `TMap`s.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/member.h
+++ b/orly/code_gen/member.h
@@ -1,6 +1,11 @@
 /* <orly/code_gen/member.h>
 
-   TODO
+   Mutable-aware member access. `TMutableRewrap` is the base that
+   rewraps a `TMutable` result around the projected member;
+   `TAddrMember` projects element `i` from an address tuple,
+   `TObjMember` projects a named field from an object. Both emit
+   the postfix accessor (`.i` / `.name`) and the corresponding
+   part id used by the mutate machinery.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/package.h
+++ b/orly/code_gen/package.h
@@ -1,6 +1,11 @@
 /* <orly/code_gen/package.h>
 
-   TODO
+   `CodeGen::TPackage` represents one orlyscript source file being
+   emitted to C++. Holds the exported functions, tests, and object
+   types; `Emit(out_dir)` writes the per-package header / .cc / link
+   files; `EmitObjectHeaders` writes the per-`TObj` C++ struct
+   headers. Inherits `L0::TPackage` for the dependency-injection
+   seam used by the rest of the code-gen layer.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/package_base.h
+++ b/orly/code_gen/package_base.h
@@ -1,6 +1,10 @@
 /* <orly/code_gen/package_base.h>
 
-   TODO
+   The dependency-injection base for `CodeGen::TPackage`. Exposes
+   just the slice that function- and inline-builders actually need
+   (the `AddrMap` / `ReverseAddrMap` index-UUID lookup, the symbol-
+   package name) without forcing every helper to include the full
+   `CodeGen::TPackage` definition. `CodeGen::TPackage` inherits this.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/range.h
+++ b/orly/code_gen/range.h
@@ -1,6 +1,9 @@
 /* <orly/code_gen/range.h>
 
-   TODO
+   `TRange` emits `[start..end]` / `[start..end..stride]` /
+   `[start..]` ranges. `IncludeEnd` selects inclusive vs exclusive;
+   `OptLimit` / `OptStride` are nullable for unbounded / unit-stride
+   ranges.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/reduce.h
+++ b/orly/code_gen/reduce.h
@@ -1,6 +1,8 @@
 /* <orly/code_gen/reduce.h>
 
-   TODO
+   `TReduce` emits a `reduce start X + that` expression: fold
+   `Seq` starting from `Start` using `Func` (a `TImplicitFunc`
+   over the (carry, that) accumulator pair).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/scope.h
+++ b/orly/code_gen/scope.h
@@ -1,6 +1,11 @@
 /* <orly/code_gen/scope.h>
 
-   TODO
+   Per-function-body code-gen scope. `TIdScope` is the per-top-level
+   `TId<Arg|Func|Var>` generator (lambdas inside a top-level function
+   share their parent's id scope so `&` captures stay valid).
+   `TCodeScope` holds the function's locals, assertions, and the
+   `TIdScope` it draws from. Inlines flow through `AddLocal` so
+   common-subexpression elimination can attach a name.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/skip.h
+++ b/orly/code_gen/skip.h
@@ -1,6 +1,7 @@
 /* <orly/code_gen/skip.h>
 
-   TODO
+   `TSkip` emits the `skip` sequence operator: drop the first
+   `count` elements of `seq`. Counterpart of `TTake`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/slice.h
+++ b/orly/code_gen/slice.h
@@ -1,6 +1,9 @@
 /* <orly/code_gen/slice.h>
 
-   TODO
+   `TSlice` emits `container[idx]` indexing and `container[lhs:rhs]`
+   slicing. `Colon` distinguishes single-index from slice; `OptLhs`
+   / `OptRhs` are nullable for open-ended slices (`container[:rhs]`,
+   `container[lhs:]`).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/sort.h
+++ b/orly/code_gen/sort.h
@@ -1,6 +1,8 @@
 /* <orly/code_gen/sort.h>
 
-   TODO
+   `TSort` emits a `sorted_by lhs < rhs` expression. The comparator
+   is a `TImplicitFunc` synthesised over the sort predicate; the
+   emitted code copies `container` and runs `Rt::Sort` against it.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/symbol_func.h
+++ b/orly/code_gen/symbol_func.h
@@ -1,6 +1,10 @@
 /* <orly/code_gen/symbol_func.h>
 
-   TODO
+   `TSymbolFunc` is the base for any code-gen function that maps
+   back to a `Symbol::TFunction` from the language frontend. Holds
+   the symbol pointer, the body inline, and a static
+   `Symbol::TFunction*` -> `TSymbolFunc*` map so calls into the
+   same named function reuse the existing code-gen.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/take.h
+++ b/orly/code_gen/take.h
@@ -1,6 +1,7 @@
 /* <orly/code_gen/take.h>
 
-   TODO
+   `TTake` emits the `take` sequence operator: keep only the first
+   `count` elements of `seq`. Counterpart of `TSkip`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/test.h
+++ b/orly/code_gen/test.h
@@ -1,6 +1,11 @@
 /* <orly/code_gen/test.h>
 
-   TODO
+   `TTestCase` emits one test from a `with { ... } test { ... }`
+   block. Inherits `TTopFunc` because tests emit as standalone
+   functions in the .cc. `TTestBlock` is the (optional) container
+   for nested sub-tests (the `t1: { t2: ... }` structure). Each
+   test gets a `TId<TIdKind::Test>` from the package-scoped
+   generator.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/top_func.h
+++ b/orly/code_gen/top_func.h
@@ -1,6 +1,10 @@
 /* <orly/code_gen/top_func.h>
 
-   TODO
+   `TTopFunc` is the base for functions emitted at package scope:
+   `TExportFunc` (user-visible) and `TTestCase` (test wrappers).
+   `IsTopLevel` returns true; `WriteDecl` / `WriteDef` emit the .h
+   declaration and .cc definition. Concrete subclasses implement
+   `WriteCcName` (the symbol name used in the .cc).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/typed_leaf.h
+++ b/orly/code_gen/typed_leaf.h
@@ -1,6 +1,10 @@
 /* <orly/code_gen/typed_leaf.h>
 
-   TODO
+   `TTypedLeaf` is a parameter-less inline (no operand dependencies)
+   that emits one of the language's typed leaf forms: `TKind::Unknown`
+   for the unknown literal of a given type, `TKind::Free` for
+   `free::(T)` placeholders in key patterns (with `TAddrDir` for
+   asc/desc).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/unary.h
+++ b/orly/code_gen/unary.h
@@ -1,6 +1,12 @@
 /* <orly/code_gen/unary.h>
 
-   TODO
+   `TUnary` emits a single-operand operator. `TOp` enumerates them:
+   `Acos`, `AddressOf`, `Asin`, `Atan`, `Cast`, `Ceiling`, `Cos`,
+   `Floor`, `IsEmpty`, `IsKnown`, `IsUnknown`, `Known`, `LengthOf`,
+   `Log`, `Log2`, `Log10`, `Negative`, `Not`, `Read`, `ReverseOf`,
+   `SequenceOf`, `Sin`, `Tan`, `TimeDiffObj`, `TimePntObj`,
+   `ToLower`, `ToUpper`, `UnwrapMutable`. Emit shape is `Call`
+   (function-call) or `Postfix`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/while.h
+++ b/orly/code_gen/while.h
@@ -1,6 +1,9 @@
 /* <orly/code_gen/while.h>
 
-   TODO
+   `TWhile` emits a `while` sequence operator: yields elements from
+   `Seq` until `Func` (a `TFunction` over the element type) returns
+   `false`. Used to express bounded streams over an unbounded
+   source.
 
    Copyright 2010-2026 Atomic Kismet Company
 


### PR DESCRIPTION
Seventh pass on #70. Follows #78, #79, #80, #81, #82, #83. Second of the three big compiler subsystems (`orly/type/` done in #83, `orly/synth/` remaining).

## What changed

43 headers under `orly/code_gen/` — the C++ emission layer that orlyc uses to lower an `Expr::TExpr` tree into compilable C++. Each docstring explains how the file fits into the four-layer architecture:

### Foundation (8)
| File | Role |
|---|---|
| `builder.h` | `Expr::TExpr` → `TInline` entry point (`BuildInline` lowers implicit maps; `Build` is the raw recursive path) |
| `cpp_printer.h` | The indented C++ output stream used by every emit path |
| `context.h` | Process-singleton stack of code-gen state (scope / function / `that` / lhs / rhs / stmt block) |
| `scope.h` | `TIdScope` (per-top-func id generator) + `TCodeScope` (locals, assertions, the id scope) |
| `interner.h` | Per-`TCodeScope` deduper backing common-subexpression elimination |
| `package.h` / `package_base.h` | The unit of emission: one orlyscript source file → one set of .h / .cc / link files |
| `error.h` | `TCgError` |

### Inline base + identity helpers (4)
| File | Role |
|---|---|
| `inline.h` | `TInline` abstract base — `WriteExpr` emits the C++, `AppendDependsOn` declares dependencies, `SetCommonSubexpressionId` hooks CSE |
| `id.h` | `TId<Arg|Func|Var|Test>` unique identifiers with kind prefixes (`a0`, `v0`, ...) |
| `typed_leaf.h` | Parameter-less inlines: `Unknown` literal and `free::(T)` placeholders |
| `literal.h` | `TVar` wrapper that emits its C++ literal form |

### Function hierarchy (7)
`TFunction` (abstract) → `TTopFunc` (top-level) / `TInlineFunc` (lambda) virtual bases → `TSymbolFunc` (the `Symbol::TFunction` map) → concrete `TExportFunc` (user-visible top-level), `TInnerFunc` (named lambda), `TImplicitFunc` (synthesised callbacks for `collect` / `filter` / `map` / `reduce` / `sort` / `while`).

### Expression-tree leaves (22)
Each one inherits `TInline` and represents one node in the lowered expression tree:

`binary`, `unary`, `binary_scoped_rhs` (`and_then` / `or_else` with lazy rhs), `built_in_call`, `call`, `basic_ctor` (addr / dict / list / set literals), `keys`, `exists`, `member` (`TMutableRewrap` / `TAddrMember` / `TObjMember`), `range`, `slice`, `take`, `skip`, `filter`, `sort`, `map`, `reduce`, `collated_by`, `collected_by`, `if_else`, `while`, `inline_scope` (wraps a body inline + its `TCodeScope`).

### Statements + tests (2)
| File | Role |
|---|---|
| `effect.h` | `TChange` / `TMutation` / `TDelete` / `TNew` / `TStmtBlock` / `TIf` for `effecting { ... }` blocks; in-file note flags that it mirrors `orly/var/mutation.h` and must change in parallel |
| `test.h` | `TTestCase` + `TTestBlock` for the `with { ... } test { ... }` shape |

A few docstrings call out load-bearing connections — e.g. `effect.h` references the parallel hierarchy in `orly/var/mutation.h`, `builder.h` warns about the `Build` vs `BuildInline` footgun (calling `Build` directly skips the implicit-map lowering pass).

## Validation

- `make debug` — 1712 / 1712 jobs, clean
- Comment-only diff: no behavioural impact

## What's next

After this PR lands:

| Subsystem | Remaining TODO docstrings |
|---|---|
| `orly/synth/` | 71 |
| Smaller leftovers (subdirs of `orly/sabot/`, `orly/atom/`, etc.) | a handful each |

`orly/synth/` is the last big one and will be its own PR.

## Test plan

- [ ] CI passes (comment-only)
- [ ] `grep -rln '^   TODO\$' orly/ | wc -l` reports 186 on master after merge
