### PR TITLE
orly/synth: replace placeholder TODO file-level docstrings (refs #70)

### DIFF
--- a/orly/synth/addr_ctor.h
+++ b/orly/synth/addr_ctor.h
@@ -1,6 +1,8 @@
 /* <orly/synth/addr_ctor.h>
 
-   TODO
+   Synth-layer node for an address literal (`<[a, b, c]>`). Holds
+   the ordered `(TAddrDir, TExpr)` element list parsed from the CST
+   and lowers to a `TBasicCtor<TAddrContainer>` on `Build()`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/addr_dir_visitor.h
+++ b/orly/synth/addr_dir_visitor.h
@@ -1,6 +1,9 @@
 /* <orly/synth/addr_dir_visitor.h>
 
-   TODO
+   Visitor over `Package::Syntax::TAddrDir` that resolves each
+   parsed direction token (`asc` / `desc`) to a `TAddrDir` enum
+   value. Used by every address-shaped synth node when reading the
+   direction modifiers off the CST.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/addr_member_expr.h
+++ b/orly/synth/addr_member_expr.h
@@ -1,6 +1,8 @@
 /* <orly/synth/addr_member_expr.h>
 
-   TODO
+   Synth-layer node for `addr.<n>` -- indexed access into an
+   address tuple. Lowers to `Expr::TAddrMember` on `Build()`, which
+   code-gen emits as `TAddrMember` with the corresponding part-id.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/addr_type.h
+++ b/orly/synth/addr_type.h
@@ -1,6 +1,9 @@
 /* <orly/synth/addr_type.h>
 
-   TODO
+   Synth-layer node for an address type (`<[type1, type2, ...]>`
+   with per-element asc/desc). Iterates element types via
+   `addr_dir_visitor.h`; `ComputeSymbolicType()` lowers to
+   `Type::TAddr`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/affix_expr.h
+++ b/orly/synth/affix_expr.h
@@ -1,6 +1,9 @@
 /* <orly/synth/affix_expr.h>
 
-   TODO
+   Synth-layer node for unary affix expressions (`not`, unary `-`,
+   `*` deref, etc.). Holds a single operand `TExpr` and a `TNew`
+   function pointer that selects which `Expr::T*` factory to invoke
+   at `Build()` time.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/assert_expr.h
+++ b/orly/synth/assert_expr.h
@@ -1,6 +1,9 @@
 /* <orly/synth/assert_expr.h>
 
-   TODO
+   Synth-layer node for `assert { ... }` blocks. Holds a vector of
+   `TAssertCase` (each optionally named) plus an outer `TExpr`.
+   Implements `TThatableExpr` so the inner cases can reference the
+   asserted value with `that`. Lowers to `Expr::TAssert`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/atomic_type.h
+++ b/orly/synth/atomic_type.h
@@ -1,6 +1,9 @@
 /* <orly/synth/atomic_type.h>
 
-   TODO
+   Synth-layer node for the atomic type literals (`int`, `real`,
+   `bool`, `str`, `id`, `time_diff`, `time_pnt`).
+   `ComputeSymbolicType()` resolves each one to its singleton
+   `Type::T*` (`TInt`, `TReal`, ...).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/binary_type.h
+++ b/orly/synth/binary_type.h
@@ -1,6 +1,8 @@
 /* <orly/synth/binary_type.h>
 
-   TODO
+   Synth-layer node for binary type expressions: container types
+   like `[T]`, `{T}`, `{K: V}`. `ComputeSymbolicType()` lowers to
+   the corresponding `Type::T*` (`TList`, `TSet`, `TDict`, ...).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/collated_by_expr.h
+++ b/orly/synth/collated_by_expr.h
@@ -1,6 +1,9 @@
 /* <orly/synth/collated_by_expr.h>
 
-   TODO
+   Synth-layer node for `collated_by ... having ...`. Holds the
+   sequence, start, reduce body, and having body. Implements both
+   `TStartableExpr` and `TThatableExpr` so the reduce body can
+   reference `start` and `that`. Lowers to `Expr::TCollatedBy`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/collected_by_expr.h
+++ b/orly/synth/collected_by_expr.h
@@ -1,6 +1,8 @@
 /* <orly/synth/collected_by_expr.h>
 
-   TODO
+   Synth-layer node for `collected_by`. Holds the sequence and the
+   collect body. Implements `TThatableExpr` for the body's `that`
+   reference. Lowers to `Expr::TCollectedBy`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/db_keys_expr.h
+++ b/orly/synth/db_keys_expr.h
@@ -1,6 +1,9 @@
 /* <orly/synth/db_keys_expr.h>
 
-   TODO
+   Synth-layer node for `keys <[pattern]>` -- the index-walking
+   expression. Holds the address-shaped key pattern plus the
+   dereferenced value type. Lowers to `Expr::TDbKeys`, which
+   code-gen turns into a `TKeys` runtime call.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/def_factory.h
+++ b/orly/synth/def_factory.h
@@ -1,6 +1,11 @@
 /* <orly/synth/def_factory.h>
 
-   TODO
+   Visitor over `Package::Syntax::TDef` that creates the right
+   `TDef` subclass for each parsed definition kind (`TFuncDef`,
+   `TTypeDef`, `TTestDef`, `TImportDef`, `TGeneratorDef`,
+   `TPackageDef`). The three abstract overloads
+   (`TInstallerDef` / `TUpgraderDef` / `TUninstallerDef`) are filled
+   in by `TPackage::TTopLevelDefFactory` for package lifecycle hooks.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/delete_stmt.h
+++ b/orly/synth/delete_stmt.h
@@ -1,6 +1,8 @@
 /* <orly/synth/delete_stmt.h>
 
-   TODO
+   Synth-layer node for `delete <[key]>;` statements inside
+   effecting blocks. Holds the key expression and lowers to
+   `Symbol::Stmt::TDelete` on `Build()`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/dict_ctor.h
+++ b/orly/synth/dict_ctor.h
@@ -1,6 +1,8 @@
 /* <orly/synth/dict_ctor.h>
 
-   TODO
+   Synth-layer node for a dict literal (`{key: val, ...}`). Holds
+   the ordered key/value expression pairs from the CST. Lowers to a
+   `TBasicCtor<TDictContainer>` on `Build()`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/effecting_expr.h
+++ b/orly/synth/effecting_expr.h
@@ -1,6 +1,9 @@
 /* <orly/synth/effecting_expr.h>
 
-   TODO
+   Synth-layer node for `(expr) effecting { stmts }`. Holds the
+   value expression plus its statement block. Implements
+   `TThatableExpr` so the statements can reference `that` (the
+   value expression's result). Lowers to `Expr::TEffecting`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/empty_ctor.h
+++ b/orly/synth/empty_ctor.h
@@ -1,6 +1,9 @@
 /* <orly/synth/empty_ctor.h>
 
-   TODO
+   Synth-layer node for typed-empty literals (`empty {T}`,
+   `empty [T]`, `empty {K:V}`, `empty <[...]>`). Carries the typed
+   element so the emitted constructor is fully resolved. Lowers to
+   an empty `TBasicCtor` of the matching container kind.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/exists_ctor.h
+++ b/orly/synth/exists_ctor.h
@@ -1,6 +1,9 @@
 /* <orly/synth/exists_ctor.h>
 
-   TODO
+   Synth-layer node for `<[key]>::(T) is known` / `... is unknown`
+   predicates. Holds the address key expression and the dereferenced
+   value type. Lowers to `Expr::TExists`, which code-gen turns into
+   a `TExists` runtime check.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/expr.h
+++ b/orly/synth/expr.h
@@ -1,6 +1,10 @@
 /* <orly/synth/expr.h>
 
-   TODO
+   Abstract base for every synth-layer expression node. Subclasses
+   implement `Build()` to lower the CST node into an `Expr::TExpr`,
+   `ForEachInnerScope` to expose nested `TScope`s for name binding,
+   and `ForEachRef` to expose unresolved `TAnyRef`s so the build
+   driver can resolve them after all definitions are known.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/filter_expr.h
+++ b/orly/synth/filter_expr.h
@@ -1,6 +1,8 @@
 /* <orly/synth/filter_expr.h>
 
-   TODO
+   Synth-layer node for `seq if (pred)` filter expressions. Holds
+   the sequence and the predicate body; implements `TThatableExpr`
+   for the predicate's `that` reference. Lowers to `Expr::TFilter`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/func_def.h
+++ b/orly/synth/func_def.h
@@ -1,6 +1,10 @@
 /* <orly/synth/func_def.h>
 
-   TODO
+   Synth-layer node for a function definition (`f = (body) where
+   { ... }`). Carries the parsed function symbol, the parameter
+   list, the where-clause scope, and the body expression. Drives
+   the multi-pass build: type-check the body, register the function
+   in its scope, lower to `Symbol::TFunction`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/given_collector.h
+++ b/orly/synth/given_collector.h
@@ -1,6 +1,9 @@
 /* <orly/synth/given_collector.h>
 
-   TODO
+   Walks an expression tree collecting every `given::(T)`
+   placeholder into a flat list. Used by `TFuncDef` to discover the
+   implicit parameters introduced by `given::(int)` etc. and build
+   the function's parameter object accordingly.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/given_expr.h
+++ b/orly/synth/given_expr.h
@@ -1,6 +1,9 @@
 /* <orly/synth/given_expr.h>
 
-   TODO
+   Synth-layer node for `given::(T)` -- a placeholder that becomes
+   a named function parameter at the enclosing function definition.
+   Carries the requested type expression; the actual binding happens
+   during the function-build pass via `TGivenCollector`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/if_else_expr.h
+++ b/orly/synth/if_else_expr.h
@@ -1,6 +1,8 @@
 /* <orly/synth/if_else_expr.h>
 
-   TODO
+   Synth-layer node for `if pred then a else b` ternary expressions
+   (and chained `if`/`else if`). Holds the predicate and the two
+   branches. Lowers to `Expr::TIfElse`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/if_stmt.h
+++ b/orly/synth/if_stmt.h
@@ -1,6 +1,9 @@
 /* <orly/synth/if_stmt.h>
 
-   TODO
+   Synth-layer node for `if pred { stmts } else { stmts }`
+   statements inside effecting blocks. Holds the predicate, the
+   then-block, and an optional else-block. Lowers to
+   `Symbol::Stmt::TIf`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/infix_expr.h
+++ b/orly/synth/infix_expr.h
@@ -1,6 +1,10 @@
 /* <orly/synth/infix_expr.h>
 
-   TODO
+   Synth-layer node for binary infix expressions (`+`, `-`, `*`,
+   `=`, `and`, `or`, `xor`, `union`, `intersection`, `member`,
+   etc.). Holds lhs / rhs subexpressions plus a `TNew` function
+   pointer that selects which `Expr::T*` factory to invoke at
+   `Build()` time.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/lhs_expr.h
+++ b/orly/synth/lhs_expr.h
@@ -1,6 +1,9 @@
 /* <orly/synth/lhs_expr.h>
 
-   TODO
+   Synth-layer node for the `lhs` keyword inside a comparator body
+   (e.g. `sorted_by lhs < rhs`). Resolves to the nearest enclosing
+   `TLhsRhsableExpr` (a sort comparator) during build and lowers
+   to `Expr::TLhs`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/lhsrhsable_expr.h
+++ b/orly/synth/lhsrhsable_expr.h
@@ -1,6 +1,10 @@
 /* <orly/synth/lhsrhsable_expr.h>
 
-   TODO
+   Mixin base for synth expressions that introduce an `lhs`/`rhs`
+   binding (notably `TSortExpr`). The outer expression's symbol
+   must be built before the rhs body so the inner `lhs`/`rhs`
+   references can be resolved to it -- the in-file comment
+   documents this ordering constraint.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/list_ctor.h
+++ b/orly/synth/list_ctor.h
@@ -1,6 +1,8 @@
 /* <orly/synth/list_ctor.h>
 
-   TODO
+   Synth-layer node for a list literal (`[elem, elem, ...]`). Holds
+   the ordered element expressions from the CST. Lowers to a
+   `TBasicCtor<TListContainer>` on `Build()`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/literal_expr.h
+++ b/orly/synth/literal_expr.h
@@ -1,6 +1,8 @@
 /* <orly/synth/literal_expr.h>
 
-   TODO
+   Synth-layer node for primitive literals (`123`, `1.5`, `true`,
+   `"foo"`, time/uuid literals). Carries the CST node and lowers to
+   `Expr::TLiteral` with a `Var::TVar` payload.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/mutate_stmt.h
+++ b/orly/synth/mutate_stmt.h
@@ -1,6 +1,8 @@
 /* <orly/synth/mutate_stmt.h>
 
-   TODO
+   Synth-layer node for mutation statements (`x += v;`, `s |= {x};`,
+   `m = v;`). Holds the lhs target, the mutator op, and the rhs
+   value. Lowers to `Symbol::Stmt::TMutate`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/new_expr.h
+++ b/orly/synth/new_expr.h
@@ -1,6 +1,8 @@
 /* <orly/synth/new_expr.h>
 
-   TODO
+   Synth-layer node for `new <[key]> <- val` expressions (the
+   creating-a-new-entry form, used outside effecting blocks).
+   Lowers to `Expr::TNew`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/new_stmt.h
+++ b/orly/synth/new_stmt.h
@@ -1,6 +1,7 @@
 /* <orly/synth/new_stmt.h>
 
-   TODO
+   Synth-layer node for `new <[key]> <- val;` statements inside
+   effecting blocks. Lowers to `Symbol::Stmt::TNew`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/new_type.h
+++ b/orly/synth/new_type.h
@@ -1,6 +1,8 @@
 /* <orly/synth/new_type.h>
 
-   TODO
+   Synth-layer node for typed `new::(T)` markers in key patterns.
+   Carries the target type. Used in key shapes where a fresh value
+   of a specific type is being constructed.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/now_expr.h
+++ b/orly/synth/now_expr.h
@@ -1,6 +1,7 @@
 /* <orly/synth/now_expr.h>
 
-   TODO
+   Synth-layer node for the `now` keyword (current time).
+   Singleton-shape with no operands. Lowers to `Expr::TNow`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/obj_ctor.h
+++ b/orly/synth/obj_ctor.h
@@ -1,6 +1,9 @@
 /* <orly/synth/obj_ctor.h>
 
-   TODO
+   Synth-layer node for an object / record literal
+   (`{.field: val, ...}`). Holds the ordered named-field
+   expressions from the CST. Lowers to a `TBasicCtor`-style
+   object constructor on `Build()`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/obj_member_expr.h
+++ b/orly/synth/obj_member_expr.h
@@ -1,6 +1,8 @@
 /* <orly/synth/obj_member_expr.h>
 
-   TODO
+   Synth-layer node for `obj.field` -- named-field access on a
+   record. Carries the source expression and the field name. Lowers
+   to `Expr::TObjMember`, which code-gen emits as `TObjMember`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/obj_type.h
+++ b/orly/synth/obj_type.h
@@ -1,6 +1,9 @@
 /* <orly/synth/obj_type.h>
 
-   TODO
+   Synth-layer node for object / record type expressions
+   (`{.name1: T1, .name2: T2}`). Holds the parsed field-name to
+   type-expression map. `ComputeSymbolicType()` lowers to
+   `Type::TObj`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/package.h
+++ b/orly/synth/package.h
@@ -1,6 +1,10 @@
 /* <orly/synth/package.h>
 
-   TODO
+   The synth-layer driver for a whole `.orly` source file. Inherits
+   `TScope` and owns the top-level `TDefFactory` and the symbol
+   package. `Build()` runs the multi-pass binder: discover
+   definitions, resolve references, compute types, and build the
+   `Symbol::TPackage`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/postfix_call.h
+++ b/orly/synth/postfix_call.h
@@ -1,6 +1,9 @@
 /* <orly/synth/postfix_call.h>
 
-   TODO
+   Synth-layer node for function call expressions
+   (`f(.name1: val1, ...)`). Holds the callee expression and the
+   named argument map. Lowers to `Expr::TCall` after the function
+   symbol is resolved.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/postfix_cast.h
+++ b/orly/synth/postfix_cast.h
@@ -1,6 +1,8 @@
 /* <orly/synth/postfix_cast.h>
 
-   TODO
+   Synth-layer node for the `expr as T` cast operator. Holds the
+   source expression and the target type. Lowers to `Expr::TAs`,
+   which code-gen turns into a `TUnary{Cast}`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/postfix_is_known.h
+++ b/orly/synth/postfix_is_known.h
@@ -1,6 +1,9 @@
 /* <orly/synth/postfix_is_known.h>
 
-   TODO
+   Synth-layer node for the `expr is known` / `expr is unknown`
+   postfix test. Lowers to `Expr::TIsKnown`. Distinct from
+   `postfix_is_known_expr.h`, which is the lhs-bound variant
+   (`expr is known otherExpr`).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/postfix_is_known_expr.h
+++ b/orly/synth/postfix_is_known_expr.h
@@ -1,6 +1,10 @@
 /* <orly/synth/postfix_is_known_expr.h>
 
-   TODO
+   Synth-layer node for `expr is known otherExpr` -- the form that
+   returns the original value if known, otherwise the alternate
+   expression. Carries both lhs and rhs. Lowers to
+   `Expr::TIsKnownExpr`. Distinct from `postfix_is_known.h`, the
+   unary form.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/postfix_slice.h
+++ b/orly/synth/postfix_slice.h
@@ -1,6 +1,8 @@
 /* <orly/synth/postfix_slice.h>
 
-   TODO
+   Synth-layer node for `expr[idx]` (index) and `expr[lhs:rhs]`
+   (slice). `Colon` distinguishes the two forms; `OptLhs` / `OptRhs`
+   are nullable for open-ended slices. Lowers to `Expr::TSlice`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/prefix_start.h
+++ b/orly/synth/prefix_start.h
@@ -1,6 +1,9 @@
 /* <orly/synth/prefix_start.h>
 
-   TODO
+   Synth-layer node for the `start` keyword inside a reduce body.
+   Resolves to the nearest enclosing `TStartableExpr` (typically a
+   `TReduceExpr` or `TCollatedByExpr`) during build and lowers to
+   `Expr::TStart`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/range_ctor.h
+++ b/orly/synth/range_ctor.h
@@ -1,6 +1,9 @@
 /* <orly/synth/range_ctor.h>
 
-   TODO
+   Synth-layer node for range constructors (`[start..end]`,
+   `[start..end..stride]`, `[start..]`). `EndIncluded` selects
+   inclusive vs exclusive; `OptStride` / `OptEnd` are nullable.
+   Lowers to `Expr::TRange`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/read_expr.h
+++ b/orly/synth/read_expr.h
@@ -1,6 +1,8 @@
 /* <orly/synth/read_expr.h>
 
-   TODO
+   Synth-layer node for `expr::(T)` typed-read expressions -- look
+   up the value at address `expr` with statically-known type `T`.
+   Lowers to `Expr::TRead`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/reduce_expr.h
+++ b/orly/synth/reduce_expr.h
@@ -1,6 +1,10 @@
 /* <orly/synth/reduce_expr.h>
 
-   TODO
+   Synth-layer node for `seq reduce start X + that` expressions.
+   Holds the sequence (lhs) and the reduce body (rhs). Implements
+   both `TStartableExpr` (so the body's `start` resolves here) and
+   `TThatableExpr` (so the body's `that` resolves here). Lowers to
+   `Expr::TReduce`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/ref_expr.h
+++ b/orly/synth/ref_expr.h
@@ -1,6 +1,9 @@
 /* <orly/synth/ref_expr.h>
 
-   TODO
+   Synth-layer node for a bare name reference -- a use of a
+   function, parameter, or local definition by name. Holds an
+   unresolved `TDef::TRef<TFuncDef>` that the multi-pass build
+   driver fills in via `ForEachRef`. Lowers to `Expr::TRef`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/ref_type.h
+++ b/orly/synth/ref_type.h
@@ -1,6 +1,9 @@
 /* <orly/synth/ref_type.h>
 
-   TODO
+   Synth-layer node for a bare type-name reference. Holds an
+   unresolved `TDef::TRef<TTypeDef>` that the multi-pass build
+   driver fills in. `ComputeSymbolicType()` returns the referenced
+   type definition's `Type::TType`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/rhs_expr.h
+++ b/orly/synth/rhs_expr.h
@@ -1,6 +1,8 @@
 /* <orly/synth/rhs_expr.h>
 
-   TODO
+   Synth-layer node for the `rhs` keyword inside a comparator body
+   (e.g. `sorted_by lhs < rhs`). Resolves to the nearest enclosing
+   `TLhsRhsableExpr` during build and lowers to `Expr::TRhs`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/session_id_expr.h
+++ b/orly/synth/session_id_expr.h
@@ -1,6 +1,8 @@
 /* <orly/synth/session_id_expr.h>
 
-   TODO
+   Synth-layer node for the `session_id` keyword. Returns the
+   calling session's UUID. Singleton-shape with no operands. Lowers
+   to `Expr::TSessionId`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/set_ctor.h
+++ b/orly/synth/set_ctor.h
@@ -1,6 +1,8 @@
 /* <orly/synth/set_ctor.h>
 
-   TODO
+   Synth-layer node for a set literal (`{elem, elem, ...}`). Holds
+   the ordered element expressions from the CST. Lowers to a
+   `TBasicCtor<TSetContainer>` on `Build()`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/sort_expr.h
+++ b/orly/synth/sort_expr.h
@@ -1,6 +1,9 @@
 /* <orly/synth/sort_expr.h>
 
-   TODO
+   Synth-layer node for `seq sorted_by (lhs OP rhs)` expressions.
+   Holds the sequence and the comparator body. Inherits
+   `TLhsRhsableExpr` so the comparator can reference `lhs` and
+   `rhs`. Lowers to `Expr::TSort`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/startable_expr.h
+++ b/orly/synth/startable_expr.h
@@ -1,6 +1,10 @@
 /* <orly/synth/startable_expr.h>
 
-   TODO
+   Mixin base for synth expressions that introduce a `start`
+   binding (`TReduceExpr`, `TCollatedByExpr`). The outer
+   expression's symbol must be built before the rhs body so the
+   inner `start` reference can resolve to it -- counterpart of
+   `TThatableExpr` / `TLhsRhsableExpr`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/stmt.h
+++ b/orly/synth/stmt.h
@@ -1,6 +1,10 @@
 /* <orly/synth/stmt.h>
 
-   TODO
+   Abstract base for every synth-layer statement node. Subclasses
+   implement `Build()` to lower the CST node into a
+   `Symbol::Stmt::TStmt`, `ForEachInnerScope` to expose nested
+   `TScope`s for name binding, and `ForEachRef` to expose
+   unresolved `TAnyRef`s for the multi-pass build driver.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/stmt_block.h
+++ b/orly/synth/stmt_block.h
@@ -1,6 +1,9 @@
 /* <orly/synth/stmt_block.h>
 
-   TODO
+   Synth-layer node for a statement block (`{ stmt; stmt; ... }`).
+   Holds the ordered statements parsed inside an
+   `effecting { ... }` block. `Build()` lowers to
+   `Symbol::Stmt::TStmtBlock`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/test_case_block.h
+++ b/orly/synth/test_case_block.h
@@ -1,6 +1,9 @@
 /* <orly/synth/test_case_block.h>
 
-   TODO
+   Synth-layer node for the optional nested sub-tests inside a
+   `test { t1: ... { t2: ... } }` block. Carries the parsed CST
+   sub-test list and lowers to a vector of `Symbol::Test::TTest`
+   during the test-def build.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/test_def.h
+++ b/orly/synth/test_def.h
@@ -1,6 +1,10 @@
 /* <orly/synth/test_def.h>
 
-   TODO
+   Synth-layer node for a test definition
+   (`test { t1: ...; t2: ...; }`). Carries each named test
+   expression and lowers to a `Symbol::Test::TTest` -- which
+   `TPackage` collects and emits as `TTestCase` in the code-gen
+   layer.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/test_kv_entry.h
+++ b/orly/synth/test_kv_entry.h
@@ -1,6 +1,9 @@
 /* <orly/synth/test_kv_entry.h>
 
-   TODO
+   Synth-layer node for one entry in a `with { ... }` clause of a
+   test: the key expression on the lhs and the value expression on
+   the rhs. Lowers to a single setup write in the test's emitted
+   setup block.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/that_expr.h
+++ b/orly/synth/that_expr.h
@@ -1,6 +1,9 @@
 /* <orly/synth/that_expr.h>
 
-   TODO
+   Synth-layer node for the `that` keyword. Resolves to the
+   nearest enclosing `TThatableExpr` (filter / sort comparator /
+   reduce / effecting / assert) during build and lowers to
+   `Expr::TThat`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/thatable_expr.h
+++ b/orly/synth/thatable_expr.h
@@ -1,6 +1,10 @@
 /* <orly/synth/thatable_expr.h>
 
-   TODO
+   Mixin base for synth expressions that introduce a `that`
+   binding. Subclasses include `TFilterExpr`, `TReduceExpr`,
+   `TCollatedByExpr`, `TCollectedByExpr`, `TAssertExpr`,
+   `TEffectingExpr`. The outer expression's symbol is built before
+   the rhs body so the inner `that` reference can resolve to it.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/time_diff_ctor.h
+++ b/orly/synth/time_diff_ctor.h
@@ -1,6 +1,9 @@
 /* <orly/synth/time_diff_ctor.h>
 
-   TODO
+   Synth-layer node for time-diff literals (the
+   `{day, hour, minute, ...}` record returned by `TimeDiff`-shape
+   constructors). Carries each component expression and lowers to
+   a typed `TBasicCtor` over the `TimeDiff` object record.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/time_pnt_ctor.h
+++ b/orly/synth/time_pnt_ctor.h
@@ -1,6 +1,9 @@
 /* <orly/synth/time_pnt_ctor.h>
 
-   TODO
+   Synth-layer node for time-point literals (the
+   `{year, month, day, ...}` record returned by `TimePnt`-shape
+   constructors). Same pattern as `time_diff_ctor.h` but for the
+   absolute-time record.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/type.h
+++ b/orly/synth/type.h
@@ -1,6 +1,10 @@
 /* <orly/synth/type.h>
 
-   TODO
+   Abstract base for every synth-layer type expression. Subclasses
+   implement `ComputeSymbolicType()` to lower the CST type-node
+   into a `Type::TType`; `GetSymbolicType()` caches the result.
+   `ForEachRef` exposes nested `TAnyRef`s (e.g. typedef lookups in
+   `TRefType`) for the multi-pass build driver.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/type_def.h
+++ b/orly/synth/type_def.h
@@ -1,6 +1,9 @@
 /* <orly/synth/type_def.h>
 
-   TODO
+   Synth-layer node for a type definition (`type Name = ...;`).
+   Holds the parsed type expression and registers itself in the
+   enclosing scope as a `TDef<TTypeDef>` that `TRefType` looks up
+   by name.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/unary_type.h
+++ b/orly/synth/unary_type.h
@@ -1,6 +1,9 @@
 /* <orly/synth/unary_type.h>
 
-   TODO
+   Synth-layer node for unary type expressions (notably `T?` --
+   optional of `T`). Carries the inner type expression.
+   `ComputeSymbolicType()` lowers to `Type::TOpt` (or other unary
+   type wrappers).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/unknown_ctor.h
+++ b/orly/synth/unknown_ctor.h
@@ -1,6 +1,8 @@
 /* <orly/synth/unknown_ctor.h>
 
-   TODO
+   Synth-layer node for typed-unknown literals (`?T`). Carries the
+   target type so the runtime knows what kind of "no value" to
+   emit. Lowers to `Expr::TUnknown`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/user_id_expr.h
+++ b/orly/synth/user_id_expr.h
@@ -1,6 +1,8 @@
 /* <orly/synth/user_id_expr.h>
 
-   TODO
+   Synth-layer node for the `user_id` keyword. Returns the calling
+   user's UUID (or unknown if no user is bound to the session).
+   Lowers to `Expr::TUserId`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/where_expr.h
+++ b/orly/synth/where_expr.h
@@ -1,6 +1,9 @@
 /* <orly/synth/where_expr.h>
 
-   TODO
+   Synth-layer node for `expr where { definitions }` -- a body
+   expression with locally-scoped definitions. Owns an inner
+   `TScope` populated by `TDefFactory` from the parsed definitions.
+   Lowers to `Expr::TWhere`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/while_expr.h
+++ b/orly/synth/while_expr.h
@@ -1,6 +1,8 @@
 /* <orly/synth/while_expr.h>
 
-   TODO
+   Synth-layer node for `seq while (pred)` -- yields elements from
+   `seq` until `pred` returns false. Implements `TThatableExpr` so
+   the predicate can reference `that`. Lowers to `Expr::TWhile`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/synth/with_clause.h
+++ b/orly/synth/with_clause.h
@@ -1,6 +1,9 @@
 /* <orly/synth/with_clause.h>
 
-   TODO
+   Synth-layer node for a `with { <key> <- val; ... }` clause --
+   the test-setup block that initializes keys before the test body
+   runs. Holds a vector of `TTestKvEntry`s and lowers to the
+   corresponding setup writes during test build.
 
    Copyright 2010-2026 Atomic Kismet Company
 


### PR DESCRIPTION
Eighth pass on #70 — the last of the three big compiler subsystems (follows #78, #79, #80, #81, #82, #83, #84). After this PR, the compiler core (`orly/type/`, `orly/code_gen/`, `orly/synth/`) is fully documented.

## What changed

71 headers under `orly/synth/` — the AST-to-typed-IR lowering pass. Parser CST nodes (in `orly/orly.package.cst.h`) flow through Synth wrappers that resolve names, build scopes, and produce the `Expr` / `Symbol` / `Type` nodes that the type checker and code-gen consume.

Each header now opens with 3–7 lines naming the CST node it wraps and the `Expr::T*` / `Symbol::Stmt::T*` / `Type::T*` it lowers to on `Build()`.

### Architecture (3 abstract bases)
- `expr.h` — `TExpr` with `Build()` / `ForEachInnerScope` / `ForEachRef`
- `stmt.h` — `TStmt` with the same triple, for `effecting { ... }` blocks
- `type.h` — `TType` with `ComputeSymbolicType` (cached)

### Special-keyword mixin bases (3)
- `startable_expr.h` — bases for expressions that bind `start` (`reduce`, `collated_by`)
- `thatable_expr.h` — bases for `that` (`filter`, `sort`, `reduce`, `effecting`, `assert`, etc.)
- `lhsrhsable_expr.h` — bases for `lhs`/`rhs` (`sort`); the in-file comment documents the build-order constraint between outer-symbol-first and rhs-body-second so inner keyword references can resolve back

### Concrete leaves (65)
One per CST node kind. Grouped by suffix:

- **`*_ctor.h` (11)** — value/container constructors: `addr`, `dict`, `list`, `set`, `obj`, `range`, `empty`, `exists`, `unknown`, `time_diff`, `time_pnt`
- **`*_expr.h` (~30)** — expression nodes: `literal`, `ref`, `infix`, `affix`, `assert`, `db_keys`, `filter`, `sort`, `reduce`, `collated_by`, `collected_by`, `while`, `if_else`, `now`, `session_id`, `user_id`, `read`, `where`, `effecting`, `addr_member`, `obj_member`, `given`, `new`, plus the `postfix_*` family (`call`, `cast`, `slice`, `is_known`, `is_known_expr`), `prefix_start`, `that`, `lhs`, `rhs`
- **`*_stmt.h` (4)** — effecting-block statements: `mutate`, `delete`, `new`, `if`
- **`*_type.h` (7)** — type expressions: `atomic`, `binary`, `unary`, `addr`, `obj`, `new`, `ref`
- **`*_def.h` (3)** — definitions: `func`, `test`, `type`
- **Helpers** — `package.h` (the driver), `def_factory.h` (the def-visitor), `given_collector.h` (implicit-parameter walker), `addr_dir_visitor.h` (asc/desc resolver), `test_case_block.h` / `test_kv_entry.h` / `with_clause.h` / `stmt_block.h` (block helpers)

## Validation

- `make debug` — 1712 / 1712 jobs, clean
- Comment-only diff: no behavioural impact

## What's next

After this PR lands, the orly/ TODO-docstring count drops to **115**. Compiler core is fully documented. The remaining 115 are scattered across smaller subdirs (e.g. `orly/sabot/state/`, `orly/atom/kit*`, `orly/var/all/`, `orly/code_gen/` subdirs, `orly/indy/` non-disk subdirs). Each is a smaller batched followup.

## Test plan

- [ ] CI passes (comment-only)
- [ ] `grep -rln '^   TODO\$' orly/ | wc -l` reports 115 on master after merge
