### PR TITLE
docs: replace TODO file-level docstrings across 10 smaller subdirs (refs #70)

### DIFF
--- a/orly/balancer/balancer.h
+++ b/orly/balancer/balancer.h
@@ -1,6 +1,9 @@
 /* <orly/balancer/balancer.h>
 
-   TODO
+   `Balancer::TBalancer` -- abstract base for orly's TCP load
+   balancer. Holds command-line parsing (`TCmd`: port + connection
+   backlog) and the abstract host-selection hook. Concrete subclass
+   is `TFailoverTestBalancer`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/balancer/failover_test_balancer.h
+++ b/orly/balancer/failover_test_balancer.h
@@ -1,6 +1,10 @@
 /* <orly/balancer/failover_test_balancer.h>
 
-   TODO
+   `TFailoverTestBalancer` -- a `TBalancer` impl that periodically
+   probes registered backend hosts and routes new connections to
+   whichever is currently reachable. Used in failover-test rigs to
+   verify the balancer's host-selection behaviour under simulated
+   outages.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/client/program/parse_image.h
+++ b/orly/client/program/parse_image.h
@@ -1,6 +1,9 @@
 /* <orly/client/program/parse_image.h>
 
-   TODO
+   Parser for the dump-image format produced by `orly_client`.
+   `ParseImageFile` / `ParseImageStr` walks the CST and invokes
+   `TForXact` per transaction; `TranslateXact` walks the
+   transaction's key-value pairs via `TForKv`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/client/program/parse_stmt.h
+++ b/orly/client/program/parse_stmt.h
@@ -1,6 +1,7 @@
 /* <orly/client/program/parse_stmt.h>
 
-   TODO
+   Parser for orly client-program statements. `ParseStmtFile` /
+   `ParseStmtStr` invokes `TForStmt` per parsed `TStmt` CST node.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/client/program/throw_syntax_errors.h
+++ b/orly/client/program/throw_syntax_errors.h
@@ -1,6 +1,9 @@
 /* <orly/client/program/throw_syntax_errors.h>
 
-   TODO
+   `ThrowSyntaxErrors(ctx)` -- given a Nycr parse context, collects
+   any accumulated errors and throws them as one. Called by every
+   parsing entry point in this directory so parser errors surface
+   as exceptions rather than being silently ignored.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/client/program/translate_expr.h
+++ b/orly/client/program/translate_expr.h
@@ -1,6 +1,12 @@
 /* <orly/client/program/translate_expr.h>
 
-   TODO
+   Bridge between client-program CST expressions and orly's sabot
+   type/state types. Templated `TUnaryExpr` / `TBinaryExpr` /
+   `TRecordExpr` / `TTupleExpr` (plus the per-leaf `State::TBool`,
+   `TInt`, `TReal`, `TStr`, ... family) adapt CST nodes to
+   `Sabot::Type` / `Sabot::State` so values typed at the client side
+   can flow into the same comparison and serialisation machinery
+   the server uses.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/closure.h
+++ b/orly/closure.h
@@ -1,6 +1,10 @@
 /* <orly/closure.h>
 
-   TODO
+   `TClosure` is a name-keyed map of `Atom::TCore` values used to
+   bundle method-call arguments. Comes with a `TWalker` that
+   optimises sequential access through the underlying ordered map
+   (rewinds when you index backwards). Used by the WS protocol and
+   replay machinery to pack / unpack RPC arguments.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/context_base.h
+++ b/orly/context_base.h
@@ -1,6 +1,11 @@
 /* <orly/context_base.h>
 
-   TODO
+   Abstract base for any "I can read keys from the database"
+   context. `operator[](key)` reads, `Exists(key)` tests. Lives at
+   the root of the include graph so anything that needs to consult
+   the database can take a `TContextBase &` without dragging in the
+   full storage stack. Subclassed by `Indy::TContext` and the SPA
+   flux-capacitor's KV-backed context.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/durable/test_manager.h
+++ b/orly/durable/test_manager.h
@@ -1,6 +1,9 @@
 /* <orly/durable/test_manager.h>
 
-   TODO
+   `Durable::TTestManager` -- an in-memory `Durable::TManager` used
+   by tests. No real disk I/O; the durable layer's `CanLoad` /
+   `CleanDisk` / `Delete` operations all run against an in-memory
+   `BlobById` map.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/disk/sim/mem_engine.h
+++ b/orly/indy/disk/sim/mem_engine.h
@@ -1,6 +1,11 @@
 /* <orly/indy/disk/sim/mem_engine.h>
 
-   TODO
+   `Sim::TMemEngine` -- assembles a `Disk::TEngine` backed entirely
+   by in-memory simulated devices. Used in tests and by
+   `orlyi --mem_sim` to run without touching real block storage.
+   Includes the stripe-alignment rounding logic (`round_up_blocks`)
+   so requested-MB counts work cleanly with the underlying volume
+   layout.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/util/block_vec.h
+++ b/orly/indy/util/block_vec.h
@@ -1,6 +1,9 @@
 /* <orly/indy/util/block_vec.h>
 
-   TODO
+   `TBlockVec` -- a sparse vector mapping logical indices to
+   (size, data) ranges, exposed via a random-access iterator. Used
+   by the disk layer to track which logical blocks belong to which
+   on-disk file extents.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/util/context_streamer.h
+++ b/orly/indy/util/context_streamer.h
@@ -1,6 +1,11 @@
 /* <orly/indy/util/context_streamer.h>
 
-   TODO
+   `TContextOutputStreamer` / `TContextInputStreamer` -- serialise
+   a sequence of updates into a binary stream and read them back.
+   Used by master->slave replication: the streamer packs
+   `TUpdateWalker::TItem`s (with their sabot arena) into a
+   transport-friendly form, the reader unpacks them on the receiver.
+   The Mutator-carrying wire format that #54 fixed lives here.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/util/growing_pool.h
+++ b/orly/indy/util/growing_pool.h
@@ -1,6 +1,10 @@
 /* <orly/indy/util/growing_pool.h>
 
-   TODO
+   `TGrowingPool` -- a block allocator that grows on demand.
+   Counterpart of `TPool` (fixed-capacity, mutex-guarded) and
+   `TLocklessPool` (fixed-capacity, lock-free). Used wherever the
+   disk layer needs many small allocations of a known block size
+   without knowing the count up front.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/util/lockless_pool.h
+++ b/orly/indy/util/lockless_pool.h
@@ -1,6 +1,10 @@
 /* <orly/indy/util/lockless_pool.h>
 
-   TODO
+   `TLocklessPool` -- a fixed-capacity block allocator with no
+   internal locking, relying on atomic operations on the free-list.
+   Counterpart of `TPool` (mutex-guarded) and `TGrowingPool`
+   (resizable). Used in hot allocation paths where contention is
+   the bottleneck.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/util/merge_sorter.h
+++ b/orly/indy/util/merge_sorter.h
@@ -1,6 +1,10 @@
 /* <orly/indy/util/merge_sorter.h>
 
-   TODO
+   `TKeySorter<TRef>` -- an in-memory linked-list sorter that keeps
+   elements in `(key, seq_num)` order on insert (ties broken by
+   higher seq num first, so the freshest write wins on equal keys).
+   Used by the index-merge paths where elements are produced
+   incrementally and need to come out sorted.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/util/min_heap.h
+++ b/orly/indy/util/min_heap.h
@@ -1,6 +1,9 @@
 /* <orly/indy/util/min_heap.h>
 
-   TODO
+   `TMinHeap<TVal, TRef, TComparator>` -- a min-heap that yields
+   the smallest of a set of (value, ref) pairs. Used by every k-way
+   merge in the disk layer (`TIndexManager::TCursor`,
+   the merge sorter, present/update walker fan-in).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/util/pool.h
+++ b/orly/indy/util/pool.h
@@ -1,6 +1,9 @@
 /* <orly/indy/util/pool.h>
 
-   TODO
+   `TPool` -- a fixed-capacity block allocator with mutex-guarded
+   alloc / free. The "boring middle" of the pool family:
+   `TLocklessPool` is faster under contention but requires atomic
+   ops; `TGrowingPool` is more flexible but pays for the grow logic.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/indy/util/sorter.h
+++ b/orly/indy/util/sorter.h
@@ -1,6 +1,11 @@
 /* <orly/indy/util/sorter.h>
 
-   TODO
+   `Indy::Util::TSorter<TVal, MemSize>` -- abstract base for
+   sortable collections. Exposes a `TCursor` so the
+   `TIndexManager` k-way merge can treat in-memory sorters and
+   spilled `TIndexSortFile`s uniformly. Subclasses include
+   `TMemSorter` (in-memory) and `TIndexSortFile::TCursor`
+   (disk-backed).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/key_generator.h
+++ b/orly/key_generator.h
@@ -1,6 +1,9 @@
 /* <orly/key_generator.h>
 
-   TODO
+   `TKeyCursor` -- abstract iterator over database keys. Subclasses
+   produce keys lazily for the various index-walking operators
+   (`keys <[...]>`, `*<[...]>::(T)`, etc.). Holds the arena that
+   the keys' sabot states are allocated against.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/package/api_version.h
+++ b/orly/package/api_version.h
@@ -1,6 +1,8 @@
 /* <orly/package/api_version.h>
 
-   TODO
+   Single `#define ORLY_API_VERSION 1` macro -- the version number
+   for the package-to-orlyi ABI. Bumped whenever the package binary
+   interface changes (today still at 1).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/package/loaded.h
+++ b/orly/package/loaded.h
@@ -1,6 +1,10 @@
 /* <orly/package/loaded.h>
 
-   TODO
+   `Package::TLoaded` -- an actual `dlopen()`'d package. Holds the
+   dlopen handle, exposes per-function / per-test introspection
+   (`ForEachFunction`, `ForEachTest`, `GetFunctionInfo`).
+   Constructed by `TLoaded::Load(package_dir, name)` and held by
+   the manager for the package's lifetime.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/package/name.h
+++ b/orly/package/name.h
@@ -1,6 +1,10 @@
 /* <orly/package/name.h>
 
-   TODO
+   `Package::TName` (a vector-of-strings fully-qualified name) and
+   `TVersionedName` (TName + version). Plus stream operators and
+   hashers so they can flow through std containers. The format is
+   what the parser produces for `package #N;` declarations and
+   what the package manager uses to look up loaded packages.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/package/rt.h
+++ b/orly/package/rt.h
@@ -1,6 +1,11 @@
 /* <orly/package/rt.h>
 
-   TODO
+   `Package::TContext` -- the per-method-invocation runtime context
+   bridge between an orlyi-loaded package and the database. Provides
+   the `AddEffect` machinery (collects writes-by-key in the effects
+   map before commit), result tracking for predicate side-conditions,
+   and the random / time hooks the runtime needs. Lives in
+   `package/` because it's the API surface a compiled package sees.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/pos_range.h
+++ b/orly/pos_range.h
@@ -1,6 +1,9 @@
 /* <orly/pos_range.h>
 
-   TODO
+   Tiny aliasing header: `Orly::TPosRange` is a typedef for
+   `Tools::Nycr::TPosRange` (the parser's position-range type).
+   Lives in `Orly::` so type / synth / code-gen don't have to
+   pierce the `Tools::Nycr::` namespace for every error message.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/rt.h
+++ b/orly/rt.h
@@ -1,6 +1,12 @@
 /* <orly/rt.h>
 
-   TODO
+   Umbrella header for the runtime helper library. Re-exports the
+   rt module set (`built_in`, `collated_by`, `collected_by`,
+   `desc`, `generator`, `mutable`, `opt`, `runtime_error`,
+   `shortest_path`, `string`, `str_replace`, `time_diff_obj`,
+   `time_pnt_obj`, `tuple`, `unknown`) plus `type/rt.h` for the
+   C++-native -> orly `TType` bridge. One include for everything
+   orlyc emits calls into.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/spa/flux_capacitor/api.h
+++ b/orly/spa/flux_capacitor/api.h
@@ -1,6 +1,9 @@
 /* <orly/spa/flux_capacitor/api.h>
 
-   TODO
+   Umbrella header for the SPA (single-process app) flux-capacitor
+   runtime: re-exports the key components so SPA-side code can
+   include just `<orly/spa/flux_capacitor/api.h>` to talk to the
+   simulator / runtime.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/symbol/stmt/binary.h
+++ b/orly/symbol/stmt/binary.h
@@ -1,6 +1,8 @@
 /* <orly/symbol/stmt/binary.h>
 
-   TODO
+   Abstract base for two-operand statements (lhs + rhs). Concrete
+   subclasses are `TMutate` (mutator op between lhs and rhs) and
+   `TNew` (lhs key gets rhs value).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/symbol/stmt/if.h
+++ b/orly/symbol/stmt/if.h
@@ -1,6 +1,10 @@
 /* <orly/symbol/stmt/if.h>
 
-   TODO
+   `TIfClause` (predicate + stmt block), `TElseClause` (just a
+   stmt block), and `TIf` (a vector of `TIfClause`s plus an
+   optional `TElseClause`). Together they represent
+   `if pred { ... } else if pred { ... } else { ... }` at the
+   symbol layer.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/symbol/stmt/mutate.h
+++ b/orly/symbol/stmt/mutate.h
@@ -1,6 +1,9 @@
 /* <orly/symbol/stmt/mutate.h>
 
-   TODO
+   `TMutate` -- one mutation statement (`x += v;`, `s |= {x};`,
+   `m = v;`). Inherits `TBinary` for the lhs / rhs operands plus a
+   `TMutator` enum recording which operator (`Add`, `Or`, `Union`,
+   ...). `TypeCheck()` resolves the type rules.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/symbol/stmt/new_and_delete.h
+++ b/orly/symbol/stmt/new_and_delete.h
@@ -1,6 +1,10 @@
 /* <orly/symbol/stmt/new_and_delete.h>
 
-   TODO
+   `TNew` (binary: lhs key gets rhs value) and `TDelete` (unary:
+   removes the key). Both are concrete `TStmt`s. `TNew` is what
+   `with { <[k]> <- v; }` and `new <[k]> <- v;` produce;
+   `TDelete` is `delete <[k]>;`. `TDelete` carries the deleted
+   value's type so the runtime knows what kind of slot to clear.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/symbol/stmt/stmt.h
+++ b/orly/symbol/stmt/stmt.h
@@ -1,6 +1,11 @@
 /* <orly/symbol/stmt/stmt.h>
 
-   TODO
+   Abstract base for orlyscript effecting-block statements at the
+   symbol layer. `TVisitor` dispatches over the four concrete
+   kinds: `TDelete`, `TIf`, `TMutate`, `TNew`. Each subclass
+   implements `Accept` and `TypeCheck`. Stmts attach back to their
+   enclosing `TStmtBlock` via `SetStmtBlock` for type-checking
+   lookups.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/symbol/stmt/stmt_arg.h
+++ b/orly/symbol/stmt/stmt_arg.h
@@ -1,6 +1,9 @@
 /* <orly/symbol/stmt/stmt_arg.h>
 
-   TODO
+   `TStmtArg` -- one operand of a statement (the target of a
+   delete, the lhs / rhs of a mutate or new). Wraps an
+   `Expr::TExpr` and tracks its owning `TStmt` for back-references
+   during type-check.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/symbol/stmt/stmt_block.h
+++ b/orly/symbol/stmt/stmt_block.h
@@ -1,6 +1,8 @@
 /* <orly/symbol/stmt/stmt_block.h>
 
-   TODO
+   `Symbol::Stmt::TStmtBlock` -- an ordered sequence of `TStmt`s
+   parsed inside an `effecting { ... }` block. Owns the stmts and
+   ticks each through `TypeCheck()` during the symbol-build pass.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/symbol/stmt/unary.h
+++ b/orly/symbol/stmt/unary.h
@@ -1,6 +1,7 @@
 /* <orly/symbol/stmt/unary.h>
 
-   TODO
+   Abstract base for one-operand statements. Concrete subclass is
+   `TDelete` (deletes the key referenced by the stmt arg).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/symbol/test/test.h
+++ b/orly/symbol/test/test.h
@@ -1,6 +1,9 @@
 /* <orly/symbol/test/test.h>
 
-   TODO
+   `Symbol::Test::TTest` -- the top-level test definition. Holds
+   the scope it was declared in, an optional `TWithClause` for
+   setup writes, and a `TTestCaseBlock` for the nested test cases.
+   Type-checked as a unit.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/symbol/test/test_case_block.h
+++ b/orly/symbol/test/test_case_block.h
@@ -1,6 +1,9 @@
 /* <orly/symbol/test/test_case_block.h>
 
-   TODO
+   `TTestCase` (one named test case with an expression and
+   optional nested sub-block) and `TTestCaseBlock` (the ordered
+   vector of cases). Tests can nest: `t1: pred { t2: pred }` --
+   the outer succeeds, sub-cases run in its evaluated context.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/symbol/test/with_clause.h
+++ b/orly/symbol/test/with_clause.h
@@ -1,6 +1,8 @@
 /* <orly/symbol/test/with_clause.h>
 
-   TODO
+   `TWithClause` -- the `with { <key> <- val; ... }` setup block
+   of a test. Holds a set of `TNew` statements that initialise
+   database state before the test body runs.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/time.h
+++ b/orly/time.h
@@ -1,6 +1,9 @@
 /* <orly/time.h>
 
-   TODO
+   Two tiny typedefs over `std::chrono`:
+   `TTtl = std::chrono::seconds` for time-to-live values, and
+   `TDeadline = std::chrono::time_point<system_clock>` for absolute
+   deadlines. Used wherever orly schedules a delayed action.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/type.h
+++ b/orly/type.h
@@ -1,6 +1,12 @@
 /* <orly/type.h>
 
-   TODO
+   Umbrella header for the static type system. Re-exports every
+   concrete type (`addr`, `any`, `bool`, `dict`, `err`, `func`,
+   `id`, `int`, `list`, `mutable`, `obj`, `opt`, `real`, `seq`,
+   `set`, `str`, `time_diff`, `time_pnt`, `unknown`) plus
+   `type/util.h` (needed to complete the `TType` template
+   instantiations). One include for "I want to talk about any
+   orlyscript type".
 
    Copyright 2010-2026 Atomic Kismet Company
 


### PR DESCRIPTION
Ninth pass on #70. Batches the smaller subdirs that don't warrant their own PR. Follows #78, #79, #80, #81, #82, #83, #84, #85.

## What changed

39 files across 10 subdirs:

| Subdir | Count | What it covers |
|---|---|---|
| `orly/` (top-level) | 7 | `closure`, `context_base`, `key_generator`, `pos_range`, `rt` (umbrella), `time`, `type` (umbrella) |
| `orly/balancer/` | 2 | `TBalancer` abstract base + `TFailoverTestBalancer` |
| `orly/client/program/` | 4 | `parse_image`, `parse_stmt`, `throw_syntax_errors`, `translate_expr` (CST -> sabot bridge) |
| `orly/durable/` | 1 | `TTestManager` (in-memory test harness) |
| `orly/indy/disk/sim/` | 1 | `TMemEngine` (mem_sim engine assembler, with the stripe-alignment rounding logic) |
| `orly/indy/util/` | 8 | `block_vec`, `context_streamer` (with the #54 Mutator-on-wire callout), three pool variants (`TPool`/`TLocklessPool`/`TGrowingPool`), `merge_sorter`, `min_heap`, `sorter` |
| `orly/package/` | 4 | `api_version` (ABI version macro), `loaded` (dlopen'd package), `name` (TName + TVersionedName), `rt` (per-call TContext) |
| `orly/spa/flux_capacitor/` | 1 | SPA umbrella header |
| `orly/symbol/stmt/` | 8 | `TStmt` hierarchy for effecting blocks -- base + binary/unary bases + TMutate/TNew/TDelete/TIf/TStmtArg/TStmtBlock |
| `orly/symbol/test/` | 3 | `TTest`, `TTestCaseBlock`, `TWithClause` |

Notable callouts in the new docstrings:

- `context_streamer.h` flags the replication wire format that **#54** fixed (the Mutator byte now carried across the master->slave link)
- `mem_engine.h` documents the stripe-alignment rounding that lets `orlyi --mem_sim` work with auto-scaled MB counts
- The three pool variants (`pool` / `lockless_pool` / `growing_pool`) explicitly cross-reference each other so the right one is obvious for new contributors
- `rt.h` and `type.h` at the top level are documented as umbrella re-exports so it's clear which one to include when you want "any orly type" or "any runtime helper"

## Validation

- `make debug` — 1712 / 1712 jobs, clean
- Comment-only diff: no behavioural impact

## What's next

After this PR lands, the **only** remaining `   TODO` file-level docstrings in `orly/` are the **76 in `orly/expr/`** -- the IR layer that `orly/synth/` lowers into and `orly/code_gen/` lowers from. It's the same scale and pattern as `orly/synth/` (which #85 just shipped); will be the final big PR on the issue-#70 arc.

## Test plan

- [ ] CI passes (comment-only)
- [ ] `grep -rln '^   TODO\$' orly/ | wc -l` reports 76 on master after merge
- [ ] All 76 remaining hits are under `orly/expr/`
