### PR TITLE
orly/expr: replace placeholder TODO file-level docstrings (closes #70)

### DIFF
--- a/orly/expr/add.h
+++ b/orly/expr/add.h
@@ -1,6 +1,9 @@
 /* <orly/expr/add.h>
 
-   TODO
+   `TAdd` -- the binary `+` IR node. Inherits `TBinary`.
+   `GetTypeImpl()` runs the result-type rules in
+   `orly/type/add_visitor.h`. Same skeleton as every other
+   arithmetic node in this directory.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/addr.h
+++ b/orly/expr/addr.h
@@ -1,6 +1,9 @@
 /* <orly/expr/addr.h>
 
-   TODO
+   `TAddr` -- the address-tuple constructor (`<[a, b, c]>` with
+   per-element asc/desc). Inherits `TNAry` over a vector of
+   `(TAddrDir, TExpr::TPtr)`. Lowered to
+   `CodeGen::TBasicCtor<TAddrContainer>`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/addr_member.h
+++ b/orly/expr/addr_member.h
@@ -1,6 +1,8 @@
 /* <orly/expr/addr_member.h>
 
-   TODO
+   `TAddrMember` -- indexed access into an address tuple
+   (`addr.<n>`). Inherits `TUnary` over the source address; code-gen
+   emits `TAddrMember` with the matching part-id.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/addr_of.h
+++ b/orly/expr/addr_of.h
@@ -1,6 +1,7 @@
 /* <orly/expr/addr_of.h>
 
-   TODO
+   `TAddrOf` -- the `addr_of` operator. Carries an expression and
+   returns its address as the wrapped value. Inherits `TUnary`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/as.h
+++ b/orly/expr/as.h
@@ -1,6 +1,9 @@
 /* <orly/expr/as.h>
 
-   TODO
+   `TAs` -- the `expr as Type` cast operator. Carries the source
+   expression and a target `Type::TType`. Code-gen lowers to
+   `TUnary{Cast}` (see `orly/rt/postfix_cast.h` for the runtime
+   specialisations).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/assert.h
+++ b/orly/expr/assert.h
@@ -1,6 +1,9 @@
 /* <orly/expr/assert.h>
 
-   TODO
+   `TAssert` -- the `assert { case1; case2; ... }` block. Each
+   `TAssertCase` is a named (or positional) sub-assertion. Inherits
+   `TThatableUnary` so the cases can reference `that` (the asserted
+   value).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/binary.h
+++ b/orly/expr/binary.h
@@ -1,6 +1,10 @@
 /* <orly/expr/binary.h>
 
-   TODO
+   Abstract base for two-operand IR nodes. Stores `Lhs` / `Rhs`
+   and inherits `TInterior` (since it has children). `TBinary`
+   itself doesn't `Accept` -- concrete subclasses (`TAdd`, `TMult`,
+   `TEqEq`, ...) do. The one-arg constructor is reserved for
+   `TThatableBinary` / `TSort` where the rhs binds late.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/ceiling.h
+++ b/orly/expr/ceiling.h
@@ -1,6 +1,7 @@
 /* <orly/expr/ceiling.h>
 
-   TODO
+   `TCeiling` -- unary `ceiling(x)` (round toward positive
+   infinity). Inherits `TUnary`. Counterpart of `TFloor`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/collated_by.h
+++ b/orly/expr/collated_by.h
@@ -1,6 +1,9 @@
 /* <orly/expr/collated_by.h>
 
-   TODO
+   `TCollatedBy` -- the `collated_by ... having ...` operator.
+   Holds the sequence, start, reduce body, and having body.
+   Inherits `TStartable` + `TThatable` so the bodies can reference
+   `start` and `that`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/collected_by.h
+++ b/orly/expr/collected_by.h
@@ -1,6 +1,8 @@
 /* <orly/expr/collected_by.h>
 
-   TODO
+   `TCollectedBy` -- the `collected_by` operator. Folds a sequence
+   of `(key, val)` pairs into a `TDict`. Inherits `TThatableUnary`
+   for the body's `that` reference.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/comp_ops.h
+++ b/orly/expr/comp_ops.h
@@ -1,6 +1,9 @@
 /* <orly/expr/comp_ops.h>
 
-   TODO
+   The six comparison operator IR nodes: `TEqEq`, `TNeq`, `TLt`,
+   `TLtEq`, `TGt`, `TGtEq`. All inherit `TBinary`. `GetTypeImpl()`
+   runs the rules in `orly/type/comp_visitor.h`; result is `TBool`
+   (or `TOpt<TBool>` if either operand carries an optional).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/ctor.h
+++ b/orly/expr/ctor.h
@@ -1,6 +1,9 @@
 /* <orly/expr/ctor.h>
 
-   TODO
+   `TCtor<TContainer>` -- abstract base for container-literal IR
+   nodes. Subclass of `TNAry<TContainer>`. Concrete subclasses
+   include `TList`, `TSet`, `TDict`, `TObj`, `TAddr` -- each picks
+   its own container shape.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/dict.h
+++ b/orly/expr/dict.h
@@ -1,6 +1,8 @@
 /* <orly/expr/dict.h>
 
-   TODO
+   `TDict` -- dictionary literal IR node (`{k: v, ...}`). Inherits
+   `TCtor<unordered_map<TExpr::TPtr, TExpr::TPtr>>`. Lowers to
+   `CodeGen::TBasicCtor<TDictContainer>`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/div.h
+++ b/orly/expr/div.h
@@ -1,6 +1,7 @@
 /* <orly/expr/div.h>
 
-   TODO
+   `TDiv` -- binary `/` (division) IR node. Same pattern as `TAdd`;
+   `GetTypeImpl()` runs `orly/type/div_visitor.h`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/effect.h
+++ b/orly/expr/effect.h
@@ -1,6 +1,9 @@
 /* <orly/expr/effect.h>
 
-   TODO
+   `TEffect` -- the `(expr) effecting { stmts }` IR node. Inherits
+   `TThatableUnary` so the statements can reference `that` (the
+   value expression's result). Owns the
+   `Symbol::Stmt::TStmtBlock`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/exists.h
+++ b/orly/expr/exists.h
@@ -1,6 +1,8 @@
 /* <orly/expr/exists.h>
 
-   TODO
+   `TExists` -- the `<[key]>::(T) is known` / `is unknown` shaped
+   predicate that reaches the storage layer. Unary over the key
+   expression; carries the read value type.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/exp.h
+++ b/orly/expr/exp.h
@@ -1,6 +1,8 @@
 /* <orly/expr/exp.h>
 
-   TODO
+   `TExp` -- binary `**` (exponentiation) IR node. Same pattern
+   as `TAdd`; `GetTypeImpl()` runs `orly/type/exp_visitor.h`
+   (always `TReal`, even on `int ** int`).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/expr.h
+++ b/orly/expr/expr.h
@@ -1,6 +1,11 @@
 /* <orly/expr/expr.h>
 
-   TODO
+   `TExpr` -- abstract base for every orlyscript expression IR
+   node. Holds the position range, caches the type from
+   `GetTypeImpl()`, and tracks its parent via `TExprParent`.
+   Subclasses implement `Accept` (visitor dispatch) and
+   `GetTypeImpl` (type computation). The (very large) `TVisitor`
+   lives in `visitor.h`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/expr_parent.h
+++ b/orly/expr/expr_parent.h
@@ -1,6 +1,9 @@
 /* <orly/expr/expr_parent.h>
 
-   TODO
+   `TExprParent` -- a tiny abstract marker class for "I can be the
+   parent of one or more `TExpr`s". Used so `TExpr::ExprParent`
+   doesn't have to be `TExpr *` (the parent might be a synth- or
+   symbol-layer object that owns the expression tree).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/filter.h
+++ b/orly/expr/filter.h
@@ -1,6 +1,9 @@
 /* <orly/expr/filter.h>
 
-   TODO
+   `TFilter` -- the `seq if (pred)` filter IR node. Inherits
+   `TThatableBinary`: lhs is the sequence, rhs is the predicate,
+   and the predicate body's `that` resolves to the sequence's
+   element type via the mixin base.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/floor.h
+++ b/orly/expr/floor.h
@@ -1,6 +1,7 @@
 /* <orly/expr/floor.h>
 
-   TODO
+   `TFloor` -- unary `floor(x)` (round toward negative infinity).
+   Inherits `TUnary`. Counterpart of `TCeiling`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/free.h
+++ b/orly/expr/free.h
@@ -1,6 +1,8 @@
 /* <orly/expr/free.h>
 
-   TODO
+   `TFree` -- the `free::(T)` typed placeholder used inside key
+   patterns (`<["stuff", free::(int)]>`). Carries the target type
+   and the address direction. Inherits `TLeaf`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/function_app.h
+++ b/orly/expr/function_app.h
@@ -1,6 +1,9 @@
 /* <orly/expr/function_app.h>
 
-   TODO
+   `TFunctionApp` -- a call expression after function resolution.
+   Carries the resolved function symbol and the named argument
+   map. Lowered to `CodeGen::TCall` (or `TBuiltInCall` when the
+   callee is a `Symbol::TBuiltInFunction`).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/if_else.h
+++ b/orly/expr/if_else.h
@@ -1,6 +1,9 @@
 /* <orly/expr/if_else.h>
 
-   TODO
+   `TIfElse` -- the ternary `if pred then a else b` IR node.
+   Inherits `TNAry<array<TExpr::TPtr, 3>>` -- predicate / true-case
+   / false-case. Type-checked to the unified type of the two
+   branches.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/in.h
+++ b/orly/expr/in.h
@@ -1,6 +1,7 @@
 /* <orly/expr/in.h>
 
-   TODO
+   `TIn` -- the `x in container` membership test. Inherits
+   `TBinary`. Code-gen lowers to `TBinary{In}`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/interior.h
+++ b/orly/expr/interior.h
@@ -1,6 +1,10 @@
 /* <orly/expr/interior.h>
 
-   TODO
+   `TInterior` -- abstract base for `TExpr`s that have child
+   expressions (the non-leaf nodes). Multiply-inherits `TExpr`
+   and `TExprParent` because an interior node is both an
+   expression and a parent of expressions. Subclassed by `TUnary`,
+   `TBinary`, `TNAry`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/is_empty.h
+++ b/orly/expr/is_empty.h
@@ -1,6 +1,7 @@
 /* <orly/expr/is_empty.h>
 
-   TODO
+   `TIsEmpty` -- unary `is_empty(x)` predicate over collections.
+   Inherits `TUnary`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/keys.h
+++ b/orly/expr/keys.h
@@ -1,6 +1,8 @@
 /* <orly/expr/keys.h>
 
-   TODO
+   `TKeys` -- the `keys <[pattern]>` IR node that walks the index
+   for matching keys. Carries the address-shaped key pattern and
+   the dereferenced value type. Lowered to `CodeGen::TKeys`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/known.h
+++ b/orly/expr/known.h
@@ -1,6 +1,9 @@
 /* <orly/expr/known.h>
 
-   TODO
+   The known / unknown discrimination operators on optional types:
+   `TIsKnown` (unary `x is known`), `TIsUnknown` (unary `x is
+   unknown`), and `TIsKnownExpr` (binary `x is known fallback` --
+   returns `x` if known, else `fallback`).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/leaf.h
+++ b/orly/expr/leaf.h
@@ -1,6 +1,9 @@
 /* <orly/expr/leaf.h>
 
-   TODO
+   `TLeaf` -- abstract base for nullary `TExpr`s (no operand
+   subexpressions). Subclassed by `TLiteral`, `TNow`, `TSessionId`,
+   `TUserId`, `TUnknown`, `TFree`, `TThat`, `TStart`, `TLhs`,
+   `TRhs`, `TRef`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/length_of.h
+++ b/orly/expr/length_of.h
@@ -1,6 +1,7 @@
 /* <orly/expr/length_of.h>
 
-   TODO
+   `TLengthOf` -- unary `length_of(x)` (collection length).
+   Inherits `TUnary`. Lowered to `CodeGen::TUnary{LengthOf}`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/lhs_and_rhs.h
+++ b/orly/expr/lhs_and_rhs.h
@@ -1,6 +1,9 @@
 /* <orly/expr/lhs_and_rhs.h>
 
-   TODO
+   `TLhs` and `TRhs` -- the `lhs` and `rhs` keyword IR nodes
+   inside a comparator body (e.g. `sorted_by lhs < rhs`). Each is
+   a `TLeaf` carrying a back-reference to its enclosing
+   `TLhsRhsable` (set at synth-build time).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/lhsrhsable.h
+++ b/orly/expr/lhsrhsable.h
@@ -1,6 +1,9 @@
 /* <orly/expr/lhsrhsable.h>
 
-   TODO
+   `TLhsRhsable` -- mixin base for `TExpr`s that introduce an
+   `lhs`/`rhs` binding (concretely, `TSort`). Provides
+   `GetLhsRhsType()` so `TLhs` / `TRhs` know what type they
+   project.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/list.h
+++ b/orly/expr/list.h
@@ -1,6 +1,8 @@
 /* <orly/expr/list.h>
 
-   TODO
+   `TList` -- list literal IR node (`[a, b, c]`). Inherits
+   `TCtor<vector<TExpr::TPtr>>`. Lowers to
+   `CodeGen::TBasicCtor<TListContainer>`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/literal.h
+++ b/orly/expr/literal.h
@@ -1,6 +1,8 @@
 /* <orly/expr/literal.h>
 
-   TODO
+   `TLiteral` -- a runtime-known value wrapped as an expression.
+   Carries a `Var::TVar`. Inherits `TLeaf`. Lowers to
+   `CodeGen::TLiteral`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/log.h
+++ b/orly/expr/log.h
@@ -1,6 +1,7 @@
 /* <orly/expr/log.h>
 
-   TODO
+   `TLog`, `TLog2`, `TLog10` -- the three logarithm IR nodes
+   (natural, base-2, base-10). All inherit `TUnary`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/logical_ops.h
+++ b/orly/expr/logical_ops.h
@@ -1,6 +1,9 @@
 /* <orly/expr/logical_ops.h>
 
-   TODO
+   The boolean operator IR nodes: `TAnd`, `TOr`, `TXor`, `TNot`
+   (eager forms), plus `TAndThen` and `TOrElse` (the short-circuit
+   forms whose rhs body needs its own scope). All inherit
+   `TBinary` except `TNot` which inherits `TUnary`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/mod.h
+++ b/orly/expr/mod.h
@@ -1,6 +1,7 @@
 /* <orly/expr/mod.h>
 
-   TODO
+   `TMod` -- binary `%` (modulo) IR node. Same pattern as `TAdd`;
+   `GetTypeImpl()` runs `orly/type/mod_visitor.h`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/mult.h
+++ b/orly/expr/mult.h
@@ -1,6 +1,7 @@
 /* <orly/expr/mult.h>
 
-   TODO
+   `TMult` -- binary `*` (multiplication) IR node. Same pattern
+   as `TAdd`; `GetTypeImpl()` runs `orly/type/mult_visitor.h`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/n_ary.h
+++ b/orly/expr/n_ary.h
@@ -1,6 +1,11 @@
 /* <orly/expr/n_ary.h>
 
-   TODO
+   `TNAry<TContainer>` -- abstract base for `TExpr`s with a
+   variadic number of children. Parameterised by the container
+   type (`vector`, `unordered_map`, `array`, `map` of string ->
+   expr). Each container has its own `ForEachExpr` overload so the
+   parent-pointer management works uniformly across container
+   shapes.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/now.h
+++ b/orly/expr/now.h
@@ -1,6 +1,7 @@
 /* <orly/expr/now.h>
 
-   TODO
+   `TNow` -- the `now` keyword IR node (current time). Inherits
+   `TLeaf`; no operands.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/obj.h
+++ b/orly/expr/obj.h
@@ -1,6 +1,8 @@
 /* <orly/expr/obj.h>
 
-   TODO
+   `TObj` -- object / record literal IR node (`{.field: val, ...}`).
+   Inherits `TCtor<map<string, TExpr::TPtr>>` (ordered by name for
+   stable iteration).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/obj_member.h
+++ b/orly/expr/obj_member.h
@@ -1,6 +1,7 @@
 /* <orly/expr/obj_member.h>
 
-   TODO
+   `TObjMember` -- named-field access (`obj.field`) on a record.
+   Inherits `TUnary` over the source object plus the field name.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/range.h
+++ b/orly/expr/range.h
@@ -1,6 +1,9 @@
 /* <orly/expr/range.h>
 
-   TODO
+   `TRange` -- the `[start..end..stride]` range constructor IR
+   node. Holds three optional expressions (start, end, stride)
+   and an inclusive-or-exclusive end flag. Inherits
+   `TNAry<array<TExpr::TPtr, 3>>`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/read.h
+++ b/orly/expr/read.h
@@ -1,6 +1,8 @@
 /* <orly/expr/read.h>
 
-   TODO
+   `TRead` -- the `expr::(T)` typed-read IR node. Carries the
+   source key expression and the read type; lowered to a runtime
+   database read.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/reduce.h
+++ b/orly/expr/reduce.h
@@ -1,6 +1,9 @@
 /* <orly/expr/reduce.h>
 
-   TODO
+   `TReduce` -- the `seq reduce start X + that` IR node. Inherits
+   `TStartable` + `TThatableBinary` so the reduce body can
+   reference both `start` and `that`. Lowered to
+   `CodeGen::TReduce`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/ref.h
+++ b/orly/expr/ref.h
@@ -1,6 +1,8 @@
 /* <orly/expr/ref.h>
 
-   TODO
+   `TRef` -- a bare name reference IR node. Carries the resolved
+   symbol (function / parameter / local). Inherits `TLeaf`; no
+   child expressions.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/reverse_of.h
+++ b/orly/expr/reverse_of.h
@@ -1,6 +1,7 @@
 /* <orly/expr/reverse_of.h>
 
-   TODO
+   `TReverseOf` -- unary `reverse_of(x)` IR node. Inherits
+   `TUnary`. Lowered to `CodeGen::TUnary{ReverseOf}`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/sequence_of.h
+++ b/orly/expr/sequence_of.h
@@ -1,6 +1,7 @@
 /* <orly/expr/sequence_of.h>
 
-   TODO
+   `TSequenceOf` -- unary `sequence_of(x)` IR node (treats `x` as
+   a sequence). Inherits `TUnary`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/session_id.h
+++ b/orly/expr/session_id.h
@@ -1,6 +1,7 @@
 /* <orly/expr/session_id.h>
 
-   TODO
+   `TSessionId` -- the `session_id` keyword IR node. Singleton-
+   shape `TLeaf` returning the calling session's UUID.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/set.h
+++ b/orly/expr/set.h
@@ -1,6 +1,8 @@
 /* <orly/expr/set.h>
 
-   TODO
+   `TSet` -- set literal IR node (`{a, b, c}`). Inherits
+   `TCtor<unordered_set<TExpr::TPtr>>`. Lowers to
+   `CodeGen::TBasicCtor<TSetContainer>`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/set_ops.h
+++ b/orly/expr/set_ops.h
@@ -1,6 +1,8 @@
 /* <orly/expr/set_ops.h>
 
-   TODO
+   The set operator IR nodes -- `TUnion`, `TIntersection`,
+   `TSymmetricDiff`. All inherit `TBinary`. `GetTypeImpl()` runs
+   `orly/type/set_ops_visitor.h`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/sign.h
+++ b/orly/expr/sign.h
@@ -1,6 +1,7 @@
 /* <orly/expr/sign.h>
 
-   TODO
+   `TNegative` (unary `-x`) and `TPositive` (unary `+x`) IR nodes.
+   Both inherit `TUnary`. Result type matches the operand.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/skip.h
+++ b/orly/expr/skip.h
@@ -1,6 +1,8 @@
 /* <orly/expr/skip.h>
 
-   TODO
+   `TSkip` -- the `seq skip count` IR node. Inherits `TBinary`;
+   drops the first `count` elements of the sequence. Counterpart
+   of `TTake`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/slice.h
+++ b/orly/expr/slice.h
@@ -1,6 +1,8 @@
 /* <orly/expr/slice.h>
 
-   TODO
+   `TSlice` -- `container[idx]` (single) and `container[lhs:rhs]`
+   (range) IR node. Holds the container expression, two optional
+   bounds, and a colon flag to distinguish the two forms.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/sort.h
+++ b/orly/expr/sort.h
@@ -1,6 +1,8 @@
 /* <orly/expr/sort.h>
 
-   TODO
+   `TSort` -- the `seq sorted_by (lhs OP rhs)` IR node. Inherits
+   `TLhsRhsable` + `TBinary`; the comparator body's `lhs` / `rhs`
+   resolve here via the mixin base. Lowered to `CodeGen::TSort`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/start.h
+++ b/orly/expr/start.h
@@ -1,6 +1,8 @@
 /* <orly/expr/start.h>
 
-   TODO
+   `TStart` -- the `start` keyword IR node inside a reduce /
+   collated_by body. Inherits `TLeaf` with a back-reference to its
+   enclosing `TStartable`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/startable.h
+++ b/orly/expr/startable.h
@@ -1,6 +1,9 @@
 /* <orly/expr/startable.h>
 
-   TODO
+   `TStartable` -- mixin base for `TExpr`s that introduce a
+   `start` binding (`TReduce`, `TCollatedBy`). Holds the
+   `TStart::TPtr` set during synth-build so subsequent code-gen
+   can find it.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/string.h
+++ b/orly/expr/string.h
@@ -1,6 +1,7 @@
 /* <orly/expr/string.h>
 
-   TODO
+   `TToLower` and `TToUpper` -- the two string-case unary
+   operator IR nodes. Both inherit `TUnary`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/sub.h
+++ b/orly/expr/sub.h
@@ -1,6 +1,7 @@
 /* <orly/expr/sub.h>
 
-   TODO
+   `TSub` -- binary `-` (subtraction) IR node. Same pattern as
+   `TAdd`; `GetTypeImpl()` runs `orly/type/sub_visitor.h`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/take.h
+++ b/orly/expr/take.h
@@ -1,6 +1,8 @@
 /* <orly/expr/take.h>
 
-   TODO
+   `TTake` -- the `seq take count` IR node. Inherits `TBinary`;
+   keeps the first `count` elements of the sequence. Counterpart
+   of `TSkip`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/test_kit.h
+++ b/orly/expr/test_kit.h
@@ -1,6 +1,9 @@
 /* <orly/expr/test_kit.h>
 
-   TODO
+   Per-test-file include kit for `orly/expr/*.test.cc`. Pulls in
+   `orly/expr.h`, the type singletons (`bool`, `int`, `real`,
+   `str`, ...), and the type czar, then `using namespace`s the
+   orly hierarchy so test files don't need to qualify every type.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/that.h
+++ b/orly/expr/that.h
@@ -1,6 +1,7 @@
 /* <orly/expr/that.h>
 
-   TODO
+   `TThat` -- the `that` keyword IR node. Inherits `TLeaf` with a
+   back-reference to its enclosing `TThatable`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/thatable.h
+++ b/orly/expr/thatable.h
@@ -1,6 +1,9 @@
 /* <orly/expr/thatable.h>
 
-   TODO
+   `TThatable` -- mixin base for `TExpr`s that introduce a `that`
+   binding (filter, reduce, collated_by, collected_by, assert,
+   effect, while). Provides `GetThatType()` so `TThat` knows the
+   type it projects.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/thatable_binary.h
+++ b/orly/expr/thatable_binary.h
@@ -1,6 +1,8 @@
 /* <orly/expr/thatable_binary.h>
 
-   TODO
+   `TThatableBinary` -- helper base that multiply-inherits
+   `TThatable` + `TBinary`. Used by `TFilter` and `TReduce` (rhs
+   body references `that` from lhs's element type).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/thatable_unary.h
+++ b/orly/expr/thatable_unary.h
@@ -1,6 +1,9 @@
 /* <orly/expr/thatable_unary.h>
 
-   TODO
+   `TThatableUnary` -- helper base that multiply-inherits
+   `TThatable` + `TUnary`. Used by `TEffect`, `TAssert`,
+   `TCollectedBy` (body references `that` from the wrapped
+   expression's type).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/time_obj.h
+++ b/orly/expr/time_obj.h
@@ -1,6 +1,8 @@
 /* <orly/expr/time_obj.h>
 
-   TODO
+   `TTimeObj` -- IR node that produces the
+   `{day, hour, minute, ...}` record from a `TimeDiff` or
+   `TimePnt`. Inherits `TUnary`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/trig.h
+++ b/orly/expr/trig.h
@@ -1,6 +1,8 @@
 /* <orly/expr/trig.h>
 
-   TODO
+   The trig operator IR nodes -- `TCos`, `TSin`, `TTan`, `TAcos`,
+   `TAsin`, `TAtan` (all `TUnary`) plus `TAtan2` (`TBinary`).
+   Result type is `TReal`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/unary.h
+++ b/orly/expr/unary.h
@@ -1,6 +1,10 @@
 /* <orly/expr/unary.h>
 
-   TODO
+   Abstract base for one-operand IR nodes. Stores the operand and
+   inherits `TInterior`. Subclassed by every unary operator
+   (`TNot`, `TNegative`, `TCeiling`, `TFloor`, `TLog`, `TCos`,
+   `TLengthOf`, `TIsEmpty`, ...). The one-arg constructor is
+   reserved for `TWhere` where the expression binds late.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/unknown.h
+++ b/orly/expr/unknown.h
@@ -1,6 +1,8 @@
 /* <orly/expr/unknown.h>
 
-   TODO
+   `TUnknown` -- the typed-unknown literal IR node (`?T`).
+   Carries the target type so the runtime knows what kind of
+   empty value to emit. Inherits `TLeaf`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/user_id.h
+++ b/orly/expr/user_id.h
@@ -1,6 +1,8 @@
 /* <orly/expr/user_id.h>
 
-   TODO
+   `TUserId` -- the `user_id` keyword IR node. Inherits `TLeaf`;
+   returns the calling user's UUID (or unknown if no user is bound
+   to the session).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/util.h
+++ b/orly/expr/util.h
@@ -1,6 +1,9 @@
 /* <orly/expr/util.h>
 
-   TODO
+   Out-of-line template definitions for `TExpr::As<T>`,
+   `TExpr::Is<T>`, `TExpr::TryAs<T>`. Lives in its own header
+   because the templates need full visibility of the concrete
+   subclasses for the `dynamic_cast`.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/visitor.h
+++ b/orly/expr/visitor.h
@@ -1,6 +1,9 @@
 /* <orly/expr/visitor.h>
 
-   TODO
+   `TExpr::TVisitor` -- the (very large) visitor interface with
+   one pure-virtual `operator()` overload per concrete `TExpr`
+   subclass (~95 total). Forward-declares every leaf, so concrete
+   visitors only need to include the leaves they actually handle.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/walker.h
+++ b/orly/expr/walker.h
@@ -1,6 +1,8 @@
 /* <orly/expr/walker.h>
 
-   TODO
+   `ForEachExpr(root, cb, include_inner_funcs)` -- recursive tree
+   walker. Calls `cb(expr)` for every expr in the tree; if `cb`
+   returns true, doesn't recurse into that subtree.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/where.h
+++ b/orly/expr/where.h
@@ -1,6 +1,9 @@
 /* <orly/expr/where.h>
 
-   TODO
+   `TWhere` -- the `expr where { defs }` IR node. Inherits
+   `TUnary` over the body expression; the definitions live in an
+   attached scope. Lowered to `CodeGen::TInlineScope` with the
+   body as its returned expression.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/expr/while.h
+++ b/orly/expr/while.h
@@ -1,6 +1,8 @@
 /* <orly/expr/while.h>
 
-   TODO
+   `TWhile` -- the `seq while (pred)` IR node. Inherits
+   `TThatableBinary`; yields elements from the sequence until
+   `pred` returns false. Lowered to `CodeGen::TWhile`.
 
    Copyright 2010-2026 Atomic Kismet Company
 


### PR DESCRIPTION
**Closes #70.** Final pass on the issue-#70 arc. After this lands, **no file in the repo has `   TODO` as its file-level docstring**.

## What changed

76 headers under `orly/expr/` — the IR layer that sits between `orly/synth/` (parser CST → TExpr, #85) and `orly/code_gen/` (TExpr → emitted C++, #84). Documented in four layers:

### Abstract bases (4)
- `expr.h` — `TExpr` (visitor-dispatched abstract root with cached type)
- `leaf.h` — nullary base
- `interior.h` — multiply-inherits `TExpr` + `TExprParent` (the non-leaves)
- `unary.h` / `binary.h` / `n_ary.h` / `ctor.h` — arity-specific bases

### Mixin bases (4)
- `thatable.h` + `thatable_unary.h` + `thatable_binary.h` — the `that` keyword scopes
- `startable.h` — `start`
- `lhsrhsable.h` — `lhs` / `rhs`

### Concrete leaves (~65)
One `TExpr` subclass per orlyscript operator. Some files hold multiple classes:

- **Arithmetic**: `add`, `sub`, `mult`, `div`, `mod`, `exp`, `sign` (`TNegative` + `TPositive`)
- **Comparison**: `comp_ops` holds `TEqEq` / `TNeq` / `TLt` / `TLtEq` / `TGt` / `TGtEq`
- **Logical**: `logical_ops` holds `TAnd` / `TOr` / `TXor` / `TAndThen` / `TOrElse` / `TNot`
- **Set ops**: `set_ops` holds `TUnion` / `TIntersection` / `TSymmetricDiff`
- **Trig / math**: `trig` (7 classes), `log` (3 classes), `string` (`TToLower` + `TToUpper`), `ceiling`, `floor`
- **Container literals**: `list`, `set`, `dict`, `obj`, `addr`, `range`
- **Sequence operators**: `filter`, `sort`, `reduce`, `collated_by`, `collected_by`, `while`, `take`, `skip`
- **Optional discrimination**: `known` (`TIsKnown` / `TIsUnknown` / `TIsKnownExpr`), `unknown`, `is_empty`
- **DB ops**: `keys`, `exists`, `read`, `in`
- **Special keywords**: `that`, `start`, `lhs_and_rhs` (`TLhs` + `TRhs`), `free`, `now`, `session_id`, `user_id`, `ref`
- **Control / misc**: `if_else`, `where`, `function_app`, `assert`, `effect`, `slice`, `length_of`, `time_obj`, `sequence_of`, `reverse_of`, `as`, `addr_member`, `addr_of`, `obj_member`

### Infrastructure (4)
- `visitor.h` — `TExpr::TVisitor` with one overload per concrete leaf (~95 total)
- `walker.h` — `ForEachExpr` tree walker
- `util.h` — `As<T>` / `Is<T>` / `TryAs<T>` template definitions
- `expr_parent.h` — parent-linkage marker class
- `test_kit.h` — test-file include kit

## Validation

- `make debug` — 1712 / 1712 jobs, clean
- Comment-only diff: no behavioural impact
- `grep -rln '^   TODO\$' orly/ base/ | wc -l` reports **0** -- the entire repo is now TODO-docstring-free at the file level

## The full #70 arc

Eleven PRs to close out:

| PR | Subsystem | Files | Count after |
|---|---|---|---|
| #78 | `orly/indy/disk/` | 19 | 320 |
| #79 | `orly/indy/disk/util/` | 8 | 312 |
| #80 | 7 small subsystems (incl. top-level `base/`) | 30 | 282 |
| #81 | `orly/rt/` | 17 | 265 |
| #82 | `base/{gz,mpl}/` | 24 | 241* |
| #83 | `orly/type/` | 41 | 200* |
| #84 | `orly/code_gen/` | 43 | 157* |
| #85 | `orly/synth/` | 71 | 86* |
| #86 | 10 smaller subdirs | 39 | 76* |
| **this** | `orly/expr/` | **76** | **0** |

*(orly/ + base/ combined count)

Starting from the 339-file grep that opened #70, every file-level `   TODO` placeholder in the repo is now a real description.

## Test plan

- [ ] CI passes (comment-only)
- [ ] Issue #70 auto-closes on merge
- [ ] `grep -rln '^   TODO\$' orly/ base/ | wc -l` reports `0` on master after merge
