### PR TITLE
lang_test: distinguish tracked failures (xfail) from unexpected failures

### DIFF
--- a/tests/lang_tests/.xfail
+++ b/tests/lang_tests/.xfail
@@ -1,0 +1,16 @@
+# Tracked expected-failure tests for tools/lang_test.py.
+#
+# Format: one entry per line. Blank lines and lines starting with "# "
+# (hash + space) are comments. Each entry is a path relative to this
+# file's directory, optionally followed by "#NNN" issue references that
+# track the underlying limitation.
+#
+# A test listed here is expected to fail. The harness reports it as a
+# tracked failure (xfail) rather than a regression. Removing an entry
+# whose test still fails causes the harness to exit non-zero; leaving
+# an entry whose test now passes is also a failure (xpass), prompting
+# the maintainer to drop the entry.
+
+general/mutablefilter.orly #73
+general/unsorted/multiple_sequences.orly #74
+general/unsorted/sequence_in_effecting.orly #75

--- a/tools/lang_test.py
+++ b/tools/lang_test.py
@@ -102,6 +102,67 @@ def GetStateFilename(filepath):
   dirpath, filename = os.path.split(filepath)
   return os.path.join(dirpath, '.' + filename + '.test.state')
 
+def LoadXFail(directory):
+  """Load expected-failure paths from <directory>/.xfail.
+
+  Returns a dict mapping the normalised filepath (as it will appear in
+  the harness's collected list) -> list of issue refs (may be empty).
+
+  File format: one entry per line. Blank lines and lines whose first
+  non-whitespace token starts with '# ' (hash + space) are comments.
+  Each entry is a path relative to <directory>, optionally followed by
+  whitespace-separated '#NNN' issue refs."""
+  xfail_path = os.path.join(directory, '.xfail')
+  entries = {}
+  try:
+    f = open(xfail_path)
+  except (IOError, OSError) as ex:
+    if ex.errno != 2:
+      raise
+    return entries
+  with f:
+    for raw_line in f:
+      line = raw_line.strip()
+      if not line or line.startswith('# '):
+        continue
+      parts = line.split()
+      rel_path = parts[0]
+      issues = [p for p in parts[1:] if p.startswith('#')]
+      key = os.path.normpath(os.path.join(directory, rel_path))
+      entries[key] = issues
+  return entries
+
+def BuildXFailMap(input_paths, treat_as_directories):
+  """Build the merged xfail map from every .xfail file reachable from
+  the input paths. In --directories mode each input is itself a
+  directory to scan; otherwise we walk up from each file's containing
+  directory until we find an .xfail (or run out of parents)."""
+  merged = {}
+  seen_dirs = set()
+
+  def _absorb(directory):
+    directory = os.path.normpath(directory)
+    if directory in seen_dirs:
+      return
+    seen_dirs.add(directory)
+    merged.update(LoadXFail(directory))
+
+  if treat_as_directories:
+    for path in input_paths:
+      _absorb(path)
+  else:
+    for path in input_paths:
+      directory = os.path.dirname(os.path.abspath(path))
+      while True:
+        if os.path.exists(os.path.join(directory, '.xfail')):
+          _absorb(directory)
+          break
+        parent = os.path.dirname(directory)
+        if parent == directory:
+          break
+        directory = parent
+  return merged
+
 def Main():
   args = GetArgParser().parse_args()
 
@@ -129,6 +190,14 @@ def Main():
             filepaths.append(os.path.join(dirname, filename))
   else:
     filepaths = args.filepaths
+
+  xfail_map = BuildXFailMap(args.filepaths, args.directories)
+
+  def IsXFail(filepath):
+    return os.path.normpath(filepath) in xfail_map
+
+  def XFailIssues(filepath):
+    return xfail_map.get(os.path.normpath(filepath), [])
 
   changed_files = []
   passed_files = []
@@ -221,11 +290,44 @@ def Main():
   if args.update:
     return 0
 
+  # Split failures into tracked (xfail) vs unexpected, and detect any
+  # tests that were marked xfail but actually passed (xpass). xpass is
+  # treated as a failure to match pytest's xfail_strict=true semantics:
+  # either the underlying limitation is fixed and the entry should be
+  # removed, or the test is no longer exercising what it claims to.
+  unexpected_failures = [f for f in failed_files if not IsXFail(f)]
+  tracked_failures = [f for f in failed_files if IsXFail(f)]
+  unexpected_passes = [f for f in passed_files if IsXFail(f)]
+
   print('Change:', ','.join(changed_files))
   print('Pass:', ','.join(passed_files))
   print('Fail:', ','.join(failed_files))
-  print('Overall: %s changed, %s passed, %s failed' % (len(changed_files), len(passed_files), len(failed_files)))
-  return 0 if len(changed_files) == 0 else -1
+  if unexpected_passes:
+    print('XPass:', ','.join(unexpected_passes))
+
+  # 'passed' counts tests that genuinely passed and were not marked
+  # xfail; xpasses are reported in their own bucket so each test sits
+  # in exactly one column.
+  pure_passed = len(passed_files) - len(unexpected_passes)
+  summary = 'Overall: %d unexpected, %d passed, %d tracked failures (xfail)' % (
+      len(unexpected_failures), pure_passed, len(tracked_failures))
+  if unexpected_passes:
+    noun = 'pass' if len(unexpected_passes) == 1 else 'passes'
+    summary += ', %d unexpected %s (xpass)' % (len(unexpected_passes), noun)
+  print(summary)
+
+  for filepath in tracked_failures:
+    issues = XFailIssues(filepath)
+    suffix = ' (%s)' % ' '.join(issues) if issues else ''
+    print('  xfail:', filepath + suffix)
+  for filepath in unexpected_passes:
+    issues = XFailIssues(filepath)
+    suffix = ' (%s)' % ' '.join(issues) if issues else ''
+    print('  xpass:', filepath + suffix,
+          '-- remove from .xfail or update the test')
+
+  ok = (not changed_files) and (not unexpected_failures) and (not unexpected_passes)
+  return 0 if ok else -1
 
 if __name__ == '__main__':
   exit(Main())


### PR DESCRIPTION
Closes #77. Followup to #69 / #76 / #73 / #74 / #75.

## Summary

- Adds an `.xfail` sentinel file mechanism to `tools/lang_test.py` so the run summary distinguishes **tracked failures** (known limitations with tracking issues) from **unexpected failures** (regressions).
- Creates `tests/lang_tests/.xfail` listing the three current tracked failures, each tagged with its issue number.
- Exit code now goes red on any unexpected failure, on any unexpected pass (xpass), or on pickle drift — so a 4th broken test surfaces immediately instead of being lost in the same "3 failed" bucket as the tracked three.

### Before

```
Overall: 0 changed, 125 passed, 3 failed
```
(no way to tell whether the `3` is "3 tracked, no regressions" or "3 actual broken things" — the concern from #69)

### After

```
Overall: 0 unexpected, 125 passed, 3 tracked failures (xfail)
  xfail: tests/lang_tests/general/mutablefilter.orly (#73)
  xfail: tests/lang_tests/general/unsorted/multiple_sequences.orly (#74)
  xfail: tests/lang_tests/general/unsorted/sequence_in_effecting.orly (#75)
```

A 4th unexpected failure would now surface as `1 unexpected, ...` and the harness exits 255.

## Design (Option A from the issue)

`.xfail` files are plain text, one entry per line. Blank lines and lines beginning with `# ` (hash + space) are comments. Each entry is a path relative to the `.xfail` file's directory, optionally followed by whitespace-separated `#NNN` issue refs:

```
general/mutablefilter.orly #73
general/unsorted/multiple_sequences.orly #74
general/unsorted/sequence_in_effecting.orly #75
```

In `--directories` / `-d` mode the harness loads `.xfail` from each input directory. In file-list mode it walks up from each file's containing directory until it finds an `.xfail` (or runs out of parents). Missing `.xfail` is not an error.

xpass (a test marked xfail that now passes) is treated as a failure — matching pytest's `xfail_strict=true` semantics — and the message points the maintainer at what to do: remove from `.xfail` or update the test. This keeps the file honest.

`--update` / `-u` short-circuits before the new classification step; its behaviour is unchanged.

## Test plan

- [x] Baseline before change: `0 changed, 125 passed, 3 failed` (exit 0)
- [x] After change with all three tracked: `0 unexpected, 125 passed, 3 tracked failures (xfail)` (exit 0)
- [x] Drop `#73` entry from `.xfail` → `1 unexpected, 125 passed, 2 tracked failures (xfail)` (exit 255)
- [x] Add a passing test (`general/strings.orly`) to `.xfail` → `0 unexpected, 124 passed, 3 tracked failures (xfail), 1 unexpected pass (xpass)` (exit 255)
- [x] Final restore + happy-path re-run: `0 unexpected, 125 passed, 3 tracked failures (xfail)` (exit 0)

## Out of scope

Fixing the underlying language limitations — those are #73 / #74 / #75.