### PR TITLE
examples/grc20-pov: GRC-20-shaped knowledge graph on Orly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,3 +248,17 @@ jobs:
         working-directory: examples/agent-swarm
         env:
           DEMO_SCALE: small
+
+      # GRC-20 reference demo: each editor's op is one set-union into a
+      # per-(entity, property) history set; reads replay the timestamp-
+      # sorted log to reconstruct entity state (or any historical
+      # state). Three phases: wiki biographical / stanford schools +
+      # relations / concurrent race on the same attribute. Self-checks
+      # that both race events land in history.
+      - name: grc20-pov run.sh (python driver, event-sourced KG)
+        run: ./run.sh
+        working-directory: examples/grc20-pov
+
+      - name: grc20-pov run-go.sh (go driver, event-sourced KG)
+        run: ./run-go.sh
+        working-directory: examples/grc20-pov

--- a/README.md
+++ b/README.md
@@ -114,7 +114,21 @@ What this would normally require:
 
 Why it matters: this is exactly the topology AI extraction pipelines have — many agents reading disjoint chunks, emitting overlapping facts into one graph — and every conventional database forces you to invent a coordination protocol on top. Orly gives it to you for free, as a direct consequence of how field calls work. The driver never reads-then-writes; it only ever calls the three commutative functions in [`graph.orly`](examples/agent-swarm/graph.orly).
 
-All four examples ship two equivalent drivers — Python (`./run.sh`) and Go (`./run-go.sh`) — and are smoke-tested in CI on every push.
+### [`examples/grc20-pov/`](examples/grc20-pov/) — GRC-20 knowledge graph: event-sourced + concurrent editors + time-travel
+
+A reference impl of Geo / The Graph's [GRC-20](https://github.com/geobrowser/grc-20) knowledge-graph standard. GRC-20 models knowledge as append-only ops (`CreateEntity`, `UpdateEntity`, `CreateRelation`, `DeleteEntity`) — exactly the shape Orly stores natively. Every op becomes one `|=` into a per-`(entity, property)` history set; concurrent editors stream into the same shared POV with **no coordination**; reads replay the timestamp-sorted log to reconstruct entity state, or any historical state if you pass a cutoff.
+
+The demo runs three phases over a corpus of six Greek philosophers:
+
+| Phase | Editor | What |
+|---|---|---|
+| 1 | `wiki` | biographical facts (`name`, `born`, `died`) |
+| 2 | `stanford` | school of thought + `student_of` relations |
+| 3 | both | concurrent race on `pythagoras.born` — both events survive in history |
+
+After each phase the demo prints a snapshot reconstructed from the event log; the final editorial diff shows per-editor event counts and overlapping entities. This example is the synthesis of the other four: time-travel from [`bitcoin-time-travel`](examples/bitcoin-time-travel/) and [`wikipedia-categories`](examples/wikipedia-categories/), concurrent multi-writer from [`wikipedia-pageviews`](examples/wikipedia-pageviews/) and [`agent-swarm`](examples/agent-swarm/), applied to a published graph standard from another project rather than a synthetic workload. The entire engine side is three commutative orlyscript functions; GRC-20's op vocabulary lives entirely in the driver.
+
+All five examples ship two equivalent drivers — Python (`./run.sh`) and Go (`./run-go.sh`) — and are smoke-tested in CI on every push.
 
 ## Walkthrough
 

--- a/examples/grc20-pov/README.md
+++ b/examples/grc20-pov/README.md
@@ -1,0 +1,128 @@
+# GRC-20-shaped knowledge graph on Orly
+
+A small reference demo aimed at the [Geo / The Graph](https://github.com/geobrowser/grc-20) team: their **GRC-20** standard models knowledge as an event-sourced property graph (`CreateEntity` / `UpdateEntity` / `CreateRelation` / `DeleteEntity` ops, append-only). Orly stores exactly that shape natively — every op is one set-union into a per-(entity, property) history set, and concurrent editors stream into the same shared POV with **no coordination**.
+
+```
+GRC-20 op             →   one `|=` into  <['hist', entity, property]>::({str})
+Reconstruct entity    ←   sort history by ts, replay events in order
+Time-travel as-of T   ←   sort history by ts, replay events with ts ≤ T
+```
+
+The driver owns the GRC-20 op vocabulary (`CreateEntity`, `SetText`, `SetInteger`, `CreateRelation`, `DeleteEntity`); the engine just stores immutable events. Three commutative orlyscript functions are the entire schema (`append_op`, `register_entity`, `register_prop`).
+
+## Run it
+
+```sh
+cd examples/grc20-pov
+./run.sh       # python driver
+./run-go.sh    # go driver
+```
+
+Both wrappers require `make debug` to have built `orlyi` + `orlyc`. The Go wrapper additionally needs the `go` toolchain. The two drivers exercise the same scenario and self-check the same invariants.
+
+## The three phases
+
+The demo runs a small corpus of six Greek philosophers as if they were being collaboratively edited by two GRC-20 sources:
+
+| Phase | Editor | Ops | What |
+|---|---|---|---|
+| 1 | `wiki` | 24 | `CreateEntity` + `SetText name` + `SetInteger born` + `SetInteger died` per philosopher |
+| 2 | `stanford` | 8 | `SetText school` per philosopher + `CreateRelation student_of` (Plato→Socrates, Aristotle→Plato) |
+| 3 | both | 2 | both editors **concurrently** rewrite `pythagoras.born` from separate WebSocket sessions |
+
+After each phase a snapshot is printed, plus a final editorial diff (events per editor, overlap).
+
+## What you'll see
+
+Snapshot 1 (after phase 1) — only `wiki`'s biographical facts:
+
+```
+=== snapshot 1: end of phase 1 (wiki only) ===
+  aristotle (Person): born=-384 [wiki], died=-322 [wiki], name=Aristotle [wiki]
+  epicurus (Person):  born=-341 [wiki], died=-270 [wiki], name=Epicurus  [wiki]
+  ...
+```
+
+Snapshot 2 (after phase 2) — `stanford` has merged in:
+
+```
+=== snapshot 2: end of phase 2 (wiki + stanford) ===
+  aristotle (Person): born=-384 [wiki], died=-322 [wiki], name=Aristotle [wiki],
+                      school=Peripateticism [stanford], student_of=→ plato [stanford]
+  ...
+```
+
+Phase 3 — the race:
+
+```
+[phase 3] wiki + stanford concurrently overwrite pythagoras.born
+  history for pythagoras.born after race (3 events, ts-sorted):
+    1780613758237  wiki       I  -570
+    1780613758647  stanford   I  -575
+    1780613758647  wiki       I  -570
+```
+
+Two writers from independent WebSocket sessions land events at the **same millisecond**; both events survive in history. The driver's deterministic tiebreaker (lex sort on the encoded entry) picks one as the "current" value — but the alternative-source claim isn't lost, exactly the editorial-workflow semantics GRC-20 needs.
+
+```
+=== editorial diff ===
+  stanford     9 events on  6 entities
+  wiki        25 events on  6 entities
+  overlap: 6 entities edited by both (stanford ∩ wiki): ['aristotle', 'epicurus', ...]
+```
+
+## Why this maps to GRC-20
+
+| GRC-20 concept | Demo realisation |
+|---|---|
+| `CreateEntity(id, type)` | `register_entity` + `append_op(id, '__type', 'L:<type>')` |
+| `SetText(id, prop, text)` | `append_op(id, prop, 'L:<text>')` |
+| `SetInteger(id, prop, n)` | `append_op(id, prop, 'I:<n>')` |
+| `CreateRelation(id, prop, target)` | `append_op(id, prop, 'R:<target_id>')` |
+| `DeleteEntity(id)` | `append_op(id, '__deleted', 'D:')` |
+| event-sourced log | history set sorted by 13-digit ms timestamp |
+| append-only | set union is the only write operation |
+| multi-editor merge | concurrent `|=` from independent WS sessions, no locks |
+| historical query | replay events with `ts ≤ target` |
+
+GRC-20's full type system is 13 data types; this demo exercises TEXT, INTEGER, and RELATION (sufficient to prove the pattern). The packed-string entry format (`<ts>:<editor>:<kind>:<value>`) is what the driver puts in the set — orlyscript treats it as an opaque string. A production binding would store binary GRC-20 ops directly.
+
+## Schema (the entire engine side)
+
+```orly
+<['hist', entity, property]>::({str})  -- set of events for one (e, p)
+<['entities']>::({str})                -- set of every entity id
+<['props',  entity]>::({str})          -- set of every property ever written on e
+```
+
+Three functions:
+
+```orly
+append_op(.entity, .property, .entry)   -- |= one event into the history
+register_entity(.entity)                -- |= entity into the global set
+register_prop(.entity, .property)       -- |= property into the entity's prop set
+```
+
+That's it. Everything else — op classification, replay, time-travel, editorial diff — happens in the driver. The engine guarantees that no event is ever lost, no matter how many editors are writing at once, because `|=` is a commutative deferred-mutation field call ([#49](https://github.com/orlyatomics/orly/issues/49) / PRs #50/#51/#52).
+
+## Caveats
+
+- **Driver-side ms timestamps** for the event timeline assume all editors share the same clock. In a real decentralised deployment, replace with a consensus-ordered sequence number or a hybrid logical clock; the schema doesn't change.
+- **Same-ms tiebreaker** is lex order on the encoded entry — deterministic, not principled. GRC-20 itself defers ordering to the on-chain proposal queue, which the driver would defer to.
+- **No compaction** of the history set in this demo. Real workloads would compact `(entity, prop)` history into a checkpoint past some age cutoff. The shape generalises — fold the prefix, keep only the tail.
+- **Six philosophers** is enough to prove the pattern, not a workload benchmark. For throughput numbers under contention, see [`examples/agent-swarm/`](../agent-swarm/) (8 concurrent agents, hot-key counters + tag sets) and [`examples/wikipedia-pageviews/`](../wikipedia-pageviews/) (5,938 events, integer counters).
+
+## Related demos
+
+- [`examples/wikipedia-categories/`](../wikipedia-categories/) — same fold-on-read pattern with set-union values, version axis in the key (year). This demo extends to heterogeneous events with timestamped editor attribution.
+- [`examples/agent-swarm/`](../agent-swarm/) — multi-writer commutative field calls (`+=`, `|=`) under contention, same lost-update-free guarantee.
+- [`examples/bitcoin-time-travel/`](../bitcoin-time-travel/) — the original time-travel-via-key-axis demo with integer-addition values (account balances).
+
+## Files
+
+| File | What |
+|---|---|
+| `grc20.orly` | The Orlyscript package: `append_op`, `register_entity`, `register_prop`, + lookups + 19 inline tests |
+| `demo.py` | Python WebSocket driver: 3 phases, snapshot replay, editorial diff, self-check |
+| `demo.go` + `go.mod` + `go.sum` | Go WebSocket driver, equivalent to Python |
+| `run.sh` / `run-go.sh` | End-to-end wrappers: compile, start fresh orlyi, run the chosen driver |

--- a/examples/grc20-pov/demo.go
+++ b/examples/grc20-pov/demo.go
@@ -1,0 +1,538 @@
+// GRC-20-shaped knowledge graph on Orly, in Go.
+//
+// Mirrors demo.py: three phases (wiki biographical / stanford schools +
+// relations / concurrent race), same encoding, same self-check.
+// Provided so readers can pick whichever language matches their
+// environment.
+//
+// Run via the wrapper:
+//
+//	./run-go.sh
+//
+// Or directly, after starting orlyi separately:
+//
+//	go run demo.go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const wsURL = "ws://127.0.0.1:8082/"
+
+type philosopher struct {
+	id         string
+	name       string
+	born, died int
+}
+
+var philosophers = []philosopher{
+	{"socrates", "Socrates", -470, -399},
+	{"plato", "Plato", -428, -348},
+	{"aristotle", "Aristotle", -384, -322},
+	{"pythagoras", "Pythagoras", -570, -495},
+	{"heraclitus", "Heraclitus", -535, -475},
+	{"epicurus", "Epicurus", -341, -270},
+}
+
+// Editor 2 ("stanford") adds the school of thought for each
+// philosopher. Map iteration order is randomised; the keys/values are
+// listed as parallel slices so the ingest order is stable.
+var schoolEntities = []string{"socrates", "plato", "aristotle", "pythagoras", "heraclitus", "epicurus"}
+var schoolValues = []string{"Classical", "Platonism", "Peripateticism", "Pythagoreanism", "Heracliteanism", "Epicureanism"}
+
+type relation struct {
+	subject, prop, target string
+}
+
+var relations = []relation{
+	{"plato", "student_of", "socrates"},
+	{"aristotle", "student_of", "plato"},
+}
+
+// Phase-3 race: both editors concurrently rewrite the same attribute on
+// the same entity. Whoever's event lands at the later ms wins on read;
+// the loser stays in history as an alternative-source claim.
+const raceEntity = "pythagoras"
+const raceProp = "born"
+const raceWiki = -570
+const raceStanford = -575
+
+// ---------------------------------------------------------------------
+// WS helpers.
+// ---------------------------------------------------------------------
+
+type reply struct {
+	Status string          `json:"status"`
+	Result json.RawMessage `json:"result"`
+}
+
+func die(msg string) {
+	fmt.Fprintln(os.Stderr, msg)
+	os.Exit(1)
+}
+
+func dial() *websocket.Conn {
+	c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		die(fmt.Sprintf("dial %s: %v", wsURL, err))
+	}
+	return c
+}
+
+func send(c *websocket.Conn, stmt string) json.RawMessage {
+	if err := c.WriteMessage(websocket.TextMessage, []byte(stmt)); err != nil {
+		die(fmt.Sprintf("write %q: %v", stmt, err))
+	}
+	_, msg, err := c.ReadMessage()
+	if err != nil {
+		die(fmt.Sprintf("read after %q: %v", stmt, err))
+	}
+	var r reply
+	if err := json.Unmarshal(msg, &r); err != nil {
+		die(fmt.Sprintf("parse reply: %v\n  raw: %s", err, msg))
+	}
+	if r.Status != "ok" {
+		die(fmt.Sprintf("%s: %s", stmt, string(msg)))
+	}
+	return r.Result
+}
+
+func sendString(c *websocket.Conn, stmt string) string {
+	raw := send(c, stmt)
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		die(fmt.Sprintf("expected string result, got %s", raw))
+	}
+	return s
+}
+
+// orlyi serialises numbers as JSON floats; cast to int via float64.
+func sendInt(c *websocket.Conn, stmt string) int {
+	raw := send(c, stmt)
+	var n float64
+	if err := json.Unmarshal(raw, &n); err != nil {
+		die(fmt.Sprintf("expected number result, got %s", raw))
+	}
+	return int(n)
+}
+
+// orlyi serialises sets as JSON arrays.
+func sendStringSet(c *websocket.Conn, stmt string) []string {
+	raw := send(c, stmt)
+	if string(raw) == "null" {
+		return nil
+	}
+	var out []string
+	if err := json.Unmarshal(raw, &out); err != nil {
+		die(fmt.Sprintf("expected array result, got %s", raw))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ---------------------------------------------------------------------
+// Op encoding: "<13-digit ms ts>:<editor>:<kind>:<value>".
+// Kind ∈ {L text, I integer, R relation target id, D tombstone}.
+// ---------------------------------------------------------------------
+
+func nowMs() int64 { return time.Now().UnixNano() / 1_000_000 }
+
+func encode(editor, kind, value string) string {
+	return fmt.Sprintf("%013d:%s:%s:%s", nowMs(), editor, kind, value)
+}
+
+type parsed struct {
+	ts             int64
+	editor, kind   string
+	value          string
+}
+
+func parseEntry(entry string) parsed {
+	parts := strings.SplitN(entry, ":", 4)
+	if len(parts) != 4 {
+		die(fmt.Sprintf("bad entry %q", entry))
+	}
+	ts, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		die(fmt.Sprintf("bad ts in %q: %v", entry, err))
+	}
+	return parsed{ts: ts, editor: parts[1], kind: parts[2], value: parts[3]}
+}
+
+func orlyStr(s string) string {
+	// Corpus has no quotes/backslashes, but be defensive.
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return `"` + s + `"`
+}
+
+// ---------------------------------------------------------------------
+// Wrappers for the grc20 package's three commutative funcs.
+// ---------------------------------------------------------------------
+
+func appendOp(c *websocket.Conn, pov, entity, prop, entry string) {
+	send(c, fmt.Sprintf(
+		`try {%s} grc20 append_op <{.entity: %s, .property: %s, .entry: %s}>;`,
+		pov, orlyStr(entity), orlyStr(prop), orlyStr(entry)))
+}
+
+func registerEntity(c *websocket.Conn, pov, entity string) {
+	send(c, fmt.Sprintf(
+		`try {%s} grc20 register_entity <{.entity: %s}>;`,
+		pov, orlyStr(entity)))
+}
+
+func registerProp(c *websocket.Conn, pov, entity, prop string) {
+	send(c, fmt.Sprintf(
+		`try {%s} grc20 register_prop <{.entity: %s, .property: %s}>;`,
+		pov, orlyStr(entity), orlyStr(prop)))
+}
+
+func histFor(c *websocket.Conn, pov, entity, prop string) []string {
+	return sendStringSet(c, fmt.Sprintf(
+		`try {%s} grc20 hist_for <{.entity: %s, .property: %s}>;`,
+		pov, orlyStr(entity), orlyStr(prop)))
+}
+
+func allEntities(c *websocket.Conn, pov string) []string {
+	return sendStringSet(c, fmt.Sprintf(`try {%s} grc20 all_entities <{}>;`, pov))
+}
+
+func propsOf(c *websocket.Conn, pov, entity string) []string {
+	return sendStringSet(c, fmt.Sprintf(
+		`try {%s} grc20 props_of <{.entity: %s}>;`,
+		pov, orlyStr(entity)))
+}
+
+func entityCount(c *websocket.Conn, pov string) int {
+	return sendInt(c, fmt.Sprintf(`try {%s} grc20 entity_count <{}>;`, pov))
+}
+
+// ---------------------------------------------------------------------
+// GRC-20-style ops (the driver owns the op vocabulary; the engine just
+// stores events).
+// ---------------------------------------------------------------------
+
+func opCreateEntity(c *websocket.Conn, pov, editor, entity, typeName string) {
+	registerEntity(c, pov, entity)
+	registerProp(c, pov, entity, "__type")
+	appendOp(c, pov, entity, "__type", encode(editor, "L", typeName))
+}
+
+func opSetText(c *websocket.Conn, pov, editor, entity, prop, text string) {
+	registerEntity(c, pov, entity)
+	registerProp(c, pov, entity, prop)
+	appendOp(c, pov, entity, prop, encode(editor, "L", text))
+}
+
+func opSetInt(c *websocket.Conn, pov, editor, entity, prop string, n int) {
+	registerEntity(c, pov, entity)
+	registerProp(c, pov, entity, prop)
+	appendOp(c, pov, entity, prop, encode(editor, "I", strconv.Itoa(n)))
+}
+
+func opCreateRelation(c *websocket.Conn, pov, editor, entity, prop, target string) {
+	registerEntity(c, pov, entity)
+	registerEntity(c, pov, target)
+	registerProp(c, pov, entity, prop)
+	appendOp(c, pov, entity, prop, encode(editor, "R", target))
+}
+
+// ---------------------------------------------------------------------
+// Replay: build the current state of every (entity, property) by
+// walking its history set in timestamp order. Optional `asOf` cutoff
+// drops events with ts > cutoff -- that's the time-travel knob.
+// ---------------------------------------------------------------------
+
+type fact struct {
+	kind, value, editor string
+	ts                  int64
+}
+
+// nil asOf means "no cutoff" -- pass &someInt64 to filter.
+func reconstruct(c *websocket.Conn, pov string, asOf *int64) map[string]map[string]fact {
+	out := map[string]map[string]fact{}
+	for _, eid := range allEntities(c, pov) {
+		deleted := false
+		state := map[string]fact{}
+		for _, prop := range propsOf(c, pov, eid) {
+			entries := histFor(c, pov, eid, prop) // already sorted
+			if asOf != nil {
+				filtered := entries[:0]
+				for _, e := range entries {
+					if parseEntry(e).ts <= *asOf {
+						filtered = append(filtered, e)
+					}
+				}
+				entries = filtered
+			}
+			if len(entries) == 0 {
+				continue
+			}
+			p := parseEntry(entries[len(entries)-1])
+			if prop == "__deleted" && p.kind == "D" {
+				deleted = true
+				break
+			}
+			state[prop] = fact{kind: p.kind, value: p.value, editor: p.editor, ts: p.ts}
+		}
+		if !deleted {
+			out[eid] = state
+		}
+	}
+	return out
+}
+
+func formatValue(f fact) string {
+	switch f.kind {
+	case "L", "I":
+		return f.value
+	case "R":
+		return "→ " + f.value
+	}
+	return "?" + f.kind + ":" + f.value
+}
+
+func printSnapshot(label string, state map[string]map[string]fact) {
+	fmt.Printf("\n=== %s ===\n", label)
+	if len(state) == 0 {
+		fmt.Println("  (empty graph)")
+		return
+	}
+	eids := make([]string, 0, len(state))
+	for eid := range state {
+		eids = append(eids, eid)
+	}
+	sort.Strings(eids)
+	for _, eid := range eids {
+		attrs := state[eid]
+		typeName := "?"
+		if t, ok := attrs["__type"]; ok {
+			typeName = t.value
+		}
+		var props []string
+		for p := range attrs {
+			if p != "__type" {
+				props = append(props, p)
+			}
+		}
+		sort.Strings(props)
+		var bits []string
+		for _, p := range props {
+			bits = append(bits, fmt.Sprintf("%s=%s [%s]", p, formatValue(attrs[p]), attrs[p].editor))
+		}
+		body := strings.Join(bits, ", ")
+		if body == "" {
+			body = "(no props)"
+		}
+		fmt.Printf("  %s (%s): %s\n", eid, typeName, body)
+	}
+}
+
+// ---------------------------------------------------------------------
+// Phases.
+// ---------------------------------------------------------------------
+
+func phase1Wiki(pov string) {
+	c := dial()
+	defer c.Close()
+	send(c, "new session;")
+	for _, p := range philosophers {
+		opCreateEntity(c, pov, "wiki", p.id, "Person")
+		opSetText(c, pov, "wiki", p.id, "name", p.name)
+		opSetInt(c, pov, "wiki", p.id, "born", p.born)
+		opSetInt(c, pov, "wiki", p.id, "died", p.died)
+	}
+}
+
+func phase2Stanford(pov string) {
+	c := dial()
+	defer c.Close()
+	send(c, "new session;")
+	for i, eid := range schoolEntities {
+		opSetText(c, pov, "stanford", eid, "school", schoolValues[i])
+	}
+	for _, r := range relations {
+		opCreateRelation(c, pov, "stanford", r.subject, r.prop, r.target)
+	}
+}
+
+func phase3Race(pov string) {
+	var wg sync.WaitGroup
+	writer := func(editor string, value int) {
+		defer wg.Done()
+		c := dial()
+		defer c.Close()
+		send(c, "new session;")
+		opSetInt(c, pov, editor, raceEntity, raceProp, value)
+	}
+	wg.Add(2)
+	go writer("wiki", raceWiki)
+	go writer("stanford", raceStanford)
+	wg.Wait()
+}
+
+func editorialDiff(c *websocket.Conn, pov string) {
+	byEditor := map[string]int{}
+	entitiesByEditor := map[string]map[string]struct{}{}
+	for _, eid := range allEntities(c, pov) {
+		for _, prop := range propsOf(c, pov, eid) {
+			for _, entry := range histFor(c, pov, eid, prop) {
+				p := parseEntry(entry)
+				byEditor[p.editor]++
+				if entitiesByEditor[p.editor] == nil {
+					entitiesByEditor[p.editor] = map[string]struct{}{}
+				}
+				entitiesByEditor[p.editor][eid] = struct{}{}
+			}
+		}
+	}
+	editors := make([]string, 0, len(byEditor))
+	for e := range byEditor {
+		editors = append(editors, e)
+	}
+	sort.Strings(editors)
+	fmt.Println("\n=== editorial diff ===")
+	for _, e := range editors {
+		fmt.Printf("  %-10s %3d events on %2d entities\n", e, byEditor[e], len(entitiesByEditor[e]))
+	}
+	if len(editors) >= 2 {
+		a, b := editors[0], editors[1]
+		var overlap []string
+		for eid := range entitiesByEditor[a] {
+			if _, ok := entitiesByEditor[b][eid]; ok {
+				overlap = append(overlap, eid)
+			}
+		}
+		sort.Strings(overlap)
+		fmt.Printf("  overlap: %d entities edited by both (%s ∩ %s): %v\n",
+			len(overlap), a, b, overlap)
+	}
+}
+
+// ---------------------------------------------------------------------
+// main.
+// ---------------------------------------------------------------------
+
+func main() {
+	boot := dial()
+	defer boot.Close()
+	sendString(boot, "new session;")
+	send(boot, "install grc20.1;")
+	pov := sendString(boot, "new safe shared pov;")
+	fmt.Printf("pov: %s\n", pov)
+	fmt.Printf("corpus: %d entities, %d schools, %d relations\n",
+		len(philosophers), len(schoolEntities), len(relations))
+
+	// --- Phase 1: wiki streams biographical facts ---
+	fmt.Println("\n[phase 1] wiki -> biographical facts (name, born, died)")
+	t0 := time.Now()
+	phase1Wiki(pov)
+	ts1 := nowMs()
+	fmt.Printf("  %d entities registered in %.2fs\n",
+		entityCount(boot, pov), time.Since(t0).Seconds())
+	printSnapshot("snapshot 1: end of phase 1 (wiki only)",
+		reconstruct(boot, pov, &ts1))
+
+	time.Sleep(50 * time.Millisecond)
+
+	// --- Phase 2: stanford streams schools + relations ---
+	fmt.Println("\n[phase 2] stanford -> school + student_of relations")
+	t0 = time.Now()
+	phase2Stanford(pov)
+	ts2 := nowMs()
+	fmt.Printf("  done in %.2fs\n", time.Since(t0).Seconds())
+	printSnapshot("snapshot 2: end of phase 2 (wiki + stanford)",
+		reconstruct(boot, pov, &ts2))
+
+	time.Sleep(50 * time.Millisecond)
+
+	// --- Phase 3: concurrent race ---
+	fmt.Printf("\n[phase 3] wiki + stanford concurrently overwrite %s.%s\n",
+		raceEntity, raceProp)
+	fmt.Printf("  wiki     -> %d\n", raceWiki)
+	fmt.Printf("  stanford -> %d\n", raceStanford)
+	phase3Race(pov)
+	ts3 := nowMs()
+	raceEntries := histFor(boot, pov, raceEntity, raceProp)
+	fmt.Printf("  history for %s.%s after race (%d events, ts-sorted):\n",
+		raceEntity, raceProp, len(raceEntries))
+	for _, e := range raceEntries {
+		p := parseEntry(e)
+		fmt.Printf("    %d  %-10s %s  %s\n", p.ts, p.editor, p.kind, p.value)
+	}
+	finalState := reconstruct(boot, pov, &ts3)
+	winning := finalState[raceEntity][raceProp]
+	fmt.Printf("  -> winning event: %s [%s, ts=%d]\n",
+		winning.value, winning.editor, winning.ts)
+
+	// --- Final state + editorial diff ---
+	printSnapshot("snapshot 3: final state", finalState)
+	editorialDiff(boot, pov)
+
+	fmt.Println("\n=== the trick ===")
+	fmt.Println("  Every editor |= a packed event into a per-(entity, prop)")
+	fmt.Println("  history set. Multi-editor writes never drop events (post-#50")
+	fmt.Println("  deferred-mutation fold). Reads replay the timestamp-sorted")
+	fmt.Println("  log -- pass a cutoff for time-travel, take the latest for")
+	fmt.Println("  the current value. The schema is three commutative funcs;")
+	fmt.Println("  GRC-20's op vocabulary lives entirely in the driver.")
+
+	// --- Self-check (mirrors demo.py) ---
+	var failures []string
+	s1 := reconstruct(boot, pov, &ts1)
+	for _, p := range philosophers {
+		e := s1[p.id]
+		if name, ok := e["name"]; !ok || name.kind != "L" || name.value != p.name {
+			failures = append(failures, fmt.Sprintf("snapshot 1: %s.name = %+v", p.id, name))
+		}
+		if born, ok := e["born"]; !ok || born.kind != "I" {
+			failures = append(failures, fmt.Sprintf("snapshot 1: %s.born missing/wrong kind", p.id))
+		} else if n, err := strconv.Atoi(born.value); err != nil || n != p.born {
+			failures = append(failures, fmt.Sprintf("snapshot 1: %s.born = %s (want %d)", p.id, born.value, p.born))
+		}
+		if _, hasSchool := e["school"]; hasSchool {
+			failures = append(failures, fmt.Sprintf("snapshot 1: %s.school leaked from phase 2", p.id))
+		}
+	}
+	s2 := reconstruct(boot, pov, &ts2)
+	for i, eid := range schoolEntities {
+		e := s2[eid]
+		if school, ok := e["school"]; !ok || school.kind != "L" || school.value != schoolValues[i] {
+			failures = append(failures, fmt.Sprintf("snapshot 2: %s.school = %+v", eid, school))
+		}
+	}
+	for _, r := range relations {
+		e := s2[r.subject]
+		if rel, ok := e[r.prop]; !ok || rel.kind != "R" || rel.value != r.target {
+			failures = append(failures, fmt.Sprintf("snapshot 2: %s.%s = %+v", r.subject, r.prop, rel))
+		}
+	}
+	if len(raceEntries) < 2 {
+		failures = append(failures,
+			fmt.Sprintf("phase 3: only %d events in race history -- expected both writers to land",
+				len(raceEntries)))
+	}
+
+	send(boot, "exit;")
+
+	if len(failures) > 0 {
+		fmt.Println("\n=== self-check FAILED ===")
+		for _, f := range failures {
+			fmt.Println("  " + f)
+		}
+		os.Exit(1)
+	}
+	fmt.Println("\n=== self-check OK ===")
+	fmt.Println("  verified 3 snapshot invariants + multi-editor race")
+}

--- a/examples/grc20-pov/demo.py
+++ b/examples/grc20-pov/demo.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""
+GRC-20-shaped knowledge graph on Orly, in Python.
+
+GRC-20 (https://github.com/geobrowser/grc-20) is a binary property-
+graph standard from Geo / The Graph. Its events are append-only
+ops -- CreateEntity, UpdateEntity, CreateRelation, DeleteEntity -- and
+the current state of an entity is the replay of its event log. That's
+exactly the storage model Orly handles natively, via commutative set
+union (`|=`) on a per-(entity, property) history set. Concurrent
+editors can stream ops into the same shared POV with no coordination;
+the read path reconstructs the graph at any point in time by replaying
+the timestamp-sorted log.
+
+The demo runs in three phases:
+
+  Phase 1 (wiki editor):     basic biographical facts on 6 Greek
+                             philosophers (name, born, died). 24 ops.
+  Phase 2 (stanford editor): school of thought + student_of relations.
+                             8 ops.
+  Phase 3 (concurrent):      both editors race to "correct" the same
+                             attribute on the same entity. Demonstrates
+                             that multi-editor `|=` writes don't drop
+                             events.
+
+Snapshots are printed after each phase, plus a final editorial-diff
+summary (events per editor, overlapping entities).
+
+Run via the wrapper:
+
+    ./run.sh
+
+Or directly, after starting orlyi separately:
+
+    python3 demo.py
+"""
+
+import json
+import os
+import sys
+import threading
+import time
+import websocket
+
+WS_URL = "ws://127.0.0.1:8082/"
+WS_TIMEOUT_S = 30
+
+
+# ---------------------------------------------------------------------
+# Corpus: six Greek philosophers. Editor 1 ("wiki") provides
+# biographical facts; editor 2 ("stanford") provides schools + the
+# student_of relation chain. Tombstones aren't exercised in the main
+# narrative -- the phase-3 race showcases concurrent overwrites.
+# ---------------------------------------------------------------------
+PHILOSOPHERS = [
+    ("socrates",   "Socrates",    -470, -399),
+    ("plato",      "Plato",       -428, -348),
+    ("aristotle",  "Aristotle",   -384, -322),
+    ("pythagoras", "Pythagoras",  -570, -495),
+    ("heraclitus", "Heraclitus",  -535, -475),
+    ("epicurus",   "Epicurus",    -341, -270),
+]
+
+SCHOOLS = {
+    "socrates":   "Classical",
+    "plato":      "Platonism",
+    "aristotle":  "Peripateticism",
+    "pythagoras": "Pythagoreanism",
+    "heraclitus": "Heracliteanism",
+    "epicurus":   "Epicureanism",
+}
+
+# (subject, "student_of", teacher) — directed relations.
+RELATIONS = [
+    ("plato",     "student_of", "socrates"),
+    ("aristotle", "student_of", "plato"),
+]
+
+# Phase-3 race: both editors concurrently rewrite the *same* attribute
+# on the *same* entity. Whoever's event has the later timestamp is the
+# "current" value; the loser's event stays in history as an
+# alternative-source claim. Models the real GRC-20 editorial workflow.
+RACE_FACT = ("pythagoras", "born", -570, -575)
+
+
+# ---------------------------------------------------------------------
+# WS helpers + op encoding.
+#
+# Each event is encoded as "<ts>:<editor>:<kind>:<value>" where ts is
+# zero-padded 13-digit ms (sorts lexicographically = chronologically),
+# kind ∈ {L text, I integer, R relation target id, D tombstone}.
+# ---------------------------------------------------------------------
+def now_ms():
+    return int(time.time() * 1000)
+
+
+def encode(editor, kind, value):
+    return f"{now_ms():013d}:{editor}:{kind}:{value}"
+
+
+def parse(entry):
+    """Returns (ts:int, editor:str, kind:str, value:str)."""
+    ts, editor, kind, value = entry.split(":", 3)
+    return int(ts), editor, kind, value
+
+
+def send(ws, stmt):
+    ws.send(stmt)
+    reply = json.loads(ws.recv())
+    if reply.get("status") != "ok":
+        raise RuntimeError(f"{stmt!r}\n  -> {reply}")
+    return reply.get("result")
+
+
+def orly_str(s):
+    """Escape a Python string for an Orlyscript string literal.
+    Our corpus has no quotes/backslashes, but be defensive."""
+    return '"' + s.replace('\\', '\\\\').replace('"', '\\"') + '"'
+
+
+def append_op(ws, pov, entity, prop, entry):
+    send(ws, (f'try {{{pov}}} grc20 append_op '
+              f'<{{.entity: {orly_str(entity)}, '
+              f'.property: {orly_str(prop)}, '
+              f'.entry: {orly_str(entry)}}}>;'))
+
+
+def register_entity(ws, pov, entity):
+    send(ws, (f'try {{{pov}}} grc20 register_entity '
+              f'<{{.entity: {orly_str(entity)}}}>;'))
+
+
+def register_prop(ws, pov, entity, prop):
+    send(ws, (f'try {{{pov}}} grc20 register_prop '
+              f'<{{.entity: {orly_str(entity)}, '
+              f'.property: {orly_str(prop)}}}>;'))
+
+
+def hist_for(ws, pov, entity, prop):
+    r = send(ws, (f'try {{{pov}}} grc20 hist_for '
+                  f'<{{.entity: {orly_str(entity)}, '
+                  f'.property: {orly_str(prop)}}}>;'))
+    return list(r or [])
+
+
+def all_entities(ws, pov):
+    r = send(ws, f'try {{{pov}}} grc20 all_entities <{{}}>;')
+    return list(r or [])
+
+
+def props_of(ws, pov, entity):
+    r = send(ws, (f'try {{{pov}}} grc20 props_of '
+                  f'<{{.entity: {orly_str(entity)}}}>;'))
+    return list(r or [])
+
+
+def entity_count(ws, pov):
+    return int(send(ws, f'try {{{pov}}} grc20 entity_count <{{}}>;'))
+
+
+# ---------------------------------------------------------------------
+# GRC-20-style ops (entity / property / relation), each implemented as
+# one append_op + entity/prop registration. The driver, not orlyscript,
+# owns the op vocabulary -- the engine just stores the events.
+# ---------------------------------------------------------------------
+def op_create_entity(ws, pov, editor, entity, type_name):
+    """CreateEntity: registers + records the entity's type as a TEXT
+    property called '__type'."""
+    register_entity(ws, pov, entity)
+    register_prop(ws, pov, entity, "__type")
+    append_op(ws, pov, entity, "__type", encode(editor, "L", type_name))
+
+
+def op_set_text(ws, pov, editor, entity, prop, text):
+    register_entity(ws, pov, entity)
+    register_prop(ws, pov, entity, prop)
+    append_op(ws, pov, entity, prop, encode(editor, "L", text))
+
+
+def op_set_int(ws, pov, editor, entity, prop, n):
+    register_entity(ws, pov, entity)
+    register_prop(ws, pov, entity, prop)
+    append_op(ws, pov, entity, prop, encode(editor, "I", str(n)))
+
+
+def op_create_relation(ws, pov, editor, entity, prop, target):
+    register_entity(ws, pov, entity)
+    register_entity(ws, pov, target)
+    register_prop(ws, pov, entity, prop)
+    append_op(ws, pov, entity, prop, encode(editor, "R", target))
+
+
+def op_delete_entity(ws, pov, editor, entity):
+    register_prop(ws, pov, entity, "__deleted")
+    append_op(ws, pov, entity, "__deleted", encode(editor, "D", ""))
+
+
+# ---------------------------------------------------------------------
+# Replay: build the current state of every (entity, property) by
+# walking its history set in timestamp order, applying each event.
+# A cutoff (`as_of_ts`) drops events with ts > cutoff -- that's the
+# time-travel knob.
+# ---------------------------------------------------------------------
+def reconstruct(ws, pov, as_of_ts=None):
+    """Returns {entity_id: {property: (kind, value, editor, ts)}}.
+
+    Entities whose latest __deleted event is in scope are omitted.
+    'kind' is L/I/R as defined in the encoding above (D is consumed
+    by the entity-tombstone branch and never surfaces here)."""
+    entities = sorted(all_entities(ws, pov))
+    out = {}
+    for eid in entities:
+        props = sorted(props_of(ws, pov, eid))
+        deleted = False
+        e_state = {}
+        for prop in props:
+            entries = sorted(hist_for(ws, pov, eid, prop))
+            if as_of_ts is not None:
+                entries = [e for e in entries if parse(e)[0] <= as_of_ts]
+            if not entries:
+                continue
+            # Latest event wins per property.
+            ts, editor, kind, value = parse(entries[-1])
+            if prop == "__deleted" and kind == "D":
+                deleted = True
+                break
+            e_state[prop] = (kind, value, editor, ts)
+        if not deleted:
+            out[eid] = e_state
+    return out
+
+
+def format_value(kind, value):
+    if kind == "L":
+        return value
+    if kind == "I":
+        return value
+    if kind == "R":
+        return f"→ {value}"
+    return f"?{kind}:{value}"
+
+
+def print_snapshot(label, state):
+    print(f"\n=== {label} ===")
+    if not state:
+        print("  (empty graph)")
+        return
+    for eid in sorted(state):
+        attrs = state[eid]
+        if not attrs:
+            print(f"  {eid}: (no props)")
+            continue
+        type_name = attrs.get("__type", ("L", "?", "", 0))[1]
+        bits = []
+        for prop in sorted(attrs):
+            if prop == "__type":
+                continue
+            kind, value, editor, _ts = attrs[prop]
+            bits.append(f"{prop}={format_value(kind, value)} [{editor}]")
+        print(f"  {eid} ({type_name}): {', '.join(bits) if bits else '(no props)'}")
+
+
+# ---------------------------------------------------------------------
+# Phases. Each phase opens its own WebSocket -- separate sessions are
+# what makes the multi-editor story testable. Phase 3 spins two threads
+# so a true interleaving happens on the wire.
+# ---------------------------------------------------------------------
+def phase1_wiki(pov):
+    """Editor 'wiki' streams biographical facts (~24 ops)."""
+    ws = websocket.create_connection(WS_URL, timeout=WS_TIMEOUT_S)
+    try:
+        send(ws, "new session;")
+        for eid, name, born, died in PHILOSOPHERS:
+            op_create_entity(ws, pov, "wiki", eid, "Person")
+            op_set_text(ws, pov, "wiki", eid, "name", name)
+            op_set_int(ws, pov, "wiki", eid, "born", born)
+            op_set_int(ws, pov, "wiki", eid, "died", died)
+    finally:
+        ws.close()
+
+
+def phase2_stanford(pov):
+    """Editor 'stanford' streams schools + relations (~8 ops)."""
+    ws = websocket.create_connection(WS_URL, timeout=WS_TIMEOUT_S)
+    try:
+        send(ws, "new session;")
+        for eid, school in SCHOOLS.items():
+            op_set_text(ws, pov, "stanford", eid, "school", school)
+        for subject, prop, target in RELATIONS:
+            op_create_relation(ws, pov, "stanford", subject, prop, target)
+    finally:
+        ws.close()
+
+
+def phase3_race(pov):
+    """Both editors concurrently rewrite the same attribute. Whichever
+    event lands with the later ms timestamp wins on the read; the loser
+    stays in history as an alternative-source claim."""
+    entity, prop, wiki_value, stanford_value = RACE_FACT
+
+    def writer(editor, value):
+        ws = websocket.create_connection(WS_URL, timeout=WS_TIMEOUT_S)
+        try:
+            send(ws, "new session;")
+            op_set_int(ws, pov, editor, entity, prop, value)
+        finally:
+            ws.close()
+
+    threads = [
+        threading.Thread(target=writer, args=("wiki", wiki_value)),
+        threading.Thread(target=writer, args=("stanford", stanford_value)),
+    ]
+    for t in threads: t.start()
+    for t in threads: t.join()
+
+
+def editorial_diff(ws, pov):
+    """Per-editor event count + overlap analysis."""
+    by_editor = {}                # editor -> int (event count)
+    entities_by_editor = {}       # editor -> set(entity ids)
+    for eid in sorted(all_entities(ws, pov)):
+        for prop in sorted(props_of(ws, pov, eid)):
+            for entry in hist_for(ws, pov, eid, prop):
+                _ts, editor, _kind, _value = parse(entry)
+                by_editor[editor] = by_editor.get(editor, 0) + 1
+                entities_by_editor.setdefault(editor, set()).add(eid)
+    print("\n=== editorial diff ===")
+    for editor in sorted(by_editor):
+        print(f"  {editor:<10} {by_editor[editor]:>3} events on "
+              f"{len(entities_by_editor[editor]):>2} entities")
+    editors = sorted(entities_by_editor)
+    if len(editors) >= 2:
+        a, b = editors[:2]
+        overlap = entities_by_editor[a] & entities_by_editor[b]
+        print(f"  overlap: {len(overlap)} entities edited by both "
+              f"({a} ∩ {b}): {sorted(overlap)}")
+
+
+def main():
+    # Bootstrap.
+    boot = websocket.create_connection(WS_URL, timeout=WS_TIMEOUT_S)
+    send(boot, "new session;")
+    send(boot, "install grc20.1;")
+    pov = send(boot, "new safe shared pov;")
+    print(f"pov: {pov}")
+    print(f"corpus: {len(PHILOSOPHERS)} entities, "
+          f"{len(SCHOOLS)} schools, {len(RELATIONS)} relations")
+
+    # --- Phase 1: wiki streams biographical facts ---
+    print("\n[phase 1] wiki -> biographical facts (name, born, died)")
+    t0 = time.monotonic()
+    phase1_wiki(pov)
+    ts1 = now_ms()
+    print(f"  {entity_count(boot, pov)} entities registered "
+          f"in {time.monotonic() - t0:.2f}s")
+    print_snapshot("snapshot 1: end of phase 1 (wiki only)",
+                   reconstruct(boot, pov, as_of_ts=ts1))
+
+    # Tiny gap so phase-2 timestamps are strictly later than phase-1
+    # timestamps -- otherwise the ms-resolution clock can blur the
+    # boundary on fast machines.
+    time.sleep(0.05)
+
+    # --- Phase 2: stanford streams schools + relations ---
+    print("\n[phase 2] stanford -> school + student_of relations")
+    t0 = time.monotonic()
+    phase2_stanford(pov)
+    ts2 = now_ms()
+    print(f"  done in {time.monotonic() - t0:.2f}s")
+    print_snapshot("snapshot 2: end of phase 2 (wiki + stanford)",
+                   reconstruct(boot, pov, as_of_ts=ts2))
+
+    time.sleep(0.05)
+
+    # --- Phase 3: concurrent race on the same attribute ---
+    entity, prop, wiki_value, stanford_value = RACE_FACT
+    print(f"\n[phase 3] wiki + stanford concurrently overwrite "
+          f"{entity}.{prop}")
+    print(f"  wiki     -> {wiki_value}")
+    print(f"  stanford -> {stanford_value}")
+    phase3_race(pov)
+    ts3 = now_ms()
+    race_entries = sorted(hist_for(boot, pov, entity, prop))
+    print(f"  history for {entity}.{prop} after race "
+          f"({len(race_entries)} events, ts-sorted):")
+    for e in race_entries:
+        ts, ed, kind, val = parse(e)
+        print(f"    {ts}  {ed:<10} {kind}  {val}")
+    final_state = reconstruct(boot, pov, as_of_ts=ts3)
+    winning = final_state[entity][prop]
+    print(f"  -> winning event: {winning[1]} [{winning[2]}, ts={winning[3]}]")
+
+    # --- Final state + editorial diff ---
+    print_snapshot("snapshot 3: final state", final_state)
+    editorial_diff(boot, pov)
+
+    # --- Self-check ---
+    print("\n=== the trick ===")
+    print("  Every editor `|=` a packed event into a per-(entity, prop)")
+    print("  history set. Multi-editor writes never drop events (post-#50")
+    print("  deferred-mutation fold). Reads replay the timestamp-sorted")
+    print("  log -- pass a cutoff for time-travel, take the latest for")
+    print("  the current value. The schema is three commutative funcs;")
+    print("  GRC-20's op vocabulary lives entirely in the driver.")
+
+    failures = []
+    # Phase-1 invariant: every philosopher has name + born + died.
+    s1 = reconstruct(boot, pov, as_of_ts=ts1)
+    for eid, name, born, died in PHILOSOPHERS:
+        e = s1.get(eid, {})
+        if e.get("name", (None,))[0] != "L" or e["name"][1] != name:
+            failures.append(f"snapshot 1: {eid}.name = {e.get('name')}")
+        if e.get("born", (None,))[0] != "I" or int(e["born"][1]) != born:
+            failures.append(f"snapshot 1: {eid}.born = {e.get('born')}")
+        # Phase-1 must NOT contain schools or relations.
+        if "school" in e:
+            failures.append(f"snapshot 1: {eid}.school leaked from phase 2")
+    # Phase-2 invariant: every philosopher now has a school.
+    s2 = reconstruct(boot, pov, as_of_ts=ts2)
+    for eid, school in SCHOOLS.items():
+        e = s2.get(eid, {})
+        if e.get("school", (None,))[0] != "L" or e["school"][1] != school:
+            failures.append(f"snapshot 2: {eid}.school = {e.get('school')}")
+    # Phase-2 must contain the student_of relations.
+    for subject, prop, target in RELATIONS:
+        e = s2.get(subject, {})
+        if e.get(prop, (None,))[0] != "R" or e[prop][1] != target:
+            failures.append(f"snapshot 2: {subject}.{prop} = {e.get(prop)}")
+    # Phase-3 invariant: both race events survive in history.
+    if len(race_entries) < 2:
+        failures.append(f"phase 3: only {len(race_entries)} events in race "
+                        f"history -- expected both writers to land")
+
+    send(boot, "exit;")
+    boot.close()
+
+    if failures:
+        print("\n=== self-check FAILED ===")
+        for f in failures:
+            print(f"  {f}")
+        sys.exit(1)
+    print("\n=== self-check OK ===")
+    print(f"  verified 3 snapshot invariants + multi-editor race")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/grc20-pov/go.mod
+++ b/examples/grc20-pov/go.mod
@@ -1,0 +1,5 @@
+module github.com/orlyatomics/orly/examples/grc20-pov
+
+go 1.22
+
+require github.com/gorilla/websocket v1.5.3

--- a/examples/grc20-pov/go.sum
+++ b/examples/grc20-pov/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/examples/grc20-pov/grc20.orly
+++ b/examples/grc20-pov/grc20.orly
@@ -1,0 +1,169 @@
+/* <examples/grc20-pov/grc20.orly>
+
+   GRC-20-shaped knowledge graph as an append-only event log, backed by
+   Orly's commutative set-union field call. Multiple editors stream ops
+   into the same shared POV with no coordination; the read path
+   reconstructs the current state (or any historical state) by replaying
+   the op log in timestamp order.
+
+   GRC-20 is a property-graph standard from Geo / The Graph
+   (https://github.com/geobrowser/grc-20). Entities have typed
+   properties (TEXT, INTEGER, ...) and directed relations. The spec
+   exposes ops like CreateEntity / UpdateEntity / CreateRelation /
+   DeleteEntity, all event-sourced -- which is exactly the shape Orly
+   stores commutatively.
+
+   This package gives the engine three operations:
+
+     - append_op    : union one event into a (entity, property) history
+     - list_entities: enumerate every entity ever touched
+     - list_props   : enumerate every property ever touched on an entity
+
+   Plus their read-side counterparts (hist_for, all_entities, props_of).
+
+   The driver formats each event as a packed string
+
+     "<13-digit ms timestamp>:<editor>:<kind>:<value>"
+
+   where kind ∈ {L (text literal), I (integer literal), R (relation
+   target id), D (tombstone)} and value is the literal or the target
+   entity id. Lexicographic sort of the resulting set is chronological
+   because the timestamp prefix is fixed-width. Driver-side replay then
+   takes "latest write wins per property" semantics with tombstones, the
+   same way GRC-20 itself does.
+
+   Why driver-side replay rather than an orlyscript fold: GRC-20 ops are
+   heterogeneous (CreateEntity / SetProperty / CreateRelation /
+   DeleteEntity), and the replay is conditional on the event kind. Set
+   union over packed strings keeps the schema simple and gives the same
+   "version axis in the keyspace" guarantee as
+   examples/wikipedia-categories/: any (entity, property) pair gets one
+   set, every op is one immutable entry, the past is structurally
+   frozen.
+
+   Schema:
+
+     <['hist', entity, property]>::({str})  events for one (e, p) pair
+     <['entities']>::({str})                set of every entity id
+     <['props',  entity]>::({str})          set of every property id ever
+                                            written on this entity
+
+   Concurrent editors writing to overlapping entities/properties all
+   land their events; the post-#50 deferred-mutation + read-time-fold
+   mechanism is what makes `|=` from multiple WS sessions safe.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package #1;
+
+/* ---------- per-(entity, property) event history ---------- */
+
+hist_for = (((*<['hist', entity, property]>::({str})) if *<['hist', entity, property]>::({str}?) is known else (empty {str}))) where {
+  entity   = given::(str);
+  property = given::(str);
+};
+
+/* Append one event into the (entity, property) history. */
+append_op = (((1) effecting {
+  *<['hist', entity, property]>::({str}) |= {entry};
+} if *<['hist', entity, property]>::({str}?) is known else (0) effecting {
+  new <['hist', entity, property]> <- {entry};
+})) where {
+  entity   = given::(str);
+  property = given::(str);
+  entry    = given::(str);
+};
+
+/* ---------- catalogue: entities + their property set ---------- */
+
+all_entities = (((*<['entities']>::({str})) if *<['entities']>::({str}?) is known else (empty {str})));
+
+register_entity = (((1) effecting {
+  *<['entities']>::({str}) |= {entity};
+} if *<['entities']>::({str}?) is known else (0) effecting {
+  new <['entities']> <- {entity};
+})) where {
+  entity = given::(str);
+};
+
+props_of = (((*<['props', entity]>::({str})) if *<['props', entity]>::({str}?) is known else (empty {str}))) where {
+  entity = given::(str);
+};
+
+register_prop = (((1) effecting {
+  *<['props', entity]>::({str}) |= {property};
+} if *<['props', entity]>::({str}?) is known else (0) effecting {
+  new <['props', entity]> <- {property};
+})) where {
+  entity   = given::(str);
+  property = given::(str);
+};
+
+/* ---------- counts (cheap orlyscript-side stats) ---------- */
+
+event_count = (length_of hist_for(.entity: entity, .property: property)) where {
+  entity   = given::(str);
+  property = given::(str);
+};
+
+entity_count = (length_of all_entities);
+
+/* ---------- inline tests ---------- */
+
+test {
+  /* Empty keyspace reads as identity. */
+  t1: all_entities == (empty {str});
+  t2: props_of(.entity: "socrates") == (empty {str});
+  t3: hist_for(.entity: "socrates", .property: "name") == (empty {str});
+
+  /* Append one event creates the set with that entry. */
+  t4: append_op(.entity: "socrates", .property: "name",
+                .entry: "0000000000001:wiki:L:Socrates") == 0 {
+    t5: hist_for(.entity: "socrates", .property: "name")
+          == {"0000000000001:wiki:L:Socrates"};
+    t6: event_count(.entity: "socrates", .property: "name") == 1;
+
+    /* Second event from a different editor unions in. */
+    t7: append_op(.entity: "socrates", .property: "name",
+                  .entry: "0000000000002:stanford:L:Socrates of Athens") == 1 {
+      t8: hist_for(.entity: "socrates", .property: "name")
+            == {"0000000000001:wiki:L:Socrates",
+                "0000000000002:stanford:L:Socrates of Athens"};
+      t9: event_count(.entity: "socrates", .property: "name") == 2;
+
+      /* Idempotent: same entry re-added doesn't grow the set. */
+      t10: append_op(.entity: "socrates", .property: "name",
+                     .entry: "0000000000001:wiki:L:Socrates") == 1 {
+        t11: event_count(.entity: "socrates", .property: "name") == 2;
+      };
+    };
+  };
+
+  /* Catalogue ops are independent from history ops. */
+  t12: register_entity(.entity: "plato") == 0 {
+    t13: register_entity(.entity: "aristotle") == 1 {
+      t14: all_entities == {"aristotle", "plato"};
+      t15: entity_count == 2;
+
+      t16: register_prop(.entity: "plato", .property: "born") == 0 {
+        t17: register_prop(.entity: "plato", .property: "school") == 1 {
+          t18: props_of(.entity: "plato") == {"born", "school"};
+          /* Different entity's props don't bleed. */
+          t19: props_of(.entity: "aristotle") == (empty {str});
+        };
+      };
+    };
+  };
+};

--- a/examples/grc20-pov/run-go.sh
+++ b/examples/grc20-pov/run-go.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Same end-to-end pipeline as run.sh, but driven by demo.go.
+# Requires the `go` toolchain on PATH.
+
+set -e
+
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../.. && pwd)"
+ORLY_OUT="${ORLY_OUT:-$REPO_ROOT/../out_orly/debug}"
+ORLYI="$ORLY_OUT/orly/server/orlyi"
+ORLYC="$ORLY_OUT/orly/orlyc"
+
+for bin in "$ORLYI" "$ORLYC"; do
+  if [ ! -x "$bin" ]; then
+    echo "missing: $bin"
+    exit 1
+  fi
+done
+
+if ! command -v go >/dev/null 2>&1; then
+  echo "missing: go (install golang-go or download from go.dev)"
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'kill -9 $ORLYI_PID 2>/dev/null || true; rm -rf "$WORK"' EXIT
+
+echo "[1/5] compile grc20.orly"
+"$ORLYC" -o "$WORK" grc20.orly
+
+echo "[2/5] populate packages/"
+mkdir "$WORK/packages"
+touch "$WORK/packages/__orly__"
+cp "$WORK/grc20.1.so" "$WORK/packages/"
+
+pkill -9 -f 'instance_name=grc20_pov_demo' 2>/dev/null || true
+sleep 1
+
+echo "[3/5] start fresh orlyi"
+"$ORLYI" --mem_sim --create=true \
+         --port_number=19400 --slave_port_number=19401 \
+         --connection_backlog=10 \
+         --instance_name=grc20_pov_demo \
+         --starting_state=SOLO \
+         --package_dir="$WORK/packages" \
+         > "$WORK/orlyi.log" 2>&1 &
+ORLYI_PID=$!
+
+echo "[4/5] wait for WebSocket port 8082"
+for _ in $(seq 1 60); do
+  if ss -tln 2>/dev/null | grep -q ':8082'; then
+    break
+  fi
+  sleep 1
+done
+if ! ss -tln 2>/dev/null | grep -q ':8082'; then
+  echo "orlyi failed to come up; last log lines:"
+  tail -20 "$WORK/orlyi.log"
+  exit 1
+fi
+
+echo "[5/5] go run demo.go"
+go run demo.go

--- a/examples/grc20-pov/run.sh
+++ b/examples/grc20-pov/run.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# End-to-end driver: compile grc20.orly, start a fresh orlyi, run demo.py.
+# Mirrors examples/wikipedia-categories/run.sh's shape.
+
+set -e
+
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../.. && pwd)"
+ORLY_OUT="${ORLY_OUT:-$REPO_ROOT/../out_orly/debug}"
+ORLYI="$ORLY_OUT/orly/server/orlyi"
+ORLYC="$ORLY_OUT/orly/orlyc"
+
+for bin in "$ORLYI" "$ORLYC"; do
+  if [ ! -x "$bin" ]; then
+    echo "missing: $bin"
+    echo ""
+    echo "Build the project first (from $REPO_ROOT):"
+    echo "  make debug"
+    echo ""
+    echo "Or set ORLY_OUT to point at your debug-build output tree."
+    exit 1
+  fi
+done
+
+WORK="$(mktemp -d)"
+trap 'kill -9 $ORLYI_PID 2>/dev/null || true; rm -rf "$WORK"' EXIT
+
+echo "[1/5] compile grc20.orly (also runs inline tests)"
+"$ORLYC" -o "$WORK" grc20.orly
+
+echo "[2/5] populate packages/"
+mkdir "$WORK/packages"
+touch "$WORK/packages/__orly__"
+cp "$WORK/grc20.1.so" "$WORK/packages/"
+
+pkill -9 -f 'instance_name=grc20_pov_demo' 2>/dev/null || true
+sleep 1
+
+echo "[3/5] start fresh orlyi (logs -> $WORK/orlyi.log)"
+"$ORLYI" --mem_sim --create=true \
+         --port_number=19400 --slave_port_number=19401 \
+         --connection_backlog=10 \
+         --instance_name=grc20_pov_demo \
+         --starting_state=SOLO \
+         --package_dir="$WORK/packages" \
+         > "$WORK/orlyi.log" 2>&1 &
+ORLYI_PID=$!
+
+echo "[4/5] wait for WebSocket port 8082"
+for _ in $(seq 1 60); do
+  if ss -tln 2>/dev/null | grep -q ':8082'; then
+    break
+  fi
+  sleep 1
+done
+if ! ss -tln 2>/dev/null | grep -q ':8082'; then
+  echo "orlyi failed to come up; last log lines:"
+  tail -20 "$WORK/orlyi.log"
+  exit 1
+fi
+
+echo "[5/5] run demo.py"
+python3 demo.py


### PR DESCRIPTION
A small reference demo aimed at the [Geo / The Graph](https://github.com/geobrowser/grc-20) team: their **GRC-20** standard models knowledge as an event-sourced property graph (`CreateEntity` / `UpdateEntity` / `CreateRelation` / `DeleteEntity` ops, append-only) — the exact shape Orly stores natively.

Every op becomes one set-union (`|=`) into a per-(entity, property) history set. Concurrent editors stream into the same shared POV with no coordination; reads replay the timestamp-sorted log to reconstruct entity state, or any historical state if you pass a cutoff.

## What the demo shows

Three phases over a corpus of six Greek philosophers:

| Phase | Editor | Ops | What |
|---|---|---|---|
| 1 | `wiki` | 24 | `CreateEntity` + `SetText name` + `SetInteger born` + `SetInteger died` per philosopher |
| 2 | `stanford` | 8 | `SetText school` + `CreateRelation student_of` (Plato→Socrates, Aristotle→Plato) |
| 3 | both | 2 | both editors concurrently rewrite `pythagoras.born` from separate WebSocket sessions |

Each phase prints a snapshot; phase 3 shows both events surviving in history (the post-#50 deferred-mutation fold). Final editorial diff lists per-editor event counts and overlapping entities.

```
[phase 3] wiki + stanford concurrently overwrite pythagoras.born
  history for pythagoras.born after race (3 events, ts-sorted):
    1780613973389  wiki       I  -570
    1780613973712  wiki       I  -570
    1780613973713  stanford   I  -575
  -> winning event: -575 [stanford, ts=1780613973713]

=== editorial diff ===
  stanford     9 events on  6 entities
  wiki        25 events on  6 entities
  overlap: 6 entities edited by both (stanford ∩ wiki): [aristotle epicurus heraclitus plato pythagoras socrates]
```

## Why this maps to GRC-20

| GRC-20 concept | Demo realisation |
|---|---|
| `CreateEntity(id, type)` | `register_entity` + `append_op(id, '__type', 'L:<type>')` |
| `SetText(id, prop, text)` | `append_op(id, prop, 'L:<text>')` |
| `SetInteger(id, prop, n)` | `append_op(id, prop, 'I:<n>')` |
| `CreateRelation(id, prop, target)` | `append_op(id, prop, 'R:<target_id>')` |
| `DeleteEntity(id)` | `append_op(id, '__deleted', 'D:')` |
| event-sourced log | history set sorted by 13-digit ms timestamp |
| append-only | set union is the only write operation |
| multi-editor merge | concurrent \`|=\` from independent WS sessions, no locks |
| historical query | replay events with \`ts ≤ target\` |

The schema is three commutative orlyscript funcs; GRC-20's op vocabulary lives entirely in the driver.

## Test plan

- [x] `grc20.orly` compiles cleanly; 19 inline tests pass under \`orlyc -m\`
- [x] \`./run.sh\` (python driver) — 3 snapshots + editorial diff + self-check all green
- [x] \`./run-go.sh\` (go driver) — same scenario, same invariants, all green
- [x] Phase 3 race: both events land in history (verified in both drivers)
- [x] CI \`examples/* end-to-end\` job extended to run both drivers

## Out of scope

- Full GRC-20 type system (demo exercises TEXT / INTEGER / RELATION; spec has 13 data types)
- On-chain ordering / consensus tiebreaker (driver uses lex sort on the encoded entry as a deterministic placeholder)
- Compaction of the history set past some age cutoff
- Binary wire format (spec is binary; demo packs ops as printable strings for legibility)