### PR TITLE
Fix storable record-set union (closes #90)

### DIFF
--- a/orly/code_gen/obj.cc
+++ b/orly/code_gen/obj.cc
@@ -96,7 +96,11 @@ void Orly::CodeGen::GenObjHeader(const std::string &out_dir, const Type::TType &
       << "#include <orly/rt/containers.h>" << Eol
       << "#include <orly/rt/obj.h>" << Eol
       << "#include <orly/type/obj.h>" << Eol
-      << "#include <orly/var/impl.h>" << Eol;
+      << "#include <orly/var/impl.h>" << Eol
+      // AsVar() (below) constructs a Var::TVar from each field; for nested-record
+      // fields that resolves to the templated TVar(const TCompound &) ctor whose
+      // definition lives in <orly/var/obj.h>.
+      << "#include <orly/var/obj.h>" << Eol;
 
   /* EXTRA */ {
     unordered_set<TType> obj_set;
@@ -177,17 +181,21 @@ void Orly::CodeGen::GenObjHeader(const std::string &out_dir, const Type::TType &
                         })
           << " {}" << Eol
           << Eol
-        #if 0
+        /* Convert this native record to a dynamic Var::TObj, populating every
+           field. Without this override the base Rt::TObj::AsVar() returns an
+           empty object, which loses all fields the moment a record crosses into
+           the dynamic-var world (e.g. building a set-union mutation). See #90. */
             << "Var::TVar AsVar() const final {" << Eol
             << "  assert(this);" << Eol
-            << "  return Var::TVar::Obj(TDynamicMembers{";
-        Base::Join(", ", obj_core_type->GetElems(), [](const TObj::TElems::value_type &it, TCppPrinter &out) {
-          out << "{ \"" << it.first << "\", Var::TVar(V"<< it.first << ")}";
-        }, out);
-        out << "});" << Eol
-            << '}' << Eol
+            << "  return Var::TVar::Obj(std::unordered_map<std::string, Var::TVar>{"
+            << Base::Join(obj_core_type->GetElems(),
+                          ", ",
+                          [](TCppPrinter &out, const TObj::TElems::value_type &it) {
+                            out << "{\"" << it.first << "\", Var::TVar(V" << it.first << ")}";
+                          })
+            << "});" << Eol
+            << "}" << Eol
             << Eol
-            #endif
         /* TODO: Should really write a generic object member function printer */
         /* helper functions (hash, equality, getters, etc.) */
         //TODO: Meta

--- a/orly/var/impl.cc
+++ b/orly/var/impl.cc
@@ -19,6 +19,8 @@
 #include <orly/var/impl.h>
 #include <orly/var.h>
 
+#include <map>
+
 #include <base/not_implemented.h>
 #include <orly/pos_range.h>
 #include <orly/type/get_prec.h>
@@ -584,10 +586,35 @@ namespace Orly {
       virtual void operator()(const TObj *, const TMutable  *) const {throw TVarCompareError(HERE);}
       virtual void operator()(const TObj *, const TOpt  *) const {throw TVarCompareError(HERE);}
       virtual void operator()(const TObj *lhs, const TObj  *rhs) const {
-        if (!IsEqeq) {
-          throw TVarCompareError(HERE);
+        if (IsEqeq) {
+          Comp = lhs->GetVal() == rhs->GetVal() ? 0 : -1;
+          return;
         }
-        Comp = lhs->GetVal() == rhs->GetVal() ? 0 : -1;
+        /* Order records field-by-field in sorted (asciibetical) field-name
+           order, then by field count. This mirrors the ordering generated for
+           native record structs and gives Var-level sets/dicts a total order
+           over record elements -- without it, building a set-of-records (e.g.
+           via a union mutation) throws when two records are compared. See #90. */
+        std::map<std::string, const TVar *> lhs_fields, rhs_fields;
+        for (const auto &item : lhs->GetVal()) {
+          lhs_fields[item.first] = &item.second;
+        }
+        for (const auto &item : rhs->GetVal()) {
+          rhs_fields[item.first] = &item.second;
+        }
+        auto lhs_iter = lhs_fields.begin();
+        auto rhs_iter = rhs_fields.begin();
+        for (; lhs_iter != lhs_fields.end() && rhs_iter != rhs_fields.end(); ++lhs_iter, ++rhs_iter) {
+          Comp = lhs_iter->first.compare(rhs_iter->first);
+          if (Comp != 0) {
+            return;
+          }
+          Var::TVar::Accept(*lhs_iter->second, *rhs_iter->second, *this);
+          if (Comp != 0) {
+            return;
+          }
+        }
+        Comp = Compare(lhs_fields.size(), rhs_fields.size());
       }
       virtual void operator()(const TObj *lhs, const TReal *rhs) const {
         Comp = CompareType(lhs->GetType(), rhs->GetType());

--- a/orly/var/impl.test.cc
+++ b/orly/var/impl.test.cc
@@ -191,3 +191,39 @@ FIXTURE(Index) {
   EXPECT_TRUE(list_.Index(1) == TVar(2));
   EXPECT_TRUE(list_.Index(1) != TVar(1));
 }
+
+/* Regression test for issue #90: records must support both equality and a
+   strict total order at the Var level, otherwise they can't live in a
+   Var-level set (which a set-union mutation builds). */
+static TVar MakeRec(const std::string &kind, int64_t ts) {
+  return TVar::Obj(std::unordered_map<std::string, TVar>{
+      {"kind", TVar(kind)}, {"ts", TVar(ts)}});
+}
+
+FIXTURE(RecordCompare) {
+  TVar a1 = MakeRec("a", 1);
+  TVar a1_dup = MakeRec("a", 1);
+  TVar b2 = MakeRec("b", 2);
+
+  /* Equality. */
+  EXPECT_TRUE(a1 == a1_dup);
+  EXPECT_FALSE(a1 == b2);
+  EXPECT_TRUE(a1 != b2);
+
+  /* Strict total order: equal values compare neither-less, and distinct
+     values order in exactly one direction. */
+  EXPECT_FALSE(a1 < a1_dup);
+  EXPECT_FALSE(a1_dup < a1);
+  EXPECT_TRUE((a1 < b2) != (b2 < a1));
+
+  /* A Var-level set (TMatchLess comparator) can hold distinct records and
+     dedups equal ones -- the operation that regressed in #90. */
+  Rt::TSet<TVar> recs;
+  recs.insert(a1);
+  recs.insert(b2);
+  recs.insert(a1_dup);
+  EXPECT_EQ(recs.size(), 2U);
+  EXPECT_TRUE(recs.find(a1) != recs.end());
+  EXPECT_TRUE(recs.find(b2) != recs.end());
+  EXPECT_TRUE(recs.find(MakeRec("c", 3)) == recs.end());
+}

--- a/tests/lang_tests/general/records_storage.orly
+++ b/tests/lang_tests/general/records_storage.orly
@@ -1,0 +1,104 @@
+/* <orly/lang_tests/general/records_storage.orly>
+
+   Regression test for issue #90: storable record values, including the
+   read-back-then-union path that previously failed.
+
+   Records (`<{.x: int, ...}>`) round-trip through storage as values, as
+   list/set/dict elements, and -- the case that regressed -- a stored
+   set-of-records can be unioned with a freshly-constructed singleton.
+
+   Two bugs sat behind the #90 symptom:
+
+     1. The generated native record struct never overrode AsVar(), so the
+        base Rt::TObj::AsVar() handed back an empty object. Any record that
+        crossed into the dynamic-var world (e.g. building a union mutation)
+        lost all its fields, tripping the "homogenous element type" check in
+        the set constructor.
+
+     2. Records had no Var-level ordering, so inserting two records into a
+        Var-level set (which a union mutation does) threw "types that are not
+        comparable".
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+/* --- single record value --- */
+read_rec = (*<[n]>::(<{.x: int, .y: int}>)) where {
+  n = given::(int);
+};
+
+/* --- set of records --- */
+read_rec_set = (*<[n]>::({<{.ts: int, .kind: str}>})) where {
+  n = given::(int);
+};
+
+/* Create-or-union: union a fresh singleton into the stored set if present,
+   otherwise create the key. This is the exact shape from issue #90. */
+union_rec = (((true) effecting {
+  *<[n]>::({<{.ts: int, .kind: str}>}) |= {<{.ts: ts, .kind: kind}>};
+} if *<[n]>::({<{.ts: int, .kind: str}>}?) is known else (true) effecting {
+  new <[n]> <- {<{.ts: ts, .kind: kind}>};
+})) where {
+  n = given::(int);
+  ts = given::(int);
+  kind = given::(str);
+};
+
+/* --- list of records --- */
+read_rec_list = (*<[n]>::([<{.x: int, .y: int}>])) where {
+  n = given::(int);
+};
+
+/* --- dict with record values --- */
+read_rec_dict = (*<[n]>::({str: <{.x: int, .y: int}>})) where {
+  n = given::(int);
+};
+
+/* Single record value round-trips through storage. */
+with {
+  <[300]> <- <{.x: 3, .y: 5}>;
+} test {
+  t1: read_rec(.n: 300) == <{.x: 3, .y: 5}>;
+  t2: read_rec(.n: 300).x == 3;
+};
+
+/* Set-of-records: read-back-then-union (the regressed path). */
+test {
+  /* First call creates the key. */
+  t10: union_rec(.n: 301, .ts: 1, .kind: "a") {
+    t11: read_rec_set(.n: 301) == {<{.ts: 1, .kind: "a"}>};
+    /* Second call hits the |= branch: read back, then union a fresh record. */
+    t12: union_rec(.n: 301, .ts: 2, .kind: "b") {
+      t13: read_rec_set(.n: 301) == {<{.ts: 1, .kind: "a"}>, <{.ts: 2, .kind: "b"}>};
+      /* Unioning a record already present is idempotent. */
+      t14: union_rec(.n: 301, .ts: 1, .kind: "a") {
+        t15: read_rec_set(.n: 301) == {<{.ts: 1, .kind: "a"}>, <{.ts: 2, .kind: "b"}>};
+      };
+    };
+  };
+};
+
+/* List-of-records round-trips through storage. */
+with {
+  <[302]> <- [<{.x: 1, .y: 2}>, <{.x: 3, .y: 4}>];
+} test {
+  t20: read_rec_list(.n: 302) == [<{.x: 1, .y: 2}>, <{.x: 3, .y: 4}>];
+};
+
+/* Dict-with-record-values round-trips through storage. */
+with {
+  <[303]> <- {"p": <{.x: 1, .y: 2}>, "q": <{.x: 3, .y: 4}>};
+} test {
+  t30: read_rec_dict(.n: 303) == {"p": <{.x: 1, .y: 2}>, "q": <{.x: 3, .y: 4}>};
+};


### PR DESCRIPTION
## Summary

Records already round-tripped through storage, but read-back-then-`|=` on a **set of records** threw `system_error[orly/var/set.cc, 122]; Set constructor requires homogenous element type.` at runtime. This closes #90.

The planning comment on #90 hypothesised that **type-interning identity was lost across deserialise**. That turned out to be wrong — both the record var's `GetType()` and `Type::ToType(record sabot)` already route through `Type::TObj::Get(elems)`, so equivalent record types are pointer-equal. The actual cause was two separate gaps on the **native-record → dynamic-`Var::TVar`** path (which the union-mutation path takes; plain native reads and `==` don't, which is why simple round-trips already worked):

1. **`Rt::TObj::AsVar()` returned an empty object.** The generated record struct extends `Rt::TObj`, whose base `AsVar()` (`orly/rt/obj.cc`) hands back `Var::TVar::Obj({})`. The per-struct override that populates fields was `#if 0`'d out in `orly/code_gen/obj.cc` and had a type bug (built a `map<string, Var::TVar>` but wrapped it as `TDynamicMembers` = `map<string, Indy::TKey>`). So any record crossing into the dynamic-var world lost all its fields — its type became `O0`, tripping the homogeneous-element check in `TSet`'s constructor.

2. **Records had no Var-level ordering.** A set is `std::set<TVar, TMatchLess>`; inserting two records needs `TVar::operator<` → `TCompareDoubleVisitor(TObj, TObj)`, which only handled `IsEqeq` and threw on ordering. The union mutation (`TSet::Union` → `std::set | std::set`) hit this.

## Changes

- `orly/code_gen/obj.cc`: emit a working `AsVar()` override per record struct (`Var::TVar::Obj(unordered_map<string, Var::TVar>{...})`); add `#include <orly/var/obj.h>` to generated headers so the templated `TVar(const TCompound&)` ctor is visible for nested-record fields.
- `orly/var/impl.cc`: implement record ordering in `TCompareDoubleVisitor::operator()(const TObj*, const TObj*)` — field-by-field in sorted (asciibetical) name order, then by field count, mirroring `TAddr`-vs-`TAddr`. Existing `IsEqeq` fast-path kept. (`TDict` still has no Var-level ordering, so a record with a dict-typed field can't be set-ordered — same pre-existing limitation as `{dict}`.)

## Tests

- `tests/lang_tests/general/records_storage.orly`: end-to-end, the exact #90 create-or-union shape, plus list/set/dict-of-records round-trips.
- `orly/var/impl.test.cc` `RecordCompare` fixture: Var-level equality, strict total order, and set dedup over records.

## Validation

- Full lang suite: `0 unexpected, 126 passed, 3 tracked failures (xfail)` — no regressions; the new test is in the Pass list.
- `orly/var/impl.test`: 6 fixtures, 0 failures.

Generated headers (`orly/rt/objects/O*.h`) are gitignored and regenerated each build, so the entire fix lives in the generator, core, and tests.