### PR TITLE
examples/grc20-pov: use real record-sets for the event log

### DIFF
--- a/examples/grc20-pov/README.md
+++ b/examples/grc20-pov/README.md
@@ -3,12 +3,12 @@
 A small reference demo aimed at the [Geo / The Graph](https://github.com/geobrowser/grc-20) team: their **GRC-20** standard models knowledge as an event-sourced property graph (`CreateEntity` / `UpdateEntity` / `CreateRelation` / `DeleteEntity` ops, append-only). Orly stores exactly that shape natively — every op is one set-union into a per-(entity, property) history set, and concurrent editors stream into the same shared POV with **no coordination**.
 
 ```
-GRC-20 op             →   one `|=` into  <['hist', entity, property]>::({str})
-Reconstruct entity    ←   sort history by ts, replay events in order
-Time-travel as-of T   ←   sort history by ts, replay events with ts ≤ T
+GRC-20 op             →   one `|=` into  <['hist', e, p]>::({<{.ts,.editor,.kind,.val}>})
+Reconstruct entity    ←   sort history by .ts, replay events in order
+Time-travel as-of T   ←   sort history by .ts, replay events with .ts ≤ T
 ```
 
-The driver owns the GRC-20 op vocabulary (`CreateEntity`, `SetText`, `SetInteger`, `CreateRelation`, `DeleteEntity`); the engine just stores immutable events. Three commutative orlyscript functions are the entire schema (`append_op`, `register_entity`, `register_prop`).
+The driver owns the GRC-20 op vocabulary (`CreateEntity`, `SetText`, `SetInteger`, `CreateRelation`, `DeleteEntity`); the engine just stores immutable event records. Each event is a first-class `<{.ts: int, .editor: str, .kind: str, .val: str}>` record, and the history is a set OF those records ([issue #90](https://github.com/orlyatomics/orly/issues/90)) — no string packing, the four typed fields travel end to end. Three commutative orlyscript functions are the entire schema (`append_op`, `register_entity`, `register_prop`).
 
 ## Run it
 
@@ -62,7 +62,7 @@ Phase 3 — the race:
     1780613758647  wiki       I  -570
 ```
 
-Two writers from independent WebSocket sessions land events at the **same millisecond**; both events survive in history. The driver's deterministic tiebreaker (lex sort on the encoded entry) picks one as the "current" value — but the alternative-source claim isn't lost, exactly the editorial-workflow semantics GRC-20 needs.
+Two writers from independent WebSocket sessions land events at the **same millisecond**; both events survive in history. The driver's deterministic tiebreaker (lex sort on the event record's `(.ts, .editor, .kind, .val)`) picks one as the "current" value — but the alternative-source claim isn't lost, exactly the editorial-workflow semantics GRC-20 needs.
 
 ```
 === editorial diff ===
@@ -75,22 +75,23 @@ Two writers from independent WebSocket sessions land events at the **same millis
 
 | GRC-20 concept | Demo realisation |
 |---|---|
-| `CreateEntity(id, type)` | `register_entity` + `append_op(id, '__type', 'L:<type>')` |
-| `SetText(id, prop, text)` | `append_op(id, prop, 'L:<text>')` |
-| `SetInteger(id, prop, n)` | `append_op(id, prop, 'I:<n>')` |
-| `CreateRelation(id, prop, target)` | `append_op(id, prop, 'R:<target_id>')` |
-| `DeleteEntity(id)` | `append_op(id, '__deleted', 'D:')` |
-| event-sourced log | history set sorted by 13-digit ms timestamp |
+| `CreateEntity(id, type)` | `register_entity` + `append_op(id, '__type', .kind:'L', .val:<type>)` |
+| `SetText(id, prop, text)` | `append_op(id, prop, .kind:'L', .val:<text>)` |
+| `SetInteger(id, prop, n)` | `append_op(id, prop, .kind:'I', .val:<n>)` |
+| `CreateRelation(id, prop, target)` | `append_op(id, prop, .kind:'R', .val:<target_id>)` |
+| `DeleteEntity(id)` | `append_op(id, '__deleted', .kind:'D', .val:'')` |
+| event-sourced log | history set sorted by the `.ts` field |
 | append-only | set union is the only write operation |
 | multi-editor merge | concurrent `|=` from independent WS sessions, no locks |
-| historical query | replay events with `ts ≤ target` |
+| historical query | replay events with `.ts ≤ target` |
 
-GRC-20's full type system is 13 data types; this demo exercises TEXT, INTEGER, and RELATION (sufficient to prove the pattern). The packed-string entry format (`<ts>:<editor>:<kind>:<value>`) is what the driver puts in the set — orlyscript treats it as an opaque string. A production binding would store binary GRC-20 ops directly.
+GRC-20's full type system is 13 data types; this demo exercises TEXT, INTEGER, and RELATION (sufficient to prove the pattern). Each event is a typed `<{.ts: int, .editor: str, .kind: str, .val: str}>` record — `kind` (`L`/`I`/`R`/`D`) discriminates how the driver interprets `val`, the same role GRC-20's op tag plays. A production binding would store binary GRC-20 ops directly.
 
 ## Schema (the entire engine side)
 
 ```orly
-<['hist', entity, property]>::({str})  -- set of events for one (e, p)
+<['hist', entity, property]>::({<{.ts: int, .editor: str, .kind: str, .val: str}>})
+                                       -- set of event records for one (e, p)
 <['entities']>::({str})                -- set of every entity id
 <['props',  entity]>::({str})          -- set of every property ever written on e
 ```
@@ -98,17 +99,18 @@ GRC-20's full type system is 13 data types; this demo exercises TEXT, INTEGER, a
 Three functions:
 
 ```orly
-append_op(.entity, .property, .entry)   -- |= one event into the history
+append_op(.entity, .property, .ts, .editor, .kind, .val)
+                                        -- |= one event record into the history
 register_entity(.entity)                -- |= entity into the global set
 register_prop(.entity, .property)       -- |= property into the entity's prop set
 ```
 
-That's it. Everything else — op classification, replay, time-travel, editorial diff — happens in the driver. The engine guarantees that no event is ever lost, no matter how many editors are writing at once, because `|=` is a commutative deferred-mutation field call ([#49](https://github.com/orlyatomics/orly/issues/49) / PRs #50/#51/#52).
+That's it. Everything else — op classification, replay, time-travel, editorial diff — happens in the driver. The engine guarantees that no event is ever lost, no matter how many editors are writing at once, because `|=` is a commutative deferred-mutation field call ([#49](https://github.com/orlyatomics/orly/issues/49) / PRs #50/#51/#52); storable record-set values are [#90](https://github.com/orlyatomics/orly/issues/90).
 
 ## Caveats
 
 - **Driver-side ms timestamps** for the event timeline assume all editors share the same clock. In a real decentralised deployment, replace with a consensus-ordered sequence number or a hybrid logical clock; the schema doesn't change.
-- **Same-ms tiebreaker** is lex order on the encoded entry — deterministic, not principled. GRC-20 itself defers ordering to the on-chain proposal queue, which the driver would defer to.
+- **Same-ms tiebreaker** is lex order on the event record's `(.ts, .editor, .kind, .val)` — deterministic, not principled. GRC-20 itself defers ordering to the on-chain proposal queue, which the driver would defer to.
 - **No compaction** of the history set in this demo. Real workloads would compact `(entity, prop)` history into a checkpoint past some age cutoff. The shape generalises — fold the prefix, keep only the tail.
 - **Six philosophers** is enough to prove the pattern, not a workload benchmark. For throughput numbers under contention, see [`examples/agent-swarm/`](../agent-swarm/) (8 concurrent agents, hot-key counters + tag sets) and [`examples/wikipedia-pageviews/`](../wikipedia-pageviews/) (5,938 events, integer counters).
 

--- a/examples/grc20-pov/demo.go
+++ b/examples/grc20-pov/demo.go
@@ -1,7 +1,7 @@
 // GRC-20-shaped knowledge graph on Orly, in Go.
 //
 // Mirrors demo.py: three phases (wiki biographical / stanford schools +
-// relations / concurrent race), same encoding, same self-check.
+// relations / concurrent race), same event records, same self-check.
 // Provided so readers can pick whichever language matches their
 // environment.
 //
@@ -141,32 +141,61 @@ func sendStringSet(c *websocket.Conn, stmt string) []string {
 }
 
 // ---------------------------------------------------------------------
-// Op encoding: "<13-digit ms ts>:<editor>:<kind>:<value>".
-// Kind ∈ {L text, I integer, R relation target id, D tombstone}.
+// Event records. Each event is a first-class
+//   <{.ts: int, .editor: str, .kind: str, .val: str}>
+// stored in a set OF records (issue #90). Kind ∈ {L text, I integer,
+// R relation target id, D tombstone}. No string packing -- the four
+// typed fields travel end to end.
 // ---------------------------------------------------------------------
 
 func nowMs() int64 { return time.Now().UnixNano() / 1_000_000 }
 
-func encode(editor, kind, value string) string {
-	return fmt.Sprintf("%013d:%s:%s:%s", nowMs(), editor, kind, value)
+type event struct {
+	ts           int64
+	editor, kind string
+	val          string
 }
 
-type parsed struct {
-	ts             int64
-	editor, kind   string
-	value          string
+// Records arrive as JSON objects; ts may be a float (orlyi serialises
+// numbers as JSON floats), so decode it loosely and narrow to int64.
+type eventWire struct {
+	Ts     float64 `json:"ts"`
+	Editor string  `json:"editor"`
+	Kind   string  `json:"kind"`
+	Val    string  `json:"val"`
 }
 
-func parseEntry(entry string) parsed {
-	parts := strings.SplitN(entry, ":", 4)
-	if len(parts) != 4 {
-		die(fmt.Sprintf("bad entry %q", entry))
+// eventLess is the total order over event records: ts first, then a
+// deterministic same-ms tiebreaker (editor, kind, val).
+func eventLess(a, b event) bool {
+	if a.ts != b.ts {
+		return a.ts < b.ts
 	}
-	ts, err := strconv.ParseInt(parts[0], 10, 64)
-	if err != nil {
-		die(fmt.Sprintf("bad ts in %q: %v", entry, err))
+	if a.editor != b.editor {
+		return a.editor < b.editor
 	}
-	return parsed{ts: ts, editor: parts[1], kind: parts[2], value: parts[3]}
+	if a.kind != b.kind {
+		return a.kind < b.kind
+	}
+	return a.val < b.val
+}
+
+// orlyi serialises a set of records as a JSON array of objects.
+func sendEventSet(c *websocket.Conn, stmt string) []event {
+	raw := send(c, stmt)
+	if string(raw) == "null" {
+		return nil
+	}
+	var wire []eventWire
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		die(fmt.Sprintf("expected array-of-objects result, got %s", raw))
+	}
+	out := make([]event, 0, len(wire))
+	for _, w := range wire {
+		out = append(out, event{ts: int64(w.Ts), editor: w.Editor, kind: w.Kind, val: w.Val})
+	}
+	sort.Slice(out, func(i, j int) bool { return eventLess(out[i], out[j]) })
+	return out
 }
 
 func orlyStr(s string) string {
@@ -180,10 +209,13 @@ func orlyStr(s string) string {
 // Wrappers for the grc20 package's three commutative funcs.
 // ---------------------------------------------------------------------
 
-func appendOp(c *websocket.Conn, pov, entity, prop, entry string) {
+// appendOp unions one event record into the (entity, property) history.
+// The engine builds the <{.ts, .editor, .kind, .val}> record from these
+// typed args; ts is an int literal, the rest are string literals.
+func appendOp(c *websocket.Conn, pov, entity, prop string, ts int64, editor, kind, val string) {
 	send(c, fmt.Sprintf(
-		`try {%s} grc20 append_op <{.entity: %s, .property: %s, .entry: %s}>;`,
-		pov, orlyStr(entity), orlyStr(prop), orlyStr(entry)))
+		`try {%s} grc20 append_op <{.entity: %s, .property: %s, .ts: %d, .editor: %s, .kind: %s, .val: %s}>;`,
+		pov, orlyStr(entity), orlyStr(prop), ts, orlyStr(editor), orlyStr(kind), orlyStr(val)))
 }
 
 func registerEntity(c *websocket.Conn, pov, entity string) {
@@ -198,8 +230,8 @@ func registerProp(c *websocket.Conn, pov, entity, prop string) {
 		pov, orlyStr(entity), orlyStr(prop)))
 }
 
-func histFor(c *websocket.Conn, pov, entity, prop string) []string {
-	return sendStringSet(c, fmt.Sprintf(
+func histFor(c *websocket.Conn, pov, entity, prop string) []event {
+	return sendEventSet(c, fmt.Sprintf(
 		`try {%s} grc20 hist_for <{.entity: %s, .property: %s}>;`,
 		pov, orlyStr(entity), orlyStr(prop)))
 }
@@ -226,26 +258,26 @@ func entityCount(c *websocket.Conn, pov string) int {
 func opCreateEntity(c *websocket.Conn, pov, editor, entity, typeName string) {
 	registerEntity(c, pov, entity)
 	registerProp(c, pov, entity, "__type")
-	appendOp(c, pov, entity, "__type", encode(editor, "L", typeName))
+	appendOp(c, pov, entity, "__type", nowMs(), editor, "L", typeName)
 }
 
 func opSetText(c *websocket.Conn, pov, editor, entity, prop, text string) {
 	registerEntity(c, pov, entity)
 	registerProp(c, pov, entity, prop)
-	appendOp(c, pov, entity, prop, encode(editor, "L", text))
+	appendOp(c, pov, entity, prop, nowMs(), editor, "L", text)
 }
 
 func opSetInt(c *websocket.Conn, pov, editor, entity, prop string, n int) {
 	registerEntity(c, pov, entity)
 	registerProp(c, pov, entity, prop)
-	appendOp(c, pov, entity, prop, encode(editor, "I", strconv.Itoa(n)))
+	appendOp(c, pov, entity, prop, nowMs(), editor, "I", strconv.Itoa(n))
 }
 
 func opCreateRelation(c *websocket.Conn, pov, editor, entity, prop, target string) {
 	registerEntity(c, pov, entity)
 	registerEntity(c, pov, target)
 	registerProp(c, pov, entity, prop)
-	appendOp(c, pov, entity, prop, encode(editor, "R", target))
+	appendOp(c, pov, entity, prop, nowMs(), editor, "R", target)
 }
 
 // ---------------------------------------------------------------------
@@ -270,7 +302,7 @@ func reconstruct(c *websocket.Conn, pov string, asOf *int64) map[string]map[stri
 			if asOf != nil {
 				filtered := entries[:0]
 				for _, e := range entries {
-					if parseEntry(e).ts <= *asOf {
+					if e.ts <= *asOf {
 						filtered = append(filtered, e)
 					}
 				}
@@ -279,12 +311,12 @@ func reconstruct(c *websocket.Conn, pov string, asOf *int64) map[string]map[stri
 			if len(entries) == 0 {
 				continue
 			}
-			p := parseEntry(entries[len(entries)-1])
+			p := entries[len(entries)-1]
 			if prop == "__deleted" && p.kind == "D" {
 				deleted = true
 				break
 			}
-			state[prop] = fact{kind: p.kind, value: p.value, editor: p.editor, ts: p.ts}
+			state[prop] = fact{kind: p.kind, value: p.val, editor: p.editor, ts: p.ts}
 		}
 		if !deleted {
 			out[eid] = state
@@ -387,13 +419,12 @@ func editorialDiff(c *websocket.Conn, pov string) {
 	entitiesByEditor := map[string]map[string]struct{}{}
 	for _, eid := range allEntities(c, pov) {
 		for _, prop := range propsOf(c, pov, eid) {
-			for _, entry := range histFor(c, pov, eid, prop) {
-				p := parseEntry(entry)
-				byEditor[p.editor]++
-				if entitiesByEditor[p.editor] == nil {
-					entitiesByEditor[p.editor] = map[string]struct{}{}
+			for _, ev := range histFor(c, pov, eid, prop) {
+				byEditor[ev.editor]++
+				if entitiesByEditor[ev.editor] == nil {
+					entitiesByEditor[ev.editor] = map[string]struct{}{}
 				}
-				entitiesByEditor[p.editor][eid] = struct{}{}
+				entitiesByEditor[ev.editor][eid] = struct{}{}
 			}
 		}
 	}
@@ -467,9 +498,8 @@ func main() {
 	raceEntries := histFor(boot, pov, raceEntity, raceProp)
 	fmt.Printf("  history for %s.%s after race (%d events, ts-sorted):\n",
 		raceEntity, raceProp, len(raceEntries))
-	for _, e := range raceEntries {
-		p := parseEntry(e)
-		fmt.Printf("    %d  %-10s %s  %s\n", p.ts, p.editor, p.kind, p.value)
+	for _, ev := range raceEntries {
+		fmt.Printf("    %d  %-10s %s  %s\n", ev.ts, ev.editor, ev.kind, ev.val)
 	}
 	finalState := reconstruct(boot, pov, &ts3)
 	winning := finalState[raceEntity][raceProp]
@@ -481,12 +511,13 @@ func main() {
 	editorialDiff(boot, pov)
 
 	fmt.Println("\n=== the trick ===")
-	fmt.Println("  Every editor |= a packed event into a per-(entity, prop)")
-	fmt.Println("  history set. Multi-editor writes never drop events (post-#50")
-	fmt.Println("  deferred-mutation fold). Reads replay the timestamp-sorted")
-	fmt.Println("  log -- pass a cutoff for time-travel, take the latest for")
-	fmt.Println("  the current value. The schema is three commutative funcs;")
-	fmt.Println("  GRC-20's op vocabulary lives entirely in the driver.")
+	fmt.Println("  Every editor |= an event record into a per-(entity, prop)")
+	fmt.Println("  set of <{.ts, .editor, .kind, .val}> (issue #90). Multi-editor")
+	fmt.Println("  writes never drop events (post-#50 deferred-mutation fold).")
+	fmt.Println("  Reads replay the timestamp-sorted log -- pass a cutoff for")
+	fmt.Println("  time-travel, take the latest for the current value. The schema")
+	fmt.Println("  is three commutative funcs; GRC-20's op vocabulary lives")
+	fmt.Println("  entirely in the driver.")
 
 	// --- Self-check (mirrors demo.py) ---
 	var failures []string

--- a/examples/grc20-pov/demo.py
+++ b/examples/grc20-pov/demo.py
@@ -84,24 +84,23 @@ RACE_FACT = ("pythagoras", "born", -570, -575)
 
 
 # ---------------------------------------------------------------------
-# WS helpers + op encoding.
+# WS helpers + event records.
 #
-# Each event is encoded as "<ts>:<editor>:<kind>:<value>" where ts is
-# zero-padded 13-digit ms (sorts lexicographically = chronologically),
-# kind ∈ {L text, I integer, R relation target id, D tombstone}.
+# Each event is a first-class record
+#   <{.ts: int, .editor: str, .kind: str, .val: str}>
+# stored in a set OF records (issue #90). ts is a ms timestamp; kind ∈
+# {L text, I integer, R relation target id, D tombstone}. No string
+# packing -- the four typed fields travel end to end. Chronological
+# order is `event_key` (ts first, then a deterministic tiebreaker).
 # ---------------------------------------------------------------------
 def now_ms():
     return int(time.time() * 1000)
 
 
-def encode(editor, kind, value):
-    return f"{now_ms():013d}:{editor}:{kind}:{value}"
-
-
-def parse(entry):
-    """Returns (ts:int, editor:str, kind:str, value:str)."""
-    ts, editor, kind, value = entry.split(":", 3)
-    return int(ts), editor, kind, value
+def event_key(ev):
+    """Total order over event records: ts first, then a deterministic
+    same-ms tiebreaker (editor, kind, val)."""
+    return (ev["ts"], ev["editor"], ev["kind"], ev["val"])
 
 
 def send(ws, stmt):
@@ -118,11 +117,17 @@ def orly_str(s):
     return '"' + s.replace('\\', '\\\\').replace('"', '\\"') + '"'
 
 
-def append_op(ws, pov, entity, prop, entry):
+def append_op(ws, pov, entity, prop, ts, editor, kind, val):
+    """Union one event record into the (entity, property) history. The
+    engine builds the <{.ts, .editor, .kind, .val}> record from these
+    typed args; ts is an int literal, the rest are string literals."""
     send(ws, (f'try {{{pov}}} grc20 append_op '
               f'<{{.entity: {orly_str(entity)}, '
               f'.property: {orly_str(prop)}, '
-              f'.entry: {orly_str(entry)}}}>;'))
+              f'.ts: {int(ts)}, '
+              f'.editor: {orly_str(editor)}, '
+              f'.kind: {orly_str(kind)}, '
+              f'.val: {orly_str(val)}}}>;'))
 
 
 def register_entity(ws, pov, entity):
@@ -137,10 +142,14 @@ def register_prop(ws, pov, entity, prop):
 
 
 def hist_for(ws, pov, entity, prop):
+    """Returns the event history as a list of dicts
+    {ts:int, editor:str, kind:str, val:str}. Records come back over the
+    wire as JSON objects; ts may arrive as a float, so normalise it."""
     r = send(ws, (f'try {{{pov}}} grc20 hist_for '
                   f'<{{.entity: {orly_str(entity)}, '
                   f'.property: {orly_str(prop)}}}>;'))
-    return list(r or [])
+    return [{"ts": int(ev["ts"]), "editor": ev["editor"],
+             "kind": ev["kind"], "val": ev["val"]} for ev in (r or [])]
 
 
 def all_entities(ws, pov):
@@ -168,31 +177,31 @@ def op_create_entity(ws, pov, editor, entity, type_name):
     property called '__type'."""
     register_entity(ws, pov, entity)
     register_prop(ws, pov, entity, "__type")
-    append_op(ws, pov, entity, "__type", encode(editor, "L", type_name))
+    append_op(ws, pov, entity, "__type", now_ms(), editor, "L", type_name)
 
 
 def op_set_text(ws, pov, editor, entity, prop, text):
     register_entity(ws, pov, entity)
     register_prop(ws, pov, entity, prop)
-    append_op(ws, pov, entity, prop, encode(editor, "L", text))
+    append_op(ws, pov, entity, prop, now_ms(), editor, "L", text)
 
 
 def op_set_int(ws, pov, editor, entity, prop, n):
     register_entity(ws, pov, entity)
     register_prop(ws, pov, entity, prop)
-    append_op(ws, pov, entity, prop, encode(editor, "I", str(n)))
+    append_op(ws, pov, entity, prop, now_ms(), editor, "I", str(n))
 
 
 def op_create_relation(ws, pov, editor, entity, prop, target):
     register_entity(ws, pov, entity)
     register_entity(ws, pov, target)
     register_prop(ws, pov, entity, prop)
-    append_op(ws, pov, entity, prop, encode(editor, "R", target))
+    append_op(ws, pov, entity, prop, now_ms(), editor, "R", target)
 
 
 def op_delete_entity(ws, pov, editor, entity):
     register_prop(ws, pov, entity, "__deleted")
-    append_op(ws, pov, entity, "__deleted", encode(editor, "D", ""))
+    append_op(ws, pov, entity, "__deleted", now_ms(), editor, "D", "")
 
 
 # ---------------------------------------------------------------------
@@ -214,17 +223,18 @@ def reconstruct(ws, pov, as_of_ts=None):
         deleted = False
         e_state = {}
         for prop in props:
-            entries = sorted(hist_for(ws, pov, eid, prop))
+            entries = sorted(hist_for(ws, pov, eid, prop), key=event_key)
             if as_of_ts is not None:
-                entries = [e for e in entries if parse(e)[0] <= as_of_ts]
+                entries = [e for e in entries if e["ts"] <= as_of_ts]
             if not entries:
                 continue
             # Latest event wins per property.
-            ts, editor, kind, value = parse(entries[-1])
-            if prop == "__deleted" and kind == "D":
+            latest = entries[-1]
+            if prop == "__deleted" and latest["kind"] == "D":
                 deleted = True
                 break
-            e_state[prop] = (kind, value, editor, ts)
+            e_state[prop] = (latest["kind"], latest["val"],
+                             latest["editor"], latest["ts"])
         if not deleted:
             out[eid] = e_state
     return out
@@ -320,8 +330,8 @@ def editorial_diff(ws, pov):
     entities_by_editor = {}       # editor -> set(entity ids)
     for eid in sorted(all_entities(ws, pov)):
         for prop in sorted(props_of(ws, pov, eid)):
-            for entry in hist_for(ws, pov, eid, prop):
-                _ts, editor, _kind, _value = parse(entry)
+            for ev in hist_for(ws, pov, eid, prop):
+                editor = ev["editor"]
                 by_editor[editor] = by_editor.get(editor, 0) + 1
                 entities_by_editor.setdefault(editor, set()).add(eid)
     print("\n=== editorial diff ===")
@@ -380,12 +390,11 @@ def main():
     print(f"  stanford -> {stanford_value}")
     phase3_race(pov)
     ts3 = now_ms()
-    race_entries = sorted(hist_for(boot, pov, entity, prop))
+    race_entries = sorted(hist_for(boot, pov, entity, prop), key=event_key)
     print(f"  history for {entity}.{prop} after race "
           f"({len(race_entries)} events, ts-sorted):")
-    for e in race_entries:
-        ts, ed, kind, val = parse(e)
-        print(f"    {ts}  {ed:<10} {kind}  {val}")
+    for ev in race_entries:
+        print(f"    {ev['ts']}  {ev['editor']:<10} {ev['kind']}  {ev['val']}")
     final_state = reconstruct(boot, pov, as_of_ts=ts3)
     winning = final_state[entity][prop]
     print(f"  -> winning event: {winning[1]} [{winning[2]}, ts={winning[3]}]")
@@ -396,12 +405,13 @@ def main():
 
     # --- Self-check ---
     print("\n=== the trick ===")
-    print("  Every editor `|=` a packed event into a per-(entity, prop)")
-    print("  history set. Multi-editor writes never drop events (post-#50")
-    print("  deferred-mutation fold). Reads replay the timestamp-sorted")
-    print("  log -- pass a cutoff for time-travel, take the latest for")
-    print("  the current value. The schema is three commutative funcs;")
-    print("  GRC-20's op vocabulary lives entirely in the driver.")
+    print("  Every editor `|=` an event record into a per-(entity, prop)")
+    print("  set of <{.ts, .editor, .kind, .val}> (issue #90). Multi-editor")
+    print("  writes never drop events (post-#50 deferred-mutation fold).")
+    print("  Reads replay the timestamp-sorted log -- pass a cutoff for")
+    print("  time-travel, take the latest for the current value. The schema")
+    print("  is three commutative funcs; GRC-20's op vocabulary lives")
+    print("  entirely in the driver.")
 
     failures = []
     # Phase-1 invariant: every philosopher has name + born + died.

--- a/examples/grc20-pov/grc20.orly
+++ b/examples/grc20-pov/grc20.orly
@@ -21,36 +21,41 @@
 
    Plus their read-side counterparts (hist_for, all_entities, props_of).
 
-   The driver formats each event as a packed string
+   Each event is a first-class record:
 
-     "<13-digit ms timestamp>:<editor>:<kind>:<value>"
+     <{.ts: int, .editor: str, .kind: str, .val: str}>
 
-   where kind ∈ {L (text literal), I (integer literal), R (relation
-   target id), D (tombstone)} and value is the literal or the target
-   entity id. Lexicographic sort of the resulting set is chronological
-   because the timestamp prefix is fixed-width. Driver-side replay then
-   takes "latest write wins per property" semantics with tombstones, the
-   same way GRC-20 itself does.
+   where ts is a millisecond timestamp, editor is the source name, kind
+   is the op class (one of "L" text literal, "I" integer literal, "R"
+   relation target id, "D" tombstone), and val is the literal text or the
+   target entity id. The history set is a set OF these records, so the
+   structure travels end to end -- the driver hands the engine four typed
+   fields and reads back four typed fields, no string packing/unpacking.
+   Sorting the set by .ts gives chronological order; driver-side replay
+   then takes "latest write wins per property" with tombstones, the same
+   way GRC-20 itself does.
 
    Why driver-side replay rather than an orlyscript fold: GRC-20 ops are
    heterogeneous (CreateEntity / SetProperty / CreateRelation /
    DeleteEntity), and the replay is conditional on the event kind. Set
-   union over packed strings keeps the schema simple and gives the same
+   union over event records keeps the schema simple and gives the same
    "version axis in the keyspace" guarantee as
    examples/wikipedia-categories/: any (entity, property) pair gets one
-   set, every op is one immutable entry, the past is structurally
+   set, every op is one immutable record, the past is structurally
    frozen.
 
    Schema:
 
-     <['hist', entity, property]>::({str})  events for one (e, p) pair
+     <['hist', entity, property]>::({<{.ts, .editor, .kind, .val}>})
+                                            events for one (e, p) pair
      <['entities']>::({str})                set of every entity id
      <['props',  entity]>::({str})          set of every property id ever
                                             written on this entity
 
    Concurrent editors writing to overlapping entities/properties all
    land their events; the post-#50 deferred-mutation + read-time-fold
-   mechanism is what makes `|=` from multiple WS sessions safe.
+   mechanism is what makes `|=` from multiple WS sessions safe. The
+   storable-record-set support is issue #90.
 
    Copyright 2010-2026 Atomic Kismet Company
 
@@ -70,20 +75,23 @@ package #1;
 
 /* ---------- per-(entity, property) event history ---------- */
 
-hist_for = (((*<['hist', entity, property]>::({str})) if *<['hist', entity, property]>::({str}?) is known else (empty {str}))) where {
+hist_for = (((*<['hist', entity, property]>::({<{.ts: int, .editor: str, .kind: str, .val: str}>})) if *<['hist', entity, property]>::({<{.ts: int, .editor: str, .kind: str, .val: str}>}?) is known else (empty {<{.ts: int, .editor: str, .kind: str, .val: str}>}))) where {
   entity   = given::(str);
   property = given::(str);
 };
 
-/* Append one event into the (entity, property) history. */
+/* Append one event record into the (entity, property) history. */
 append_op = (((1) effecting {
-  *<['hist', entity, property]>::({str}) |= {entry};
-} if *<['hist', entity, property]>::({str}?) is known else (0) effecting {
-  new <['hist', entity, property]> <- {entry};
+  *<['hist', entity, property]>::({<{.ts: int, .editor: str, .kind: str, .val: str}>}) |= {<{.ts: ts, .editor: editor, .kind: kind, .val: val}>};
+} if *<['hist', entity, property]>::({<{.ts: int, .editor: str, .kind: str, .val: str}>}?) is known else (0) effecting {
+  new <['hist', entity, property]> <- {<{.ts: ts, .editor: editor, .kind: kind, .val: val}>};
 })) where {
   entity   = given::(str);
   property = given::(str);
-  entry    = given::(str);
+  ts       = given::(int);
+  editor   = given::(str);
+  kind     = given::(str);
+  val      = given::(str);
 };
 
 /* ---------- catalogue: entities + their property set ---------- */
@@ -126,26 +134,30 @@ test {
   /* Empty keyspace reads as identity. */
   t1: all_entities == (empty {str});
   t2: props_of(.entity: "socrates") == (empty {str});
-  t3: hist_for(.entity: "socrates", .property: "name") == (empty {str});
+  t3: hist_for(.entity: "socrates", .property: "name")
+        == (empty {<{.ts: int, .editor: str, .kind: str, .val: str}>});
 
-  /* Append one event creates the set with that entry. */
+  /* Append one event creates the set with that record. */
   t4: append_op(.entity: "socrates", .property: "name",
-                .entry: "0000000000001:wiki:L:Socrates") == 0 {
+                .ts: 1, .editor: "wiki", .kind: "L", .val: "Socrates") == 0 {
     t5: hist_for(.entity: "socrates", .property: "name")
-          == {"0000000000001:wiki:L:Socrates"};
+          == {<{.ts: 1, .editor: "wiki", .kind: "L", .val: "Socrates"}>};
     t6: event_count(.entity: "socrates", .property: "name") == 1;
 
     /* Second event from a different editor unions in. */
     t7: append_op(.entity: "socrates", .property: "name",
-                  .entry: "0000000000002:stanford:L:Socrates of Athens") == 1 {
+                  .ts: 2, .editor: "stanford", .kind: "L",
+                  .val: "Socrates of Athens") == 1 {
       t8: hist_for(.entity: "socrates", .property: "name")
-            == {"0000000000001:wiki:L:Socrates",
-                "0000000000002:stanford:L:Socrates of Athens"};
+            == {<{.ts: 1, .editor: "wiki", .kind: "L", .val: "Socrates"}>,
+                <{.ts: 2, .editor: "stanford", .kind: "L",
+                  .val: "Socrates of Athens"}>};
       t9: event_count(.entity: "socrates", .property: "name") == 2;
 
-      /* Idempotent: same entry re-added doesn't grow the set. */
+      /* Idempotent: same record re-added doesn't grow the set. */
       t10: append_op(.entity: "socrates", .property: "name",
-                     .entry: "0000000000001:wiki:L:Socrates") == 1 {
+                     .ts: 1, .editor: "wiki", .kind: "L",
+                     .val: "Socrates") == 1 {
         t11: event_count(.entity: "socrates", .property: "name") == 2;
       };
     };


### PR DESCRIPTION
## Summary

Now that storable record-sets work (#90, merged in #91), this rewrites the GRC-20 demo's per-(entity, property) event history from a set of packed strings to a set of **first-class records**.

Before:

```orly
<['hist', entity, property]>::({str})            -- "<ts>:<editor>:<kind>:<value>"
```

After:

```orly
<['hist', entity, property]>::({<{.ts: int, .editor: str, .kind: str, .val: str}>})
```

The four typed fields travel end to end: the driver hands the engine typed args and reads the history back as a JSON array of objects — no string packing/parsing on either side.

This also makes the demo the **workload-level integration test** for #90 — it exercises read-back-then-`|=` of a set-of-records over the WebSocket path, including the concurrent multi-editor race where two writers land events at the same millisecond.

## Changes

- `grc20.orly`: history set + `append_op` use the record schema; `append_op` now takes `.ts/.editor/.kind/.val`; inline tests updated to compare against record sets.
- `demo.py` / `demo.go`: drop the `encode()`/`parse()` string helpers; send the four typed fields; read records back as dicts/structs; sort by `(ts, editor, kind, val)`.
- `README.md`: schema block, GRC-20 mapping table, and same-ms tiebreaker docs updated for records.

The catalogue sets (`entities`, `props`) stay `{str}` — those are genuinely sets of ids/names.

## Validation

- `orlyc -m grc20.orly`: 19 inline tests pass.
- `./run.sh` (Python driver) and `./run-go.sh` (Go driver): both self-checks green end-to-end — 3 snapshot invariants + the multi-editor race (3 same-ms events all survive in history).
- `go vet` / `gofmt` clean.