### PR TITLE
examples/agent-swarm: give tags provenance via record-sets

### DIFF
--- a/examples/agent-swarm/README.md
+++ b/examples/agent-swarm/README.md
@@ -1,18 +1,20 @@
 # Multi-agent knowledge graph — concurrent extraction demo
 
-The shape multi-agent LLM systems keep reinventing badly: many extractor agents reading disjoint chunks of a corpus, each emitting facts about overlapping entities into one shared knowledge graph. N concurrent WebSocket "agents" all stream tags, mentions, and co-occurrences into the same Orly POV with **zero coordination** — no locks, no per-agent partitioning, no merge-on-read logic in the driver. The demo self-checks that every contribution lands.
+The shape multi-agent LLM systems keep reinventing badly: many extractor agents reading disjoint chunks of a corpus, each emitting facts about overlapping entities into one shared knowledge graph. N concurrent WebSocket "agents" all stream tags, mentions, and co-occurrences into the same Orly POV with **zero coordination** — no locks, no per-agent partitioning, no merge-on-read logic in the driver. Every tag carries **provenance** — the agent that asserted it — so a tag three agents independently produce is three records you can read back, not a collapsed string. The demo self-checks that every contribution lands.
 
 ## The trick
 
 Three commutative field calls — no read-modify-write anywhere:
 
 ```orly
-*<['entity', e]>::({str})    |= {tag}    # set union per entity
-*<['mention', e, d]>::(int)  += 1        # per (entity, doc) counter
-*<['cooccur', a, b]>::(int)  += 1        # per unordered-pair counter
+*<['entity', e]>::({<{.tag: str, .agent: str}>})  |= {<{.tag, .agent}>}  # provenance set per entity
+*<['mention', e, d]>::(int)                       += 1   # per (entity, doc) counter
+*<['cooccur', a, b]>::(int)                       += 1   # per unordered-pair counter
 ```
 
-`|=` and `+=` are field **calls**, not field changes. Two agents concurrently doing `add_tag("Python", "popular")` each emit a deferred `{Union, {"popular"}}` mutation at the storage layer; the read path folds them via `Rt::Mutate` back into the correct set. No lock, no race, no lost updates — the same mechanism powers [`wikipedia-pageviews/`](../wikipedia-pageviews/) (counters) and [`wikipedia-categories/`](../wikipedia-categories/) (set unions).
+`|=` and `+=` are field **calls**, not field changes. Two agents concurrently doing `add_tag("Python", "popular", ...)` each emit a deferred `{Union, ...}` mutation at the storage layer; the read path folds them via `Rt::Mutate` back into the correct set. No lock, no race, no lost updates — the same mechanism powers [`wikipedia-pageviews/`](../wikipedia-pageviews/) (counters) and [`wikipedia-categories/`](../wikipedia-categories/) (set unions).
+
+The entity tag set is a set **of records** — `{<{.tag: str, .agent: str}>}`, storable record-sets being [issue #90](https://github.com/orlyatomics/orly/issues/90). Distinct tags and their contributing agents both fall out of the one set on read; the rollup below annotates any tag more than one agent corroborated (`language×5`).
 
 What an LLM-extraction pipeline would normally need:
 
@@ -21,7 +23,7 @@ What an LLM-extraction pipeline would normally need:
 | Per-agent local graph + post-hoc merge | Doubles storage; merge logic has to commute by hand. |
 | Read-modify-write per fact (Postgres `UPDATE ... SET tags = tags <> ...`) | Row lock per write; N agents serialize on hot entities. |
 | Single-writer service in front of the store | Throughput ceiling = one writer; agents wait on the queue. |
-| Orly: `*<['entity', e]>::({str}) \|= {tag}` | Field call; lock-free; N agents land their unions, the engine aggregates. |
+| Orly: `*<['entity', e]>::({<{.tag,.agent}>}) \|= {<{.tag,.agent}>}` | Field call; lock-free; N agents land their provenance records, the engine aggregates. |
 
 ## Run it
 
@@ -43,12 +45,12 @@ Both wrappers require `make debug` to have produced `orlyi` and `orlyc`. Each ki
 
 `DEMO_SCALE=small` runs 4 agents over the first 20 docs (CI default). The default (`DEMO_SCALE=large` or unset) runs 8 agents over all 40 docs.
 
-Exit code is non-zero if the verifier finds any tag set, mention counter, or cooccurrence counter that disagrees with the independently-derived ground truth.
+Exit code is non-zero if the verifier finds any tag provenance set, mention counter, or cooccurrence counter that disagrees with the independently-derived ground truth.
 
 ## What the demo proves
 
 - **No lost extractions under contention.** Hot entities (Python, OpenAI, Anthropic, Claude, GPT-4, Microsoft, Google) appear in many docs; agents are assigned docs round-robin so multiple agents hit the same entity concurrently. Every `add_tag` / `add_mention` / `add_cooccur` call lands.
-- **Tag sets converge.** Different docs assign different tags to the same entity (Python picks up `language` from some docs, `popular` from others). The on-disk tag set after ingest equals the union derived from the corpus.
+- **Tag provenance sets converge.** Different docs assign different tags to the same entity (Python picks up `language` from some docs, `popular` from others), and different agents independently corroborate the same tag. The on-disk set of `(tag, agent)` records after ingest equals the union derived from the corpus — every contributing agent is preserved.
 - **No driver-side merge logic.** The driver never reads-then-writes. It only ever calls the three field-call functions in [`graph.orly`](graph.orly). Aggregation is the engine's job.
 
 ## Related demos

--- a/examples/agent-swarm/demo.go
+++ b/examples/agent-swarm/demo.go
@@ -192,21 +192,31 @@ type pairKey struct {
 	a, b string
 }
 
-func computeGroundTruth(docs []doc) (
-	expectedTags map[string]map[string]bool,
+// tagRecord is one provenance fact: agent asserted tag. It's the set
+// element behind <['entity', e]>::({<{.tag, .agent}>}).
+type tagRecord struct {
+	tag, agent string
+}
+
+func computeGroundTruth(docs []doc, numAgents int) (
+	expectedTagRecords map[string]map[tagRecord]bool,
 	expectedMentions map[mentionKey]int,
 	expectedCooccur map[pairKey]int,
 ) {
-	expectedTags = map[string]map[string]bool{}
+	// Tags carry provenance: doc `docID` is processed by agent
+	// `docID % numAgents` (the round-robin split in main), so the
+	// expected tag set is the set of (tag, agent) records.
+	expectedTagRecords = map[string]map[tagRecord]bool{}
 	expectedMentions = map[mentionKey]int{}
 	expectedCooccur = map[pairKey]int{}
 	for docID, d := range docs {
+		agentName := fmt.Sprintf("agent-%d", docID%numAgents)
 		for entity, tags := range d.entities {
-			if expectedTags[entity] == nil {
-				expectedTags[entity] = map[string]bool{}
+			if expectedTagRecords[entity] == nil {
+				expectedTagRecords[entity] = map[tagRecord]bool{}
 			}
 			for _, t := range tags {
-				expectedTags[entity][t] = true
+				expectedTagRecords[entity][tagRecord{t, agentName}] = true
 			}
 			expectedMentions[mentionKey{entity, docID}] = 1
 		}
@@ -261,10 +271,10 @@ func mustSend(c *websocket.Conn, stmt string) interface{} {
 	return r
 }
 
-func addTag(c *websocket.Conn, pov, entity, tag string) {
+func addTag(c *websocket.Conn, pov, entity, tag, agent string) {
 	mustSend(c, fmt.Sprintf(
-		`try {%s} graph add_tag <{.e: %q, .t: %q}>;`,
-		pov, entity, tag))
+		`try {%s} graph add_tag <{.e: %q, .t: %q, .agent: %q}>;`,
+		pov, entity, tag, agent))
 }
 
 func addMention(c *websocket.Conn, pov, entity string, docID int) {
@@ -279,16 +289,19 @@ func addCooccur(c *websocket.Conn, pov, a, b string) {
 		pov, a, b))
 }
 
-func tagsForEntity(c *websocket.Conn, pov, entity string) map[string]bool {
+func tagsForEntity(c *websocket.Conn, pov, entity string) map[tagRecord]bool {
 	r := mustSend(c, fmt.Sprintf(
 		`try {%s} graph tags_for_entity <{.e: %q}>;`,
 		pov, entity))
-	out := map[string]bool{}
+	out := map[tagRecord]bool{}
 	if r == nil {
 		return out
 	}
+	// graph.orly returns a set of <{.tag, .agent}> records; WS wire form
+	// is a JSON array of objects.
 	for _, v := range r.([]interface{}) {
-		out[v.(string)] = true
+		rec := v.(map[string]interface{})
+		out[tagRecord{rec["tag"].(string), rec["agent"].(string)}] = true
 	}
 	return out
 }
@@ -322,8 +335,10 @@ type agentDoc struct {
 
 // agent runs one writer goroutine: opens a fresh WS, opens a session,
 // ingests its slice of (doc_id, extraction) pairs into the shared POV.
-func agent(pov string, docs []agentDoc, wg *sync.WaitGroup) {
+// Every tag it asserts is stamped with this agent's name for provenance.
+func agent(id int, pov string, docs []agentDoc, wg *sync.WaitGroup) {
 	defer wg.Done()
+	agentName := fmt.Sprintf("agent-%d", id)
 	dialer := *websocket.DefaultDialer
 	dialer.HandshakeTimeout = wsTimeout
 	c, _, err := dialer.Dial(wsURL, nil)
@@ -335,7 +350,7 @@ func agent(pov string, docs []agentDoc, wg *sync.WaitGroup) {
 	for _, ad := range docs {
 		for entity, tags := range ad.doc.entities {
 			for _, t := range tags {
-				addTag(c, pov, entity, t)
+				addTag(c, pov, entity, t, agentName)
 			}
 			addMention(c, pov, entity, ad.id)
 		}
@@ -378,7 +393,7 @@ func sortedTagList(m map[string]bool) []string {
 	return out
 }
 
-func tagSetsEqual(a, b map[string]bool) bool {
+func recordSetsEqual(a, b map[tagRecord]bool) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -390,11 +405,48 @@ func tagSetsEqual(a, b map[string]bool) bool {
 	return true
 }
 
+// sortedRecords renders a record set as sorted "tag@agent" strings, for
+// readable failure messages.
+func sortedRecords(m map[tagRecord]bool) []string {
+	out := make([]string, 0, len(m))
+	for rec := range m {
+		out = append(out, rec.tag+"@"+rec.agent)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// tagSummary rolls a provenance record set up to distinct tags,
+// annotating any tag more than one agent independently asserted (×N).
+func tagSummary(records map[tagRecord]bool) string {
+	agentsByTag := map[string]map[string]bool{}
+	for rec := range records {
+		if agentsByTag[rec.tag] == nil {
+			agentsByTag[rec.tag] = map[string]bool{}
+		}
+		agentsByTag[rec.tag][rec.agent] = true
+	}
+	tags := make([]string, 0, len(agentsByTag))
+	for t := range agentsByTag {
+		tags = append(tags, t)
+	}
+	sort.Strings(tags)
+	parts := make([]string, 0, len(tags))
+	for _, t := range tags {
+		if n := len(agentsByTag[t]); n > 1 {
+			parts = append(parts, fmt.Sprintf("%s×%d", t, n))
+		} else {
+			parts = append(parts, t)
+		}
+	}
+	return strings.Join(parts, ",")
+}
+
 func main() {
 	initScale()
 
 	docs := corpus[:numDocs]
-	expectedTags, expectedMentions, expectedCooccur := computeGroundTruth(docs)
+	expectedTagRecords, expectedMentions, expectedCooccur := computeGroundTruth(docs, numAgents)
 
 	// Round-robin assignment so hot entities collide across agents.
 	perAgent := make([][]agentDoc, numAgents)
@@ -402,10 +454,13 @@ func main() {
 		perAgent[id%numAgents] = append(perAgent[id%numAgents], agentDoc{id, d})
 	}
 
-	totalWrites := 0
-	for _, tags := range expectedTags {
-		totalWrites += len(tags) // add_tag calls
+	addTagCalls := 0 // one per (doc, entity, tag)
+	for _, d := range docs {
+		for _, tags := range d.entities {
+			addTagCalls += len(tags)
+		}
 	}
+	totalWrites := addTagCalls
 	totalWrites += len(expectedMentions) // add_mention calls
 	for _, n := range expectedCooccur {
 		totalWrites += n // add_cooccur calls
@@ -423,16 +478,22 @@ func main() {
 	pov := mustSend(boot, "new safe shared pov;").(string)
 	fmt.Printf("pov: %s\n", pov)
 	fmt.Printf("agents: %d, docs: %d, entities: %d, unordered pairs: %d\n",
-		numAgents, numDocs, len(expectedTags), len(expectedCooccur))
+		numAgents, numDocs, len(expectedTagRecords), len(expectedCooccur))
 	fmt.Printf("total writes from agents: %s\n", commaize(totalWrites))
 
 	// Pre-initialise every key so concurrent agents take the
 	// commutative |= / += branch (never the `new <-` create branch).
 	fmt.Println("\npre-initialising all keys via the bootstrap session...")
-	for entity, tags := range expectedTags {
-		// Seed with the lex-first tag for determinism; agents union the rest.
-		first := sortedTagList(tags)[0]
-		addTag(boot, pov, entity, first)
+	for entity, records := range expectedTagRecords {
+		// Seed with the lex-first tag for determinism, stamped with a
+		// dedicated "seed" agent; the agents union the rest.
+		tagset := map[string]bool{}
+		for rec := range records {
+			tagset[rec.tag] = true
+		}
+		first := sortedTagList(tagset)[0]
+		addTag(boot, pov, entity, first, "seed")
+		records[tagRecord{first, "seed"}] = true
 	}
 	for mk := range expectedMentions {
 		addMention(boot, pov, mk.entity, mk.docID)
@@ -456,7 +517,7 @@ func main() {
 	t0 := time.Now()
 	for i := 0; i < numAgents; i++ {
 		wg.Add(1)
-		go agent(pov, perAgent[i], &wg)
+		go agent(i, pov, perAgent[i], &wg)
 	}
 	wg.Wait()
 	elapsed := time.Since(t0)
@@ -471,12 +532,12 @@ func main() {
 	fmt.Println("=== verifying knowledge graph ===")
 	var failures []string
 
-	for entity, wantTags := range expectedTags {
-		gotTags := tagsForEntity(boot, pov, entity)
-		if !tagSetsEqual(gotTags, wantTags) {
+	for entity, wantRecords := range expectedTagRecords {
+		gotRecords := tagsForEntity(boot, pov, entity)
+		if !recordSetsEqual(gotRecords, wantRecords) {
 			failures = append(failures, fmt.Sprintf(
 				"tags(%s): got %v, want %v",
-				entity, sortedTagList(gotTags), sortedTagList(wantTags)))
+				entity, sortedRecords(gotRecords), sortedRecords(wantRecords)))
 		}
 	}
 	for mk, want := range expectedMentionCount {
@@ -515,7 +576,7 @@ func main() {
 	dash14 := strings.Repeat("-", 14)
 	dash9 := strings.Repeat("-", 9)
 	dash30 := strings.Repeat("-", 30)
-	fmt.Printf("  %-14s  %9s  %9s  %s\n", "entity", "mentions", "expected", "tags")
+	fmt.Printf("  %-14s  %9s  %9s  %s\n", "entity", "mentions", "expected", "tags (×contributing agents)")
 	fmt.Printf("  %-14s  %9s  %9s  %s\n", dash14, dash9, dash9, dash30)
 	for _, entity := range entitiesByHeat {
 		gotTotal := mentionsTotal(boot, pov, entity, 0, numDocs-1)
@@ -527,7 +588,7 @@ func main() {
 				"mentions_total(%s): got %d, want %d",
 				entity, gotTotal, wantTotal))
 		}
-		tagStr := strings.Join(sortedTagList(expectedTags[entity]), ",")
+		tagStr := tagSummary(expectedTagRecords[entity])
 		fmt.Printf("  %-14s  %9d  %9d  %s  %s\n",
 			entity, gotTotal, wantTotal, tagStr, marker)
 	}
@@ -566,8 +627,9 @@ func main() {
 	fmt.Println()
 	fmt.Println("=== the trick ===")
 	fmt.Printf("  %d concurrent agents all wrote into the same knowledge\n", numAgents)
-	fmt.Println("  graph with zero coordination. Tag-set unions and per-entity")
-	fmt.Println("  / per-pair counters all aggregate correctly: this is the shape")
+	fmt.Println("  graph with zero coordination. Tag records (with per-agent")
+	fmt.Println("  provenance) union into one set per entity, and the per-entity")
+	fmt.Println("  / per-pair counters aggregate correctly: this is the shape")
 	fmt.Println("  multi-agent LLM extraction pipelines keep reinventing badly.")
 
 	mustSend(boot, "exit;")
@@ -586,7 +648,11 @@ func main() {
 		}
 		os.Exit(1)
 	}
+	totalTagRecords := 0
+	for _, recs := range expectedTagRecords {
+		totalTagRecords += len(recs)
+	}
 	fmt.Println("\n=== self-check OK ===")
-	fmt.Printf("  verified %d tag sets + %d mention counters + %d cooccurrence counters across %d concurrent agents\n",
-		len(expectedTags), len(expectedMentionCount), len(expectedCooccurCount), numAgents)
+	fmt.Printf("  verified %d tag provenance records across %d entities + %d mention counters + %d cooccurrence counters across %d concurrent agents\n",
+		totalTagRecords, len(expectedTagRecords), len(expectedMentionCount), len(expectedCooccurCount), numAgents)
 }

--- a/examples/agent-swarm/demo.py
+++ b/examples/agent-swarm/demo.py
@@ -184,21 +184,27 @@ def canonical_pair(a, b):
     return (a, b) if a < b else (b, a)
 
 
-def compute_ground_truth(docs):
-    """Derive the expected end-state from the corpus alone."""
-    expected_tags = {}        # entity -> set(tags)
-    expected_mentions = {}    # (entity, doc_id) -> 1
-    expected_cooccur = {}     # (a, b) -> count
+def compute_ground_truth(docs, num_agents):
+    """Derive the expected end-state from the corpus alone.
+
+    Tags carry provenance: doc_id `d` is processed by agent `d %
+    num_agents` (the round-robin split below), so the expected tag set
+    for an entity is the set of (tag, agent) records, not just tags."""
+    expected_tag_records = {}  # entity -> set((tag, agent))
+    expected_mentions = {}     # (entity, doc_id) -> 1
+    expected_cooccur = {}      # (a, b) -> count
     for doc_id, (_text, entities) in enumerate(docs):
+        agent_name = f"agent-{doc_id % num_agents}"
         for entity, tags in entities.items():
-            expected_tags.setdefault(entity, set()).update(tags)
+            for tag in tags:
+                expected_tag_records.setdefault(entity, set()).add((tag, agent_name))
             expected_mentions[(entity, doc_id)] = 1
         names = sorted(entities.keys())
         for i, a in enumerate(names):
             for b in names[i + 1:]:
                 key = canonical_pair(a, b)
                 expected_cooccur[key] = expected_cooccur.get(key, 0) + 1
-    return expected_tags, expected_mentions, expected_cooccur
+    return expected_tag_records, expected_mentions, expected_cooccur
 
 
 def send(ws, stmt):
@@ -209,9 +215,9 @@ def send(ws, stmt):
     return reply.get("result")
 
 
-def add_tag(ws, pov, entity, tag):
+def add_tag(ws, pov, entity, tag, agent):
     send(ws, f'try {{{pov}}} graph add_tag '
-             f'<{{.e: "{entity}", .t: "{tag}"}}>;')
+             f'<{{.e: "{entity}", .t: "{tag}", .agent: "{agent}"}}>;')
 
 
 def add_mention(ws, pov, entity, doc_id):
@@ -226,8 +232,9 @@ def add_cooccur(ws, pov, a, b):
 
 def tags_for_entity(ws, pov, entity):
     r = send(ws, f'try {{{pov}}} graph tags_for_entity <{{.e: "{entity}"}}>;')
-    # graph.orly returns a set; WS wire form is a JSON array.
-    return set(r or [])
+    # graph.orly returns a set of <{.tag, .agent}> records; WS wire form
+    # is a JSON array of objects. Surface it as a set of (tag, agent).
+    return {(rec["tag"], rec["agent"]) for rec in (r or [])}
 
 
 def mention_count(ws, pov, entity, doc_id):
@@ -250,7 +257,9 @@ def cooccur_count(ws, pov, a, b):
 
 def agent(agent_id, pov, docs):
     """One agent: open a fresh WebSocket, open a session, ingest its
-    slice of (doc_id, extraction) pairs into the shared POV."""
+    slice of (doc_id, extraction) pairs into the shared POV. Every tag
+    it asserts is stamped with this agent's name for provenance."""
+    agent_name = f"agent-{agent_id}"
     ws = websocket.create_connection(WS_URL, timeout=WS_TIMEOUT_S)
     try:
         send(ws, "new session;")
@@ -259,7 +268,7 @@ def agent(agent_id, pov, docs):
             # one cooccurrence per unordered pair.
             for entity, tags in entities.items():
                 for tag in tags:
-                    add_tag(ws, pov, entity, tag)
+                    add_tag(ws, pov, entity, tag, agent_name)
                 add_mention(ws, pov, entity, doc_id)
             names = sorted(entities.keys())
             for i, a in enumerate(names):
@@ -272,7 +281,8 @@ def agent(agent_id, pov, docs):
 
 def main():
     docs = CORPUS[:NUM_DOCS]
-    expected_tags, expected_mentions, expected_cooccur = compute_ground_truth(docs)
+    expected_tag_records, expected_mentions, expected_cooccur = compute_ground_truth(
+        docs, NUM_AGENTS)
 
     # Split docs across agents round-robin so hot entities collide
     # across multiple agents (real contention on shared keys).
@@ -280,10 +290,11 @@ def main():
     for doc_id, doc in enumerate(docs):
         per_agent_docs[doc_id % NUM_AGENTS].append((doc_id, doc))
 
+    add_tag_calls = sum(len(tags) for _text, ents in docs for tags in ents.values())
     total_writes = (
-        sum(len(tags) for _e, tags in expected_tags.items())  # add_tag calls
-        + len(expected_mentions)                              # add_mention calls
-        + sum(expected_cooccur.values())                      # add_cooccur calls
+        add_tag_calls                       # add_tag calls (one per doc/entity/tag)
+        + len(expected_mentions)            # add_mention calls
+        + sum(expected_cooccur.values())    # add_cooccur calls
     )
 
     # Bootstrap connection: install graph + create the shared POV.
@@ -293,7 +304,7 @@ def main():
     pov = send(boot, "new safe shared pov;")
     print(f"pov: {pov}")
     print(f"agents: {NUM_AGENTS}, docs: {NUM_DOCS}, "
-          f"entities: {len(expected_tags)}, "
+          f"entities: {len(expected_tag_records)}, "
           f"unordered pairs: {len(expected_cooccur)}")
     print(f"total writes from agents: {total_writes:,}")
 
@@ -302,12 +313,14 @@ def main():
     # Isolates whether lost updates come from the create-race or from
     # the field-call itself -- if the demo passes, it's the field-call.
     print("\npre-initialising all keys via the bootstrap session...")
-    for entity, tags in expected_tags.items():
+    for entity, records in expected_tag_records.items():
         # Seed with one arbitrary tag so the set exists; the agents
         # union the rest. Pick the lexicographically first tag for
-        # determinism.
-        first_tag = sorted(tags)[0]
-        add_tag(boot, pov, entity, first_tag)
+        # determinism, stamped with a dedicated "seed" agent so it's a
+        # distinct, predictable provenance record.
+        first_tag = sorted({tag for tag, _agent in records})[0]
+        add_tag(boot, pov, entity, first_tag, "seed")
+        records.add((first_tag, "seed"))
     for (entity, doc_id) in expected_mentions:
         # Seed with a count of 1, then the agent's add_mention bumps
         # to the expected 2. Adjust ground truth accordingly.
@@ -341,11 +354,12 @@ def main():
     print("=== verifying knowledge graph ===")
     failures = []
 
-    for entity, want_tags in expected_tags.items():
-        got_tags = tags_for_entity(boot, pov, entity)
-        if got_tags != want_tags:
+    for entity, want_records in expected_tag_records.items():
+        got_records = tags_for_entity(boot, pov, entity)
+        if got_records != want_records:
             failures.append(
-                f"tags({entity}): got {sorted(got_tags)}, want {sorted(want_tags)}")
+                f"tags({entity}): got {sorted(got_records)}, "
+                f"want {sorted(want_records)}")
 
     for (entity, doc_id), want in expected_mention_count.items():
         got = mention_count(boot, pov, entity, doc_id)
@@ -367,14 +381,21 @@ def main():
     for (entity, _doc_id), v in expected_mention_count.items():
         per_entity_mentions[entity] = per_entity_mentions.get(entity, 0) + v
 
-    print(f"  {'entity':<14}  {'mentions':>9}  {'expected':>9}  {'tags'}")
+    print(f"  {'entity':<14}  {'mentions':>9}  {'expected':>9}  {'tags (×contributing agents)'}")
     print(f"  {'-'*14}  {'-'*9}  {'-'*9}  {'-'*30}")
     for entity in sorted(per_entity_mentions, key=lambda e: -per_entity_mentions[e]):
         # Doc IDs in this corpus are 0..NUM_DOCS-1, all dense.
         got_total = mentions_total(boot, pov, entity, 0, NUM_DOCS - 1)
         want_total = per_entity_mentions[entity]
         marker = "✓" if got_total == want_total else "✗"
-        tag_str = ",".join(sorted(expected_tags[entity]))
+        # Roll the provenance records up to distinct tags, annotating any
+        # tag that more than one agent independently asserted (×N).
+        tag_agents = {}
+        for tag, ag in expected_tag_records[entity]:
+            tag_agents.setdefault(tag, set()).add(ag)
+        tag_str = ",".join(
+            f"{t}×{len(ags)}" if len(ags) > 1 else t
+            for t, ags in sorted(tag_agents.items()))
         print(f"  {entity:<14}  {got_total:>9}  {want_total:>9}  "
               f"{tag_str}  {marker}")
         if got_total != want_total:
@@ -393,8 +414,9 @@ def main():
     print()
     print("=== the trick ===")
     print(f"  {NUM_AGENTS} concurrent agents all wrote into the same knowledge")
-    print(f"  graph with zero coordination. Tag-set unions and per-entity")
-    print(f"  / per-pair counters all aggregate correctly: this is the shape")
+    print(f"  graph with zero coordination. Tag records (with per-agent")
+    print(f"  provenance) union into one set per entity, and the per-entity")
+    print(f"  / per-pair counters aggregate correctly: this is the shape")
     print(f"  multi-agent LLM extraction pipelines keep reinventing badly.")
 
     send(boot, "exit;")
@@ -407,8 +429,10 @@ def main():
         if len(failures) > 20:
             print(f"  ... and {len(failures) - 20} more")
         sys.exit(1)
+    total_tag_records = sum(len(recs) for recs in expected_tag_records.values())
     print("\n=== self-check OK ===")
-    print(f"  verified {len(expected_tags)} tag sets + "
+    print(f"  verified {total_tag_records} tag provenance records across "
+          f"{len(expected_tag_records)} entities + "
           f"{len(expected_mention_count)} mention counters + "
           f"{len(expected_cooccur_count)} cooccurrence counters across "
           f"{NUM_AGENTS} concurrent agents")

--- a/examples/agent-swarm/graph.orly
+++ b/examples/agent-swarm/graph.orly
@@ -5,9 +5,15 @@
    shared POV. Every write is commutative -- there is zero coordination
    between agents:
 
-     *<['entity', e]>::({str})    |= {tag}    set union per entity
-     *<['mention', e, d]>::(int)  += 1        per (entity, doc) counter
-     *<['cooccur', a, b]>::(int)  += 1        per unordered-pair counter
+     *<['entity', e]>::({<{.tag, .agent}>})  |= {<{.tag,.agent}>}  per entity
+     *<['mention', e, d]>::(int)             += 1   per (entity, doc) counter
+     *<['cooccur', a, b]>::(int)             += 1   per unordered-pair counter
+
+   Each tag carries provenance: the entity tag set is a set OF records
+   <{.tag: str, .agent: str}> (storable record-sets are issue #90), so a
+   tag asserted by three different agents is three records -- corroboration
+   you can read back, not a collapsed single string. Distinct tags and
+   their contributing agents both fall out of the one set on read.
 
    This is the shape AI builders keep reinventing badly: many extractors
    need to roll up into one knowledge graph, and the naive "read, merge,
@@ -41,22 +47,25 @@
 
 package #1;
 
-/* ---------- entity -> tag set ---------- */
+/* ---------- entity -> set of (tag, agent) provenance records ---------- */
 
-tags_for_entity = (((*<['entity', e]>::({str})) if *<['entity', e]>::({str}?) is known else (empty {str}))) where {
+tags_for_entity = (((*<['entity', e]>::({<{.tag: str, .agent: str}>})) if *<['entity', e]>::({<{.tag: str, .agent: str}>}?) is known else (empty {<{.tag: str, .agent: str}>}))) where {
   e = given::(str);
 };
 
-/* Union one tag into the entity's set. First call creates with {t};
-   subsequent calls union -- both shapes commute under concurrent
-   callers writing different tags at the same key. */
+/* Union one (tag, agent) record into the entity's set. First call
+   creates with the singleton; subsequent calls union -- both shapes
+   commute under concurrent callers writing different records at the
+   same key. Re-asserting the same (tag, agent) is idempotent; the same
+   tag from a different agent is a distinct provenance record. */
 add_tag = (((1) effecting {
-  *<['entity', e]>::({str}) |= {t};
-} if *<['entity', e]>::({str}?) is known else (0) effecting {
-  new <['entity', e]> <- {t};
+  *<['entity', e]>::({<{.tag: str, .agent: str}>}) |= {<{.tag: t, .agent: agent}>};
+} if *<['entity', e]>::({<{.tag: str, .agent: str}>}?) is known else (0) effecting {
+  new <['entity', e]> <- {<{.tag: t, .agent: agent}>};
 })) where {
-  e = given::(str);
-  t = given::(str);
+  e     = given::(str);
+  t     = given::(str);
+  agent = given::(str);
 };
 
 /* ---------- per-(entity, doc) mention counter ---------- */
@@ -105,44 +114,55 @@ add_cooccur = (((1) effecting {
 
 test {
   /* Unknown keys read as identity values (empty set / 0). */
-  t1: tags_for_entity(.e: "Python") == (empty {str});
+  t1: tags_for_entity(.e: "Python") == (empty {<{.tag: str, .agent: str}>});
   t2: mention_count(.e: "Python", .d: 0) == 0;
   t3: cooccur_count(.a: "Python", .b: "GPT-4") == 0;
 
   /* First add_tag creates (returns 0); subsequent unions return 1. */
-  t4: add_tag(.e: "Python", .t: "language") == 0 {
-    t5: tags_for_entity(.e: "Python") == {"language"};
-    t6: add_tag(.e: "Python", .t: "popular") == 1 {
-      t7: tags_for_entity(.e: "Python") == {"language", "popular"};
-      /* Idempotent: re-adding doesn't grow the set. */
-      t8: add_tag(.e: "Python", .t: "popular") == 1 {
-        t9: tags_for_entity(.e: "Python") == {"language", "popular"};
+  t4: add_tag(.e: "Python", .t: "language", .agent: "a1") == 0 {
+    t5: tags_for_entity(.e: "Python") == {<{.tag: "language", .agent: "a1"}>};
+    t6: add_tag(.e: "Python", .t: "popular", .agent: "a1") == 1 {
+      t7: tags_for_entity(.e: "Python")
+            == {<{.tag: "language", .agent: "a1"}>,
+                <{.tag: "popular", .agent: "a1"}>};
+      /* Re-asserting the same (tag, agent) is idempotent. */
+      t8: add_tag(.e: "Python", .t: "popular", .agent: "a1") == 1 {
+        t9: tags_for_entity(.e: "Python")
+              == {<{.tag: "language", .agent: "a1"}>,
+                  <{.tag: "popular", .agent: "a1"}>};
+        /* Same tag, different agent -> a distinct provenance record. */
+        t10: add_tag(.e: "Python", .t: "popular", .agent: "a2") == 1 {
+          t11: tags_for_entity(.e: "Python")
+                 == {<{.tag: "language", .agent: "a1"}>,
+                     <{.tag: "popular", .agent: "a1"}>,
+                     <{.tag: "popular", .agent: "a2"}>};
+        };
       };
     };
   };
 
   /* Mention counter accumulates across calls; per-doc keys are
      independent; the range-fold sums them all. */
-  t10: add_mention(.e: "GPT-4", .d: 0) == 0 {
-    t11: mention_count(.e: "GPT-4", .d: 0) == 1;
-    t12: add_mention(.e: "GPT-4", .d: 0) == 1 {
-      t13: mention_count(.e: "GPT-4", .d: 0) == 2;
-      t14: add_mention(.e: "GPT-4", .d: 1) == 0 {
-        t15: mention_count(.e: "GPT-4", .d: 0) == 2;
-        t16: mention_count(.e: "GPT-4", .d: 1) == 1;
-        t17: mentions_total(.e: "GPT-4", .d_start: 0, .d_end: 1) == 3;
-        t18: mentions_total(.e: "GPT-4", .d_start: 5, .d_end: 9) == 0;
+  t12: add_mention(.e: "GPT-4", .d: 0) == 0 {
+    t13: mention_count(.e: "GPT-4", .d: 0) == 1;
+    t14: add_mention(.e: "GPT-4", .d: 0) == 1 {
+      t15: mention_count(.e: "GPT-4", .d: 0) == 2;
+      t16: add_mention(.e: "GPT-4", .d: 1) == 0 {
+        t17: mention_count(.e: "GPT-4", .d: 0) == 2;
+        t18: mention_count(.e: "GPT-4", .d: 1) == 1;
+        t19: mentions_total(.e: "GPT-4", .d_start: 0, .d_end: 1) == 3;
+        t20: mentions_total(.e: "GPT-4", .d_start: 5, .d_end: 9) == 0;
       };
     };
   };
 
   /* Cooccurrence counter, same shape as mention. */
-  t19: add_cooccur(.a: "Python", .b: "GPT-4") == 0 {
-    t20: cooccur_count(.a: "Python", .b: "GPT-4") == 1;
-    t21: add_cooccur(.a: "Python", .b: "GPT-4") == 1 {
-      t22: cooccur_count(.a: "Python", .b: "GPT-4") == 2;
+  t21: add_cooccur(.a: "Python", .b: "GPT-4") == 0 {
+    t22: cooccur_count(.a: "Python", .b: "GPT-4") == 1;
+    t23: add_cooccur(.a: "Python", .b: "GPT-4") == 1 {
+      t24: cooccur_count(.a: "Python", .b: "GPT-4") == 2;
       /* Reversed-order pair is a DIFFERENT key (driver canonicalises). */
-      t23: cooccur_count(.a: "GPT-4", .b: "Python") == 0;
+      t25: cooccur_count(.a: "GPT-4", .b: "Python") == 0;
     };
   };
 };


### PR DESCRIPTION
## Summary

Now that storable record-sets work (#90), this enriches the agent-swarm demo's entity tag set from a bag of bare strings to a set of **provenance records**:

```orly
# before
<['entity', e]>::({str})
# after
<['entity', e]>::({<{.tag: str, .agent: str}>})
```

Each tag now records **which agent asserted it**. A tag three agents independently produce is three records you can read back — corroboration, not a collapsed string. This is exactly the agent-swarm angle: many independent extractors writing into one shared graph, and now you can see who contributed what. The rollup annotates tags by how many distinct agents asserted them:

```
  entity          mentions   expected  tags (×contributing agents)
  Python                15         15  language×5,popular×5  ✓
  OpenAI                14         14  ai-lab×4,company×4  ✓
  ...
```

The `mention` / `cooccur` `int` counters are unchanged — they're the `+=` contention story, where records don't apply.

## Changes

- `graph.orly`: tag set + `add_tag` use the record schema (`add_tag` gains `.agent`); inline tests cover same-`(tag, agent)` idempotency **and** the same-tag-different-agent distinct-record case.
- `demo.py` / `demo.go`: agents stamp their name on every tag; ground truth tracks `(tag, agent)` records; pre-init seeds with a dedicated `"seed"` agent; the rollup shows per-tag contributor counts.
- `README.md`: schema, comparison table, and "what the demo proves" updated for provenance.

## Validation

- `orlyc -m graph.orly`: inline tests pass.
- `./run.sh` (Python) and `./run-go.sh` (Go): both self-checks green end-to-end — 147 tag provenance records across 25 entities, 105 mention counters, 76 cooccurrence counters, under 8 concurrent agents.
- `go vet` / `gofmt` clean.

Depends on #90 (merged); the record-set is only storable with that fix in `master`.