### PR TITLE
Exhaustive `when` variant match (#95 Phase 4)

### DIFF
--- a/orly/code_gen/builder.cc
+++ b/orly/code_gen/builder.cc
@@ -177,6 +177,7 @@ bool IsCoreSeq(const Expr::TExpr::TPtr &expr) {
     virtual void operator()(const Expr::TUserId        *) const {}
     virtual void operator()(const Expr::TVariantCtor   *) const {}
     virtual void operator()(const Expr::TVariantIs      *) const {}
+    virtual void operator()(const Expr::TWhen          *) const {}
     virtual void operator()(const Expr::TWhere         *) const {}
     virtual void operator()(const Expr::TWhile         *) const { Res = true; }
     virtual void operator()(const Expr::TXor           *) const {}
@@ -693,6 +694,19 @@ TInline::TPtr Orly::CodeGen::Build(const L0::TPackage *package, const Expr::TExp
     virtual void operator()(const Expr::TVariantIs *that) const {
       Res = TVariantIs::TPtr(new TVariantIs(Package, ReturnType,
           Build(Package, that->GetExpr(), false), that->GetWhich()));
+    }
+    virtual void operator()(const Expr::TWhen *that) const {
+      /* Lower to a nested ternary on the operand's active arm (#95 Phase 4),
+         reusing the M4 GetWhich() primitive. The operand inline is shared
+         across arms; exhaustiveness was checked at type time, so the last
+         arm is the unconditional fall-through. */
+      TInline::TPtr operand = Build(Package, that->GetOperand(), false);
+      TVariantWhen::TArmVec arms;
+      for (size_t arm_idx = 0; arm_idx < that->GetArmCount(); ++arm_idx) {
+        arms.emplace_back(that->GetArmWhich(arm_idx),
+            Build(Package, that->GetArmBody(arm_idx), false));
+      }
+      Res = TInline::TPtr(new TVariantWhen(Package, ReturnType, operand, arms));
     }
     virtual void operator()(const Expr::TWhere *that) const { Res = Build(Package, that->GetExpr(), true); }
     virtual void operator()(const Expr::TWhile *that) const {

--- a/orly/code_gen/variant_access.cc
+++ b/orly/code_gen/variant_access.cc
@@ -44,3 +44,20 @@ void TVariantMember::WriteExpr(TCppPrinter &out) const {
      active -- callers gate this with `is <Tag>`. */
   out << '(' << Operand << ").GetV" << Tag << "()";
 }
+
+TVariantWhen::TVariantWhen(const L0::TPackage *package,
+                           const Type::TType &type,
+                           const TInline::TPtr &operand,
+                           const TArmVec &arms)
+    : TInline(package, type), Operand(operand), Arms(arms) {}
+
+void TVariantWhen::WriteExpr(TCppPrinter &out) const {
+  /* Nested ternary on the operand's active arm. All arms but the last are
+     guarded; the last is the exhaustive fall-through. */
+  out << '(';
+  for (size_t arm_idx = 0; arm_idx + 1 < Arms.size(); ++arm_idx) {
+    out << "((" << Operand << ").GetWhich() == " << Arms[arm_idx].first
+        << ") ? (" << Arms[arm_idx].second << ") : ";
+  }
+  out << '(' << Arms.back().second << "))";
+}

--- a/orly/code_gen/variant_access.h
+++ b/orly/code_gen/variant_access.h
@@ -33,6 +33,8 @@
 
 #include <cstddef>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include <orly/code_gen/cpp_printer.h>
 #include <orly/code_gen/inline.h>
@@ -85,6 +87,38 @@ namespace Orly {
         TInline::TPtr Operand;
         std::string Tag;
     }; // TVariantMember
+
+    /* Exhaustive `(e) when { Tag: body; ... }` (#95 Phase 4) -> a nested
+       ternary on the operand's active arm:
+         ((op).GetWhich() == w0) ? (b0) : ((op).GetWhich() == w1) ? (b1) : (bN)
+       The last arm is unconditional (exhaustiveness is checked at type
+       time, so the trailing arm always applies if none earlier did). */
+    class TVariantWhen : public TInline {
+      NO_COPY(TVariantWhen);
+      public:
+
+      typedef std::vector<std::pair<size_t, TInline::TPtr>> TArmVec;
+
+      TVariantWhen(const L0::TPackage *package,
+                   const Type::TType &type,
+                   const TInline::TPtr &operand,
+                   const TArmVec &arms);
+
+      void WriteExpr(TCppPrinter &out) const;
+
+      virtual void AppendDependsOn(std::unordered_set<TInline::TPtr> &dependency_set) const override {
+        dependency_set.insert(Operand);
+        Operand->AppendDependsOn(dependency_set);
+        for (const auto &arm : Arms) {
+          dependency_set.insert(arm.second);
+          arm.second->AppendDependsOn(dependency_set);
+        }
+      }
+
+      private:
+        TInline::TPtr Operand;
+        TArmVec Arms;
+    }; // TVariantWhen
 
   } // CodeGen
 

--- a/orly/expr.h
+++ b/orly/expr.h
@@ -73,5 +73,6 @@
 #include <orly/expr/user_id.h>
 #include <orly/expr/variant.h>
 #include <orly/expr/variant_is.h>
+#include <orly/expr/when.h>
 #include <orly/expr/where.h>
 #include <orly/expr/while.h>

--- a/orly/expr/addr_walker.cc
+++ b/orly/expr/addr_walker.cc
@@ -58,6 +58,12 @@ class expr_visitor_t
   virtual void operator()(const TUserId *)      const {}
   virtual void operator()(const TVariantCtor *that) const { Unary(that); }
   virtual void operator()(const TVariantIs *that) const { Unary(that); }
+  virtual void operator()(const TWhen *that) const {
+    Yield(that->GetOperand());
+    for (size_t arm_idx = 0; arm_idx < that->GetArmCount(); ++arm_idx) {
+      Yield(that->GetArmBody(arm_idx));
+    }
+  }
   // Trig
   virtual void operator()(const TCos *that)             const { Unary(that); }
   virtual void operator()(const TSin *that)             const { Unary(that); }
@@ -286,6 +292,12 @@ class expr_visitor_t
     virtual void operator()(const TUserId *)      const {}
     virtual void operator()(const TVariantCtor *that) const { Unary(that); }
     virtual void operator()(const TVariantIs *that) const { Unary(that); }
+    virtual void operator()(const TWhen *that) const {
+      Yield(that->GetOperand());
+      for (size_t arm_idx = 0; arm_idx < that->GetArmCount(); ++arm_idx) {
+        Yield(that->GetArmBody(arm_idx));
+      }
+    }
     // Trig
     virtual void operator()(const TCos *that)             const { Unary(that); }
     virtual void operator()(const TSin *that)             const { Unary(that); }

--- a/orly/expr/visitor.h
+++ b/orly/expr/visitor.h
@@ -113,6 +113,7 @@ namespace Orly {
     class TUserId;
     class TVariantCtor;
     class TVariantIs;
+    class TWhen;
     class TWhere;
     class TWhile;
     class TXor;
@@ -208,6 +209,7 @@ namespace Orly {
       virtual void operator()(const TUserId        *) const = 0;
       virtual void operator()(const TVariantCtor   *) const = 0;
       virtual void operator()(const TVariantIs     *) const = 0;
+      virtual void operator()(const TWhen          *) const = 0;
       virtual void operator()(const TWhere         *) const = 0;
       virtual void operator()(const TWhile         *) const = 0;
       virtual void operator()(const TXor           *) const = 0;

--- a/orly/expr/walker.cc
+++ b/orly/expr/walker.cc
@@ -312,6 +312,12 @@ void Orly::Expr::ForEachExpr(const TExpr::TPtr &root, const TCb &cb, bool includ
     virtual void operator()(const TVariantIs *that) const {
       Unary(that);
     }
+    virtual void operator()(const TWhen *that) const {
+      Yield(that->GetOperand());
+      for (size_t arm_idx = 0; arm_idx < that->GetArmCount(); ++arm_idx) {
+        Yield(that->GetArmBody(arm_idx));
+      }
+    }
     virtual void operator()(const TWhere *that) const {
       Unary(that);
       if (IncludeInnerFuncs) {

--- a/orly/expr/when.cc
+++ b/orly/expr/when.cc
@@ -1,0 +1,172 @@
+/* <orly/expr/when.cc>
+
+   Implements <orly/expr/when.h>
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <orly/expr/when.h>
+
+#include <unordered_set>
+
+#include <base/as_str.h>
+#include <orly/error.h>
+#include <orly/expr/visitor.h>
+#include <orly/type.h>
+#include <orly/type/equal_visitor.h>
+#include <orly/type/impl.h>
+#include <orly/type/unwrap.h>
+#include <orly/type/variant.h>
+
+using namespace Orly;
+using namespace Orly::Expr;
+
+static TWhen::TExprVec MakeContainer(const TExpr::TPtr &operand, const TWhen::TExprVec &bodies) {
+  TWhen::TExprVec out;
+  out.reserve(bodies.size() + 1U);
+  out.push_back(Base::AssertTrue(operand));
+  for (const auto &body : bodies) {
+    out.push_back(Base::AssertTrue(body));
+  }
+  return out;
+}
+
+TWhen::TPtr TWhen::New(
+    const TExpr::TPtr &operand,
+    const std::vector<std::string> &tags,
+    const TExprVec &bodies,
+    const TPosRange &pos_range) {
+  return TWhen::TPtr(new TWhen(operand, tags, bodies, pos_range));
+}
+
+TWhen::TWhen(
+    const TExpr::TPtr &operand,
+    const std::vector<std::string> &tags,
+    const TExprVec &bodies,
+    const TPosRange &pos_range)
+    : TNAry(MakeContainer(operand, bodies), pos_range), Tags(tags) {
+  assert(tags.size() == bodies.size());
+}
+
+void TWhen::Accept(const TVisitor &visitor) const {
+  visitor(this);
+}
+
+size_t TWhen::GetArmWhich(size_t arm_idx) const {
+  const Type::TVariant *variant = Type::Unwrap(GetOperand()->GetType()).TryAs<Type::TVariant>();
+  if (!variant) {
+    throw TExprError(HERE, GetPosRange(), "`when` operand is not a variant type");
+  }
+  const std::string &tag = Tags[arm_idx];
+  size_t idx = 0;
+  for (const auto &elem : variant->GetElems()) {
+    if (elem.first == tag) {
+      return idx;
+    }
+    ++idx;
+  }
+  std::string msg = Base::AsStr("`when` arm `", tag, "` names a tag that is not an arm of the operand variant type");
+  throw TExprError(HERE, GetPosRange(), msg.c_str());
+}
+
+Type::TType TWhen::GetTypeImpl() const {
+  /* Operand must be a variant. */
+  const Type::TVariant *variant = Type::Unwrap(GetOperand()->GetType()).TryAs<Type::TVariant>();
+  if (!variant) {
+    throw TExprError(HERE, GetPosRange(), "`when` operand must be a variant type");
+  }
+  const Type::TVariantElems &elems = variant->GetElems();
+
+  /* Exhaustiveness: every arm names a real tag, with no duplicates, and
+     every tag of the variant has an arm. */
+  std::unordered_set<std::string> seen;
+  for (const auto &tag : Tags) {
+    if (elems.find(tag) == elems.end()) {
+      std::string msg = Base::AsStr("`when` arm `", tag, "` is not a tag of the operand variant type");
+      throw TExprError(HERE, GetPosRange(), msg.c_str());
+    }
+    if (!seen.insert(tag).second) {
+      std::string msg = Base::AsStr("`when` has a duplicate arm for tag `", tag, "`");
+      throw TExprError(HERE, GetPosRange(), msg.c_str());
+    }
+  }
+  for (const auto &elem : elems) {
+    if (seen.find(elem.first) == seen.end()) {
+      std::string msg = Base::AsStr("`when` is not exhaustive: missing arm for tag `", elem.first, "`");
+      throw TExprError(HERE, GetPosRange(), msg.c_str());
+    }
+  }
+  if (Tags.empty()) {
+    throw TExprError(HERE, GetPosRange(), "`when` must have at least one arm");
+  }
+
+  /* Result type: the unified type of the arm bodies. Mirrors the join in
+     TIfElse::GetTypeImpl (Type::TEqualVisitor). */
+  class TWhenJoinVisitor : public Type::TEqualVisitor {
+    NO_COPY(TWhenJoinVisitor);
+    public:
+    TWhenJoinVisitor(Type::TType &type, const TPosRange &pos_range) : TEqualVisitor(type, pos_range) {}
+    virtual void operator()(const Type::TAny *, const Type::TAny *) const {
+      throw TExprError(HERE, PosRange, "`when` arms do not resolve to a single result type");
+    }
+    virtual void operator()(const Type::TAny *, const Type::TAddr     *rhs) const { Type = rhs->AsType(); }
+    virtual void operator()(const Type::TAny *, const Type::TBool     *rhs) const { Type = rhs->AsType(); }
+    virtual void operator()(const Type::TAny *, const Type::TDict     *rhs) const { Type = rhs->AsType(); }
+    virtual void operator()(const Type::TAny *, const Type::TId       *rhs) const { Type = rhs->AsType(); }
+    virtual void operator()(const Type::TAny *, const Type::TInt      *rhs) const { Type = rhs->AsType(); }
+    virtual void operator()(const Type::TAny *, const Type::TList     *rhs) const { Type = rhs->AsType(); }
+    virtual void operator()(const Type::TAny *, const Type::TMutable  *rhs) const { Type = rhs->AsType(); }
+    virtual void operator()(const Type::TAny *, const Type::TObj      *rhs) const { Type = rhs->AsType(); }
+    virtual void operator()(const Type::TAny *, const Type::TReal     *rhs) const { Type = rhs->AsType(); }
+    virtual void operator()(const Type::TAny *, const Type::TSet      *rhs) const { Type = rhs->AsType(); }
+    virtual void operator()(const Type::TAny *, const Type::TSeq      *rhs) const { Type = rhs->AsType(); }
+    virtual void operator()(const Type::TAny *, const Type::TStr      *rhs) const { Type = rhs->AsType(); }
+    virtual void operator()(const Type::TAny *, const Type::TTimeDiff *rhs) const { Type = rhs->AsType(); }
+    virtual void operator()(const Type::TAny *, const Type::TTimePnt  *rhs) const { Type = rhs->AsType(); }
+    virtual void operator()(const Type::TAddr     *lhs, const Type::TAny *) const final { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TBool     *lhs, const Type::TAny *) const final { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TDict     *lhs, const Type::TAny *) const final { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TId       *lhs, const Type::TAny *) const final { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TInt      *lhs, const Type::TAny *) const final { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TList     *lhs, const Type::TAny *) const final { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TMutable  *lhs, const Type::TAny *) const final { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TObj      *lhs, const Type::TAny *) const final { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TReal     *lhs, const Type::TAny *) const final { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TSet      *lhs, const Type::TAny *) const final { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TSeq      *lhs, const Type::TAny *) const final { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TStr      *lhs, const Type::TAny *) const final { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TTimeDiff *lhs, const Type::TAny *) const final { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TTimePnt  *lhs, const Type::TAny *) const final { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TAddr     *lhs, const Type::TAddr     *) const { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TBool     *lhs, const Type::TBool     *) const { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TDict     *lhs, const Type::TDict     *) const { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TId       *lhs, const Type::TId       *) const { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TInt      *lhs, const Type::TInt      *) const { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TList     *lhs, const Type::TList     *) const { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TObj      *lhs, const Type::TObj      *) const { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TReal     *lhs, const Type::TReal     *) const { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TSet      *lhs, const Type::TSet      *) const { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TStr      *lhs, const Type::TStr      *) const { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TTimeDiff *lhs, const Type::TTimeDiff *) const { Type = lhs->AsType(); }
+    virtual void operator()(const Type::TTimePnt  *lhs, const Type::TTimePnt  *) const { Type = lhs->AsType(); }
+  };  // TWhenJoinVisitor
+
+  Type::TType type = GetArmBody(0)->GetType();
+  for (size_t arm_idx = 1; arm_idx < Tags.size(); ++arm_idx) {
+    Type::TType joined;
+    Type::TType::Accept(type, GetArmBody(arm_idx)->GetType(), TWhenJoinVisitor(joined, GetPosRange()));
+    type = joined;
+  }
+  return type;
+}

--- a/orly/expr/when.h
+++ b/orly/expr/when.h
@@ -1,0 +1,100 @@
+/* <orly/expr/when.h>
+
+   `TWhen` -- the exhaustive `(e) when { Tag: body; ... }` variant match
+   expression IR node (#95 Phase 4). The operand must type-check as a
+   `Type::TVariant`; the arm tags must cover its tag set EXACTLY (every
+   arm a real tag, no duplicates, no missing arm), checked at compile
+   time in `GetTypeImpl`. The result type is the unified type of the arm
+   bodies (the same join `TIfElse` uses).
+
+   It carries the operand and the arm bodies as `TNAry` children
+   (container[0] is the operand; container[1..] are the bodies, parallel
+   to `Tags`). The code_gen layer lowers it to a nested ternary on the
+   operand's `GetWhich()` selecting the matching arm -- reusing the M4
+   primitives. Arm bodies read the active payload via the `e.<Tag>`
+   accessor; v1 has no payload binder.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <base/class_traits.h>
+#include <orly/expr/n_ary.h>
+
+namespace Orly {
+
+  namespace Expr {
+
+    class TWhen
+        : public TNAry<std::vector<TExpr::TPtr>> {
+      NO_COPY(TWhen);
+      public:
+
+      typedef std::shared_ptr<TWhen> TPtr;
+
+      typedef std::vector<TExpr::TPtr> TExprVec;
+
+      /* `tags` and `bodies` are parallel (one per arm); `operand` is the
+         matched variant. */
+      static TPtr New(
+          const TExpr::TPtr &operand,
+          const std::vector<std::string> &tags,
+          const TExprVec &bodies,
+          const TPosRange &pos_range);
+
+      virtual void Accept(const TVisitor &visitor) const;
+
+      const TExpr::TPtr &GetOperand() const {
+        return GetContainer()[0];
+      }
+
+      size_t GetArmCount() const {
+        return Tags.size();
+      }
+
+      const std::string &GetArmTag(size_t arm_idx) const {
+        return Tags[arm_idx];
+      }
+
+      const TExpr::TPtr &GetArmBody(size_t arm_idx) const {
+        return GetContainer()[arm_idx + 1];
+      }
+
+      /* The asciibetical index (the value the generated native struct's
+         GetWhich() returns) of arm `arm_idx`'s tag in the operand variant
+         type. Valid once the operand has type-checked as a variant. */
+      size_t GetArmWhich(size_t arm_idx) const;
+
+      virtual Type::TType GetTypeImpl() const override;
+
+      private:
+
+      TWhen(
+          const TExpr::TPtr &operand,
+          const std::vector<std::string> &tags,
+          const TExprVec &bodies,
+          const TPosRange &pos_range);
+
+      std::vector<std::string> Tags;
+
+    };  // TWhen
+
+  }  // Expr
+
+}  // Orly

--- a/orly/orly.nycr
+++ b/orly/orly.nycr
@@ -150,6 +150,7 @@ to_upper_kwd      = '"to_upper"';
 unknown_kwd       = '"unknown"' unary_prec right;
 user_id_kwd       = '"user_id"';
 using_kwd         = '"using"';
+when_kwd          = '"when"';
 where_kwd         = '"where"';
 while_kwd	  = '"while"' lowest_prec left;  /* like if */
 with_kwd          = '"with"';
@@ -563,6 +564,16 @@ assert_expr : expr -> open_paren expr close_paren assert_kwd open_brace opt_asse
   bad_assertion       : assertion -> error semi;
   labeled_assertion   : assertion -> name colon expr semi;
   unlabeled_assertion : assertion -> expr semi;
+
+when_expr : expr -> open_paren expr close_paren when_kwd open_brace opt_when_arm_seq close_brace;
+
+  opt_when_arm_seq;
+  no_when_arm_seq : opt_when_arm_seq -> empty;
+  when_arm_seq    : opt_when_arm_seq -> when_arm opt_when_arm_seq;
+
+  when_arm;
+  bad_when_arm     : when_arm -> error semi;
+  labeled_when_arm : when_arm -> name colon expr semi;
 
 effecting_expr : expr -> open_paren expr close_paren effecting_kwd stmt_block;
 

--- a/orly/spa/checkpoint.cc
+++ b/orly/spa/checkpoint.cc
@@ -217,6 +217,7 @@ class TExprVisitor : public Orly::Checkpoint::Syntax::TExpr::TVisitor {
   virtual void operator()(const Orly::Checkpoint::Syntax::TPrefixExists *) const {NOT_IMPLEMENTED();}
   virtual void operator()(const Orly::Checkpoint::Syntax::TEffectingExpr *) const {NOT_IMPLEMENTED();}
   virtual void operator()(const Orly::Checkpoint::Syntax::TAssertExpr *) const {NOT_IMPLEMENTED();}
+  virtual void operator()(const Orly::Checkpoint::Syntax::TWhenExpr *) const {NOT_IMPLEMENTED();}
   virtual void operator()(const Orly::Checkpoint::Syntax::TWhereExpr *) const {NOT_IMPLEMENTED();}
   virtual void operator()(const Orly::Checkpoint::Syntax::TPrefixMinus *) const;
   virtual void operator()(const Orly::Checkpoint::Syntax::TPrefixPlus *) const;

--- a/orly/spa/command.cc
+++ b/orly/spa/command.cc
@@ -226,6 +226,7 @@ namespace FooBar {
     virtual void operator()(const Syntax::TPrefixExists *) const {NOT_IMPLEMENTED();}
     virtual void operator()(const Syntax::TEffectingExpr *) const {NOT_IMPLEMENTED();}
     virtual void operator()(const Syntax::TAssertExpr *) const {NOT_IMPLEMENTED();}
+    virtual void operator()(const Syntax::TWhenExpr *) const {NOT_IMPLEMENTED();}
     virtual void operator()(const Syntax::TWhereExpr *) const {NOT_IMPLEMENTED();}
     virtual void operator()(const Syntax::TPrefixMinus *) const;
     virtual void operator()(const Syntax::TPrefixPlus *) const;

--- a/orly/synth/cst_utils.h
+++ b/orly/synth/cst_utils.h
@@ -220,6 +220,27 @@ namespace Orly {
     };  // ItemInfo<Package::Syntax::TAssertion>
 
     template <>
+    struct ItemInfo<Package::Syntax::TWhenArm> {
+      NO_CONSTRUCTION(ItemInfo);
+
+      typedef Package::Syntax::TOptWhenArmSeq TOptNode;
+      typedef Package::Syntax::TNoWhenArmSeq  TNoNode;
+      typedef Package::Syntax::TWhenArmSeq    TNode;
+      typedef Package::Syntax::TWhenArm       TItem;
+
+      static const TItem *GetItem(const TNode *node) {
+        assert(node);
+        return node->GetWhenArm();
+      }
+
+      static const TNode *TryGetNext(const TNode *node) {
+        assert(node);
+        return TryGetNode<TNode, TNoNode>(node->GetOptWhenArmSeq());
+      }
+
+    };  // ItemInfo<Package::Syntax::TWhenArm>
+
+    template <>
     struct ItemInfo<Package::Syntax::TDbKeysMember> {
       NO_CONSTRUCTION(ItemInfo);
 

--- a/orly/synth/get_pos_range.cc
+++ b/orly/synth/get_pos_range.cc
@@ -562,6 +562,10 @@ TPosRange Orly::Synth::GetPosRange(const Package::Syntax::TUserIdExpr *that) {
 }
 
 template <>
+TPosRange Orly::Synth::GetPosRange(const Package::Syntax::TWhenExpr *that) {
+  return Orly::Synth::GetPosRange(that->GetOpenParen(), that->GetCloseBrace());
+}
+
 TPosRange Orly::Synth::GetPosRange(const Package::Syntax::TWhereExpr *that) {
   return Orly::Synth::GetPosRange(that->GetOpenParen(), that->GetCloseBrace());
 }
@@ -676,6 +680,7 @@ TPosRange Orly::Synth::GetPosRange(const Package::Syntax::TExpr *expr) {
     virtual void operator()(const Package::Syntax::TUnknownCtor          *that) const { PosRange = Orly::Synth::GetPosRange(that); }
     virtual void operator()(const Package::Syntax::TUserIdExpr           *that) const { PosRange = Orly::Synth::GetPosRange(that); }
     virtual void operator()(const Package::Syntax::TVariantCtor          *that) const { PosRange = Orly::Synth::GetPosRange(that); }
+    virtual void operator()(const Package::Syntax::TWhenExpr             *that) const { PosRange = Orly::Synth::GetPosRange(that); }
     virtual void operator()(const Package::Syntax::TWhereExpr            *that) const { PosRange = Orly::Synth::GetPosRange(that); }
     private:
     TPosRange &PosRange;

--- a/orly/synth/get_pos_range.h
+++ b/orly/synth/get_pos_range.h
@@ -333,6 +333,8 @@ namespace Orly {
     TPosRange GetPosRange(const Package::Syntax::TUserIdExpr *that);
 
     template <>
+    TPosRange GetPosRange(const Package::Syntax::TWhenExpr *that);
+
     TPosRange GetPosRange(const Package::Syntax::TWhereExpr *that);
 
     template <>

--- a/orly/synth/given_collector.h
+++ b/orly/synth/given_collector.h
@@ -236,6 +236,7 @@ namespace Orly {
           Push(payload->GetExpr());
         }
       }
+      virtual void operator()(const Package::Syntax::TWhenExpr *that) const { Push(that->GetExpr()); }
       virtual void operator()(const Package::Syntax::TWhereExpr *that) const { Push(that->GetExpr()); }
 
       /* Push expr onto the stack */

--- a/orly/synth/new_expr.cc
+++ b/orly/synth/new_expr.cc
@@ -71,6 +71,7 @@
 #include <orly/synth/time_pnt_ctor.h>
 #include <orly/synth/unknown_ctor.h>
 #include <orly/synth/user_id_expr.h>
+#include <orly/synth/when_expr.h>
 #include <orly/synth/where_expr.h>
 #include <orly/synth/while_expr.h>
 
@@ -216,6 +217,7 @@ TExpr *TExprFactory::NewExpr(const Package::Syntax::TExpr *root) const {
     virtual void operator()(const Syntax::TUnknownCtor *that) const { Out = new TUnknownCtor(that); }
     virtual void operator()(const Syntax::TVariantCtor *that) const { Out = new TVariantCtor(ExprFactory, that); }
     virtual void operator()(const Syntax::TUserIdExpr *that) const { Out = new TUserIdExpr(that); }
+    virtual void operator()(const Syntax::TWhenExpr *that) const { Out = new TWhenExpr(ExprFactory, that); }
     virtual void operator()(const Syntax::TWhereExpr *that) const { Out = new TWhereExpr(ExprFactory, that); }
     private:
     void OnAffix(const Syntax::TExpr *that, TAffixExpr::TNew new_, const TPosRange &pos_range) const {

--- a/orly/synth/when_expr.cc
+++ b/orly/synth/when_expr.cc
@@ -1,0 +1,99 @@
+/* <orly/synth/when_expr.cc>
+
+   Implements <orly/synth/when_expr.h>.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <orly/synth/when_expr.h>
+
+#include <cassert>
+
+#include <base/assert_true.h>
+#include <orly/expr/when.h>
+#include <orly/synth/cst_utils.h>
+#include <orly/synth/get_pos_range.h>
+#include <orly/synth/new_expr.h>
+
+using namespace Orly;
+using namespace Orly::Synth;
+
+TWhenExpr::TWhenExpr(const TExprFactory *expr_factory, const Package::Syntax::TWhenExpr *when_expr)
+    : WhenExpr(Base::AssertTrue(when_expr)), Operand(nullptr) {
+  class TArmVisitor
+      : public Package::Syntax::TWhenArm::TVisitor {
+    NO_COPY(TArmVisitor);
+    public:
+    TArmVisitor(std::vector<std::string> &tags, std::vector<TExpr *> &bodies, const TExprFactory *expr_factory)
+        : Tags(tags), Bodies(bodies), ExprFactory(expr_factory) {}
+    virtual void operator()(const Package::Syntax::TBadWhenArm *) const { /* DO NOTHING */ }
+    virtual void operator()(const Package::Syntax::TLabeledWhenArm *that) const {
+      Tags.push_back(TName(that->GetName()).GetText());
+      Bodies.push_back(ExprFactory->NewExpr(that->GetExpr()));
+    }
+    private:
+    std::vector<std::string> &Tags;
+    std::vector<TExpr *> &Bodies;
+    const TExprFactory *ExprFactory;
+  };  // TArmVisitor
+  assert(expr_factory);
+  try {
+    Operand = expr_factory->NewExpr(WhenExpr->GetExpr());
+    TArmVisitor visitor(Tags, Bodies, expr_factory);
+    ForEach<Package::Syntax::TWhenArm>(WhenExpr->GetOptWhenArmSeq(),
+        [&visitor](const Package::Syntax::TWhenArm *arm) -> bool {
+          arm->Accept(visitor);
+          return true;
+        });
+  } catch (...) {
+    Cleanup();
+    throw;
+  }
+}
+
+TWhenExpr::~TWhenExpr() {
+  Cleanup();
+}
+
+void TWhenExpr::Cleanup() {
+  delete Operand;
+  for (auto *body : Bodies) {
+    delete body;
+  }
+}
+
+Expr::TExpr::TPtr TWhenExpr::Build() const {
+  Expr::TWhen::TExprVec bodies;
+  bodies.reserve(Bodies.size());
+  for (auto *body : Bodies) {
+    bodies.push_back(body->Build());
+  }
+  return Expr::TWhen::New(Operand->Build(), Tags, bodies, GetPosRange(WhenExpr));
+}
+
+void TWhenExpr::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
+  assert(cb);
+  Operand->ForEachInnerScope(cb);
+  for (auto *body : Bodies) {
+    body->ForEachInnerScope(cb);
+  }
+}
+
+void TWhenExpr::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
+  assert(cb);
+  Operand->ForEachRef(cb);
+  for (auto *body : Bodies) {
+    body->ForEachRef(cb);
+  }
+}

--- a/orly/synth/when_expr.h
+++ b/orly/synth/when_expr.h
@@ -1,0 +1,70 @@
+/* <orly/synth/when_expr.h>
+
+   Synth-layer node for the exhaustive `(e) when { Tag: body; ... }`
+   variant match expression (#95 Phase 4). Lowers to `Expr::TWhen`.
+   Holds the operand and the arm bodies as plain sub-expressions (arms
+   introduce no new binding -- a v1 arm body reads the active payload via
+   the `e.<Tag>` accessor), so unlike `TAssertExpr` it needs no thatable
+   or symbol machinery.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <base/class_traits.h>
+#include <orly/orly.package.cst.h>
+#include <orly/synth/expr.h>
+
+namespace Orly {
+
+  namespace Synth {
+
+    class TExprFactory;
+
+    class TWhenExpr
+        : public TExpr {
+      NO_COPY(TWhenExpr);
+      public:
+
+      TWhenExpr(const TExprFactory *expr_factory, const Package::Syntax::TWhenExpr *when_expr);
+
+      virtual ~TWhenExpr();
+
+      virtual Expr::TExpr::TPtr Build() const;
+
+      virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
+
+      virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
+
+      private:
+
+      void Cleanup();
+
+      const Package::Syntax::TWhenExpr *WhenExpr;
+
+      TExpr *Operand;
+
+      std::vector<std::string> Tags;
+
+      std::vector<TExpr *> Bodies;
+
+    };  // TWhenExpr
+
+  }  // Synth
+
+}  // Orly

--- a/tests/lang_tests/general/variants_when.orly
+++ b/tests/lang_tests/general/variants_when.orly
@@ -1,0 +1,76 @@
+/* <orly/lang_tests/general/variants_when.orly>
+
+   End-to-end test for issue #95 Phase 4: the exhaustive `when` variant
+   match expression.
+
+   `(e) when { Tag: body; ... }` branches on the active arm of a variant
+   `e`, evaluating the matching arm's body. The arm tags must cover the
+   variant's tag set EXACTLY -- a missing, unknown, or duplicate arm is a
+   compile-time error (verified by hand; see below). The result is the
+   unified type of the arm bodies. It lowers to a nested ternary on the
+   operand's GetWhich(), reusing the Phase 3 M4 primitives; an arm body
+   reads the active payload via the `e.<Tag>` accessor (v1 has no payload
+   binder).
+
+   Syntax: `(operand) when { Tag: body; ... }` -- the operand is
+   parenthesised (like `where`/`assert`), and every arm ends in `;`.
+
+   Exhaustiveness is enforced at compile time (checked manually with
+   orlyc, not encoded here since lang_test has no "expect compile error"
+   form):
+     - `(v) when { Integer: ...; }` over `<| Integer(int) | Deleted |>`
+       -> "`when` is not exhaustive: missing arm for tag `Deleted`"
+     - an arm naming a tag not in the variant
+       -> "`when` arm `Bogus` is not a tag of the operand variant type"
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+read_var = (*<[n]>::(<| Integer(int) | Deleted |>)) where {
+  n = given::(int);
+};
+
+/* Exhaustive fold: the typed arm yields its payload, the tag-only arm a
+   sentinel. The arm body reads the payload via the `.Integer` accessor. */
+classify = ((v) when {
+  Integer: v.Integer;
+  Deleted: -1;
+}) where {
+  v = given::(<| Integer(int) | Deleted |>);
+};
+
+with {
+  <[400]> <- <| Integer(int) | Deleted |>.Integer(7);
+  <[401]> <- <| Integer(int) | Deleted |>.Deleted;
+} test {
+  /* `when` over a stored, read-back variant selects the right arm. */
+  t1: classify(.v: read_var(.n: 400)) == 7;
+  t2: classify(.v: read_var(.n: 401)) == -1;
+
+  /* `when` over an inline-constructed variant. */
+  t3: ((<| Integer(int) | Deleted |>.Integer(5)) when {
+         Integer: 100;
+         Deleted: 0;
+       }) == 100;
+  t4: ((<| Integer(int) | Deleted |>.Deleted) when {
+         Integer: 100;
+         Deleted: 0;
+       }) == 0;
+
+  /* Arm order does not matter; coverage does. */
+  t5: ((<| Integer(int) | Deleted |>.Integer(9)) when {
+         Deleted: 0;
+         Integer: 9;
+       }) == 9;
+};


### PR DESCRIPTION
## Summary

The headline sum-types capability (#95 Phase 4): an **exhaustive `when` match** over a variant's arms, with **compile-time exhaustiveness checking**. This is what moves heterogeneous-event folds from the driver into orlyscript — the whole point of sum types.

```orly
classify = ((v) when {
  Integer: v.Integer;   # arm body reads the payload via the M4 `.<Tag>` accessor
  Deleted: -1;
}) where { v = given::(<| Integer(int) | Deleted |>); };
```

Syntax: the operand is parenthesised (like `where`/`assert`), and every arm ends in `;`. `match` stays the existing regex operator, so this uses a new `when` keyword.

## What it does

- **Exhaustiveness (the deliverable):** the arm tags must cover the variant's tag set *exactly*. A missing, unknown, or duplicate arm is a **compile error** in `Expr::TWhen::GetTypeImpl`. Verified by hand:
  - `(v) when { Integer: ...; }` over `<| Integer(int) | Deleted |>` → *"`when` is not exhaustive: missing arm for tag `Deleted`"*
  - an arm naming a non-tag → *"`when` arm `Bogus` is not a tag of the operand variant type"*
- **Result type:** the unified type of the arm bodies (the same join `TIfElse` uses).
- **Lowering:** a nested ternary on the operand's `GetWhich()`, reusing the Phase 3 M4 `GetWhich()`/`GetV<Tag>()` primitives (`CodeGen::TVariantWhen`). The native-struct emitter is untouched, so the Phase-2 frozen snapshot stays valid.
- **v1 has no payload binder** — arm bodies read the active payload via `e.<Tag>`. The `Tag(n)` binder (which needs the synth `TScope`/`TDef` multi-pass) is a documented follow-up.

## Layers touched

`orly.nycr` (new `when` token + `when_expr`/`when_arm` productions, mirroring `assert_expr` → **no new parser conflicts**); `Expr::TWhen` + the visitor matrix (`walker`/`addr_walker`/`builder`); `Synth::TWhenExpr` + `new_expr` dispatch + `cst_utils` `ItemInfo` + `get_pos_range` + `given_collector`; the spa CST cells.

## Tests / validation

- `tests/lang_tests/general/variants_when.orly`: `when` over a stored-and-read-back variant, over inline-constructed variants, and arm-order independence. **Passes.**
- Exhaustiveness rejection verified manually with `orlyc` (lang_test has no "expect compile error" form).
- `make debug` + `make test` exit 0; `lang_test` **exit 0**, `0 unexpected, 129 passed, 4 tracked failures (xfail)`; variant C++ tests green (`var/impl` 7/0, `code_gen/variant` 1/0, `variant_emit` 2/0).

Builds on the merged Phases 0–3 (#97). Remaining on #95: the `Tag(n)` payload binder, set-of-variants storage (#96), and the grc20-pov in-engine-fold capstone.