### PR TITLE
grc20-pov: in-engine reduce+when replay over typed variant events

### DIFF
--- a/examples/grc20-pov/README.md
+++ b/examples/grc20-pov/README.md
@@ -1,14 +1,42 @@
 # GRC-20-shaped knowledge graph on Orly
 
-A small reference demo aimed at the [Geo / The Graph](https://github.com/geobrowser/grc-20) team: their **GRC-20** standard models knowledge as an event-sourced property graph (`CreateEntity` / `UpdateEntity` / `CreateRelation` / `DeleteEntity` ops, append-only). Orly stores exactly that shape natively — every op is one set-union into a per-(entity, property) history set, and concurrent editors stream into the same shared POV with **no coordination**.
+A small reference demo aimed at the [Geo / The Graph](https://github.com/geobrowser/grc-20) team: their **GRC-20** standard models knowledge as an event-sourced property graph (`CreateEntity` / `SetProperty` / `CreateRelation` / `DeleteEntity` ops, append-only). Orly stores exactly that shape natively — every op is one set-union into a per-(entity, property) history set, concurrent editors stream into the same shared POV with **no coordination**, and the replay that turns a log into the current graph runs **inside the engine**.
 
 ```
-GRC-20 op             →   one `|=` into  <['hist', e, p]>::({<{.ts,.editor,.kind,.val}>})
-Reconstruct entity    ←   sort history by .ts, replay events in order
-Time-travel as-of T   ←   sort history by .ts, replay events with .ts ≤ T
+GRC-20 op             →   one `|=` into  <['hist', e, p]>::({<{.ts,.editor,.op}>})
+Resolve property      ←   sort history by .ts, `reduce` to the latest, `when` over its op
+Time-travel as-of T   ←   same, filtered to events with .ts ≤ T
 ```
 
-The driver owns the GRC-20 op vocabulary (`CreateEntity`, `SetText`, `SetInteger`, `CreateRelation`, `DeleteEntity`); the engine just stores immutable event records. Each event is a first-class `<{.ts: int, .editor: str, .kind: str, .val: str}>` record, and the history is a set OF those records ([issue #90](https://github.com/orlyatomics/orly/issues/90)) — no string packing, the four typed fields travel end to end. Three commutative orlyscript functions are the entire schema (`append_op`, `register_entity`, `register_prop`).
+The op is a **typed sum type**, not a string-packed `(kind, val)` pair:
+
+```orly
+op_t  is  <| Text(str) | Number(int) | Relation(str) | Deleted |>
+evt_t is  <{.ts: int, .editor: str, .op: op_t}>
+```
+
+The history of one (entity, property) pair is a **set of these variant-bearing records** — storable because a set of differently-tagged variants is homogeneous on disk ([issue #96](https://github.com/orlyatomics/orly/issues/96)). The typed op travels end to end: the driver hands the engine a typed value and reads back a resolved typed value — no string packing, no driver-side `if kind == "L"` dispatch.
+
+## What moved into the engine
+
+This demo is the capstone of Orly's sum-types line ([#95](https://github.com/orlyatomics/orly/issues/95) / [#96](https://github.com/orlyatomics/orly/issues/96)). The replay — latest-write-wins, tombstones, value formatting, time-travel — used to live in the driver. It now lives in orlyscript, as a fold over the event set:
+
+```orly
+resolve_as_of = (((**((((**hist_for(.entity: entity, .property: property))
+                        if (that.ts <= as_of))           /* time-travel cutoff   */
+                       as [evt_t]) sorted_by lhs.ts < rhs.ts) /* chronological    */
+                  ) reduce (start seed if false else that)    /* latest .ts wins  */
+                 ).op);                                        /* the resolved op  */
+
+display_as_of = ((op) when {                /* exhaustive match over the op kind */
+  Text:     op.Text;
+  Number:   (op.Number) as str;
+  Relation: "-> " + op.Relation;
+  Deleted:  "(absent)";                     /* tombstone (and empty history)     */
+}) where { op = resolve_as_of(...); ... };
+```
+
+`reduce`'s seed is a `Deleted` sentinel, so an empty (or fully-filtered) history resolves to "absent" for free, and `when` is checked for exhaustiveness at compile time. **Compare `demo.py`'s `reconstruct` to [the previous version](https://github.com/orlyatomics/orly/commits/master/examples/grc20-pov/demo.py): the latest-wins loop, the `event_key` tiebreaker, and `format_value` are all gone** — the driver enumerates entities and asks the engine `display_as_of`.
 
 ## Run it
 
@@ -18,37 +46,37 @@ cd examples/grc20-pov
 ./run-go.sh    # go driver
 ```
 
-Both wrappers require `make debug` to have built `orlyi` + `orlyc`. The Go wrapper additionally needs the `go` toolchain. The two drivers exercise the same scenario and self-check the same invariants.
+Both wrappers require `make debug` to have built `orlyi` + `orlyc`. The Go wrapper additionally needs the `go` toolchain. The two drivers exercise the same scenario and self-check the same invariants. Compiling `grc20.orly` also runs its inline test suite (40+ assertions over the resolve/display/tombstone/time-travel/lifecycle paths).
 
 ## The three phases
 
-The demo runs a small corpus of six Greek philosophers as if they were being collaboratively edited by two GRC-20 sources:
+The demo runs a small corpus of six Greek philosophers as if collaboratively edited by two GRC-20 sources:
 
-| Phase | Editor | Ops | What |
-|---|---|---|---|
-| 1 | `wiki` | 24 | `CreateEntity` + `SetText name` + `SetInteger born` + `SetInteger died` per philosopher |
-| 2 | `stanford` | 8 | `SetText school` per philosopher + `CreateRelation student_of` (Plato→Socrates, Aristotle→Plato) |
-| 3 | both | 2 | both editors **concurrently** rewrite `pythagoras.born` from separate WebSocket sessions |
+| Phase | Editor | What |
+|---|---|---|
+| 1 | `wiki` | `CreateEntity` + `SetText name` + `SetInteger born` + `SetInteger died` per philosopher |
+| 2 | `stanford` | `SetText school` per philosopher + `CreateRelation student_of` (Plato→Socrates, Aristotle→Plato) |
+| 3 | both | both editors **concurrently** rewrite `pythagoras.born` from separate WebSocket sessions |
 
-After each phase a snapshot is printed, plus a final editorial diff (events per editor, overlap).
+After each phase a snapshot is printed — each one a **time-travel read** at that phase's `.ts` cutoff — plus a final editorial diff (events per editor, overlap).
 
 ## What you'll see
 
-Snapshot 1 (after phase 1) — only `wiki`'s biographical facts:
+Snapshot 1 (after phase 1) — only `wiki`'s biographical facts, formatted by the engine:
 
 ```
 === snapshot 1: end of phase 1 (wiki only) ===
-  aristotle (Person): born=-384 [wiki], died=-322 [wiki], name=Aristotle [wiki]
-  epicurus (Person):  born=-341 [wiki], died=-270 [wiki], name=Epicurus  [wiki]
+  aristotle (Person): born=-384, died=-322, name=Aristotle
+  plato (Person): born=-428, died=-348, name=Plato
   ...
 ```
 
-Snapshot 2 (after phase 2) — `stanford` has merged in:
+Snapshot 2 (after phase 2) — `stanford` has merged in; relations render via the `Relation` arm:
 
 ```
 === snapshot 2: end of phase 2 (wiki + stanford) ===
-  aristotle (Person): born=-384 [wiki], died=-322 [wiki], name=Aristotle [wiki],
-                      school=Peripateticism [stanford], student_of=→ plato [stanford]
+  aristotle (Person): born=-384, died=-322, name=Aristotle, school=Peripateticism, student_of=-> plato
+  plato (Person): born=-428, died=-348, name=Plato, school=Platonism, student_of=-> socrates
   ...
 ```
 
@@ -57,66 +85,63 @@ Phase 3 — the race:
 ```
 [phase 3] wiki + stanford concurrently overwrite pythagoras.born
   history for pythagoras.born after race (3 events, ts-sorted):
-    1780613758237  wiki       I  -570
-    1780613758647  stanford   I  -575
-    1780613758647  wiki       I  -570
+    1780700632132  wiki
+    1780700632518  stanford
+    1780700632518  wiki
+  -> engine-resolved current value: pythagoras.born = -570
 ```
 
-Two writers from independent WebSocket sessions land events at the **same millisecond**; both events survive in history. The driver's deterministic tiebreaker (lex sort on the event record's `(.ts, .editor, .kind, .val)`) picks one as the "current" value — but the alternative-source claim isn't lost, exactly the editorial-workflow semantics GRC-20 needs.
+Two writers from independent WebSocket sessions land events (here even at the **same millisecond**); every event survives in history. The engine's `reduce` resolves the latest as the current value — the alternative-source claim isn't lost, exactly the editorial-workflow semantics GRC-20 needs.
 
 ```
 === editorial diff ===
   stanford     9 events on  6 entities
   wiki        25 events on  6 entities
-  overlap: 6 entities edited by both (stanford ∩ wiki): ['aristotle', 'epicurus', ...]
+  overlap: 6 entities edited by both (stanford ∩ wiki): ['aristotle', ...]
 ```
 
 ## Why this maps to GRC-20
 
 | GRC-20 concept | Demo realisation |
 |---|---|
-| `CreateEntity(id, type)` | `register_entity` + `append_op(id, '__type', .kind:'L', .val:<type>)` |
-| `SetText(id, prop, text)` | `append_op(id, prop, .kind:'L', .val:<text>)` |
-| `SetInteger(id, prop, n)` | `append_op(id, prop, .kind:'I', .val:<n>)` |
-| `CreateRelation(id, prop, target)` | `append_op(id, prop, .kind:'R', .val:<target_id>)` |
-| `DeleteEntity(id)` | `append_op(id, '__deleted', .kind:'D', .val:'')` |
-| event-sourced log | history set sorted by the `.ts` field |
+| `CreateEntity(id, type)` | `create_entity(id, ts, editor, type)` → typed marker on `"__entity"` + catalogue |
+| `SetText(id, prop, text)` | `set_text(...)` → `op_t.Text(text)` event |
+| `SetInteger(id, prop, n)` | `set_number(...)` → `op_t.Number(n)` event |
+| `CreateRelation(id, prop, target)` | `set_relation(...)` → `op_t.Relation(target)` event |
+| `DeleteEntity(id)` | `delete_entity(...)` → `op_t.Deleted` on `"__entity"` |
+| op type tag | the `op_t` variant arm — typed, exhaustively matched, not a string |
+| event-sourced log | history set, replayed by `reduce` over the `.ts`-sorted events |
 | append-only | set union is the only write operation |
 | multi-editor merge | concurrent `|=` from independent WS sessions, no locks |
-| historical query | replay events with `.ts ≤ target` |
+| current value | `reduce` to the latest `.ts`, `when` over the op |
+| tombstone delete | the `Deleted` arm — `when` collapses it to absent |
+| historical query | the same fold with an `.ts ≤ T` filter (`display_as_of`) |
 
-GRC-20's full type system is 13 data types; this demo exercises TEXT, INTEGER, and RELATION (sufficient to prove the pattern). Each event is a typed `<{.ts: int, .editor: str, .kind: str, .val: str}>` record — `kind` (`L`/`I`/`R`/`D`) discriminates how the driver interprets `val`, the same role GRC-20's op tag plays. A production binding would store binary GRC-20 ops directly.
+GRC-20's full type system is 13 data types; this demo exercises TEXT, INTEGER, and RELATION (sufficient to prove the pattern), plus the tombstone. A production binding would add the remaining arms to `op_t` and store binary GRC-20 ops directly.
 
 ## Schema (the entire engine side)
 
 ```orly
-<['hist', entity, property]>::({<{.ts: int, .editor: str, .kind: str, .val: str}>})
-                                       -- set of event records for one (e, p)
-<['entities']>::({str})                -- set of every entity id
-<['props',  entity]>::({str})          -- set of every property ever written on e
+op_t  is <| Text(str) | Number(int) | Relation(str) | Deleted |>;
+evt_t is <{.ts: int, .editor: str, .op: op_t}>;
+
+<['hist', entity, property]>::({evt_t})   -- set of typed event records for one (e, p)
+<['entities']>::({str})                   -- set of every entity id
+<['props',  entity]>::({str})             -- set of every property written on e
 ```
 
-Three functions:
-
-```orly
-append_op(.entity, .property, .ts, .editor, .kind, .val)
-                                        -- |= one event record into the history
-register_entity(.entity)                -- |= entity into the global set
-register_prop(.entity, .property)       -- |= property into the entity's prop set
-```
-
-That's it. Everything else — op classification, replay, time-travel, editorial diff — happens in the driver. The engine guarantees that no event is ever lost, no matter how many editors are writing at once, because `|=` is a commutative deferred-mutation field call ([#49](https://github.com/orlyatomics/orly/issues/49) / PRs #50/#51/#52); storable record-set values are [#90](https://github.com/orlyatomics/orly/issues/90).
+Writes are typed appends (`set_text` / `set_number` / `set_relation` / `clear_prop`, plus `create_entity` / `delete_entity`); reads are the in-engine replay (`resolve` / `display` / `is_present` / `entity_live`, each with an `_as_of` time-travel form). The engine guarantees no event is ever lost, no matter how many editors write at once, because `|=` is a commutative deferred-mutation field call ([#49](https://github.com/orlyatomics/orly/issues/49) / PRs #50/#51/#52); storable record sets are [#90](https://github.com/orlyatomics/orly/issues/90), storable variant sets [#96](https://github.com/orlyatomics/orly/issues/96).
 
 ## Caveats
 
-- **Driver-side ms timestamps** for the event timeline assume all editors share the same clock. In a real decentralised deployment, replace with a consensus-ordered sequence number or a hybrid logical clock; the schema doesn't change.
-- **Same-ms tiebreaker** is lex order on the event record's `(.ts, .editor, .kind, .val)` — deterministic, not principled. GRC-20 itself defers ordering to the on-chain proposal queue, which the driver would defer to.
-- **No compaction** of the history set in this demo. Real workloads would compact `(entity, prop)` history into a checkpoint past some age cutoff. The shape generalises — fold the prefix, keep only the tail.
-- **Six philosophers** is enough to prove the pattern, not a workload benchmark. For throughput numbers under contention, see [`examples/agent-swarm/`](../agent-swarm/) (8 concurrent agents, hot-key counters + tag sets) and [`examples/wikipedia-pageviews/`](../wikipedia-pageviews/) (5,938 events, integer counters).
+- **Driver-side ms timestamps** for the event timeline assume all editors share the same clock. In a real decentralised deployment, replace with a consensus-ordered sequence number or a hybrid logical clock; the schema doesn't change (`.ts` is just an `int`).
+- **Same-ms tiebreaker** falls out of the engine's total order on event records — deterministic, not principled. GRC-20 itself defers ordering to the on-chain proposal queue, which the driver would feed into `.ts`.
+- **No compaction** of the history set in this demo. Real workloads would fold `(entity, prop)` history into a checkpoint past some age cutoff — the same `reduce`, kept on the tail.
+- **Six philosophers** is enough to prove the pattern, not a workload benchmark. For throughput under contention, see [`examples/agent-swarm/`](../agent-swarm/) and [`examples/wikipedia-pageviews/`](../wikipedia-pageviews/).
 
 ## Related demos
 
-- [`examples/wikipedia-categories/`](../wikipedia-categories/) — same fold-on-read pattern with set-union values, version axis in the key (year). This demo extends to heterogeneous events with timestamped editor attribution.
+- [`examples/wikipedia-categories/`](../wikipedia-categories/) — same fold-on-read pattern with set-union values, version axis in the key (year). This demo extends it to *heterogeneous typed* events with editor attribution and an in-engine `reduce`/`when` replay.
 - [`examples/agent-swarm/`](../agent-swarm/) — multi-writer commutative field calls (`+=`, `|=`) under contention, same lost-update-free guarantee.
 - [`examples/bitcoin-time-travel/`](../bitcoin-time-travel/) — the original time-travel-via-key-axis demo with integer-addition values (account balances).
 
@@ -124,7 +149,7 @@ That's it. Everything else — op classification, replay, time-travel, editorial
 
 | File | What |
 |---|---|
-| `grc20.orly` | The Orlyscript package: `append_op`, `register_entity`, `register_prop`, + lookups + 19 inline tests |
-| `demo.py` | Python WebSocket driver: 3 phases, snapshot replay, editorial diff, self-check |
+| `grc20.orly` | The Orlyscript package: typed `op_t`/`evt_t`, typed appends, in-engine `resolve`/`display`/`is_present`/`entity_live` (+ `_as_of` forms), catalogue + counts, 40+ inline tests |
+| `demo.py` | Python WebSocket driver: 3 phases, time-travel snapshots, editorial diff, self-check |
 | `demo.go` + `go.mod` + `go.sum` | Go WebSocket driver, equivalent to Python |
 | `run.sh` / `run-go.sh` | End-to-end wrappers: compile, start fresh orlyi, run the chosen driver |

--- a/examples/grc20-pov/demo.go
+++ b/examples/grc20-pov/demo.go
@@ -1,9 +1,10 @@
 // GRC-20-shaped knowledge graph on Orly, in Go.
 //
 // Mirrors demo.py: three phases (wiki biographical / stanford schools +
-// relations / concurrent race), same event records, same self-check.
-// Provided so readers can pick whichever language matches their
-// environment.
+// relations / concurrent race), the same typed event model, the same
+// self-check. The op is a sum type (op_t) and the replay -- latest-wins,
+// tombstones, formatting, time-travel -- runs in the engine (grc20.orly);
+// this driver streams typed events and reads resolved values.
 //
 // Run via the wrapper:
 //
@@ -17,6 +18,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"sort"
 	"strconv"
@@ -28,6 +30,10 @@ import (
 )
 
 const wsURL = "ws://127.0.0.1:8082/"
+
+// A .ts beyond any real event -- "now / all events" (mirrors grc20.orly's
+// `forever`).
+const forever int64 = math.MaxInt64
 
 type philosopher struct {
 	id         string
@@ -44,8 +50,7 @@ var philosophers = []philosopher{
 	{"epicurus", "Epicurus", -341, -270},
 }
 
-// Editor 2 ("stanford") adds the school of thought for each
-// philosopher. Map iteration order is randomised; the keys/values are
+// Editor 2 ("stanford") adds the school of thought for each philosopher,
 // listed as parallel slices so the ingest order is stable.
 var schoolEntities = []string{"socrates", "plato", "aristotle", "pythagoras", "heraclitus", "epicurus"}
 var schoolValues = []string{"Classical", "Platonism", "Peripateticism", "Pythagoreanism", "Heracliteanism", "Epicureanism"}
@@ -60,8 +65,8 @@ var relations = []relation{
 }
 
 // Phase-3 race: both editors concurrently rewrite the same attribute on
-// the same entity. Whoever's event lands at the later ms wins on read;
-// the loser stays in history as an alternative-source claim.
+// the same entity. The engine's `reduce` resolves the later .ts as the
+// current value; the loser stays in history as an alternative-source claim.
 const raceEntity = "pythagoras"
 const raceProp = "born"
 const raceWiki = -570
@@ -126,6 +131,15 @@ func sendInt(c *websocket.Conn, stmt string) int {
 	return int(n)
 }
 
+func sendBool(c *websocket.Conn, stmt string) bool {
+	raw := send(c, stmt)
+	var b bool
+	if err := json.Unmarshal(raw, &b); err != nil {
+		die(fmt.Sprintf("expected bool result, got %s", raw))
+	}
+	return b
+}
+
 // orlyi serialises sets as JSON arrays.
 func sendStringSet(c *websocket.Conn, stmt string) []string {
 	raw := send(c, stmt)
@@ -140,63 +154,7 @@ func sendStringSet(c *websocket.Conn, stmt string) []string {
 	return out
 }
 
-// ---------------------------------------------------------------------
-// Event records. Each event is a first-class
-//   <{.ts: int, .editor: str, .kind: str, .val: str}>
-// stored in a set OF records (issue #90). Kind ∈ {L text, I integer,
-// R relation target id, D tombstone}. No string packing -- the four
-// typed fields travel end to end.
-// ---------------------------------------------------------------------
-
 func nowMs() int64 { return time.Now().UnixNano() / 1_000_000 }
-
-type event struct {
-	ts           int64
-	editor, kind string
-	val          string
-}
-
-// Records arrive as JSON objects; ts may be a float (orlyi serialises
-// numbers as JSON floats), so decode it loosely and narrow to int64.
-type eventWire struct {
-	Ts     float64 `json:"ts"`
-	Editor string  `json:"editor"`
-	Kind   string  `json:"kind"`
-	Val    string  `json:"val"`
-}
-
-// eventLess is the total order over event records: ts first, then a
-// deterministic same-ms tiebreaker (editor, kind, val).
-func eventLess(a, b event) bool {
-	if a.ts != b.ts {
-		return a.ts < b.ts
-	}
-	if a.editor != b.editor {
-		return a.editor < b.editor
-	}
-	if a.kind != b.kind {
-		return a.kind < b.kind
-	}
-	return a.val < b.val
-}
-
-// orlyi serialises a set of records as a JSON array of objects.
-func sendEventSet(c *websocket.Conn, stmt string) []event {
-	raw := send(c, stmt)
-	if string(raw) == "null" {
-		return nil
-	}
-	var wire []eventWire
-	if err := json.Unmarshal(raw, &wire); err != nil {
-		die(fmt.Sprintf("expected array-of-objects result, got %s", raw))
-	}
-	out := make([]event, 0, len(wire))
-	for _, w := range wire {
-		out = append(out, event{ts: int64(w.Ts), editor: w.Editor, kind: w.Kind, val: w.Val})
-	}
-	sort.Slice(out, func(i, j int) bool { return eventLess(out[i], out[j]) })
-	return out
-}
 
 func orlyStr(s string) string {
 	// Corpus has no quotes/backslashes, but be defensive.
@@ -206,34 +164,103 @@ func orlyStr(s string) string {
 }
 
 // ---------------------------------------------------------------------
-// Wrappers for the grc20 package's three commutative funcs.
+// Event provenance. The op is a typed variant resolved by the engine, so
+// the driver only ever reads the .ts / .editor fields off the raw log --
+// for per-editor analytics, never for replay.
 // ---------------------------------------------------------------------
 
-// appendOp unions one event record into the (entity, property) history.
-// The engine builds the <{.ts, .editor, .kind, .val}> record from these
-// typed args; ts is an int literal, the rest are string literals.
-func appendOp(c *websocket.Conn, pov, entity, prop string, ts int64, editor, kind, val string) {
-	send(c, fmt.Sprintf(
-		`try {%s} grc20 append_op <{.entity: %s, .property: %s, .ts: %d, .editor: %s, .kind: %s, .val: %s}>;`,
-		pov, orlyStr(entity), orlyStr(prop), ts, orlyStr(editor), orlyStr(kind), orlyStr(val)))
+type eventMeta struct {
+	ts     int64
+	editor string
 }
 
+type eventWire struct {
+	Ts     float64 `json:"ts"`
+	Editor string  `json:"editor"`
+}
+
+func histMeta(c *websocket.Conn, pov, entity, prop string) []eventMeta {
+	raw := send(c, fmt.Sprintf(
+		`try {%s} grc20 hist_for <{.entity: %s, .property: %s}>;`,
+		pov, orlyStr(entity), orlyStr(prop)))
+	if string(raw) == "null" {
+		return nil
+	}
+	var wire []eventWire
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		die(fmt.Sprintf("expected array-of-objects result, got %s", raw))
+	}
+	out := make([]eventMeta, 0, len(wire))
+	for _, w := range wire {
+		out = append(out, eventMeta{ts: int64(w.Ts), editor: w.Editor})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].ts != out[j].ts {
+			return out[i].ts < out[j].ts
+		}
+		return out[i].editor < out[j].editor
+	})
+	return out
+}
+
+// ---------------------------------------------------------------------
+// Writes -- typed appends; the engine builds the op_t variant.
+// ---------------------------------------------------------------------
+
 func registerEntity(c *websocket.Conn, pov, entity string) {
-	send(c, fmt.Sprintf(
-		`try {%s} grc20 register_entity <{.entity: %s}>;`,
+	send(c, fmt.Sprintf(`try {%s} grc20 register_entity <{.entity: %s}>;`,
 		pov, orlyStr(entity)))
 }
 
 func registerProp(c *websocket.Conn, pov, entity, prop string) {
-	send(c, fmt.Sprintf(
-		`try {%s} grc20 register_prop <{.entity: %s, .property: %s}>;`,
+	send(c, fmt.Sprintf(`try {%s} grc20 register_prop <{.entity: %s, .property: %s}>;`,
 		pov, orlyStr(entity), orlyStr(prop)))
 }
 
-func histFor(c *websocket.Conn, pov, entity, prop string) []event {
-	return sendEventSet(c, fmt.Sprintf(
-		`try {%s} grc20 hist_for <{.entity: %s, .property: %s}>;`,
-		pov, orlyStr(entity), orlyStr(prop)))
+func createEntity(c *websocket.Conn, pov, entity string, ts int64, editor, kind string) {
+	send(c, fmt.Sprintf(
+		`try {%s} grc20 create_entity <{.entity: %s, .ts: %d, .editor: %s, .kind: %s}>;`,
+		pov, orlyStr(entity), ts, orlyStr(editor), orlyStr(kind)))
+}
+
+func deleteEntity(c *websocket.Conn, pov, entity string, ts int64, editor string) {
+	send(c, fmt.Sprintf(
+		`try {%s} grc20 delete_entity <{.entity: %s, .ts: %d, .editor: %s}>;`,
+		pov, orlyStr(entity), ts, orlyStr(editor)))
+}
+
+func setText(c *websocket.Conn, pov, entity, prop string, ts int64, editor, text string) {
+	send(c, fmt.Sprintf(
+		`try {%s} grc20 set_text <{.entity: %s, .property: %s, .ts: %d, .editor: %s, .text: %s}>;`,
+		pov, orlyStr(entity), orlyStr(prop), ts, orlyStr(editor), orlyStr(text)))
+}
+
+func setNumber(c *websocket.Conn, pov, entity, prop string, ts int64, editor string, n int) {
+	send(c, fmt.Sprintf(
+		`try {%s} grc20 set_number <{.entity: %s, .property: %s, .ts: %d, .editor: %s, .n: %d}>;`,
+		pov, orlyStr(entity), orlyStr(prop), ts, orlyStr(editor), n))
+}
+
+func setRelation(c *websocket.Conn, pov, entity, prop string, ts int64, editor, target string) {
+	send(c, fmt.Sprintf(
+		`try {%s} grc20 set_relation <{.entity: %s, .property: %s, .ts: %d, .editor: %s, .target: %s}>;`,
+		pov, orlyStr(entity), orlyStr(prop), ts, orlyStr(editor), orlyStr(target)))
+}
+
+// ---------------------------------------------------------------------
+// Reads -- the engine resolves the value; the driver enumerates.
+// ---------------------------------------------------------------------
+
+func displayAsOf(c *websocket.Conn, pov, entity, prop string, asOf int64) string {
+	return sendString(c, fmt.Sprintf(
+		`try {%s} grc20 display_as_of <{.entity: %s, .property: %s, .as_of: %d}>;`,
+		pov, orlyStr(entity), orlyStr(prop), asOf))
+}
+
+func entityLiveAsOf(c *websocket.Conn, pov, entity string, asOf int64) bool {
+	return sendBool(c, fmt.Sprintf(
+		`try {%s} grc20 entity_live_as_of <{.entity: %s, .as_of: %d}>;`,
+		pov, orlyStr(entity), asOf))
 }
 
 func allEntities(c *websocket.Conn, pov string) []string {
@@ -241,8 +268,7 @@ func allEntities(c *websocket.Conn, pov string) []string {
 }
 
 func propsOf(c *websocket.Conn, pov, entity string) []string {
-	return sendStringSet(c, fmt.Sprintf(
-		`try {%s} grc20 props_of <{.entity: %s}>;`,
+	return sendStringSet(c, fmt.Sprintf(`try {%s} grc20 props_of <{.entity: %s}>;`,
 		pov, orlyStr(entity)))
 }
 
@@ -251,91 +277,54 @@ func entityCount(c *websocket.Conn, pov string) int {
 }
 
 // ---------------------------------------------------------------------
-// GRC-20-style ops (the driver owns the op vocabulary; the engine just
-// stores events).
+// GRC-20-style ops. Thin: pick the typed setter + register the property.
 // ---------------------------------------------------------------------
 
 func opCreateEntity(c *websocket.Conn, pov, editor, entity, typeName string) {
-	registerEntity(c, pov, entity)
-	registerProp(c, pov, entity, "__type")
-	appendOp(c, pov, entity, "__type", nowMs(), editor, "L", typeName)
+	createEntity(c, pov, entity, nowMs(), editor, typeName)
 }
 
 func opSetText(c *websocket.Conn, pov, editor, entity, prop, text string) {
-	registerEntity(c, pov, entity)
 	registerProp(c, pov, entity, prop)
-	appendOp(c, pov, entity, prop, nowMs(), editor, "L", text)
+	setText(c, pov, entity, prop, nowMs(), editor, text)
 }
 
 func opSetInt(c *websocket.Conn, pov, editor, entity, prop string, n int) {
-	registerEntity(c, pov, entity)
 	registerProp(c, pov, entity, prop)
-	appendOp(c, pov, entity, prop, nowMs(), editor, "I", strconv.Itoa(n))
+	setNumber(c, pov, entity, prop, nowMs(), editor, n)
 }
 
 func opCreateRelation(c *websocket.Conn, pov, editor, entity, prop, target string) {
-	registerEntity(c, pov, entity)
 	registerEntity(c, pov, target)
 	registerProp(c, pov, entity, prop)
-	appendOp(c, pov, entity, prop, nowMs(), editor, "R", target)
+	setRelation(c, pov, entity, prop, nowMs(), editor, target)
 }
 
 // ---------------------------------------------------------------------
-// Replay: build the current state of every (entity, property) by
-// walking its history set in timestamp order. Optional `asOf` cutoff
-// drops events with ts > cutoff -- that's the time-travel knob.
+// Reconstruct: enumerate the graph at `asOf`, asking the engine for each
+// value. No latest-wins loop, no tombstone bookkeeping, no formatting --
+// that all lives in grc20.orly now.
 // ---------------------------------------------------------------------
 
-type fact struct {
-	kind, value, editor string
-	ts                  int64
-}
-
-// nil asOf means "no cutoff" -- pass &someInt64 to filter.
-func reconstruct(c *websocket.Conn, pov string, asOf *int64) map[string]map[string]fact {
-	out := map[string]map[string]fact{}
+// reconstruct returns entity -> {"__type": typeStr, prop: displayStr}.
+func reconstruct(c *websocket.Conn, pov string, asOf int64) map[string]map[string]string {
+	out := map[string]map[string]string{}
 	for _, eid := range allEntities(c, pov) {
-		deleted := false
-		state := map[string]fact{}
+		if !entityLiveAsOf(c, pov, eid, asOf) {
+			continue
+		}
+		state := map[string]string{"__type": displayAsOf(c, pov, eid, "__entity", asOf)}
 		for _, prop := range propsOf(c, pov, eid) {
-			entries := histFor(c, pov, eid, prop) // already sorted
-			if asOf != nil {
-				filtered := entries[:0]
-				for _, e := range entries {
-					if e.ts <= *asOf {
-						filtered = append(filtered, e)
-					}
-				}
-				entries = filtered
+			if v := displayAsOf(c, pov, eid, prop, asOf); v != "(absent)" {
+				state[prop] = v
 			}
-			if len(entries) == 0 {
-				continue
-			}
-			p := entries[len(entries)-1]
-			if prop == "__deleted" && p.kind == "D" {
-				deleted = true
-				break
-			}
-			state[prop] = fact{kind: p.kind, value: p.val, editor: p.editor, ts: p.ts}
 		}
-		if !deleted {
-			out[eid] = state
-		}
+		out[eid] = state
 	}
 	return out
 }
 
-func formatValue(f fact) string {
-	switch f.kind {
-	case "L", "I":
-		return f.value
-	case "R":
-		return "→ " + f.value
-	}
-	return "?" + f.kind + ":" + f.value
-}
-
-func printSnapshot(label string, state map[string]map[string]fact) {
+func printSnapshot(label string, state map[string]map[string]string) {
 	fmt.Printf("\n=== %s ===\n", label)
 	if len(state) == 0 {
 		fmt.Println("  (empty graph)")
@@ -348,9 +337,9 @@ func printSnapshot(label string, state map[string]map[string]fact) {
 	sort.Strings(eids)
 	for _, eid := range eids {
 		attrs := state[eid]
-		typeName := "?"
-		if t, ok := attrs["__type"]; ok {
-			typeName = t.value
+		typeName := attrs["__type"]
+		if typeName == "" {
+			typeName = "?"
 		}
 		var props []string
 		for p := range attrs {
@@ -361,7 +350,7 @@ func printSnapshot(label string, state map[string]map[string]fact) {
 		sort.Strings(props)
 		var bits []string
 		for _, p := range props {
-			bits = append(bits, fmt.Sprintf("%s=%s [%s]", p, formatValue(attrs[p]), attrs[p].editor))
+			bits = append(bits, fmt.Sprintf("%s=%s", p, attrs[p]))
 		}
 		body := strings.Join(bits, ", ")
 		if body == "" {
@@ -418,8 +407,9 @@ func editorialDiff(c *websocket.Conn, pov string) {
 	byEditor := map[string]int{}
 	entitiesByEditor := map[string]map[string]struct{}{}
 	for _, eid := range allEntities(c, pov) {
-		for _, prop := range propsOf(c, pov, eid) {
-			for _, ev := range histFor(c, pov, eid, prop) {
+		props := append(propsOf(c, pov, eid), "__entity")
+		for _, prop := range props {
+			for _, ev := range histMeta(c, pov, eid, prop) {
 				byEditor[ev.editor]++
 				if entitiesByEditor[ev.editor] == nil {
 					entitiesByEditor[ev.editor] = map[string]struct{}{}
@@ -473,7 +463,7 @@ func main() {
 	fmt.Printf("  %d entities registered in %.2fs\n",
 		entityCount(boot, pov), time.Since(t0).Seconds())
 	printSnapshot("snapshot 1: end of phase 1 (wiki only)",
-		reconstruct(boot, pov, &ts1))
+		reconstruct(boot, pov, ts1))
 
 	time.Sleep(50 * time.Millisecond)
 
@@ -484,7 +474,7 @@ func main() {
 	ts2 := nowMs()
 	fmt.Printf("  done in %.2fs\n", time.Since(t0).Seconds())
 	printSnapshot("snapshot 2: end of phase 2 (wiki + stanford)",
-		reconstruct(boot, pov, &ts2))
+		reconstruct(boot, pov, ts2))
 
 	time.Sleep(50 * time.Millisecond)
 
@@ -495,64 +485,60 @@ func main() {
 	fmt.Printf("  stanford -> %d\n", raceStanford)
 	phase3Race(pov)
 	ts3 := nowMs()
-	raceEntries := histFor(boot, pov, raceEntity, raceProp)
+	raceEvents := histMeta(boot, pov, raceEntity, raceProp)
 	fmt.Printf("  history for %s.%s after race (%d events, ts-sorted):\n",
-		raceEntity, raceProp, len(raceEntries))
-	for _, ev := range raceEntries {
-		fmt.Printf("    %d  %-10s %s  %s\n", ev.ts, ev.editor, ev.kind, ev.val)
+		raceEntity, raceProp, len(raceEvents))
+	for _, ev := range raceEvents {
+		fmt.Printf("    %d  %s\n", ev.ts, ev.editor)
 	}
-	finalState := reconstruct(boot, pov, &ts3)
-	winning := finalState[raceEntity][raceProp]
-	fmt.Printf("  -> winning event: %s [%s, ts=%d]\n",
-		winning.value, winning.editor, winning.ts)
+	winning := displayAsOf(boot, pov, raceEntity, raceProp, ts3)
+	fmt.Printf("  -> engine-resolved current value: %s.%s = %s\n",
+		raceEntity, raceProp, winning)
 
 	// --- Final state + editorial diff ---
-	printSnapshot("snapshot 3: final state", finalState)
+	printSnapshot("snapshot 3: final state", reconstruct(boot, pov, ts3))
 	editorialDiff(boot, pov)
 
 	fmt.Println("\n=== the trick ===")
-	fmt.Println("  Every editor |= an event record into a per-(entity, prop)")
-	fmt.Println("  set of <{.ts, .editor, .kind, .val}> (issue #90). Multi-editor")
-	fmt.Println("  writes never drop events (post-#50 deferred-mutation fold).")
-	fmt.Println("  Reads replay the timestamp-sorted log -- pass a cutoff for")
-	fmt.Println("  time-travel, take the latest for the current value. The schema")
-	fmt.Println("  is three commutative funcs; GRC-20's op vocabulary lives")
-	fmt.Println("  entirely in the driver.")
+	fmt.Println("  Each op is a typed variant")
+	fmt.Println("    op_t is <| Text(str) | Number(int) | Relation(str) | Deleted |>")
+	fmt.Println("  unioned into a per-(entity, prop) set of <{.ts,.editor,.op}>")
+	fmt.Println("  records (storable variants, #96). Multi-editor |= never")
+	fmt.Println("  drops events (post-#50 fold). The REPLAY -- sort by .ts,")
+	fmt.Println("  reduce to the latest, when over the op to format/tombstone,")
+	fmt.Println("  filtered by an as_of cutoff for time-travel -- runs in the")
+	fmt.Println("  engine. This driver just enumerates and reads.")
 
 	// --- Self-check (mirrors demo.py) ---
 	var failures []string
-	s1 := reconstruct(boot, pov, &ts1)
+	s1 := reconstruct(boot, pov, ts1)
 	for _, p := range philosophers {
 		e := s1[p.id]
-		if name, ok := e["name"]; !ok || name.kind != "L" || name.value != p.name {
-			failures = append(failures, fmt.Sprintf("snapshot 1: %s.name = %+v", p.id, name))
+		if e["name"] != p.name {
+			failures = append(failures, fmt.Sprintf("snapshot 1: %s.name = %q", p.id, e["name"]))
 		}
-		if born, ok := e["born"]; !ok || born.kind != "I" {
-			failures = append(failures, fmt.Sprintf("snapshot 1: %s.born missing/wrong kind", p.id))
-		} else if n, err := strconv.Atoi(born.value); err != nil || n != p.born {
-			failures = append(failures, fmt.Sprintf("snapshot 1: %s.born = %s (want %d)", p.id, born.value, p.born))
+		if e["born"] != strconv.Itoa(p.born) {
+			failures = append(failures, fmt.Sprintf("snapshot 1: %s.born = %q (want %d)", p.id, e["born"], p.born))
 		}
 		if _, hasSchool := e["school"]; hasSchool {
 			failures = append(failures, fmt.Sprintf("snapshot 1: %s.school leaked from phase 2", p.id))
 		}
 	}
-	s2 := reconstruct(boot, pov, &ts2)
+	s2 := reconstruct(boot, pov, ts2)
 	for i, eid := range schoolEntities {
-		e := s2[eid]
-		if school, ok := e["school"]; !ok || school.kind != "L" || school.value != schoolValues[i] {
-			failures = append(failures, fmt.Sprintf("snapshot 2: %s.school = %+v", eid, school))
+		if s2[eid]["school"] != schoolValues[i] {
+			failures = append(failures, fmt.Sprintf("snapshot 2: %s.school = %q", eid, s2[eid]["school"]))
 		}
 	}
 	for _, r := range relations {
-		e := s2[r.subject]
-		if rel, ok := e[r.prop]; !ok || rel.kind != "R" || rel.value != r.target {
-			failures = append(failures, fmt.Sprintf("snapshot 2: %s.%s = %+v", r.subject, r.prop, rel))
+		if got := s2[r.subject][r.prop]; got != "-> "+r.target {
+			failures = append(failures, fmt.Sprintf("snapshot 2: %s.%s = %q", r.subject, r.prop, got))
 		}
 	}
-	if len(raceEntries) < 2 {
+	if len(raceEvents) < 2 {
 		failures = append(failures,
 			fmt.Sprintf("phase 3: only %d events in race history -- expected both writers to land",
-				len(raceEntries)))
+				len(raceEvents)))
 	}
 
 	send(boot, "exit;")
@@ -565,5 +551,5 @@ func main() {
 		os.Exit(1)
 	}
 	fmt.Println("\n=== self-check OK ===")
-	fmt.Println("  verified 3 snapshot invariants + multi-editor race")
+	fmt.Println("  verified 3 time-travel snapshot invariants + multi-editor race")
 }

--- a/examples/grc20-pov/demo.py
+++ b/examples/grc20-pov/demo.py
@@ -2,29 +2,37 @@
 """
 GRC-20-shaped knowledge graph on Orly, in Python.
 
-GRC-20 (https://github.com/geobrowser/grc-20) is a binary property-
-graph standard from Geo / The Graph. Its events are append-only
-ops -- CreateEntity, UpdateEntity, CreateRelation, DeleteEntity -- and
-the current state of an entity is the replay of its event log. That's
-exactly the storage model Orly handles natively, via commutative set
-union (`|=`) on a per-(entity, property) history set. Concurrent
-editors can stream ops into the same shared POV with no coordination;
-the read path reconstructs the graph at any point in time by replaying
-the timestamp-sorted log.
+GRC-20 (https://github.com/geobrowser/grc-20) is a property-graph
+standard from Geo / The Graph. Its events are append-only ops --
+CreateEntity, SetProperty, CreateRelation, DeleteEntity -- and the
+current state of an entity is the *replay* of its event log: latest
+write per property wins, a tombstone deletes. That's exactly Orly's
+storage model: commutative set union (`|=`) into a per-(entity,
+property) history set, with the replay folded inside the engine.
+
+What's new in this version (the #95 / #96 capstone): the op is a typed
+tagged union, not a string-packed (kind, val) pair --
+
+    op_t  is  <| Text(str) | Number(int) | Relation(str) | Deleted |>
+
+-- the history is a *set of variant-bearing records* (storable thanks to
+#96), and the replay -- latest-write-wins, tombstones, value formatting,
+time-travel -- runs *in orlyscript* via `reduce` + the exhaustive `when`
+match, not in this driver. Compare this file's `reconstruct` to the old
+one: there is no `event_key`, no latest-wins loop, no `format_value`. The
+driver just enumerates entities and asks the engine `display_as_of`.
 
 The demo runs in three phases:
 
-  Phase 1 (wiki editor):     basic biographical facts on 6 Greek
-                             philosophers (name, born, died). 24 ops.
+  Phase 1 (wiki editor):     biographical facts on 6 Greek philosophers
+                             (name, born, died).
   Phase 2 (stanford editor): school of thought + student_of relations.
-                             8 ops.
   Phase 3 (concurrent):      both editors race to "correct" the same
-                             attribute on the same entity. Demonstrates
-                             that multi-editor `|=` writes don't drop
-                             events.
+                             attribute on the same entity -- multi-editor
+                             `|=` never drops events; latest .ts wins.
 
-Snapshots are printed after each phase, plus a final editorial-diff
-summary (events per editor, overlapping entities).
+Snapshots are printed after each phase (each a time-travel read at that
+phase's cutoff), plus a final editorial-diff summary.
 
 Run via the wrapper:
 
@@ -36,7 +44,6 @@ Or directly, after starting orlyi separately:
 """
 
 import json
-import os
 import sys
 import threading
 import time
@@ -45,12 +52,15 @@ import websocket
 WS_URL = "ws://127.0.0.1:8082/"
 WS_TIMEOUT_S = 30
 
+# A .ts beyond any real event -- "now / all events" (mirrors grc20.orly's
+# `forever`). int64 max.
+FOREVER = 9223372036854775807
+
 
 # ---------------------------------------------------------------------
 # Corpus: six Greek philosophers. Editor 1 ("wiki") provides
 # biographical facts; editor 2 ("stanford") provides schools + the
-# student_of relation chain. Tombstones aren't exercised in the main
-# narrative -- the phase-3 race showcases concurrent overwrites.
+# student_of relation chain.
 # ---------------------------------------------------------------------
 PHILOSOPHERS = [
     ("socrates",   "Socrates",    -470, -399),
@@ -78,29 +88,16 @@ RELATIONS = [
 
 # Phase-3 race: both editors concurrently rewrite the *same* attribute
 # on the *same* entity. Whoever's event has the later timestamp is the
-# "current" value; the loser's event stays in history as an
-# alternative-source claim. Models the real GRC-20 editorial workflow.
+# "current" value (the engine's `reduce` picks it); the loser's event
+# stays in history as an alternative-source claim.
 RACE_FACT = ("pythagoras", "born", -570, -575)
 
 
 # ---------------------------------------------------------------------
-# WS helpers + event records.
-#
-# Each event is a first-class record
-#   <{.ts: int, .editor: str, .kind: str, .val: str}>
-# stored in a set OF records (issue #90). ts is a ms timestamp; kind ∈
-# {L text, I integer, R relation target id, D tombstone}. No string
-# packing -- the four typed fields travel end to end. Chronological
-# order is `event_key` (ts first, then a deterministic tiebreaker).
+# WS plumbing.
 # ---------------------------------------------------------------------
 def now_ms():
     return int(time.time() * 1000)
-
-
-def event_key(ev):
-    """Total order over event records: ts first, then a deterministic
-    same-ms tiebreaker (editor, kind, val)."""
-    return (ev["ts"], ev["editor"], ev["kind"], ev["val"])
 
 
 def send(ws, stmt):
@@ -112,24 +109,16 @@ def send(ws, stmt):
 
 
 def orly_str(s):
-    """Escape a Python string for an Orlyscript string literal.
-    Our corpus has no quotes/backslashes, but be defensive."""
+    """Escape a Python string for an Orlyscript string literal."""
     return '"' + s.replace('\\', '\\\\').replace('"', '\\"') + '"'
 
 
-def append_op(ws, pov, entity, prop, ts, editor, kind, val):
-    """Union one event record into the (entity, property) history. The
-    engine builds the <{.ts, .editor, .kind, .val}> record from these
-    typed args; ts is an int literal, the rest are string literals."""
-    send(ws, (f'try {{{pov}}} grc20 append_op '
-              f'<{{.entity: {orly_str(entity)}, '
-              f'.property: {orly_str(prop)}, '
-              f'.ts: {int(ts)}, '
-              f'.editor: {orly_str(editor)}, '
-              f'.kind: {orly_str(kind)}, '
-              f'.val: {orly_str(val)}}}>;'))
-
-
+# ---------------------------------------------------------------------
+# Writes. The engine owns the op vocabulary now: the driver hands it
+# typed scalars and orlyscript builds the `op_t` variant. ts is supplied
+# by the driver (now_ms) so concurrent writers get a real wall-clock
+# order; the engine resolves latest-.ts-wins.
+# ---------------------------------------------------------------------
 def register_entity(ws, pov, entity):
     send(ws, (f'try {{{pov}}} grc20 register_entity '
               f'<{{.entity: {orly_str(entity)}}}>;'))
@@ -141,15 +130,85 @@ def register_prop(ws, pov, entity, prop):
               f'.property: {orly_str(prop)}}}>;'))
 
 
-def hist_for(ws, pov, entity, prop):
-    """Returns the event history as a list of dicts
-    {ts:int, editor:str, kind:str, val:str}. Records come back over the
-    wire as JSON objects; ts may arrive as a float, so normalise it."""
-    r = send(ws, (f'try {{{pov}}} grc20 hist_for '
-                  f'<{{.entity: {orly_str(entity)}, '
-                  f'.property: {orly_str(prop)}}}>;'))
-    return [{"ts": int(ev["ts"]), "editor": ev["editor"],
-             "kind": ev["kind"], "val": ev["val"]} for ev in (r or [])]
+def create_entity(ws, pov, entity, ts, editor, kind):
+    send(ws, (f'try {{{pov}}} grc20 create_entity '
+              f'<{{.entity: {orly_str(entity)}, .ts: {int(ts)}, '
+              f'.editor: {orly_str(editor)}, .kind: {orly_str(kind)}}}>;'))
+
+
+def delete_entity(ws, pov, entity, ts, editor):
+    send(ws, (f'try {{{pov}}} grc20 delete_entity '
+              f'<{{.entity: {orly_str(entity)}, .ts: {int(ts)}, '
+              f'.editor: {orly_str(editor)}}}>;'))
+
+
+def set_text(ws, pov, entity, prop, ts, editor, text):
+    send(ws, (f'try {{{pov}}} grc20 set_text '
+              f'<{{.entity: {orly_str(entity)}, .property: {orly_str(prop)}, '
+              f'.ts: {int(ts)}, .editor: {orly_str(editor)}, '
+              f'.text: {orly_str(text)}}}>;'))
+
+
+def set_number(ws, pov, entity, prop, ts, editor, n):
+    send(ws, (f'try {{{pov}}} grc20 set_number '
+              f'<{{.entity: {orly_str(entity)}, .property: {orly_str(prop)}, '
+              f'.ts: {int(ts)}, .editor: {orly_str(editor)}, .n: {int(n)}}}>;'))
+
+
+def set_relation(ws, pov, entity, prop, ts, editor, target):
+    send(ws, (f'try {{{pov}}} grc20 set_relation '
+              f'<{{.entity: {orly_str(entity)}, .property: {orly_str(prop)}, '
+              f'.ts: {int(ts)}, .editor: {orly_str(editor)}, '
+              f'.target: {orly_str(target)}}}>;'))
+
+
+# ---------------------------------------------------------------------
+# GRC-20-style ops. Thin: pick the typed setter, register the property
+# in the catalogue so reads can enumerate it. CreateEntity registers the
+# id + stamps a typed marker on the reserved "__entity" property (which
+# the engine's `entity_live` reads back); it is deliberately NOT listed
+# as a normal property.
+# ---------------------------------------------------------------------
+def op_create_entity(ws, pov, editor, entity, type_name):
+    create_entity(ws, pov, entity, now_ms(), editor, type_name)
+
+
+def op_set_text(ws, pov, editor, entity, prop, text):
+    register_prop(ws, pov, entity, prop)
+    set_text(ws, pov, entity, prop, now_ms(), editor, text)
+
+
+def op_set_int(ws, pov, editor, entity, prop, n):
+    register_prop(ws, pov, entity, prop)
+    set_number(ws, pov, entity, prop, now_ms(), editor, n)
+
+
+def op_create_relation(ws, pov, editor, entity, prop, target):
+    register_entity(ws, pov, target)
+    register_prop(ws, pov, entity, prop)
+    set_relation(ws, pov, entity, prop, now_ms(), editor, target)
+
+
+def op_delete_entity(ws, pov, editor, entity):
+    delete_entity(ws, pov, entity, now_ms(), editor)
+
+
+# ---------------------------------------------------------------------
+# Reads. The replay -- latest-wins, tombstone, formatting, time-travel --
+# is the engine's job. `display_as_of` returns the already-formatted
+# current value (or "(absent)" for an unset/deleted property);
+# `entity_live_as_of` replays the entity tombstone.
+# ---------------------------------------------------------------------
+def display_as_of(ws, pov, entity, prop, as_of):
+    return send(ws, (f'try {{{pov}}} grc20 display_as_of '
+                     f'<{{.entity: {orly_str(entity)}, '
+                     f'.property: {orly_str(prop)}, .as_of: {int(as_of)}}}>;'))
+
+
+def entity_live_as_of(ws, pov, entity, as_of):
+    return bool(send(ws, (f'try {{{pov}}} grc20 entity_live_as_of '
+                          f'<{{.entity: {orly_str(entity)}, '
+                          f'.as_of: {int(as_of)}}}>;')))
 
 
 def all_entities(ws, pov):
@@ -167,87 +226,36 @@ def entity_count(ws, pov):
     return int(send(ws, f'try {{{pov}}} grc20 entity_count <{{}}>;'))
 
 
-# ---------------------------------------------------------------------
-# GRC-20-style ops (entity / property / relation), each implemented as
-# one append_op + entity/prop registration. The driver, not orlyscript,
-# owns the op vocabulary -- the engine just stores the events.
-# ---------------------------------------------------------------------
-def op_create_entity(ws, pov, editor, entity, type_name):
-    """CreateEntity: registers + records the entity's type as a TEXT
-    property called '__type'."""
-    register_entity(ws, pov, entity)
-    register_prop(ws, pov, entity, "__type")
-    append_op(ws, pov, entity, "__type", now_ms(), editor, "L", type_name)
-
-
-def op_set_text(ws, pov, editor, entity, prop, text):
-    register_entity(ws, pov, entity)
-    register_prop(ws, pov, entity, prop)
-    append_op(ws, pov, entity, prop, now_ms(), editor, "L", text)
-
-
-def op_set_int(ws, pov, editor, entity, prop, n):
-    register_entity(ws, pov, entity)
-    register_prop(ws, pov, entity, prop)
-    append_op(ws, pov, entity, prop, now_ms(), editor, "I", str(n))
-
-
-def op_create_relation(ws, pov, editor, entity, prop, target):
-    register_entity(ws, pov, entity)
-    register_entity(ws, pov, target)
-    register_prop(ws, pov, entity, prop)
-    append_op(ws, pov, entity, prop, now_ms(), editor, "R", target)
-
-
-def op_delete_entity(ws, pov, editor, entity):
-    register_prop(ws, pov, entity, "__deleted")
-    append_op(ws, pov, entity, "__deleted", now_ms(), editor, "D", "")
+def hist_meta(ws, pov, entity, prop):
+    """Raw event log for one (entity, property), but only the provenance
+    fields (.ts, .editor) -- used for per-editor analytics, never for
+    replay. The typed .op is resolved by the engine, so the driver does
+    not parse it."""
+    r = send(ws, (f'try {{{pov}}} grc20 hist_for '
+                  f'<{{.entity: {orly_str(entity)}, '
+                  f'.property: {orly_str(prop)}}}>;'))
+    return [{"ts": int(ev["ts"]), "editor": ev["editor"]} for ev in (r or [])]
 
 
 # ---------------------------------------------------------------------
-# Replay: build the current state of every (entity, property) by
-# walking its history set in timestamp order, applying each event.
-# A cutoff (`as_of_ts`) drops events with ts > cutoff -- that's the
-# time-travel knob.
+# Reconstruct: enumerate the graph at `as_of`, asking the engine for each
+# value. No latest-wins loop, no tombstone bookkeeping, no formatting --
+# that all moved into grc20.orly. Live entities only (entity tombstone is
+# an engine replay), present properties only ("(absent)" filtered out).
 # ---------------------------------------------------------------------
-def reconstruct(ws, pov, as_of_ts=None):
-    """Returns {entity_id: {property: (kind, value, editor, ts)}}.
-
-    Entities whose latest __deleted event is in scope are omitted.
-    'kind' is L/I/R as defined in the encoding above (D is consumed
-    by the entity-tombstone branch and never surfaces here)."""
-    entities = sorted(all_entities(ws, pov))
+def reconstruct(ws, pov, as_of=FOREVER):
+    """Returns {entity_id: {"__type": type_str, property: display_str}}."""
     out = {}
-    for eid in entities:
-        props = sorted(props_of(ws, pov, eid))
-        deleted = False
-        e_state = {}
-        for prop in props:
-            entries = sorted(hist_for(ws, pov, eid, prop), key=event_key)
-            if as_of_ts is not None:
-                entries = [e for e in entries if e["ts"] <= as_of_ts]
-            if not entries:
-                continue
-            # Latest event wins per property.
-            latest = entries[-1]
-            if prop == "__deleted" and latest["kind"] == "D":
-                deleted = True
-                break
-            e_state[prop] = (latest["kind"], latest["val"],
-                             latest["editor"], latest["ts"])
-        if not deleted:
-            out[eid] = e_state
+    for eid in sorted(all_entities(ws, pov)):
+        if not entity_live_as_of(ws, pov, eid, as_of):
+            continue
+        e_state = {"__type": display_as_of(ws, pov, eid, "__entity", as_of)}
+        for prop in sorted(props_of(ws, pov, eid)):
+            value = display_as_of(ws, pov, eid, prop, as_of)
+            if value != "(absent)":
+                e_state[prop] = value
+        out[eid] = e_state
     return out
-
-
-def format_value(kind, value):
-    if kind == "L":
-        return value
-    if kind == "I":
-        return value
-    if kind == "R":
-        return f"→ {value}"
-    return f"?{kind}:{value}"
 
 
 def print_snapshot(label, state):
@@ -256,27 +264,19 @@ def print_snapshot(label, state):
         print("  (empty graph)")
         return
     for eid in sorted(state):
-        attrs = state[eid]
-        if not attrs:
-            print(f"  {eid}: (no props)")
-            continue
-        type_name = attrs.get("__type", ("L", "?", "", 0))[1]
-        bits = []
-        for prop in sorted(attrs):
-            if prop == "__type":
-                continue
-            kind, value, editor, _ts = attrs[prop]
-            bits.append(f"{prop}={format_value(kind, value)} [{editor}]")
-        print(f"  {eid} ({type_name}): {', '.join(bits) if bits else '(no props)'}")
+        attrs = dict(state[eid])
+        type_name = attrs.pop("__type", "?")
+        bits = [f"{prop}={attrs[prop]}" for prop in sorted(attrs)]
+        body = ', '.join(bits) if bits else '(no props)'
+        print(f"  {eid} ({type_name}): {body}")
 
 
 # ---------------------------------------------------------------------
-# Phases. Each phase opens its own WebSocket -- separate sessions are
-# what makes the multi-editor story testable. Phase 3 spins two threads
-# so a true interleaving happens on the wire.
+# Phases. Each opens its own WebSocket -- separate sessions are what make
+# the multi-editor story testable. Phase 3 spins two threads so a true
+# interleaving happens on the wire.
 # ---------------------------------------------------------------------
 def phase1_wiki(pov):
-    """Editor 'wiki' streams biographical facts (~24 ops)."""
     ws = websocket.create_connection(WS_URL, timeout=WS_TIMEOUT_S)
     try:
         send(ws, "new session;")
@@ -290,7 +290,6 @@ def phase1_wiki(pov):
 
 
 def phase2_stanford(pov):
-    """Editor 'stanford' streams schools + relations (~8 ops)."""
     ws = websocket.create_connection(WS_URL, timeout=WS_TIMEOUT_S)
     try:
         send(ws, "new session;")
@@ -325,12 +324,12 @@ def phase3_race(pov):
 
 
 def editorial_diff(ws, pov):
-    """Per-editor event count + overlap analysis."""
+    """Per-editor event count + overlap analysis, over the raw log."""
     by_editor = {}                # editor -> int (event count)
     entities_by_editor = {}       # editor -> set(entity ids)
     for eid in sorted(all_entities(ws, pov)):
-        for prop in sorted(props_of(ws, pov, eid)):
-            for ev in hist_for(ws, pov, eid, prop):
+        for prop in sorted(props_of(ws, pov, eid)) + ["__entity"]:
+            for ev in hist_meta(ws, pov, eid, prop):
                 editor = ev["editor"]
                 by_editor[editor] = by_editor.get(editor, 0) + 1
                 entities_by_editor.setdefault(editor, set()).add(eid)
@@ -347,7 +346,6 @@ def editorial_diff(ws, pov):
 
 
 def main():
-    # Bootstrap.
     boot = websocket.create_connection(WS_URL, timeout=WS_TIMEOUT_S)
     send(boot, "new session;")
     send(boot, "install grc20.1;")
@@ -364,11 +362,10 @@ def main():
     print(f"  {entity_count(boot, pov)} entities registered "
           f"in {time.monotonic() - t0:.2f}s")
     print_snapshot("snapshot 1: end of phase 1 (wiki only)",
-                   reconstruct(boot, pov, as_of_ts=ts1))
+                   reconstruct(boot, pov, as_of=ts1))
 
-    # Tiny gap so phase-2 timestamps are strictly later than phase-1
-    # timestamps -- otherwise the ms-resolution clock can blur the
-    # boundary on fast machines.
+    # Tiny gap so phase-2 timestamps are strictly later than phase-1's --
+    # otherwise the ms-resolution clock can blur the phase boundary.
     time.sleep(0.05)
 
     # --- Phase 2: stanford streams schools + relations ---
@@ -378,7 +375,7 @@ def main():
     ts2 = now_ms()
     print(f"  done in {time.monotonic() - t0:.2f}s")
     print_snapshot("snapshot 2: end of phase 2 (wiki + stanford)",
-                   reconstruct(boot, pov, as_of_ts=ts2))
+                   reconstruct(boot, pov, as_of=ts2))
 
     time.sleep(0.05)
 
@@ -390,55 +387,55 @@ def main():
     print(f"  stanford -> {stanford_value}")
     phase3_race(pov)
     ts3 = now_ms()
-    race_entries = sorted(hist_for(boot, pov, entity, prop), key=event_key)
+    race_events = sorted(hist_meta(boot, pov, entity, prop),
+                         key=lambda ev: (ev["ts"], ev["editor"]))
     print(f"  history for {entity}.{prop} after race "
-          f"({len(race_entries)} events, ts-sorted):")
-    for ev in race_entries:
-        print(f"    {ev['ts']}  {ev['editor']:<10} {ev['kind']}  {ev['val']}")
-    final_state = reconstruct(boot, pov, as_of_ts=ts3)
-    winning = final_state[entity][prop]
-    print(f"  -> winning event: {winning[1]} [{winning[2]}, ts={winning[3]}]")
+          f"({len(race_events)} events, ts-sorted):")
+    for ev in race_events:
+        print(f"    {ev['ts']}  {ev['editor']}")
+    winning = display_as_of(boot, pov, entity, prop, ts3)
+    print(f"  -> engine-resolved current value: {entity}.{prop} = {winning}")
 
     # --- Final state + editorial diff ---
-    print_snapshot("snapshot 3: final state", final_state)
+    print_snapshot("snapshot 3: final state", reconstruct(boot, pov, as_of=ts3))
     editorial_diff(boot, pov)
 
     # --- Self-check ---
     print("\n=== the trick ===")
-    print("  Every editor `|=` an event record into a per-(entity, prop)")
-    print("  set of <{.ts, .editor, .kind, .val}> (issue #90). Multi-editor")
-    print("  writes never drop events (post-#50 deferred-mutation fold).")
-    print("  Reads replay the timestamp-sorted log -- pass a cutoff for")
-    print("  time-travel, take the latest for the current value. The schema")
-    print("  is three commutative funcs; GRC-20's op vocabulary lives")
-    print("  entirely in the driver.")
+    print("  Each op is a typed variant")
+    print("    op_t is <| Text(str) | Number(int) | Relation(str) | Deleted |>")
+    print("  unioned into a per-(entity, prop) set of <{.ts,.editor,.op}>")
+    print("  records (storable variants, #96). Multi-editor `|=` never")
+    print("  drops events (post-#50 fold). The REPLAY -- sort by .ts,")
+    print("  `reduce` to the latest, `when` over the op to format/tombstone,")
+    print("  filtered by an `as_of` cutoff for time-travel -- runs in the")
+    print("  engine. This driver just enumerates and reads.")
 
     failures = []
-    # Phase-1 invariant: every philosopher has name + born + died.
-    s1 = reconstruct(boot, pov, as_of_ts=ts1)
+    # Phase-1 invariant: every philosopher has name + born; no school yet.
+    s1 = reconstruct(boot, pov, as_of=ts1)
     for eid, name, born, died in PHILOSOPHERS:
         e = s1.get(eid, {})
-        if e.get("name", (None,))[0] != "L" or e["name"][1] != name:
-            failures.append(f"snapshot 1: {eid}.name = {e.get('name')}")
-        if e.get("born", (None,))[0] != "I" or int(e["born"][1]) != born:
-            failures.append(f"snapshot 1: {eid}.born = {e.get('born')}")
-        # Phase-1 must NOT contain schools or relations.
+        if e.get("name") != name:
+            failures.append(f"snapshot 1: {eid}.name = {e.get('name')!r}")
+        if e.get("born") != str(born):
+            failures.append(f"snapshot 1: {eid}.born = {e.get('born')!r}")
         if "school" in e:
             failures.append(f"snapshot 1: {eid}.school leaked from phase 2")
     # Phase-2 invariant: every philosopher now has a school.
-    s2 = reconstruct(boot, pov, as_of_ts=ts2)
+    s2 = reconstruct(boot, pov, as_of=ts2)
     for eid, school in SCHOOLS.items():
         e = s2.get(eid, {})
-        if e.get("school", (None,))[0] != "L" or e["school"][1] != school:
-            failures.append(f"snapshot 2: {eid}.school = {e.get('school')}")
-    # Phase-2 must contain the student_of relations.
+        if e.get("school") != school:
+            failures.append(f"snapshot 2: {eid}.school = {e.get('school')!r}")
+    # Phase-2 invariant: the student_of relations are formatted "-> target".
     for subject, prop, target in RELATIONS:
         e = s2.get(subject, {})
-        if e.get(prop, (None,))[0] != "R" or e[prop][1] != target:
-            failures.append(f"snapshot 2: {subject}.{prop} = {e.get(prop)}")
+        if e.get(prop) != f"-> {target}":
+            failures.append(f"snapshot 2: {subject}.{prop} = {e.get(prop)!r}")
     # Phase-3 invariant: both race events survive in history.
-    if len(race_entries) < 2:
-        failures.append(f"phase 3: only {len(race_entries)} events in race "
+    if len(race_events) < 2:
+        failures.append(f"phase 3: only {len(race_events)} events in race "
                         f"history -- expected both writers to land")
 
     send(boot, "exit;")
@@ -450,7 +447,7 @@ def main():
             print(f"  {f}")
         sys.exit(1)
     print("\n=== self-check OK ===")
-    print(f"  verified 3 snapshot invariants + multi-editor race")
+    print("  verified 3 time-travel snapshot invariants + multi-editor race")
 
 
 if __name__ == "__main__":

--- a/examples/grc20-pov/grc20.orly
+++ b/examples/grc20-pov/grc20.orly
@@ -1,61 +1,73 @@
 /* <examples/grc20-pov/grc20.orly>
 
    GRC-20-shaped knowledge graph as an append-only event log, backed by
-   Orly's commutative set-union field call. Multiple editors stream ops
-   into the same shared POV with no coordination; the read path
-   reconstructs the current state (or any historical state) by replaying
-   the op log in timestamp order.
+   Orly's commutative set-union field call -- with the replay folded
+   *inside the engine* via sum types (#95), set-of-variant storage (#96),
+   `reduce`, and the exhaustive `when` match.
 
    GRC-20 is a property-graph standard from Geo / The Graph
-   (https://github.com/geobrowser/grc-20). Entities have typed
-   properties (TEXT, INTEGER, ...) and directed relations. The spec
-   exposes ops like CreateEntity / UpdateEntity / CreateRelation /
-   DeleteEntity, all event-sourced -- which is exactly the shape Orly
-   stores commutatively.
+   (https://github.com/geobrowser/grc-20). Entities have typed properties
+   (TEXT, INTEGER, ...) and directed relations. The spec exposes ops like
+   CreateEntity / SetProperty / CreateRelation / DeleteEntity, all
+   event-sourced -- exactly the shape Orly stores commutatively.
 
-   This package gives the engine three operations:
+   ## Typed events (the #95 / #96 payoff)
 
-     - append_op    : union one event into a (entity, property) history
-     - list_entities: enumerate every entity ever touched
-     - list_props   : enumerate every property ever touched on an entity
+   An op is a tagged union -- one of four typed shapes -- not a
+   string-packed `(kind, val)` pair:
 
-   Plus their read-side counterparts (hist_for, all_entities, props_of).
+     op_t  is  <| Text(str) | Number(int) | Relation(str) | Deleted |>
 
-   Each event is a first-class record:
+   and an event wraps an op with its provenance:
 
-     <{.ts: int, .editor: str, .kind: str, .val: str}>
+     evt_t is  <{.ts: int, .editor: str, .op: op_t}>
 
-   where ts is a millisecond timestamp, editor is the source name, kind
-   is the op class (one of "L" text literal, "I" integer literal, "R"
-   relation target id, "D" tombstone), and val is the literal text or the
-   target entity id. The history set is a set OF these records, so the
-   structure travels end to end -- the driver hands the engine four typed
-   fields and reads back four typed fields, no string packing/unpacking.
-   Sorting the set by .ts gives chronological order; driver-side replay
-   then takes "latest write wins per property" with tombstones, the same
-   way GRC-20 itself does.
+   The history of one (entity, property) pair is a *set of these
+   variant-bearing records* -- which is only storable because of #96
+   (a set of differently-tagged variants is homogeneous on disk). The op
+   travels end to end fully typed: the driver hands the engine a typed
+   value and the engine hands back a resolved typed value -- no
+   kind/val string packing, no driver-side `if kind == "L"` dispatch.
 
-   Why driver-side replay rather than an orlyscript fold: GRC-20 ops are
-   heterogeneous (CreateEntity / SetProperty / CreateRelation /
-   DeleteEntity), and the replay is conditional on the event kind. Set
-   union over event records keeps the schema simple and gives the same
-   "version axis in the keyspace" guarantee as
-   examples/wikipedia-categories/: any (entity, property) pair gets one
-   set, every op is one immutable record, the past is structurally
-   frozen.
+   ## In-engine replay (the capstone)
 
-   Schema:
+   The current value of a property is the replay of its event log:
+   latest-timestamp write wins, a `Deleted` op tombstones it. That replay
+   used to live in the driver (Python/Go). It now lives in orlyscript:
 
-     <['hist', entity, property]>::({<{.ts, .editor, .kind, .val}>})
-                                            events for one (e, p) pair
-     <['entities']>::({str})                set of every entity id
-     <['props',  entity]>::({str})          set of every property id ever
-                                            written on this entity
+     resolve_as_of = filter the (e, p) history to .ts <= as_of, sort by
+                     .ts, `reduce` to the last (== latest) event, take its
+                     .op                                       -> op_t
+     display_as_of = `when` over that op_t -> a formatted string
+     present_as_of = `when` over that op_t -> a liveness bool
 
-   Concurrent editors writing to overlapping entities/properties all
-   land their events; the post-#50 deferred-mutation + read-time-fold
-   mechanism is what makes `|=` from multiple WS sessions safe. The
-   storable-record-set support is issue #90.
+   `reduce`'s "exactly one start" seed is a `Deleted` sentinel, so an empty
+   (or fully-filtered) history resolves to absent for free. The `as_of`
+   cutoff is the time-travel knob -- pass `forever` (a .ts beyond any real
+   event) for the live value, or any past timestamp to replay the graph as
+   it stood then; the past is structurally frozen because every op is an
+   immutable set member. `resolve` / `display` / `is_present` are the
+   `as_of: forever` convenience forms.
+
+   Entity existence reuses the same machinery: CreateEntity sets a
+   non-Deleted marker on the reserved `"__entity"` property, DeleteEntity
+   sets `Deleted`, and `entity_live` is just `is_present(entity,
+   "__entity")` -- a never-created entity reads absent (the seed), a
+   deleted one reads `Deleted`, a live one reads its marker.
+
+   ## Schema
+
+     <['hist', entity, property]>::({evt_t})   events for one (e, p) pair
+     <['entities']>::({str})                   set of every entity id
+     <['props',  entity]>::({str})             property ids touched on it
+
+   Concurrent editors writing overlapping entities/properties all land
+   their events; the post-#50 deferred-mutation + read-time-fold mechanism
+   makes `|=` from independent WS sessions safe. Storable record/variant
+   sets are #90 / #96. The "version axis in the keyspace" guarantee
+   (cf. examples/wikipedia-categories/) holds: every op is one immutable
+   record, the past is structurally frozen, any historical state is a
+   replay over a `.ts` bound.
 
    Copyright 2010-2026 Atomic Kismet Company
 
@@ -73,31 +85,183 @@
 
 package #1;
 
+/* ---------- typed event model ---------- */
+
+/* One GRC-20 op, as a tagged union. Text/Number/Relation carry their
+   literal payload; Deleted is the tombstone (a unit arm). Type aliases are
+   usable wherever a *type* is expected (reads, `given`, `as`); constructing
+   a value still uses the `<| ... |>.Tag(v)` literal form. */
+op_t  is <| Text(str) | Number(int) | Relation(str) | Deleted |>;
+
+/* One event: an op plus when (ms timestamp) and who (editor). */
+evt_t is <{.ts: int, .editor: str, .op: op_t}>;
+
 /* ---------- per-(entity, property) event history ---------- */
 
-hist_for = (((*<['hist', entity, property]>::({<{.ts: int, .editor: str, .kind: str, .val: str}>})) if *<['hist', entity, property]>::({<{.ts: int, .editor: str, .kind: str, .val: str}>}?) is known else (empty {<{.ts: int, .editor: str, .kind: str, .val: str}>}))) where {
+hist_for = (((*<['hist', entity, property]>::({evt_t})) if *<['hist', entity, property]>::({evt_t}?) is known else (empty {evt_t}))) where {
   entity   = given::(str);
   property = given::(str);
 };
 
-/* Append one event record into the (entity, property) history. */
-append_op = (((1) effecting {
-  *<['hist', entity, property]>::({<{.ts: int, .editor: str, .kind: str, .val: str}>}) |= {<{.ts: ts, .editor: editor, .kind: kind, .val: val}>};
-} if *<['hist', entity, property]>::({<{.ts: int, .editor: str, .kind: str, .val: str}>}?) is known else (0) effecting {
-  new <['hist', entity, property]> <- {<{.ts: ts, .editor: editor, .kind: kind, .val: val}>};
+/* ---------- in-engine replay: resolve / display / presence ---------- */
+
+/* A .ts beyond any real (millisecond) event -- "now / all events". Pass it
+   as `as_of` to read the live value; pass a past timestamp to time-travel. */
+forever = 9223372036854775807;
+
+/* Replay one (entity, property) history as of a timestamp: keep events with
+   .ts <= as_of, sort by .ts, `reduce` to the last (latest) event, take its
+   .op. The seed is a Deleted sentinel at .ts -1, so an empty/fully-filtered
+   history resolves to Deleted == absent (and -1 never beats a real ms
+   timestamp). This is the latest-write-wins replay that used to live in the
+   driver. */
+resolve_as_of = (((**((((**hist_for(.entity: entity, .property: property)) if (that.ts <= as_of)) as [evt_t]) sorted_by lhs.ts < rhs.ts)) reduce (start seed if false else that)).op) where {
+  seed     = <{.ts: -1, .editor: "", .op: <| Text(str) | Number(int) | Relation(str) | Deleted |>.Deleted}>;
+  entity   = given::(str);
+  property = given::(str);
+  as_of    = given::(int);
+};
+
+/* The resolved op as of a timestamp, formatted for display -- the GRC-20
+   `format_value` moved in-engine. `when` is exhaustive over op_t's arms. */
+display_as_of = ((op) when {
+  Text:     op.Text;
+  Number:   (op.Number) as str;
+  Relation: "-> " + op.Relation;
+  Deleted:  "(absent)";
+}) where {
+  op       = resolve_as_of(.entity: entity, .property: property, .as_of: as_of);
+  entity   = given::(str);
+  property = given::(str);
+  as_of    = given::(int);
+};
+
+/* Is the property set as of a timestamp (latest op is not a tombstone)? */
+present_as_of = ((op) when {
+  Text:     true;
+  Number:   true;
+  Relation: true;
+  Deleted:  false;
+}) where {
+  op       = resolve_as_of(.entity: entity, .property: property, .as_of: as_of);
+  entity   = given::(str);
+  property = given::(str);
+  as_of    = given::(int);
+};
+
+/* Current-value convenience forms (as_of: forever). */
+resolve = (resolve_as_of(.entity: entity, .property: property, .as_of: forever)) where {
+  entity   = given::(str);
+  property = given::(str);
+};
+
+display = (display_as_of(.entity: entity, .property: property, .as_of: forever)) where {
+  entity   = given::(str);
+  property = given::(str);
+};
+
+is_present = (present_as_of(.entity: entity, .property: property, .as_of: forever)) where {
+  entity   = given::(str);
+  property = given::(str);
+};
+
+/* ---------- property ops (typed appends) ---------- */
+
+/* Each set_* / clear_prop unions one typed event into the (e, p) history,
+   creating the set on first write. The event is built once in `where` and
+   referenced from both effect branches. */
+
+set_text = (((1) effecting {
+  *<['hist', entity, property]>::({evt_t}) |= {ev};
+} if *<['hist', entity, property]>::({evt_t}?) is known else (0) effecting {
+  new <['hist', entity, property]> <- {ev};
 })) where {
+  ev       = <{.ts: ts, .editor: editor, .op: <| Text(str) | Number(int) | Relation(str) | Deleted |>.Text(text)}>;
   entity   = given::(str);
   property = given::(str);
   ts       = given::(int);
   editor   = given::(str);
-  kind     = given::(str);
-  val      = given::(str);
+  text     = given::(str);
+};
+
+set_number = (((1) effecting {
+  *<['hist', entity, property]>::({evt_t}) |= {ev};
+} if *<['hist', entity, property]>::({evt_t}?) is known else (0) effecting {
+  new <['hist', entity, property]> <- {ev};
+})) where {
+  ev       = <{.ts: ts, .editor: editor, .op: <| Text(str) | Number(int) | Relation(str) | Deleted |>.Number(n)}>;
+  entity   = given::(str);
+  property = given::(str);
+  ts       = given::(int);
+  editor   = given::(str);
+  n        = given::(int);
+};
+
+set_relation = (((1) effecting {
+  *<['hist', entity, property]>::({evt_t}) |= {ev};
+} if *<['hist', entity, property]>::({evt_t}?) is known else (0) effecting {
+  new <['hist', entity, property]> <- {ev};
+})) where {
+  ev       = <{.ts: ts, .editor: editor, .op: <| Text(str) | Number(int) | Relation(str) | Deleted |>.Relation(target)}>;
+  entity   = given::(str);
+  property = given::(str);
+  ts       = given::(int);
+  editor   = given::(str);
+  target   = given::(str);
+};
+
+clear_prop = (((1) effecting {
+  *<['hist', entity, property]>::({evt_t}) |= {ev};
+} if *<['hist', entity, property]>::({evt_t}?) is known else (0) effecting {
+  new <['hist', entity, property]> <- {ev};
+})) where {
+  ev       = <{.ts: ts, .editor: editor, .op: <| Text(str) | Number(int) | Relation(str) | Deleted |>.Deleted}>;
+  entity   = given::(str);
+  property = given::(str);
+  ts       = given::(int);
+  editor   = given::(str);
+};
+
+/* ---------- entity lifecycle ---------- */
+
+/* CreateEntity: mark the reserved "__entity" property with a non-Deleted
+   op carrying the type name, and register the id in the catalogue. */
+create_entity = (((set_text(.entity: entity, .property: "__entity", .ts: ts, .editor: editor, .text: kind)) effecting {
+  *<['entities']>::({str}) |= {entity};
+} if *<['entities']>::({str}?) is known else (set_text(.entity: entity, .property: "__entity", .ts: ts, .editor: editor, .text: kind)) effecting {
+  new <['entities']> <- {entity};
+})) where {
+  entity = given::(str);
+  ts     = given::(int);
+  editor = given::(str);
+  kind   = given::(str);
+};
+
+/* DeleteEntity: tombstone the "__entity" marker. */
+delete_entity = (clear_prop(.entity: entity, .property: "__entity", .ts: ts, .editor: editor)) where {
+  entity = given::(str);
+  ts     = given::(int);
+  editor = given::(str);
+};
+
+/* An entity is live (as of a timestamp) iff its "__entity" marker resolves
+   to a non-Deleted op (never created -> absent -> not live; deleted ->
+   Deleted -> not live). */
+entity_live_as_of = (present_as_of(.entity: entity, .property: "__entity", .as_of: as_of)) where {
+  entity = given::(str);
+  as_of  = given::(int);
+};
+
+entity_live = (entity_live_as_of(.entity: entity, .as_of: forever)) where {
+  entity = given::(str);
 };
 
 /* ---------- catalogue: entities + their property set ---------- */
 
 all_entities = (((*<['entities']>::({str})) if *<['entities']>::({str}?) is known else (empty {str})));
 
+/* Bare catalogue add -- used for relation targets that may be named before
+   they are created. CreateEntity (above) registers as a side effect too. */
 register_entity = (((1) effecting {
   *<['entities']>::({str}) |= {entity};
 } if *<['entities']>::({str}?) is known else (0) effecting {
@@ -131,51 +295,94 @@ entity_count = (length_of all_entities);
 /* ---------- inline tests ---------- */
 
 test {
-  /* Empty keyspace reads as identity. */
+  /* Empty keyspace reads as identity / absent. */
   t1: all_entities == (empty {str});
   t2: props_of(.entity: "socrates") == (empty {str});
-  t3: hist_for(.entity: "socrates", .property: "name")
-        == (empty {<{.ts: int, .editor: str, .kind: str, .val: str}>});
+  t3: hist_for(.entity: "socrates", .property: "name") == (empty {evt_t});
+  t4: display(.entity: "socrates", .property: "name") == "(absent)";
+  t5: is_present(.entity: "socrates", .property: "name") == false;
+  t6: entity_live(.entity: "socrates") == false;
 
-  /* Append one event creates the set with that record. */
-  t4: append_op(.entity: "socrates", .property: "name",
-                .ts: 1, .editor: "wiki", .kind: "L", .val: "Socrates") == 0 {
-    t5: hist_for(.entity: "socrates", .property: "name")
-          == {<{.ts: 1, .editor: "wiki", .kind: "L", .val: "Socrates"}>};
-    t6: event_count(.entity: "socrates", .property: "name") == 1;
+  /* One text op sets the value; replay resolves it. */
+  t7: set_text(.entity: "socrates", .property: "name", .ts: 1, .editor: "wiki", .text: "Socrates") == 0 {
+    t8: hist_for(.entity: "socrates", .property: "name")
+          == {<{.ts: 1, .editor: "wiki", .op: <| Text(str) | Number(int) | Relation(str) | Deleted |>.Text("Socrates")}>};
+    t9: display(.entity: "socrates", .property: "name") == "Socrates";
+    t10: is_present(.entity: "socrates", .property: "name") == true;
+    t11: event_count(.entity: "socrates", .property: "name") == 1;
 
-    /* Second event from a different editor unions in. */
-    t7: append_op(.entity: "socrates", .property: "name",
-                  .ts: 2, .editor: "stanford", .kind: "L",
-                  .val: "Socrates of Athens") == 1 {
-      t8: hist_for(.entity: "socrates", .property: "name")
-            == {<{.ts: 1, .editor: "wiki", .kind: "L", .val: "Socrates"}>,
-                <{.ts: 2, .editor: "stanford", .kind: "L",
-                  .val: "Socrates of Athens"}>};
-      t9: event_count(.entity: "socrates", .property: "name") == 2;
+    /* A later op from another editor wins (latest .ts). */
+    t12: set_text(.entity: "socrates", .property: "name", .ts: 3, .editor: "sep", .text: "Socrates of Athens") == 1 {
+      t13: display(.entity: "socrates", .property: "name") == "Socrates of Athens";
+      t14: event_count(.entity: "socrates", .property: "name") == 2;
 
-      /* Idempotent: same record re-added doesn't grow the set. */
-      t10: append_op(.entity: "socrates", .property: "name",
-                     .ts: 1, .editor: "wiki", .kind: "L",
-                     .val: "Socrates") == 1 {
-        t11: event_count(.entity: "socrates", .property: "name") == 2;
+      /* An *earlier* op (lower .ts) does not change the resolved value. */
+      t15: set_text(.entity: "socrates", .property: "name", .ts: 2, .editor: "late", .text: "stale") == 1 {
+        t16: display(.entity: "socrates", .property: "name") == "Socrates of Athens";
+        t17: event_count(.entity: "socrates", .property: "name") == 3;
+
+        /* Idempotent: re-adding an identical event doesn't grow the set. */
+        t18: set_text(.entity: "socrates", .property: "name", .ts: 1, .editor: "wiki", .text: "Socrates") == 1 {
+          t19: event_count(.entity: "socrates", .property: "name") == 3;
+        };
+
+        /* A tombstone with the highest .ts clears the property. */
+        t20: clear_prop(.entity: "socrates", .property: "name", .ts: 9, .editor: "mod") == 1 {
+          t21: display(.entity: "socrates", .property: "name") == "(absent)";
+          t22: is_present(.entity: "socrates", .property: "name") == false;
+        };
       };
     };
   };
 
-  /* Catalogue ops are independent from history ops. */
-  t12: register_entity(.entity: "plato") == 0 {
-    t13: register_entity(.entity: "aristotle") == 1 {
-      t14: all_entities == {"aristotle", "plato"};
-      t15: entity_count == 2;
+  /* Heterogeneous ops on different properties of one entity. (Effects from
+     the t7 block above have rolled back, so these (e, p) pairs are fresh
+     and the first write to each returns 0.) */
+  t23: set_number(.entity: "socrates", .property: "born", .ts: 1, .editor: "wiki", .n: -470) == 0 {
+    t24: display(.entity: "socrates", .property: "born") == "-470";
+    t25: set_relation(.entity: "socrates", .property: "student", .ts: 1, .editor: "wiki", .target: "plato") == 0 {
+      t26: display(.entity: "socrates", .property: "student") == "-> plato";
+      /* The text property from the block above is unaffected. */
+      t27: display(.entity: "socrates", .property: "name") == "(absent)";
+    };
+  };
 
-      t16: register_prop(.entity: "plato", .property: "born") == 0 {
-        t17: register_prop(.entity: "plato", .property: "school") == 1 {
-          t18: props_of(.entity: "plato") == {"born", "school"};
-          /* Different entity's props don't bleed. */
-          t19: props_of(.entity: "aristotle") == (empty {str});
-        };
-      };
+  /* Entity lifecycle: create marks it live, delete tombstones it. */
+  t28: create_entity(.entity: "plato", .ts: 1, .editor: "wiki", .kind: "Person") == 0 {
+    t29: entity_live(.entity: "plato") == true;
+    t30: all_entities == {"plato"};
+    t31: entity_count == 1;
+    t32: delete_entity(.entity: "plato", .ts: 5, .editor: "mod") == 1 {
+      t33: entity_live(.entity: "plato") == false;
+      /* Still in the catalogue -- the log is append-only; liveness is a replay. */
+      t34: all_entities == {"plato"};
+    };
+  };
+
+  /* Time-travel: the same key replays to different values at different
+     `as_of` cutoffs, and `resolve` returns the typed op variant. */
+  t39: set_text(.entity: "h", .property: "name", .ts: 10, .editor: "a", .text: "old") == 0 {
+    t40: set_text(.entity: "h", .property: "name", .ts: 20, .editor: "b", .text: "new") == 1 {
+      /* live value is the latest */
+      t41: display(.entity: "h", .property: "name") == "new";
+      /* as of ts 15, only the first op is in scope */
+      t42: display_as_of(.entity: "h", .property: "name", .as_of: 15) == "old";
+      /* as of ts 5, nothing is in scope yet -> absent */
+      t43: present_as_of(.entity: "h", .property: "name", .as_of: 5) == false;
+      /* resolve hands back the typed variant, not a string */
+      t44: resolve(.entity: "h", .property: "name")
+             == <| Text(str) | Number(int) | Relation(str) | Deleted |>.Text("new");
+      t45: resolve_as_of(.entity: "h", .property: "name", .as_of: 15)
+             == <| Text(str) | Number(int) | Relation(str) | Deleted |>.Text("old");
+    };
+  };
+
+  /* Property catalogue is independent of history ops. */
+  t35: register_prop(.entity: "aristotle", .property: "born") == 0 {
+    t36: register_prop(.entity: "aristotle", .property: "school") == 1 {
+      t37: props_of(.entity: "aristotle") == {"born", "school"};
+      /* A different entity's props don't bleed. */
+      t38: props_of(.entity: "plato") == (empty {str});
     };
   };
 };


### PR DESCRIPTION
## Summary

The capstone of the sum-types line (#95 / #96): rewrites the GRC-20 demo so the event op is a **typed tagged union** and the replay runs **inside the engine** via `reduce` + the exhaustive `when` match. Previously the op was a string-packed `(kind, val)` pair and the latest-write-wins / tombstone / formatting / time-travel replay lived in the Python and Go drivers.

```orly
op_t  is  <| Text(str) | Number(int) | Relation(str) | Deleted |>;
evt_t is  <{.ts: int, .editor: str, .op: op_t}>;
```

The per-(entity, property) history is a **set of these variant-bearing records** — storable only because a set of differently-tagged variants is now homogeneous on disk (#96). This demo is the end-to-end exercise of that feature on a real workload.

## In-engine replay

```orly
resolve_as_of = filter history to .ts <= as_of, sort by .ts,
                `reduce` to the latest event, take its .op   -> op_t
display_as_of = `when` over that op_t -> a formatted string
present_as_of = `when` over that op_t -> a liveness bool
```

`reduce`'s "exactly one start" seed is a `Deleted` sentinel, so an empty/fully-filtered history resolves to absent for free; `when` is exhaustiveness-checked at compile time. The `as_of` cutoff is the time-travel knob (`forever` == live); `resolve` / `display` / `is_present` / `entity_live` are the `as_of: forever` convenience forms. Entity existence reuses the same fold over a reserved `"__entity"` marker.

## What changed

- **`grc20.orly`** — typed `op_t` / `evt_t` aliases; typed appends (`set_text` / `set_number` / `set_relation` / `clear_prop`, `create_entity` / `delete_entity`); in-engine `resolve` / `display` / `is_present` / `entity_live` (+ `_as_of` forms); catalogue + counts; **40+ inline tests** over resolution, tombstones, time-travel, the typed round-trip, and entity lifecycle.
- **`demo.py` / `demo.go`** — dropped the driver-side replay entirely: no `event_key`, no latest-wins loop, no `format_value`. `reconstruct` now enumerates live entities and asks the engine `display_as_of`. The driver never parses the op variant — it streams typed scalars in and reads resolved values out.
- **`README.md`** — rewritten around the inverted pitch: the engine owns the typed op vocabulary and the replay; the driver is plumbing.

## Validation

- `orlyc -m grc20.orly` runs the inline suite — all pass.
- **Both drivers verified end-to-end** against a fresh `orlyi` (`./run.sh` and `./run-go.sh`): three time-travel snapshot invariants (phase-1 facts, phase-2 schools + relations, no phase-2 leakage into phase-1) plus the multi-editor race (both concurrent events survive, engine resolves the latest `.ts`). Self-check OK for both.

Depends on #96 (merged). Closes out the sum-types capstone from the #95 plan.