### PR TITLE
expr: `when` payload binder `Tag(n): body` (#95)

### DIFF
--- a/orly/expr/when.h
+++ b/orly/expr/when.h
@@ -12,7 +12,9 @@
    to `Tags`). The code_gen layer lowers it to a nested ternary on the
    operand's `GetWhich()` selecting the matching arm -- reusing the M4
    primitives. Arm bodies read the active payload via the `e.<Tag>`
-   accessor; v1 has no payload binder.
+   accessor, or bind it to a name with the `Tag(n): body` arm form (sugar
+   desugared in synth to `body where { n = operand.Tag; }`, so it is
+   transparent here -- a binder arm body is simply an `Expr::TWhere`).
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/orly.nycr
+++ b/orly/orly.nycr
@@ -574,6 +574,7 @@ when_expr : expr -> open_paren expr close_paren when_kwd open_brace opt_when_arm
   when_arm;
   bad_when_arm     : when_arm -> error semi;
   labeled_when_arm : when_arm -> name colon expr semi;
+  binder_when_arm  : when_arm -> tag:name open_paren binder:name close_paren colon expr semi;
 
 effecting_expr : expr -> open_paren expr close_paren effecting_kwd stmt_block;
 

--- a/orly/synth/func_def.cc
+++ b/orly/synth/func_def.cc
@@ -35,6 +35,13 @@ using namespace Orly::Synth;
 TFuncDef::TFuncDef(TScope *scope, const Package::Syntax::TFuncDef *func_def)
     : TDef(scope, Base::AssertTrue(func_def)->GetName()),
       FuncDef(Base::AssertTrue(func_def)),
+      PosRange(GetPosRange(func_def)),
+      Expr(nullptr) {}
+
+TFuncDef::TFuncDef(TScope *scope, const TName &name, const TPosRange &pos_range)
+    : TDef(scope, name),
+      FuncDef(nullptr),
+      PosRange(pos_range),
       Expr(nullptr) {}
 
 TFuncDef::~TFuncDef() {
@@ -59,8 +66,8 @@ TAction TFuncDef::Build(int pass) {
       Symbol = Symbol::TFunction::New(
                  GetOuterScope()->GetScopeSymbol(), /* scope */
                  GetName().GetText(), /* name */
-                 GetPosRange(FuncDef)); /* pos_range */
-      Symbol::TResultDef::New(Symbol, GetName().GetText(), GetPosRange(FuncDef));
+                 PosRange); /* pos_range */
+      Symbol::TResultDef::New(Symbol, GetName().GetText(), PosRange);
       action = Continue;
       break;
     }

--- a/orly/synth/func_def.h
+++ b/orly/synth/func_def.h
@@ -26,6 +26,7 @@
 #include <unordered_set>
 
 #include <orly/orly.package.cst.h>
+#include <orly/pos_range.h>
 #include <orly/symbol/function.h>
 #include <orly/symbol/param_def.h>
 #include <orly/symbol/result_def.h>
@@ -65,14 +66,25 @@ namespace Orly {
       /* TODO */
       TFuncDef(TScope *scope, const Package::Syntax::TFuncDef *func_def);
 
+      /* Build a function def that has no backing CST node -- a synthetic
+         binding such as a `when`-arm payload binder (`Tag(n): ...`), whose
+         name, position, and body are supplied directly rather than parsed.
+         See <orly/synth/when_expr.cc>. */
+      TFuncDef(TScope *scope, const TName &name, const TPosRange &pos_range);
+
       /* TODO */
       virtual void BuildSecondarySymbol();
 
       /* TODO */
       void SetExpr(TExpr *expr);
 
-      /* TODO */
+      /* The backing CST node, or null for a synthetic def (see the
+         CST-less constructor above). */
       const Package::Syntax::TFuncDef *FuncDef;
+
+      /* The def's source position -- from the CST node when there is one,
+         else supplied directly. */
+      TPosRange PosRange;
 
       private:
 

--- a/orly/synth/obj_member_expr.cc
+++ b/orly/synth/obj_member_expr.cc
@@ -32,14 +32,21 @@ using namespace Orly::Synth;
 TObjMemberExpr::TObjMemberExpr(const TExprFactory *expr_factory, const Package::Syntax::TPostfixObjMember *postfix_obj_member)
     : PostfixObjMember(Base::AssertTrue(postfix_obj_member)),
       Expr(Base::AssertTrue(expr_factory)->NewExpr(PostfixObjMember->GetExpr())),
-      Name(PostfixObjMember->GetName()) {}
+      Name(PostfixObjMember->GetName()),
+      PosRange(GetPosRange(PostfixObjMember)) {}
+
+TObjMemberExpr::TObjMemberExpr(TExpr *source, const TName &name, const TPosRange &pos_range)
+    : PostfixObjMember(nullptr),
+      Expr(Base::AssertTrue(source)),
+      Name(name),
+      PosRange(pos_range) {}
 
 TObjMemberExpr::~TObjMemberExpr() {
   delete Expr;
 }
 
 Expr::TExpr::TPtr TObjMemberExpr::Build() const {
-  return Expr::TObjMember::New(Expr->Build(), Name.GetText(), GetPosRange(PostfixObjMember));
+  return Expr::TObjMember::New(Expr->Build(), Name.GetText(), PosRange);
 }
 
 void TObjMemberExpr::ForEachInnerScope(const std::function<void (TScope *)> &cb) {

--- a/orly/synth/obj_member_expr.h
+++ b/orly/synth/obj_member_expr.h
@@ -23,7 +23,9 @@
 #include <base/class_traits.h>
 #include <orly/expr/expr.h>
 #include <orly/orly.package.cst.h>
+#include <orly/pos_range.h>
 #include <orly/synth/expr.h>
+#include <orly/synth/name.h>
 
 namespace Orly {
 
@@ -41,6 +43,12 @@ namespace Orly {
       /* TODO */
       TObjMemberExpr(const TExprFactory *expr_factory, const Package::Syntax::TPostfixObjMember *postfix_obj_member);
 
+      /* Build `<source>.<name>` from an already-synthesized source
+         expression (taking ownership) rather than from a CST node -- used to
+         synthesize a `when`-arm payload binder's `operand.Tag` accessor.
+         See <orly/synth/when_expr.cc>. */
+      TObjMemberExpr(TExpr *source, const TName &name, const TPosRange &pos_range);
+
       /* TODO */
       virtual ~TObjMemberExpr();
 
@@ -55,7 +63,7 @@ namespace Orly {
 
       private:
 
-      /* TODO */
+      /* The backing CST node, or null for the synthesized accessor. */
       const Package::Syntax::TPostfixObjMember *PostfixObjMember;
 
       /* TODO */
@@ -63,6 +71,10 @@ namespace Orly {
 
       /* TODO */
       TName Name;
+
+      /* Source position -- from the CST node when there is one, else
+         supplied directly. */
+      TPosRange PosRange;
 
     };  // TObjMemberExpr
 

--- a/orly/synth/when_expr.cc
+++ b/orly/synth/when_expr.cc
@@ -22,12 +22,125 @@
 
 #include <base/assert_true.h>
 #include <orly/expr/when.h>
+#include <orly/expr/where.h>
+#include <orly/symbol/scope.h>
 #include <orly/synth/cst_utils.h>
+#include <orly/synth/func_def.h>
 #include <orly/synth/get_pos_range.h>
+#include <orly/synth/name.h>
 #include <orly/synth/new_expr.h>
+#include <orly/synth/obj_member_expr.h>
+#include <orly/synth/scope_and_def.h>
 
 using namespace Orly;
 using namespace Orly::Synth;
+
+namespace {
+
+  /* The payload binder of a `Tag(n): body` arm: a zero-argument function
+     def `n = operand.Tag`, so a reference to `n` in the arm body resolves
+     (like any name) to the active payload. Reuses the whole TFuncDef build
+     machinery; the body is supplied directly rather than parsed (the
+     CST-less TFuncDef constructor). */
+  class TWhenBinderDef final
+      : public TFuncDef {
+    NO_COPY(TWhenBinderDef);
+    public:
+
+    TWhenBinderDef(TScope *scope, const TName &name, TExpr *accessor, const TPosRange &pos_range)
+        : TFuncDef(scope, name, pos_range) {
+      SetExpr(accessor);
+    }
+
+  };  // TWhenBinderDef
+
+  /* The local scope a `Tag(n): body` arm introduces. Structurally a
+     stripped-down where-clause: it owns one TWhenBinderDef (binding the
+     payload name) and the arm body, and lowers to an Expr::TWhere wrapping
+     the body -- which Expr::TWhen / code_gen consume as an ordinary arm
+     body, needing no variant-match-specific change. */
+  class TWhenBinderScope final
+      : public TExpr, public TScope {
+    NO_COPY(TWhenBinderScope);
+    public:
+
+    TWhenBinderScope(
+        const TExprFactory *expr_factory,
+        const Package::Syntax::TExpr *operand,
+        const TName &tag,
+        const TName &binder,
+        const Package::Syntax::TExpr *body,
+        const TPosRange &pos_range)
+          : TScope(Base::AssertTrue(expr_factory)->OuterScope),
+            PosRange(pos_range),
+            Body(nullptr) {
+      /* The accessor `operand.Tag` is evaluated in the *enclosing* scope
+         (its own refs -- e.g. the operand name -- resolve out there), so
+         build it with the incoming factory. */
+      TExpr *accessor = new TObjMemberExpr(expr_factory->NewExpr(operand), tag, pos_range);
+      /* The binder def lives in *this* scope (it owns the def). */
+      new TWhenBinderDef(this, binder, accessor, pos_range);
+      /* The body sees this scope, so a use of the binder name resolves to
+         the def above. */
+      TExprFactory local_expr_factory = *expr_factory;
+      local_expr_factory.OuterScope = this;
+      Body = local_expr_factory.NewExpr(body);
+    }
+
+    ~TWhenBinderScope() {
+      delete Body;
+    }
+
+    /* See TExpr. */
+    virtual Expr::TExpr::TPtr Build() const override {
+      assert(Symbol);
+      Symbol->SetExpr(Body->Build());
+      return Symbol;
+    }
+
+    /* See TScope. */
+    virtual void BuildSymbol() override {
+      assert(!Symbol);
+      Symbol = Expr::TWhere::New(PosRange);
+    }
+
+    /* See TScope. */
+    virtual Symbol::TScope::TPtr GetScopeSymbol() const override {
+      assert(Symbol);
+      return Symbol;
+    }
+
+    /* See TScope. */
+    virtual bool HasSymbol() const override {
+      return Symbol.get();
+    }
+
+    /* See TExpr. The binder scope is itself an inner scope. */
+    virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb) override {
+      assert(cb);
+      cb(this);
+      Body->ForEachInnerScope(cb);
+    }
+
+    private:
+
+    /* See TScope. The body's refs are controlled by this scope (so a use of
+       the binder name binds here); they are intentionally NOT exposed via
+       TExpr::ForEachRef, so they don't leak to the enclosing scope. */
+    virtual void ForEachControlledRef(const std::function<void (TAnyRef &)> &cb) const override {
+      assert(cb);
+      Body->ForEachRef(cb);
+    }
+
+    TPosRange PosRange;
+
+    TExpr *Body;
+
+    Expr::TWhere::TPtr Symbol;
+
+  };  // TWhenBinderScope
+
+}  // namespace
 
 TWhenExpr::TWhenExpr(const TExprFactory *expr_factory, const Package::Syntax::TWhenExpr *when_expr)
     : WhenExpr(Base::AssertTrue(when_expr)), Operand(nullptr) {
@@ -35,22 +148,36 @@ TWhenExpr::TWhenExpr(const TExprFactory *expr_factory, const Package::Syntax::TW
       : public Package::Syntax::TWhenArm::TVisitor {
     NO_COPY(TArmVisitor);
     public:
-    TArmVisitor(std::vector<std::string> &tags, std::vector<TExpr *> &bodies, const TExprFactory *expr_factory)
-        : Tags(tags), Bodies(bodies), ExprFactory(expr_factory) {}
+    TArmVisitor(
+        std::vector<std::string> &tags,
+        std::vector<TExpr *> &bodies,
+        const TExprFactory *expr_factory,
+        const Package::Syntax::TExpr *operand)
+        : Tags(tags), Bodies(bodies), ExprFactory(expr_factory), Operand(operand) {}
     virtual void operator()(const Package::Syntax::TBadWhenArm *) const { /* DO NOTHING */ }
     virtual void operator()(const Package::Syntax::TLabeledWhenArm *that) const {
       Tags.push_back(TName(that->GetName()).GetText());
       Bodies.push_back(ExprFactory->NewExpr(that->GetExpr()));
     }
+    /* `Tag(n): body` -- the payload binder arm (#95). Same tag handling as a
+       labeled arm, but the body is wrapped in a scope binding `n` to the
+       active payload `operand.Tag`. */
+    virtual void operator()(const Package::Syntax::TBinderWhenArm *that) const {
+      Tags.push_back(TName(that->GetTag()).GetText());
+      Bodies.push_back(new TWhenBinderScope(
+          ExprFactory, Operand, TName(that->GetTag()), TName(that->GetBinder()),
+          that->GetExpr(), GetPosRange(that->GetExpr())));
+    }
     private:
     std::vector<std::string> &Tags;
     std::vector<TExpr *> &Bodies;
     const TExprFactory *ExprFactory;
+    const Package::Syntax::TExpr *Operand;
   };  // TArmVisitor
   assert(expr_factory);
   try {
     Operand = expr_factory->NewExpr(WhenExpr->GetExpr());
-    TArmVisitor visitor(Tags, Bodies, expr_factory);
+    TArmVisitor visitor(Tags, Bodies, expr_factory, WhenExpr->GetExpr());
     ForEach<Package::Syntax::TWhenArm>(WhenExpr->GetOptWhenArmSeq(),
         [&visitor](const Package::Syntax::TWhenArm *arm) -> bool {
           arm->Accept(visitor);

--- a/orly/synth/when_expr.h
+++ b/orly/synth/when_expr.h
@@ -1,11 +1,14 @@
 /* <orly/synth/when_expr.h>
 
    Synth-layer node for the exhaustive `(e) when { Tag: body; ... }`
-   variant match expression (#95 Phase 4). Lowers to `Expr::TWhen`.
-   Holds the operand and the arm bodies as plain sub-expressions (arms
-   introduce no new binding -- a v1 arm body reads the active payload via
-   the `e.<Tag>` accessor), so unlike `TAssertExpr` it needs no thatable
-   or symbol machinery.
+   variant match expression (#95). Lowers to `Expr::TWhen`, holding the
+   operand and one sub-expression per arm body.
+
+   A plain `Tag: body` arm reads the active payload via the `e.<Tag>`
+   accessor. A `Tag(n): body` arm additionally binds the payload to the
+   name `n`: its body is wrapped (in when_expr.cc) in a local scope that
+   defines `n = operand.Tag`, lowering to an `Expr::TWhere` that
+   `Expr::TWhen` consumes as an ordinary arm body. See when_expr.cc.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/tests/lang_tests/general/variants_when.orly
+++ b/tests/lang_tests/general/variants_when.orly
@@ -9,11 +9,12 @@
    compile-time error (verified by hand; see below). The result is the
    unified type of the arm bodies. It lowers to a nested ternary on the
    operand's GetWhich(), reusing the Phase 3 M4 primitives; an arm body
-   reads the active payload via the `e.<Tag>` accessor (v1 has no payload
-   binder).
+   reads the active payload via the `e.<Tag>` accessor, or binds it to a
+   name with the `Tag(n): body` arm form (see classify_bind and t6-t10).
 
-   Syntax: `(operand) when { Tag: body; ... }` -- the operand is
-   parenthesised (like `where`/`assert`), and every arm ends in `;`.
+   Syntax: `(operand) when { Tag: body; Tag(n): body; ... }` -- the operand
+   is parenthesised (like `where`/`assert`), and every arm ends in `;`. A
+   `Tag(n)` arm binds the active payload to `n` within that arm's body.
 
    Exhaustiveness is enforced at compile time (checked manually with
    orlyc, not encoded here since lang_test has no "expect compile error"
@@ -50,6 +51,15 @@ classify = ((v) when {
   v = given::(<| Integer(int) | Deleted |>);
 };
 
+/* Payload binder: `Tag(n)` binds `n` to the active arm's payload in the
+   arm body -- sugar over the `.Tag` accessor (#95). */
+classify_bind = ((v) when {
+  Integer(n): n + 100;
+  Deleted: -1;
+}) where {
+  v = given::(<| Integer(int) | Deleted |>);
+};
+
 with {
   <[400]> <- <| Integer(int) | Deleted |>.Integer(7);
   <[401]> <- <| Integer(int) | Deleted |>.Deleted;
@@ -73,4 +83,28 @@ with {
          Deleted: 0;
          Integer: 9;
        }) == 9;
+
+  /* Payload binder over a stored, read-back variant: `n` is the payload. */
+  t6: classify_bind(.v: read_var(.n: 400)) == 107;
+  t7: classify_bind(.v: read_var(.n: 401)) == -1;
+
+  /* Binder over an inline variant; the bound name is usable like any name
+     (here referenced twice). Mixing a binder arm with a plain arm is fine. */
+  t8: ((<| Integer(int) | Deleted |>.Integer(5)) when {
+         Integer(x): x * x;
+         Deleted: 0;
+       }) == 25;
+  t9: ((<| Integer(int) | Deleted |>.Deleted) when {
+         Integer(x): x * x;
+         Deleted: 0;
+       }) == 0;
+
+  /* The binder is sugar for the accessor: both forms agree. */
+  t10: ((<| Integer(int) | Deleted |>.Integer(8)) when {
+          Integer(n): n + 1;
+          Deleted: 0;
+        }) == ((<| Integer(int) | Deleted |>.Integer(8)) when {
+          Integer: (<| Integer(int) | Deleted |>.Integer(8)).Integer + 1;
+          Deleted: 0;
+        });
 };


### PR DESCRIPTION
## Summary

The last polish item of the #95 sum-types line: the **payload-binder arm** for the exhaustive `when` match. A `Tag(n): body` arm binds the active payload to the name `n` within that arm's body — sugar over the existing `e.<Tag>` accessor:

```orly
(op) when {
  Text:     op.Text;
  Number(n): n + 1;          // <-- binds the payload to `n`
  Relation: "-> " + op.Relation;
  Deleted:  "(absent)";
}
```

## How it works

A binder arm desugars, in synth, to `body where { n = operand.Tag; }`. `when_expr.cc` wraps the arm body in a small local scope (`TWhenBinderScope`, structurally a stripped-down where-clause) that defines `n` as a zero-arg function (`TWhenBinderDef`) whose body is the `operand.Tag` accessor. It lowers to an `Expr::TWhere`, which `Expr::TWhen` and code_gen **already** consume as an ordinary arm body — so there are no variant-match-specific changes downstream, and exhaustiveness still falls out of the arm tags.

Synthesizing a binding with no backing CST node needs a CST-less way to build two existing synth nodes; both constructors are additive and used only here:

- `TFuncDef(scope, name, pos)` — a function def whose name/pos/body are supplied directly (pos is now stored rather than re-derived from the CST node).
- `TObjMemberExpr(source, name, pos)` — `source.name` over an already-built synth source expression.

Grammar: `binder_when_arm -> tag:name ( binder:name ) : expr ;`. One-token LR lookahead (`:` vs `(` after the tag name) distinguishes it from `labeled_when_arm`.

## Tests

- `tests/lang_tests/general/variants_when.orly` — adds `classify_bind` + `t6`–`t10`: the bound name over stored and inline operands, referenced multiple times, mixed binder/plain arms in one `when`, and binder/accessor equivalence.
- **Full lang suite green**: 0 unexpected, 130 passed, 3 tracked xfails (no regressions from the core-synth `TFuncDef` / `TObjMemberExpr` changes).
- Verified separately: record, string, and unit (tag-only) payloads, and a single `when` with multiple distinct binder names.

With this, the #95 line is complete (Phases 0–4, set-of-variants storage #96, the grc20 capstone, and now the payload binder).