### PR TITLE
code_gen: fix inline filter of dereferenced values (#73)

### DIFF
--- a/orly/code_gen/builder.cc
+++ b/orly/code_gen/builder.cc
@@ -429,7 +429,14 @@ TInline::TPtr Orly::CodeGen::Build(const L0::TPackage *package, const Expr::TExp
     }
     virtual void operator()(const Expr::TExp *that) const { Binary(Package, TBinary::Exponent, that); }
     virtual void operator()(const Expr::TFilter *that) const {
-      auto seq = BuildInline(Package, that->GetLhs(), false);
+      // Build the filtered sequence keeping element mutability so that the
+      // implicit-map element type stays consistent with the "that" arg type
+      // and the generator element type. Building with keep_mutable=false would
+      // unwrap a TMutable element (emitting a spurious .GetVal()) while the
+      // map's declared return type stayed TMutable, producing C++ that fails
+      // to compile (issue #73). The outer list-materialization unwraps at the
+      // boundary, exactly as the bare-deref case already does.
+      auto seq = BuildInline(Package, that->GetLhs(), true);
 
       //TODO: Filling in the "that" arg then using GetArg to get it back is more than sort of fugly.
       //TODO: Common sub expression elimination for the filter func.

--- a/tests/lang_tests/.xfail
+++ b/tests/lang_tests/.xfail
@@ -11,6 +11,5 @@
 # an entry whose test now passes is also a failure (xpass), prompting
 # the maintainer to drop the entry.
 
-general/mutablefilter.orly #73
 general/unsorted/multiple_sequences.orly #74
 general/unsorted/sequence_in_effecting.orly #75

--- a/tests/lang_tests/general/mutablefilter.orly
+++ b/tests/lang_tests/general/mutablefilter.orly
@@ -1,7 +1,9 @@
 /* <orly/lang_tests/general/mutablefilter.orly>
 
-   This Orly script contains an error case where you cannot filter values
-   returned from dereferencing a set of keys directly.
+   Regression test for inline filtering of values produced by dereferencing
+   a set of keys. Filtering the dereferenced values directly (without first
+   binding them to a name) used to fail at C++ codegen time; this test pins
+   that it now works (issue #73).
 
    Copyright 2010-2026 Atomic Kismet Company
 
@@ -27,14 +29,14 @@ with {
 test {
 
   /* These two work just fine */
-  t1: *(keys <["stuff", free::(int) ]>)::(int) as [int] == [3,7,10,13,17];
-  t2: *(keys <["stuff", free::(int) ]> if (that.1 >= 4))::(int) as [int] == [13,17];
+  t1: *(keys(int)@<["stuff", free::(int)]>)::(int) as [int] == [3,7,10,13,17];
+  t2: *(keys(int)@<["stuff", free::(int)]> if (that.1 >= 4))::(int) as [int] == [13,17];
 
-  /* This is the case that fails because we can't filter returned values */
-  t3: ((*(keys <["stuff", free::(int)]>)::(int)) if (that > 4)) as [int] == [7,10,13,17];
+  /* The inline filter of dereferenced values -- the case #73 is about */
+  t3: ((*(keys(int)@<["stuff", free::(int)]>)::(int)) if (that > 4)) as [int] == [7,10,13,17];
 
-  /* This works though -- even though literally it's just putting that "dereference these" call into a function */
+  /* Same dereference behind a name, then filtered */
   t4: (get_me_ints if (that > 4)) as [int] == [7,10,13,17];
 };
 
-get_me_ints = *(keys <["stuff", free::(int) ]>)::(int);
+get_me_ints = *(keys(int)@<["stuff", free::(int)]>)::(int);


### PR DESCRIPTION
## Summary

Fixes #73 — Orlyscript could not filter the values produced by dereferencing a set of keys *inline* (e.g. `((*(keys(int)@<["stuff", free::(int)]>)::(int)) if (that > 4))`). The same dereference bound to a name and then filtered worked fine, which made it look like a language limitation; it was actually a C++ **code generation** bug.

## Root cause

In `orly/code_gen/builder.cc`, the `TFilter` visitor built its LHS sequence with `BuildInline(..., keep_mutable=false)`, while the filter's `that` arg type, the implicit-map element type, and the generator element type all kept mutability (`TMutable`). With `keep_mutable=false`, `BuildInline` wrapped the `TMutable` element in `TUnary::UnwrapMutable` — emitting a spurious `.GetVal()` inside the implicit-map function body — while that function's *declared* return type stayed `TMutable`. The generated map function was therefore declared to return `TMutable<...>` but its body returned the unwrapped value, which the C++ compiler rejected (`compiler.cc:285`, "Compiling C++ and linking").

The bare-deref case (no filter) already works because it keeps the element as a `TMutable` and lets the outer `as [int]` materialization unwrap at the boundary.

## Fix

Build the filter's LHS sequence with `keep_mutable=true` so the dereferenced element stays a `TMutable`, consistent with the `that` binding and the implicit-map/generator element types. The outer list-materialization unwraps at the boundary exactly as the bare-deref case already does. This is a no-op for the common case (filtering a plain `[int]`): the unwrap at `builder.cc:756` only fires when the element `Is<TMutable>`.

## Test changes

- Ported `tests/lang_tests/general/mutablefilter.orly` from the obsolete `keys <[...]>` syntax (which no longer parses) to the current `keys(type)@<[...]>` form, and turned the former "this case fails" comment into a passing regression assertion for inline filtering of dereferenced values (t3).
- Removed the `general/mutablefilter.orly #73` pin from `tests/lang_tests/.xfail`.

## Validation

`make debug` + the lang-test gate (the only suite that exercises the orlyc shell-out codegen path — `make test` does not):

```
python3 tools/lang_test.py -d orly/data tests/lang_tests
Overall: 0 unexpected, 131 passed, 2 tracked failures (xfail)
  xfail: tests/lang_tests/general/unsorted/multiple_sequences.orly (#74)
  xfail: tests/lang_tests/general/unsorted/sequence_in_effecting.orly (#75)
```

No regressions, no unexpected xpass; the two remaining xfails are unrelated (#74/#75).

Closes #73.
