### PR TITLE
ci: make incremental builds work by restoring source mtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,14 @@
 #                            its Python and Go drivers (orlyc + orlyi + WS)
 #
 # Caching: both apt packages and the build output tree (../out_orly,
-# ../.jhm) are cached across runs. Incremental builds rely on jhm's own
-# per-file checksum tracking, which we know works (it's how `make debug`
-# after a fresh bootstrap takes seconds). To guard against silent stale-
-# cache bugs masking real issues, a `schedule:` trigger runs the
-# same jobs daily with caching disabled. If the nightly ever diverges
-# from the cached PR runs, that's the signal to investigate.
+# ../.jhm) are cached across runs. jhm decides what to rebuild by comparing
+# file mtimes, so each job runs `git restore-mtime` after checkout to date
+# every tracked file by its last commit -- otherwise actions/checkout stamps
+# everything with the clone time, every source looks newer than the cached
+# outputs, and the build is fully redone (~12 min) even on a no-op change.
+# To guard against silent stale-cache bugs masking real issues, a `schedule:`
+# trigger runs the same jobs daily with caching disabled. If the nightly ever
+# diverges from the cached PR runs, that's the signal to investigate.
 name: ci
 
 on:
@@ -31,12 +33,25 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Full history so git-restore-mtime (below) can date each file by
+          # its last commit; jhm keys incremental rebuilds on mtime.
+          fetch-depth: 0
 
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
-          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind
-          version: 1.0
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind git-restore-mtime
+          version: 1.1
+
+      - name: Restore source mtimes
+        # jhm decides what to rebuild by comparing file mtimes, and
+        # actions/checkout stamps every file with the clone time -- which
+        # makes every source look newer than the cached build outputs and
+        # forces a full ~12-min rebuild even on a no-op change. Reset each
+        # tracked file's mtime to its last-commit time so unchanged files
+        # stay older than the restored outputs and the build goes incremental.
+        run: git restore-mtime
 
       - name: Cache build outputs
         if: github.event_name != 'schedule'
@@ -71,12 +86,25 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Full history so git-restore-mtime (below) can date each file by
+          # its last commit; jhm keys incremental rebuilds on mtime.
+          fetch-depth: 0
 
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
-          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind
-          version: 1.0
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind git-restore-mtime
+          version: 1.1
+
+      - name: Restore source mtimes
+        # jhm decides what to rebuild by comparing file mtimes, and
+        # actions/checkout stamps every file with the clone time -- which
+        # makes every source look newer than the cached build outputs and
+        # forces a full ~12-min rebuild even on a no-op change. Reset each
+        # tracked file's mtime to its last-commit time so unchanged files
+        # stay older than the restored outputs and the build goes incremental.
+        run: git restore-mtime
 
       - name: Cache build outputs
         if: github.event_name != 'schedule'
@@ -122,12 +150,25 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Full history so git-restore-mtime (below) can date each file by
+          # its last commit; jhm keys incremental rebuilds on mtime.
+          fetch-depth: 0
 
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
-          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind
-          version: 1.0
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind git-restore-mtime
+          version: 1.1
+
+      - name: Restore source mtimes
+        # jhm decides what to rebuild by comparing file mtimes, and
+        # actions/checkout stamps every file with the clone time -- which
+        # makes every source look newer than the cached build outputs and
+        # forces a full ~12-min rebuild even on a no-op change. Reset each
+        # tracked file's mtime to its last-commit time so unchanged files
+        # stay older than the restored outputs and the build goes incremental.
+        run: git restore-mtime
 
       - name: Cache build outputs
         if: github.event_name != 'schedule'
@@ -155,12 +196,25 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Full history so git-restore-mtime (below) can date each file by
+          # its last commit; jhm keys incremental rebuilds on mtime.
+          fetch-depth: 0
 
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
-          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind
-          version: 1.0
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind git-restore-mtime
+          version: 1.1
+
+      - name: Restore source mtimes
+        # jhm decides what to rebuild by comparing file mtimes, and
+        # actions/checkout stamps every file with the clone time -- which
+        # makes every source look newer than the cached build outputs and
+        # forces a full ~12-min rebuild even on a no-op change. Reset each
+        # tracked file's mtime to its last-commit time so unchanged files
+        # stay older than the restored outputs and the build goes incremental.
+        run: git restore-mtime
 
       - name: Install python websocket-client
         run: pip3 install --break-system-packages websocket-client


### PR DESCRIPTION
## Summary

Makes CI builds actually incremental. Today every CI run does a full ~12-min `make debug` — **even a one-file no-op PR** (observed on #108: a PR that changed a single `.state` file still rebuilt for 11–14 min in each job).

## Root cause

jhm decides what to rebuild purely by **file mtime** (`jhm/work_finder.cc`: *oldest input newer than newest output ⇒ rebuild*; `GetTimestamp()` → `stat()`). It does **not** hash content — the `.jhm` cache file stores build-info metadata, not source hashes. (The workflow's old comment claiming "per-file checksum tracking" was wrong.)

`actions/checkout` does a fresh clone every run, stamping every file with mtime = clone time. The cached build outputs (`../out_orly`, restored with their original older mtimes) are therefore *older* than every source → jhm rebuilds the world.

Reproduced locally: a `git pull` that only bumped mtimes (identical content) triggered a 683-job rebuild.

## Fix

Each job now:
- checks out with `fetch-depth: 0` (full history, required below),
- installs `git-restore-mtime` (Ubuntu package), and
- runs `git restore-mtime` after checkout — dating each tracked file by its **last commit** instead of the clone time.

Unchanged files then stay older than the restored `.o` outputs → jhm skips them; only files actually touched by the new commits rebuild.

## Expected effect

The `make debug` step should drop from ~12 min to seconds on cache-warm runs, cutting the critical-path job (`lang_test` = build + lang_test) from ~21 min toward **~8–9 min**, and removing the phantom rebuild from all three build jobs.

This PR is itself a clean demonstration: it changes only `ci.yml` (no build inputs), so its own run restores master's cache and should build incrementally — watch the `make debug` step duration.

CI-only change; no engine risk.
