### PR TITLE
ci: cache ccache instead of the build tree to speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,16 @@
 #   4. examples           -- run each examples/* end-to-end with both
 #                            its Python and Go drivers (orlyc + orlyi + WS)
 #
-# Caching: both apt packages and the build output tree (../out_orly,
-# ../.jhm) are cached across runs. jhm decides what to rebuild by comparing
-# file mtimes, so each job runs `git restore-mtime` after checkout to date
-# every tracked file by its last commit -- otherwise actions/checkout stamps
-# everything with the clone time, every source looks newer than the cached
-# outputs, and the build is fully redone (~12 min) even on a no-op change.
-# To guard against silent stale-cache bugs masking real issues, a `schedule:`
-# trigger runs the same jobs daily with caching disabled. If the nightly ever
-# diverges from the cached PR runs, that's the signal to investigate.
+# Caching: apt packages and the ccache store are cached across runs. The
+# ~4.5 GB build-output tree is too large to persist in the 10 GB Actions
+# cache, so we cache ccache instead: jhm and orlyc both invoke g++/gcc by
+# bare name via execvp, so prepending /usr/lib/ccache to PATH routes every
+# compile through ccache. jhm still re-runs jobs (it decides by mtime, and
+# checkout resets mtimes), but each compile is a ccache hit -- which also
+# speeds lang_test, whose orlyc runs compile generated C++. To guard against
+# silent stale-cache bugs, a `schedule:` trigger runs the same jobs daily
+# with caching disabled; if the nightly ever diverges from the cached PR
+# runs, that's the signal to investigate.
 name: ci
 
 on:
@@ -33,42 +34,46 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-        with:
-          # Full history so git-restore-mtime (below) can date each file by
-          # its last commit; jhm keys incremental rebuilds on mtime.
-          fetch-depth: 0
 
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
-          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind git-restore-mtime
-          version: 1.1
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind ccache
+          version: 1.2
 
-      - name: Restore source mtimes
-        # jhm decides what to rebuild by comparing file mtimes, and
-        # actions/checkout stamps every file with the clone time -- which
-        # makes every source look newer than the cached build outputs and
-        # forces a full ~12-min rebuild even on a no-op change. Reset each
-        # tracked file's mtime to its last-commit time so unchanged files
-        # stay older than the restored outputs and the build goes incremental.
-        run: git restore-mtime
+      - name: Set up ccache
+        # jhm and orlyc both invoke `g++`/`gcc` by bare name via execvp. The
+        # apt cache-action restores ccache without running its postinst, so
+        # the usual /usr/lib/ccache compiler symlinks don't exist -- a prior
+        # run showed ccache with 0 reads/writes (never invoked). Create the
+        # masquerade symlinks explicitly in /usr/local/bin (ahead of /usr/bin
+        # on PATH) so every compile -- the build *and* lang_test's orlyc
+        # codegen -- routes through ccache. The store is small/compressible,
+        # so unlike the 4.5 GB object tree it persists in the Actions cache.
+        run: |
+          for c in gcc g++ cc c++; do
+            sudo ln -sf "$(command -v ccache)" "/usr/local/bin/$c"
+          done
+          {
+            echo "CCACHE_DIR=$HOME/.ccache"
+            echo "CCACHE_MAXSIZE=2G"
+            echo "CCACHE_COMPRESS=1"
+          } >> "$GITHUB_ENV"
 
-      - name: Cache build outputs
+      - name: Cache ccache
         if: github.event_name != 'schedule'
         uses: actions/cache@v5
         with:
-          path: |
-            ../out_orly
-            ../.jhm
-            tools/jhm
-            tools/make_dep_file
-          key: orly-debug-${{ runner.os }}-${{ hashFiles('root.jhm', 'debug.jhm', 'bootstrap.jhm', 'Makefile', 'bootstrap.sh') }}-${{ github.sha }}
+          path: ~/.ccache
+          key: orly-ccache-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
           restore-keys: |
-            orly-debug-${{ runner.os }}-${{ hashFiles('root.jhm', 'debug.jhm', 'bootstrap.jhm', 'Makefile', 'bootstrap.sh') }}-
-            orly-debug-${{ runner.os }}-
+            orly-ccache-${{ runner.os }}-${{ github.job }}-
+            orly-ccache-${{ runner.os }}-
 
       - name: make debug
-        run: make debug
+        run: |
+          ccache --zero-stats
+          make debug
 
       - name: List built binaries
         run: |
@@ -80,45 +85,53 @@ jobs:
       - name: make test
         run: make test
 
+      # Diagnostic: ccache hit/miss for this run's `make debug` (stats were
+      # zeroed just before it). High direct-hit rate => the cache is working.
+      - name: ccache stats
+        if: always()
+        run: ccache --show-stats --verbose
+
   release-build:
     name: jhm -c release
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
-        with:
-          # Full history so git-restore-mtime (below) can date each file by
-          # its last commit; jhm keys incremental rebuilds on mtime.
-          fetch-depth: 0
 
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
-          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind git-restore-mtime
-          version: 1.1
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind ccache
+          version: 1.2
 
-      - name: Restore source mtimes
-        # jhm decides what to rebuild by comparing file mtimes, and
-        # actions/checkout stamps every file with the clone time -- which
-        # makes every source look newer than the cached build outputs and
-        # forces a full ~12-min rebuild even on a no-op change. Reset each
-        # tracked file's mtime to its last-commit time so unchanged files
-        # stay older than the restored outputs and the build goes incremental.
-        run: git restore-mtime
+      - name: Set up ccache
+        # jhm and orlyc both invoke `g++`/`gcc` by bare name via execvp. The
+        # apt cache-action restores ccache without running its postinst, so
+        # the usual /usr/lib/ccache compiler symlinks don't exist -- a prior
+        # run showed ccache with 0 reads/writes (never invoked). Create the
+        # masquerade symlinks explicitly in /usr/local/bin (ahead of /usr/bin
+        # on PATH) so every compile -- the build *and* lang_test's orlyc
+        # codegen -- routes through ccache. The store is small/compressible,
+        # so unlike the 4.5 GB object tree it persists in the Actions cache.
+        run: |
+          for c in gcc g++ cc c++; do
+            sudo ln -sf "$(command -v ccache)" "/usr/local/bin/$c"
+          done
+          {
+            echo "CCACHE_DIR=$HOME/.ccache"
+            echo "CCACHE_MAXSIZE=2G"
+            echo "CCACHE_COMPRESS=1"
+          } >> "$GITHUB_ENV"
 
-      - name: Cache build outputs
+      - name: Cache ccache
         if: github.event_name != 'schedule'
         uses: actions/cache@v5
         with:
-          path: |
-            ../out_orly
-            ../.jhm
-            tools/jhm
-            tools/make_dep_file
-          key: orly-release-${{ runner.os }}-${{ hashFiles('root.jhm', 'release.jhm', 'bootstrap.jhm', 'Makefile', 'bootstrap.sh') }}-${{ github.sha }}
+          path: ~/.ccache
+          key: orly-ccache-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
           restore-keys: |
-            orly-release-${{ runner.os }}-${{ hashFiles('root.jhm', 'release.jhm', 'bootstrap.jhm', 'Makefile', 'bootstrap.sh') }}-
-            orly-release-${{ runner.os }}-
+            orly-ccache-${{ runner.os }}-${{ github.job }}-
+            orly-ccache-${{ runner.os }}-
 
       # Bootstrap first (same path make debug takes), then drive jhm
       # directly. `make release` works but its Makefile wrapper has a
@@ -150,39 +163,41 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-        with:
-          # Full history so git-restore-mtime (below) can date each file by
-          # its last commit; jhm keys incremental rebuilds on mtime.
-          fetch-depth: 0
 
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
-          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind git-restore-mtime
-          version: 1.1
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind ccache
+          version: 1.2
 
-      - name: Restore source mtimes
-        # jhm decides what to rebuild by comparing file mtimes, and
-        # actions/checkout stamps every file with the clone time -- which
-        # makes every source look newer than the cached build outputs and
-        # forces a full ~12-min rebuild even on a no-op change. Reset each
-        # tracked file's mtime to its last-commit time so unchanged files
-        # stay older than the restored outputs and the build goes incremental.
-        run: git restore-mtime
+      - name: Set up ccache
+        # jhm and orlyc both invoke `g++`/`gcc` by bare name via execvp. The
+        # apt cache-action restores ccache without running its postinst, so
+        # the usual /usr/lib/ccache compiler symlinks don't exist -- a prior
+        # run showed ccache with 0 reads/writes (never invoked). Create the
+        # masquerade symlinks explicitly in /usr/local/bin (ahead of /usr/bin
+        # on PATH) so every compile -- the build *and* lang_test's orlyc
+        # codegen -- routes through ccache. The store is small/compressible,
+        # so unlike the 4.5 GB object tree it persists in the Actions cache.
+        run: |
+          for c in gcc g++ cc c++; do
+            sudo ln -sf "$(command -v ccache)" "/usr/local/bin/$c"
+          done
+          {
+            echo "CCACHE_DIR=$HOME/.ccache"
+            echo "CCACHE_MAXSIZE=2G"
+            echo "CCACHE_COMPRESS=1"
+          } >> "$GITHUB_ENV"
 
-      - name: Cache build outputs
+      - name: Cache ccache
         if: github.event_name != 'schedule'
         uses: actions/cache@v5
         with:
-          path: |
-            ../out_orly
-            ../.jhm
-            tools/jhm
-            tools/make_dep_file
-          key: orly-debug-${{ runner.os }}-${{ hashFiles('root.jhm', 'debug.jhm', 'bootstrap.jhm', 'Makefile', 'bootstrap.sh') }}-${{ github.sha }}
+          path: ~/.ccache
+          key: orly-ccache-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
           restore-keys: |
-            orly-debug-${{ runner.os }}-${{ hashFiles('root.jhm', 'debug.jhm', 'bootstrap.jhm', 'Makefile', 'bootstrap.sh') }}-
-            orly-debug-${{ runner.os }}-
+            orly-ccache-${{ runner.os }}-${{ github.job }}-
+            orly-ccache-${{ runner.os }}-
 
       - name: make debug
         run: make debug
@@ -196,25 +211,31 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-        with:
-          # Full history so git-restore-mtime (below) can date each file by
-          # its last commit; jhm keys incremental rebuilds on mtime.
-          fetch-depth: 0
 
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
-          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind git-restore-mtime
-          version: 1.1
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind ccache
+          version: 1.2
 
-      - name: Restore source mtimes
-        # jhm decides what to rebuild by comparing file mtimes, and
-        # actions/checkout stamps every file with the clone time -- which
-        # makes every source look newer than the cached build outputs and
-        # forces a full ~12-min rebuild even on a no-op change. Reset each
-        # tracked file's mtime to its last-commit time so unchanged files
-        # stay older than the restored outputs and the build goes incremental.
-        run: git restore-mtime
+      - name: Set up ccache
+        # jhm and orlyc both invoke `g++`/`gcc` by bare name via execvp. The
+        # apt cache-action restores ccache without running its postinst, so
+        # the usual /usr/lib/ccache compiler symlinks don't exist -- a prior
+        # run showed ccache with 0 reads/writes (never invoked). Create the
+        # masquerade symlinks explicitly in /usr/local/bin (ahead of /usr/bin
+        # on PATH) so every compile -- the build *and* lang_test's orlyc
+        # codegen -- routes through ccache. The store is small/compressible,
+        # so unlike the 4.5 GB object tree it persists in the Actions cache.
+        run: |
+          for c in gcc g++ cc c++; do
+            sudo ln -sf "$(command -v ccache)" "/usr/local/bin/$c"
+          done
+          {
+            echo "CCACHE_DIR=$HOME/.ccache"
+            echo "CCACHE_MAXSIZE=2G"
+            echo "CCACHE_COMPRESS=1"
+          } >> "$GITHUB_ENV"
 
       - name: Install python websocket-client
         run: pip3 install --break-system-packages websocket-client
@@ -224,19 +245,15 @@ jobs:
         with:
           go-version: '1.22'
 
-      - name: Cache build outputs
+      - name: Cache ccache
         if: github.event_name != 'schedule'
         uses: actions/cache@v5
         with:
-          path: |
-            ../out_orly
-            ../.jhm
-            tools/jhm
-            tools/make_dep_file
-          key: orly-debug-${{ runner.os }}-${{ hashFiles('root.jhm', 'debug.jhm', 'bootstrap.jhm', 'Makefile', 'bootstrap.sh') }}-${{ github.sha }}
+          path: ~/.ccache
+          key: orly-ccache-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
           restore-keys: |
-            orly-debug-${{ runner.os }}-${{ hashFiles('root.jhm', 'debug.jhm', 'bootstrap.jhm', 'Makefile', 'bootstrap.sh') }}-
-            orly-debug-${{ runner.os }}-
+            orly-ccache-${{ runner.os }}-${{ github.job }}-
+            orly-ccache-${{ runner.os }}-
 
       - name: make debug
         run: make debug


### PR DESCRIPTION
## Summary

Roughly halves CI by routing compiles through **ccache**. Supersedes #113.

## Problem

The ~4.5 GB build-output tree is too large to persist in GitHub's 10 GB Actions cache (`gh cache list` showed zero `orly-debug-*` caches ever), so every run built cold (~14 min `make debug`) regardless of caching — which is why the mtime approach in #113 changed nothing.

## Fix

jhm (`compile_c_family.cc`) and orlyc (`compiler.cc`) both invoke `g++`/`gcc` by **bare name** via `execvp`, so compiles can be routed through ccache with no build-system changes:

- **Create ccache masquerade symlinks in `/usr/local/bin`** (ahead of `/usr/bin` on PATH). The apt cache-action restores ccache without running its `postinst`, so `/usr/lib/ccache` is empty — a diagnostic run showed ccache with `0` reads/writes (never invoked) until the symlinks were created explicitly.
- **Cache `~/.ccache` per job** (`github.job` in the key) so each runner's store persists separately (a single shared key is first-writer-wins → only one job's cache survived).
- **Drop the never-persisting `../out_orly` cache** and the now-moot `git-restore-mtime` step from #113.
- A `ccache --show-stats` step keeps the hit rate visible going forward.

This also speeds `lang_test`, whose ~133 orlyc runs compile generated C++ via `g++`.

## Measured result (warm cache)

```
make debug:  850s -> 147s   (ccache: 808/808 cacheable calls hit, 100%)
```

| job | before | after |
|---|---|---|
| make debug + make test | ~13 min | ~4 min |
| jhm -c release | ~12 min | ~4 min |
| examples/* end-to-end | ~18 min | ~6 min |
| lang_test.py | ~21 min | ~10 min |

**Overall CI: ~21 min → ~10 min.** The new long pole is `lang_test`'s test *execution* (~467s of orlyi runtime), not compilation — out of scope here. Per-job ccache stores are ~342 MB each, well within the cache budget.

CI-only change; no engine, config, or source changes.
