### PR TITLE
lang: recursive variants under list/set/dict containers (#116)

### DIFF
--- a/orly/code_gen/variant.cc
+++ b/orly/code_gen/variant.cc
@@ -19,6 +19,7 @@
 #include <orly/code_gen/variant.h>
 
 #include <cstddef>
+#include <functional>
 #include <iterator>
 
 #include <base/as_str.h>
@@ -96,6 +97,14 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
   auto arm_is_recursive = [](const Type::TType &payload) {
     return Type::HasFreeSelfRef(payload);
   };
+  /* A box or boxed-struct payload compares via direct method calls (its
+     Rt:: dispatch specializations aren't declared at the point the
+     variant's member bodies need them); a CONTAINER of boxes (#116) has
+     no methods and goes through the Rt:: machinery, which resolves fine
+     in the variant's member bodies (complete-class context). */
+  auto arm_has_methods = [](const Type::TType &payload) {
+    return payload.Is<Type::TSelfRef>() || payload.Is<Type::TObj>();
+  };
   bool is_recursive = false;
   for (const auto &elem : elems) {
     if (arm_is_recursive(elem.second)) {
@@ -106,15 +115,45 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
   auto boxed_name = [&class_name](const string &tag) {
     return class_name + "_Boxed" + tag;
   };
-  /* The C++ type in which an arm's payload is stored. */
-  auto storage_type = [&](const string &tag, const Type::TType &payload) {
-    if (!Type::HasFreeSelfRef(payload)) {
-      return Base::AsStr(payload);
+  /* Prints a type with every free self-reference replaced by its boxed
+     storage, elementwise through the containers the placement rules
+     allow (#116): `[self]` -> `std::vector<Rt::TBox<V>>`, `self?` ->
+     `Orly::Rt::TOpt<Rt::TBox<V>>`, etc. A self-free subtree prints
+     verbatim. Used for payload-record fields and container payloads;
+     a record payload's own storage is the adjacent boxed struct. */
+  std::function<string (const Type::TType &)> subst_storage =
+      [&](const Type::TType &t) -> string {
+    if (!Type::HasFreeSelfRef(t)) {
+      return Base::AsStr(t);
     }
-    if (payload.Is<Type::TSelfRef>()) {
+    if (t.Is<Type::TSelfRef>()) {
       return Base::AsStr("Rt::TBox<", class_name, '>');
     }
-    return boxed_name(tag);
+    if (const auto *list = t.TryAs<Type::TList>()) {
+      return Base::AsStr("std::vector<", subst_storage(list->GetElem()), '>');
+    }
+    if (const auto *set = t.TryAs<Type::TSet>()) {
+      return Base::AsStr("Orly::Rt::TSet<", subst_storage(set->GetElem()), '>');
+    }
+    if (const auto *opt = t.TryAs<Type::TOpt>()) {
+      return Base::AsStr("Orly::Rt::TOpt<", subst_storage(opt->GetElem()), '>');
+    }
+    if (const auto *dict = t.TryAs<Type::TDict>()) {
+      /* The placement rules keep keys self-free. */
+      return Base::AsStr("Orly::Rt::TDict<", Base::AsStr(dict->GetKey()), ", ",
+                         subst_storage(dict->GetVal()), '>');
+    }
+    /* Placement validation (orly/synth/type_def.cc) bans free refs under
+       anything else. */
+    assert(false);
+    return Base::AsStr(t);
+  };
+  /* The C++ type in which an arm's payload is stored. */
+  auto storage_type = [&](const string &tag, const Type::TType &payload) {
+    if (Type::HasFreeSelfRef(payload) && payload.Is<Type::TObj>()) {
+      return boxed_name(tag);
+    }
+    return subst_storage(payload);
   };
 
   TCppPrinter out(AsStr(path));
@@ -148,9 +187,12 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
       << "#include <orly/native/type.h>" << Eol
       << "#include <orly/type/new_sabot.h>" << Eol;
   if (is_recursive) {
-    // Rt::TBox (recursive arm storage) and Type::TSelfRef (the TDt
-    // specialization reconstructs the declared payload map, #103).
-    out << "#include <orly/rt/box.h>" << Eol
+    // Rt::TBox / DeepBox / DeepUnbox (recursive arm storage, #103/#116),
+    // Type::TSelfRef (the TDt specialization reconstructs the declared
+    // payload map), and <utility> for the std::declval the boxed structs'
+    // ToUnrolled uses to name TRet's field types.
+    out << "#include <utility>" << Eol
+        << "#include <orly/rt/box.h>" << Eol
         << "#include <orly/type/self_ref.h>" << Eol;
   }
 
@@ -189,19 +231,20 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
             << Eol;
         for (const auto &elem : elems) {
           const auto &payload = elem.second;
-          if (!arm_is_recursive(payload) || payload.Is<Type::TSelfRef>()) {
+          if (!arm_is_recursive(payload) || !payload.Is<Type::TObj>()) {
             continue;
           }
           auto bname = boxed_name(elem.first);
           const auto &fields = payload.As<Type::TObj>()->GetElems();
           out << "/* Boxed storage for the self-referential payload record of arm `"
-              << elem.first << "` (#103): each self field holds the variant via Rt::TBox. */" << Eol
+              << elem.first << "` (#103): each self field holds the variant via Rt::TBox," << Eol
+              << "   elementwise through containers (#116). */" << Eol
               << "class " << bname << " {" << Eol
               << "  public:" << Eol
               << "  " << bname << "() {}" << Eol
               << Eol
               << "  /* From the unrolled payload record (deduced at the call site);" << Eol
-              << "     self fields box implicitly. */" << Eol
+              << "     self fields box via Rt::DeepBox. */" << Eol
               << "  template <typename TRec>" << Eol
               << "  explicit " << bname << "(const TRec &rec)";
           if (!fields.empty()) {
@@ -209,8 +252,9 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
           }
           out << Base::Join(fields,
                             ", ",
-                            [](TCppPrinter &strm, const Type::TObj::TElems::value_type &it) {
-                              strm << 'V' << it.first << "(rec.GetV" << it.first << "())";
+                            [&subst_storage](TCppPrinter &strm, const Type::TObj::TElems::value_type &it) {
+                              strm << 'V' << it.first << "(Rt::DeepBox<" << subst_storage(it.second)
+                                   << ">(rec.GetV" << it.first << "()))";
                             })
               << " {}" << Eol
               << Eol
@@ -221,10 +265,8 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
               << Base::Join(fields,
                             ", ",
                             [](TCppPrinter &strm, const Type::TObj::TElems::value_type &it) {
-                              strm << 'V' << it.first;
-                              if (it.second.Is<Type::TSelfRef>()) {
-                                strm << ".Get()";
-                              }
+                              strm << "Rt::DeepUnbox<decltype(std::declval<TRet>().GetV"
+                                   << it.first << "())>(V" << it.first << ')';
                             })
               << ");" << Eol
               << "  }" << Eol
@@ -239,7 +281,7 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
               << Eol
               << "  private:" << Eol;
           for (const auto &field : fields) {
-            out << "  " << storage_type(elem.first, field.second) << " V" << field.first << ";" << Eol;
+            out << "  " << subst_storage(field.second) << " V" << field.first << ";" << Eol;
           }
           out << "}; // " << bname << Eol
               << Eol;
@@ -267,17 +309,13 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
           size_t idx = 0;
           for (const auto &elem : elems) {
             if (arm_is_recursive(elem.second)) {
-              const bool direct_self = elem.second.Is<Type::TSelfRef>();
               out << "template <typename TPayload>" << Eol
                   << "static " << class_name << ' ' << elem.first
                   << "(const TPayload &vv) {" << Eol
                   << "  " << class_name << " out;" << Eol
                   << "  out.Which = " << idx << ";" << Eol
-                  << "  out.V" << elem.first << " = "
-                  << (direct_self
-                          ? Base::AsStr("Rt::TBox<", class_name, ">(vv)")
-                          : Base::AsStr(boxed_name(elem.first), "(vv)"))
-                  << ";" << Eol
+                  << "  out.V" << elem.first << " = Rt::DeepBox<"
+                  << storage_type(elem.first, elem.second) << ">(vv);" << Eol
                   << "  return out;" << Eol
                   << "}" << Eol;
             } else {
@@ -316,12 +354,13 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
         {
           size_t idx = 0;
           for (const auto &elem : elems) {
-            if (arm_is_recursive(elem.second)) {
+            if (arm_is_recursive(elem.second) && arm_has_methods(elem.second)) {
               out << "    case " << idx << ": return std::hash<size_t>()(" << idx
                   << ") ^ V" << elem.first << ".GetHash();" << Eol;
             } else {
               out << "    case " << idx << ": return std::hash<size_t>()(" << idx
-                  << ") ^ std::hash<" << elem.second << ">()(V" << elem.first << ");" << Eol;
+                  << ") ^ std::hash<" << storage_type(elem.first, elem.second)
+                  << ">()(V" << elem.first << ");" << Eol;
             }
             ++idx;
           }
@@ -342,11 +381,19 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
           size_t idx = 0;
           for (const auto &elem : elems) {
             if (arm_is_recursive(elem.second)) {
-              /* Direct method call (not Rt:: dispatch): the boxed types'
-                 comparisons are declared above and defined after this
-                 class, which keeps every name resolvable right here. */
-              out << "    case " << idx << ": return V" << elem.first
-                  << ".EqEq(that.V" << elem.first << ");" << Eol;
+              if (arm_has_methods(elem.second)) {
+                /* Direct method call (not Rt:: dispatch): the boxed types'
+                   comparisons are declared above and defined after this
+                   class, which keeps every name resolvable right here. */
+                out << "    case " << idx << ": return V" << elem.first
+                    << ".EqEq(that.V" << elem.first << ");" << Eol;
+              } else {
+                /* Container of boxes: EqEq is Match (a recursive payload
+                   compares structurally all the way down), and Rt::Match
+                   uniformly returns bool through the containers. */
+                out << "    case " << idx << ": return Rt::Match(V" << elem.first
+                    << ", that.V" << elem.first << ");" << Eol;
+              }
             } else {
               out << "    case " << idx << ": return Rt::EqEq(V" << elem.first
                   << ", that.V" << elem.first << ");" << Eol;
@@ -377,7 +424,7 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
         {
           size_t idx = 0;
           for (const auto &elem : elems) {
-            if (arm_is_recursive(elem.second)) {
+            if (arm_is_recursive(elem.second) && arm_has_methods(elem.second)) {
               out << "    case " << idx << ": return V" << elem.first
                   << ".Match(that.V" << elem.first << ");" << Eol;
             } else {
@@ -403,7 +450,7 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
         {
           size_t idx = 0;
           for (const auto &elem : elems) {
-            if (arm_is_recursive(elem.second)) {
+            if (arm_is_recursive(elem.second) && arm_has_methods(elem.second)) {
               out << "    case " << idx << ": return V" << elem.first
                   << ".MatchLess(that.V" << elem.first << ");" << Eol;
             } else {
@@ -431,13 +478,15 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
               /* TRet is the UNROLLED payload type; the code generator
                  supplies it explicitly at the access site
                  (orly/code_gen/variant_access.cc). */
-              const bool direct_self = elem.second.Is<Type::TSelfRef>();
+              const bool record_payload = elem.second.Is<Type::TObj>();
               out << "template <typename TRet>" << Eol
                   << "TRet GetV" << elem.first << "() const {" << Eol
                   << "  assert(this);" << Eol
                   << "  assert(Which == " << idx << ");" << Eol
-                  << "  return V" << elem.first
-                  << (direct_self ? ".Get()" : ".template ToUnrolled<TRet>()")
+                  << "  return "
+                  << (record_payload
+                          ? Base::AsStr('V', elem.first, ".template ToUnrolled<TRet>()")
+                          : Base::AsStr("Rt::DeepUnbox<TRet>(V", elem.first, ')'))
                   << ";" << Eol
                   << "}" << Eol;
             } else {
@@ -466,7 +515,7 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
       if (is_recursive) {
         for (const auto &elem : elems) {
           const auto &payload = elem.second;
-          if (!arm_is_recursive(payload) || payload.Is<Type::TSelfRef>()) {
+          if (!arm_is_recursive(payload) || !payload.Is<Type::TObj>()) {
             continue;
           }
           auto bname = boxed_name(elem.first);
@@ -528,11 +577,12 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
           }
           out << Base::Join(fields,
                             " ^ ",
-                            [](TCppPrinter &strm, const Type::TObj::TElems::value_type &it) {
+                            [&subst_storage](TCppPrinter &strm, const Type::TObj::TElems::value_type &it) {
                               if (it.second.Is<Type::TSelfRef>()) {
                                 strm << 'V' << it.first << ".GetHash()";
                               } else {
-                                strm << "std::hash<" << it.second << ">()(V" << it.first << ')';
+                                strm << "std::hash<" << subst_storage(it.second)
+                                     << ">()(V" << it.first << ')';
                               }
                             })
               << ';' << Eol

--- a/orly/expr/known.cc
+++ b/orly/expr/known.cc
@@ -59,6 +59,10 @@ class TIsKnownUnknownTypeVisitor
       virtual void operator()(const Type::TOpt      *) const {
         throw TExprError(HERE, PosRange, "Cannot have nested optionals");
       }
+      /* An optional variant (incl. an optional self-reference, #116) is a
+         leaf here, just like a record: `x is known` / `is unknown` is a
+         bool regardless of the wrapped element. */
+      virtual void operator()(const Type::TVariant  *) const { Type = Type::TBool::Get(); }
       virtual void operator()(const Type::TReal     *) const { Type = Type::TBool::Get(); }
       virtual void operator()(const Type::TSet      *) const { Type = Type::TBool::Get(); }
       virtual void operator()(const Type::TSeq      *) const { Type = Type::TBool::Get(); }

--- a/orly/expr/unknown.cc
+++ b/orly/expr/unknown.cc
@@ -76,6 +76,11 @@ Type::TType TUnknown::GetTypeImpl() const {
     virtual void operator()(const Type::TObj      *that) const {
       Type = Type::TOpt::Get(that->AsType());
     }
+    /* `unknown <variant>` -- incl. a self-referential variant (#116) --
+       yields an optional of that variant, like any other leaf type. */
+    virtual void operator()(const Type::TVariant  *that) const {
+      Type = Type::TOpt::Get(that->AsType());
+    }
     virtual void operator()(const Type::TOpt      *) const {
       throw TExprError(HERE, PosRange, "Unknown optional is not allowed.");
     }

--- a/orly/rt/box.h
+++ b/orly/rt/box.h
@@ -37,8 +37,11 @@
 #include <cassert>
 #include <functional>
 #include <memory>
+#include <vector>
 
+#include <orly/rt/containers.h>
 #include <orly/rt/operator.h>
+#include <orly/rt/opt.h>
 
 namespace Orly {
 
@@ -116,6 +119,135 @@ namespace Orly {
     template <typename TVal>
     bool MatchLess(const TBox<TVal> &lhs, const TBox<TVal> &rhs) {
       return lhs.MatchLess(rhs);
+    }
+
+    /* DeepBox / DeepUnbox: map a value between its unrolled shape and its
+       boxed storage shape, elementwise through the containers a recursive
+       arm's payload may use (issue #116): `[self]` stores as
+       `std::vector<TBox<V>>`, `self?` as `TOpt<TBox<V>>`, and so on. The
+       primary templates handle the leaves -- TBoxed constructible from
+       TVal covers both the box itself (TBox<V> from V, or a generated
+       boxed payload struct from its unrolled record) and the identity
+       copy of a self-free subvalue. The generated variant header calls
+       these from member templates only, so TVal may be incomplete where
+       the header is parsed. */
+
+    template <typename TBoxed, typename TVal>
+    struct TDeepBox {
+      static TBoxed Do(const TVal &val) {
+        return TBoxed(val);
+      }
+    };  // TDeepBox
+
+    template <typename TElemB, typename TElem>
+    struct TDeepBox<std::vector<TElemB>, std::vector<TElem>> {
+      static std::vector<TElemB> Do(const std::vector<TElem> &val) {
+        std::vector<TElemB> out;
+        out.reserve(val.size());
+        for (const auto &elem : val) {
+          out.push_back(TDeepBox<TElemB, TElem>::Do(elem));
+        }
+        return out;
+      }
+    };  // TDeepBox<vector>
+
+    template <typename TElemB, typename TElem>
+    struct TDeepBox<TOpt<TElemB>, TOpt<TElem>> {
+      static TOpt<TElemB> Do(const TOpt<TElem> &val) {
+        return val.IsKnown() ? TOpt<TElemB>(TDeepBox<TElemB, TElem>::Do(val.GetVal()))
+                             : TOpt<TElemB>();
+      }
+    };  // TDeepBox<TOpt>
+
+    template <typename TElemB, typename TElem>
+    struct TDeepBox<TSet<TElemB>, TSet<TElem>> {
+      static TSet<TElemB> Do(const TSet<TElem> &val) {
+        TSet<TElemB> out;
+        for (const auto &elem : val) {
+          out.insert(TDeepBox<TElemB, TElem>::Do(elem));
+        }
+        return out;
+      }
+    };  // TDeepBox<TSet>
+
+    template <typename TKey, typename TValB, typename TVal>
+    struct TDeepBox<TDict<TKey, TValB>, TDict<TKey, TVal>> {
+      static TDict<TKey, TValB> Do(const TDict<TKey, TVal> &val) {
+        TDict<TKey, TValB> out;
+        for (const auto &elem : val) {
+          out.insert(std::make_pair(elem.first, TDeepBox<TValB, TVal>::Do(elem.second)));
+        }
+        return out;
+      }
+    };  // TDeepBox<TDict>
+
+    template <typename TBoxed, typename TVal>
+    TBoxed DeepBox(const TVal &val) {
+      return TDeepBox<TBoxed, TVal>::Do(val);
+    }
+
+    /* The inverse: identity for self-free subvalues, TBox::Get() at the
+       box, elementwise through the containers. */
+
+    template <typename TVal, typename TBoxed>
+    struct TDeepUnbox {
+      static TVal Do(const TBoxed &boxed) {
+        return boxed;
+      }
+    };  // TDeepUnbox
+
+    template <typename TVal>
+    struct TDeepUnbox<TVal, TBox<TVal>> {
+      static TVal Do(const TBox<TVal> &boxed) {
+        return boxed.Get();
+      }
+    };  // TDeepUnbox<TBox>
+
+    template <typename TElem, typename TElemB>
+    struct TDeepUnbox<std::vector<TElem>, std::vector<TElemB>> {
+      static std::vector<TElem> Do(const std::vector<TElemB> &boxed) {
+        std::vector<TElem> out;
+        out.reserve(boxed.size());
+        for (const auto &elem : boxed) {
+          out.push_back(TDeepUnbox<TElem, TElemB>::Do(elem));
+        }
+        return out;
+      }
+    };  // TDeepUnbox<vector>
+
+    template <typename TElem, typename TElemB>
+    struct TDeepUnbox<TOpt<TElem>, TOpt<TElemB>> {
+      static TOpt<TElem> Do(const TOpt<TElemB> &boxed) {
+        return boxed.IsKnown() ? TOpt<TElem>(TDeepUnbox<TElem, TElemB>::Do(boxed.GetVal()))
+                               : TOpt<TElem>();
+      }
+    };  // TDeepUnbox<TOpt>
+
+    template <typename TElem, typename TElemB>
+    struct TDeepUnbox<TSet<TElem>, TSet<TElemB>> {
+      static TSet<TElem> Do(const TSet<TElemB> &boxed) {
+        TSet<TElem> out;
+        for (const auto &elem : boxed) {
+          out.insert(TDeepUnbox<TElem, TElemB>::Do(elem));
+        }
+        return out;
+      }
+    };  // TDeepUnbox<TSet>
+
+    template <typename TKey, typename TVal, typename TValB>
+    struct TDeepUnbox<TDict<TKey, TVal>, TDict<TKey, TValB>> {
+      static TDict<TKey, TVal> Do(const TDict<TKey, TValB> &boxed) {
+        TDict<TKey, TVal> out;
+        for (const auto &elem : boxed) {
+          out.insert(std::make_pair(elem.first, TDeepUnbox<TVal, TValB>::Do(elem.second)));
+        }
+        return out;
+      }
+    };  // TDeepUnbox<TDict>
+
+    template <typename TVal, typename TBoxed>
+    TVal DeepUnbox(const TBoxed &boxed) {
+      return TDeepUnbox<TVal, TBoxed>::Do(boxed);
     }
 
   }  // Rt

--- a/orly/rt/containers.h
+++ b/orly/rt/containers.h
@@ -135,6 +135,24 @@ namespace Orly {
       return true;
     }
 
+    /* MatchLess a TSet<TVal> and TSet<TVal>: lexicographic over the
+       (already MatchLess-ordered) elements. Without this overload set
+       ordering falls to the generic `lhs < rhs`, which requires an
+       element operator< -- absent for e.g. Rt::TBox (#116). */
+    template <typename TVal>
+    bool MatchLess(const TSet<TVal> &lhs, const TSet<TVal> &rhs) {
+      auto lhs_iter = lhs.begin();
+      auto rhs_iter = rhs.begin();
+      for (; lhs_iter != lhs.end() && rhs_iter != rhs.end(); ++lhs_iter, ++rhs_iter) {
+        if (MatchLess(*lhs_iter, *rhs_iter)) {
+          return true;
+        } else if (!Match(*lhs_iter, *rhs_iter)) {
+          return false;
+        }
+      }
+      return lhs_iter == lhs.end() && rhs_iter != rhs.end();
+    }
+
     /* Match an TDict<TVal> and TDict<TVal> */
     template <typename TKey, typename TVal>
     bool Match(const TDict<TKey, TVal> &lhs, const TDict<TKey, TVal> &rhs) {
@@ -148,6 +166,27 @@ namespace Orly {
         }
       }
       return true;
+    }
+
+    /* MatchLess a TDict and TDict: lexicographic over the (key-ordered)
+       entries, keys first. Same rationale as the TSet overload above. */
+    template <typename TKey, typename TVal>
+    bool MatchLess(const TDict<TKey, TVal> &lhs, const TDict<TKey, TVal> &rhs) {
+      auto lhs_iter = lhs.begin();
+      auto rhs_iter = rhs.begin();
+      for (; lhs_iter != lhs.end() && rhs_iter != rhs.end(); ++lhs_iter, ++rhs_iter) {
+        if (MatchLess(lhs_iter->first, rhs_iter->first)) {
+          return true;
+        } else if (!Match(lhs_iter->first, rhs_iter->first)) {
+          return false;
+        }
+        if (MatchLess(lhs_iter->second, rhs_iter->second)) {
+          return true;
+        } else if (!Match(lhs_iter->second, rhs_iter->second)) {
+          return false;
+        }
+      }
+      return lhs_iter == lhs.end() && rhs_iter != rhs.end();
     }
 
     template <typename TAddr, typename TVal>

--- a/orly/synth/type_def.cc
+++ b/orly/synth/type_def.cc
@@ -94,14 +94,49 @@ const Type::TType &TTypeDef::GetSymbolicType() const {
   }
 }
 
-/* The v1 placement rules for self-references (issue #103), enforced only
-   on a def that actually minted one (a def that merely *uses* some other
-   recursive type is exempt): the def's type must be a variant at its top
-   level -- the variant is the binder, so anything else means the
+/* True iff every free self-reference in `t` sits where the native
+   representation can box it (issues #103/#116): at the position itself,
+   or below any chain of list/set/dict-VALUE containers. Dict keys stay
+   self-free.
+
+   `opt` of self is deliberately NOT allowed yet: a nullable child needs
+   to construct a *known* optional variant (`x as t?`) and compare one,
+   and optional-of-variant is unsupported across the cast/equality
+   operators independently of recursion -- that is its own follow-up
+   (see the issue linked from #116). `unknown t` and `is known`/`is
+   unknown` on an optional variant DO work, but that is not enough to
+   build a populated chain, so the whole position is gated for now. A
+   free reference also may not thread through a nested variant or any
+   other compound (the #116 remainder). */
+static bool SelfRefPlacementOk(const Type::TType &t) {
+  if (!Type::HasFreeSelfRef(t)) {
+    return true;
+  }
+  if (t.Is<Type::TSelfRef>()) {
+    return true;
+  }
+  if (const auto *list = t.TryAs<Type::TList>()) {
+    return SelfRefPlacementOk(list->GetElem());
+  }
+  if (const auto *set = t.TryAs<Type::TSet>()) {
+    return SelfRefPlacementOk(set->GetElem());
+  }
+  if (const auto *dict = t.TryAs<Type::TDict>()) {
+    return !Type::HasFreeSelfRef(dict->GetKey()) && SelfRefPlacementOk(dict->GetVal());
+  }
+  return false;
+}
+
+/* The placement rules for self-references (issues #103/#116), enforced
+   only on a def that actually minted one (a def that merely *uses* some
+   other recursive type is exempt): the def's type must be a variant at
+   its top level -- the variant is the binder, so anything else means the
    reference doesn't denote the def -- and each FREE self-reference must
-   sit at an arm payload's root or as a field of an arm's payload record.
-   Anything deeper (under a container, through a nested variant) has no
-   native representation yet. Reports errors against the def's name. */
+   sit at an arm payload's root, as a field of an arm's payload record,
+   or under list/set/dict-value containers within those positions.
+   Free references through a NESTED variant, in an optional, in a dict
+   key, or under any other compound have no native representation yet.
+   Reports errors against the def's name. */
 static void ValidateSelfRefPlacement(const TTypeDef *def, const Type::TType &type) {
   const TPosRange &pos_range = def->GetName().GetPosRange();
   const Type::TVariant *variant = type.TryAs<Type::TVariant>();
@@ -112,26 +147,26 @@ static void ValidateSelfRefPlacement(const TTypeDef *def, const Type::TType &typ
   }
   for (const auto &arm : variant->GetElems()) {
     const Type::TType &payload = arm.second;
-    if (payload.Is<Type::TSelfRef>()) {
-      continue;
-    }
+    bool ok;
+    /* One record layer is allowed at the payload root only. */
     const Type::TObj *rec = payload.TryAs<Type::TObj>();
-    bool ok = true;
     if (rec) {
+      ok = true;
       for (const auto &field : rec->GetElems()) {
-        if (!field.second.Is<Type::TSelfRef>() && Type::HasFreeSelfRef(field.second)) {
+        if (!SelfRefPlacementOk(field.second)) {
           ok = false;
           break;
         }
       }
     } else {
-      ok = !Type::HasFreeSelfRef(payload);
+      ok = SelfRefPlacementOk(payload);
     }
     if (!ok) {
       GetContext().AddError(pos_range,
           Base::AsStr("in arm \"", arm.first,
-                      "\": a self-reference may only appear as an arm's payload or as a "
-                      "field of an arm's payload record (issue #103)"));
+                      "\": a self-reference may only appear as an arm's payload, as a field "
+                      "of the arm's payload record, or under list/set/dict-value "
+                      "containers within those positions (issues #103/#116)"));
     }
   }
 }

--- a/tests/lang_tests/general/.variants_recursive_containers.orly.test.state
+++ b/tests/lang_tests/general/.variants_recursive_containers.orly.test.state
@@ -1,0 +1,21 @@
+[
+  0,
+  [
+    [],
+    [
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++"
+    ],
+    [
+      "Running tests"
+    ],
+    [
+      "Tests done"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/variants_recursive_containers.orly
+++ b/tests/lang_tests/general/variants_recursive_containers.orly
@@ -1,0 +1,135 @@
+/* <orly/lang_tests/general/variants_recursive_containers.orly>
+
+   End-to-end test for issue #116 (part): a recursive variant's self-
+   reference may sit under list / set / dict-value containers, not just
+   as a bare payload or payload-record field (#103). This is what makes
+   genuinely tree-shaped, arbitrary-arity data -- JSON being the flagship
+   -- expressible:
+
+     json   is <| Null | N(int) | Str(str) | A([json]) |>;
+     tagged is <| Leaf(int) | Map({str: tagged}) |>;
+
+   A self-reference under a container stores boxed elementwise
+   (`[json]` -> `std::vector<Rt::TBox<json>>`, `{str: tagged}` ->
+   `Rt::TDict<str, Rt::TBox<tagged>>`); the `.<Tag>` accessor hands back
+   the ordinary unrolled container (`a.A : [json]`), so indexing,
+   `length_of`, deep `==`, dict lookup, and set membership all compose.
+   Construction is through the type name, as for any recursive variant.
+
+   Recursive folds over a list payload are written as ordinary recursive
+   functions: the list walk is a TOP-LEVEL mutually-recursive helper
+   (`leaves` <-> `walk_arr`) using arithmetic recursion and indexing.
+   Two forms that do NOT work are pre-existing limitations unrelated to
+   this feature:
+     - a recursive `reduce` (the recursive call's result type cannot be
+       inferred through the reduce, orly/expr/reduce.cc -- reproducible
+       with no variants at all); and
+     - a nested helper that calls its *enclosing* function (the enclosing
+       function's value isn't bound yet -> bad_function_call at runtime),
+       which is why `walk_arr` is a sibling of `leaves`, not nested.
+   (There is no generic dict-value iteration operator, so the dict case
+   is exercised for representation -- construct / lookup / equality /
+   set -- rather than a recursive fold.)
+
+   Scope notes: `opt` of self (a nullable child, `<{.next: t?}>`) is not
+   yet allowed -- it needs optional-of-variant construction/comparison,
+   which is unsupported independently of recursion (its own follow-up).
+   Self through a nested variant and mutual type recursion remain the
+   #116 remainder. All are clean compile errors.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+json is <| Null | N(int) | Str(str) | A([json]) |>;
+
+/* Count the scalar leaves of a json document. `leaves` dispatches on the
+   active arm; the array arm hands off to `walk_arr`, which walks the
+   `[json]` by index with arithmetic recursion and calls back into
+   `leaves`. The two are mutually recursive at top level. */
+leaves = ((j) when {
+  Null: 1;
+  N: 1;
+  Str: 1;
+  A(xs): walk_arr(.xs: xs, .i: 0);
+}) where {
+  j = given::(json);
+};
+
+walk_arr = ((0 if i >= length_of xs else leaves(.j: xs[i]) + walk_arr(.xs: xs, .i: i + 1))) where {
+  xs = given::([json]);
+  i = given::(int);
+};
+
+/* json fixtures (list-of-self). */
+doc = (json.A([
+  json.N(1),
+  json.Str("two"),
+  json.A([json.N(3), json.Null()]),
+  json.A([json.N(5), json.A([json.N(6), json.N(7)])])
+])) where {};
+
+a1 = (json.A([json.N(1), json.N(2)])) where {};
+a2 = (json.A([json.N(1), json.N(2)])) where {};
+a3 = (json.A([json.N(1), json.N(3)])) where {};
+
+/* tagged fixtures (dict-of-self). */
+tagged is <| Leaf(int) | Map({str: tagged}) |>;
+
+m1 = (tagged.Map({"a": tagged.Leaf(1), "b": tagged.Map({"c": tagged.Leaf(2)})})) where {};
+m2 = (tagged.Map({"a": tagged.Leaf(1), "b": tagged.Map({"c": tagged.Leaf(2)})})) where {};
+m3 = (tagged.Map({"a": tagged.Leaf(1), "b": tagged.Map({"c": tagged.Leaf(9)})})) where {};
+
+/* A flat optional-of-variant. `unknown <variant>` and `is known`/`is
+   unknown` over an optional variant were unimplemented before this work
+   (a #95-era gap); they are the groundwork for an eventual opt-of-self
+   (which also needs optional-of-variant *construction* and *equality* --
+   still missing, so opt-of-self stays gated). */
+flat is <| A | B(int) |>;
+maybe_flat = (unknown flat) where {};
+
+test {
+  /* The headline: a real recursive fold over arbitrary-depth json,
+     through the array containers, in the engine. doc's leaves are
+     1, "two", 3, Null, 5, 6, 7 = 7. */
+  t1: leaves(.j: doc) == 7;
+  t2: leaves(.j: json.N(9)) == 1;
+  t3: leaves(.j: json.A(empty [json])) == 0;
+
+  /* Deep structural equality reaches through the boxed list elements. */
+  t4: a1 == a2;
+  t5: a1 != a3;
+
+  /* The accessor returns the ordinary unrolled container; index and
+     length_of compose, and nesting peels one level at a time. */
+  t6: (a1.A)[0].N == 1;
+  t7: length_of (a1.A) == 2;
+  t8: ((doc.A)[2].A)[0].N == 3;
+
+  /* Recursive variants in a local set: hashing and ordering reach
+     through the boxed list, so the duplicate collapses. */
+  t9: length_of {a1, a2, a3} == 2;
+
+  /* Dict-of-self: construct nested, look up by key, peel to a leaf. */
+  t10: ((m1.Map)["b"].Map)["c"].Leaf == 2;
+  t11: (m1.Map)["a"].Leaf == 1;
+
+  /* Deep equality and set membership through the boxed dict values. */
+  t12: m1 == m2;
+  t13: m1 != m3;
+  t14: length_of {m1, m2, m3} == 2;
+
+  /* Optional-of-variant: unknown construction + is known / is unknown. */
+  t15: maybe_flat is unknown;
+  t16: not (maybe_flat is known);
+};


### PR DESCRIPTION
Part of #116. Lands **containers-of-self**: a recursive variant's self-reference may sit under list / set / dict-value containers, not just as a bare payload or payload-record field (#103). This is the JSON unlock.

Follow-ups remaining on #116: opt-of-self (gated on #118), nested-variant back-refs, mutual recursion. Found en route: #119 (arm named `S` collides with a macro in generated C++).

## What

```orly
json   is <| Null | N(int) | Str(str) | A([json]) | O({str: json}) |>;
tagged is <| Leaf(int) | Map({str: tagged}) |>;
```

```orly
/* a real recursive fold over arbitrary-depth json, in the engine */
leaves = ((j) when {
  Null: 1; N: 1; Str: 1;
  A(xs): walk_arr(.xs: xs, .i: 0);
}) where { j = given::(json); };

walk_arr = ((0 if i >= length_of xs else leaves(.j: xs[i]) + walk_arr(.xs: xs, .i: i + 1)))
  where { xs = given::([json]); i = given::(int); };
```

Construction is through the type name (`json.A([...])`, `tagged.Map({...})`). The `.<Tag>` accessor returns the ordinary unrolled container, so `(a.A)[0]`, `length_of (a.A)`, `(m.Map)["k"]`, deep `==`, and set membership all compose.

## How

- **Storage** (`orly/code_gen/variant.cc`): a self-reference under a container stores boxed elementwise — `[json]` → `std::vector<Rt::TBox<json>>`, `{str: tagged}` → `Rt::TDict<str, Rt::TBox<tagged>>`. The storage printer (`subst_storage`) substitutes `TSelfRef → Rt::TBox<V>` recursively; per-arm factories/getters convert via new `Rt::DeepBox`/`DeepUnbox` (`orly/rt/box.h`) with the unrolled payload type supplied at the call site. Container-of-box payloads compare through the `Rt::` machinery (no methods on a container) rather than the direct method calls used for box/record payloads.
- **Ordering** (`orly/rt/containers.h`): added `MatchLess` overloads for `TSet`/`TDict` — ordering previously fell to `lhs < rhs`, which a `TBox` element has no `operator<` for. Lexicographic over the already-ordered elements; benefits any element without `operator<`.
- **Placement** (`orly/synth/type_def.cc`): a free self-reference is allowed below any chain of list/set/dict-value containers (dict keys stay self-free). `opt` of self stays gated — see below.
- **Incidental opt-of-variant groundwork** (`orly/expr/unknown.cc`, `orly/expr/known.cc`): `unknown <variant>` and `is known`/`is unknown` over an optional variant were `NOT_IMPLEMENTED`; both now treat a variant as a leaf. Correct and useful, but not sufficient for opt-of-self alone.

## Why opt-of-self is *not* in this PR

`opt` of self (`<{.next: t?}>`, nullable children) needs to construct (`v as t?`) and compare a *populated* optional variant, and optional-of-variant is unsupported across the cast/equality operators independently of recursion — that is **#118**. The boxing for `TOpt<TBox<V>>` is already in place here, so opt-of-self is one ungating line in `SelfRefPlacementOk` away once #118 lands. Gating it now gives a clean compile error instead of a half-working surface.

## Testing

- New `tests/lang_tests/general/variants_recursive_containers.orly`: recursive json-array fold (top-level mutual recursion), deep `==`/`!=`, accessor/index/`length_of`, nested peel, set membership, dict-of-self construct/lookup/equality/set, and the optional-of-variant `unknown`/`is unknown` path. Checked-in `.state` baseline.
- Full lang suite: **0 unexpected, 133 passed, 2 tracked xfails (#74/#75), exit 0** (incl. the #103 recursive test, unchanged).
- `make test` (C++ unit suite) passes.
- The gated/limit paths (opt-of-self, recursive `reduce`, nested-function-calling-enclosing) and their pre-existing-vs-new status are documented in the test header.