### PR TITLE
lang: optional-of-variant; unblocks opt-of-self (#118)

### DIFF
--- a/orly/expr/as.cc
+++ b/orly/expr/as.cc
@@ -175,6 +175,17 @@ Type::TType TAs::GetTypeImpl() const {
       }
       Type = rhs->AsType();
     }
+    /* Casting a variant is only an identity cast (variants are invariant
+       in v1, #95). Its real purpose is widening to an optional variant:
+       `v as op_t?` -- the infix machinery unwraps the optional target to
+       reach (variant, variant) here, then re-wraps the result, which is
+       the only way to build a KNOWN optional variant (#118). */
+    virtual void operator()(const Type::TVariant  *lhs, const Type::TVariant  *rhs) const {
+      if (lhs != rhs) {
+        throw TExprError(HERE, PosRange, "A variant can only be cast to its own type.");
+      }
+      Type = rhs->AsType();
+    }
     virtual void operator()(const Type::TObj      *, const Type::TReal     *) const { throw TExprError(HERE, PosRange); }
     virtual void operator()(const Type::TObj      *, const Type::TSet      *) const { throw TExprError(HERE, PosRange); }
     virtual void operator()(const Type::TObj      *, const Type::TStr      *) const { throw TExprError(HERE, PosRange); }

--- a/orly/synth/type_def.cc
+++ b/orly/synth/type_def.cc
@@ -96,18 +96,11 @@ const Type::TType &TTypeDef::GetSymbolicType() const {
 
 /* True iff every free self-reference in `t` sits where the native
    representation can box it (issues #103/#116): at the position itself,
-   or below any chain of list/set/dict-VALUE containers. Dict keys stay
-   self-free.
-
-   `opt` of self is deliberately NOT allowed yet: a nullable child needs
-   to construct a *known* optional variant (`x as t?`) and compare one,
-   and optional-of-variant is unsupported across the cast/equality
-   operators independently of recursion -- that is its own follow-up
-   (see the issue linked from #116). `unknown t` and `is known`/`is
-   unknown` on an optional variant DO work, but that is not enough to
-   build a populated chain, so the whole position is gated for now. A
-   free reference also may not thread through a nested variant or any
-   other compound (the #116 remainder). */
+   or below any chain of list / set / opt / dict-VALUE containers. Dict
+   keys stay self-free. `opt` of self (`<{.next: t?}>`, a nullable child)
+   works now that optional-of-variant construction and comparison are
+   supported (#118). A free reference still may not thread through a
+   nested variant or any other compound (the #116 remainder). */
 static bool SelfRefPlacementOk(const Type::TType &t) {
   if (!Type::HasFreeSelfRef(t)) {
     return true;
@@ -121,6 +114,9 @@ static bool SelfRefPlacementOk(const Type::TType &t) {
   if (const auto *set = t.TryAs<Type::TSet>()) {
     return SelfRefPlacementOk(set->GetElem());
   }
+  if (const auto *opt = t.TryAs<Type::TOpt>()) {
+    return SelfRefPlacementOk(opt->GetElem());
+  }
   if (const auto *dict = t.TryAs<Type::TDict>()) {
     return !Type::HasFreeSelfRef(dict->GetKey()) && SelfRefPlacementOk(dict->GetVal());
   }
@@ -133,10 +129,10 @@ static bool SelfRefPlacementOk(const Type::TType &t) {
    its top level -- the variant is the binder, so anything else means the
    reference doesn't denote the def -- and each FREE self-reference must
    sit at an arm payload's root, as a field of an arm's payload record,
-   or under list/set/dict-value containers within those positions.
-   Free references through a NESTED variant, in an optional, in a dict
-   key, or under any other compound have no native representation yet.
-   Reports errors against the def's name. */
+   or under list/set/opt/dict-value containers within those positions.
+   Free references through a NESTED variant, in a dict key, or under any
+   other compound have no native representation yet. Reports errors
+   against the def's name. */
 static void ValidateSelfRefPlacement(const TTypeDef *def, const Type::TType &type) {
   const TPosRange &pos_range = def->GetName().GetPosRange();
   const Type::TVariant *variant = type.TryAs<Type::TVariant>();
@@ -165,7 +161,7 @@ static void ValidateSelfRefPlacement(const TTypeDef *def, const Type::TType &typ
       GetContext().AddError(pos_range,
           Base::AsStr("in arm \"", arm.first,
                       "\": a self-reference may only appear as an arm's payload, as a field "
-                      "of the arm's payload record, or under list/set/dict-value "
+                      "of the arm's payload record, or under list/set/opt/dict-value "
                       "containers within those positions (issues #103/#116)"));
     }
   }

--- a/tests/lang_tests/general/.variants_optional.orly.test.state
+++ b/tests/lang_tests/general/.variants_optional.orly.test.state
@@ -1,0 +1,21 @@
+[
+  0,
+  [
+    [],
+    [
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++"
+    ],
+    [
+      "Running tests"
+    ],
+    [
+      "Tests done"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/variants_optional.orly
+++ b/tests/lang_tests/general/variants_optional.orly
@@ -1,0 +1,89 @@
+/* <orly/lang_tests/general/variants_optional.orly>
+
+   End-to-end test for issue #118: optional of a variant. Before this,
+   `op_t?` for a variant `op_t` was only half-supported -- `unknown op_t`
+   and `is known`/`is unknown` worked (groundwork from #116), but there
+   was no way to construct a *known* optional variant or compare one.
+
+   The missing piece was a single cast case: `v as op_t?` widens a
+   variant to an optional variant (the infix machinery unwraps the
+   optional target to reach the variant-to-variant cast, then re-wraps).
+   Equality then composes for free -- the comparison operators already
+   auto-unwrap optionals down to the variant-to-variant `==`, yielding an
+   optional bool exactly like any other optional comparison.
+
+   Because optional-of-variant now works, a self-reference may sit under
+   an `opt` in a recursive variant (#116): a linked list can use a
+   nullable `next` instead of a tag-only base arm:
+
+     node is <| Nd(<{.v: int, .next: node?}>) |>;
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+/* ---- Flat optional-of-variant ---- */
+
+op_t is <| A | B(int) |>;
+
+k  = (op_t.B(1) as op_t?) where {};   /* a known optional variant */
+k2 = (op_t.B(1) as op_t?) where {};
+ka = (op_t.A() as op_t?) where {};
+u  = (unknown op_t) where {};         /* an unknown optional variant */
+
+/* ---- opt-of-self: a linked list with a nullable next (#116 via #118) ---- */
+
+node is <| Nd(<{.v: int, .next: node?}>) |>;
+
+node_sum = ((n.Nd).v + (node_sum(.n: known (n.Nd).next) if (n.Nd).next is known else 0)) where {
+  n = given::(node);
+};
+
+node_len = (1 + (node_len(.n: known (n.Nd).next) if (n.Nd).next is known else 0)) where {
+  n = given::(node);
+};
+
+c3 = (node.Nd(<{.v: 1, .next:
+      node.Nd(<{.v: 2, .next:
+      node.Nd(<{.v: 3, .next: unknown node}>) as node?}>) as node?}>)) where {};
+c1 = (node.Nd(<{.v: 9, .next: unknown node}>)) where {};
+
+test {
+  /* Construction and known/unknown discrimination. */
+  t1: k is known;
+  t2: u is unknown;
+  t3: not (u is known);
+
+  /* `known` peels back to the underlying variant. */
+  t4: known k == op_t.B(1);
+  t5: known ka == op_t.A();
+
+  /* Equality of optional variants yields an optional bool (like any
+     optional comparison); both-known compares the payloads, and a
+     known-vs-unknown pair is itself unknown. */
+  t6: known (k == k2);
+  t7: not known (k == ka);
+  t8: (k == u) is unknown;
+  t9: known (k != ka);
+
+  /* opt-of-self: recursive fold down a nullable-next chain. */
+  t10: node_sum(.n: c3) == 6;
+  t11: node_len(.n: c3) == 3;
+  t12: node_sum(.n: c1) == 9;
+  t13: node_len(.n: c1) == 1;
+
+  /* Deep equality and set membership reach through the boxed optional. */
+  t14: c3 == c3;
+  t15: c1 != c3;
+  t16: length_of {c1, c3, c3} == 2;
+};


### PR DESCRIPTION
Closes #118. Also resolves the opt-of-self item of #116.

## What

Optional of a variant — `op_t?` for any variant — now works end to end: construct (`v as op_t?`), `unknown op_t`, `is known`/`is unknown`, `known`, and `==`/`!=` (yielding an optional bool, like any optional comparison).

```orly
op_t is <| A | B(int) |>;
k = (op_t.B(1) as op_t?) where {};
/* k is known; known k == op_t.B(1); known (k == k); (k == unknown op_t) is unknown */
```

And the payoff — a self-reference under an `opt`, so a linked list can use a nullable `next` instead of a tag-only base arm:

```orly
node is <| Nd(<{.v: int, .next: node?}>) |>;
```

## How

One cast case. `unknown`/`is known`/`is unknown` over an optional variant already landed in #120; the only thing missing was constructing a *known* one. `v as op_t?` dispatches (via the infix machinery's optional auto-unwrap) to a variant-to-variant cast, which `TAsTypeVisitor` didn't handle — added a `(TVariant, TVariant)` case (identity cast; variants are invariant in v1). Equality composes for free: the comparison operators auto-unwrap optionals to the variant-to-variant `==` already overridden in `TEqCompVisitor`.

The "record-equality path" the issue worried about was the same cast failing inside record construction, not a separate gap.

opt-of-self then falls out by re-adding `TOpt` to `SelfRefPlacementOk` in `orly/synth/type_def.cc` — the `TOpt<TBox<V>>` boxing was already in place from #120.

## Testing

- New `tests/lang_tests/general/variants_optional.orly`: flat optional-of-variant (construct/known/unknown/equality with optional-bool results) and opt-of-self (nullable-next linked list — recursive sum/len fold, deep `==`, set membership).
- Full lang suite: **0 unexpected, 134 passed, 2 tracked xfails (#74/#75), exit 0**.
- `make test` passes.

Diff is small: a `(TVariant, TVariant)` case in `orly/expr/as.cc` and the one-line placement ungating (+ comment/message updates) in `orly/synth/type_def.cc`.

## #116 status after this

Remaining: nested-variant back-refs (`<| A(<| B(t) |>) |>`) and mutual/transitive recursion — the binder-stack work, still its own planning pass.