### PR TITLE
code_gen: prefix variant arm factories with Mk to avoid macro clashes (#119)

### DIFF
--- a/orly/code_gen/variant.cc
+++ b/orly/code_gen/variant.cc
@@ -301,16 +301,23 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
            record; the visitor reads the one key, dispatches on its tag, and
            builds this native variant via the per-arm static factories). */
 
-        /* One static factory per arm. A recursive arm's factory takes the
-           UNROLLED payload (deduced at the call site -- a template, so this
-           header needn't include the unrolled record's header) and stores
-           it boxed. */
+        /* One static factory per arm, named `Mk<Tag>`. The `Mk` prefix
+           keeps the method name from colliding with a function-like macro
+           that happens to share the tag's spelling -- e.g. an arm named
+           `S` would otherwise expand the `S(x)` stringize macro from
+           <base/code_location.h> (#119). This mirrors the `V` prefix the
+           record/variant generators already use on field/payload storage
+           for the same reason. The other tag-derived names (GetV<Tag>,
+           V<Tag>, <class>_Boxed<Tag>) are already prefixed and safe.
+           A recursive arm's factory takes the UNROLLED payload (deduced
+           at the call site -- a template, so this header needn't include
+           the unrolled record's header) and stores it boxed. */
         {
           size_t idx = 0;
           for (const auto &elem : elems) {
             if (arm_is_recursive(elem.second)) {
               out << "template <typename TPayload>" << Eol
-                  << "static " << class_name << ' ' << elem.first
+                  << "static " << class_name << " Mk" << elem.first
                   << "(const TPayload &vv) {" << Eol
                   << "  " << class_name << " out;" << Eol
                   << "  out.Which = " << idx << ";" << Eol
@@ -319,7 +326,7 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
                   << "  return out;" << Eol
                   << "}" << Eol;
             } else {
-              out << "static " << class_name << ' ' << elem.first
+              out << "static " << class_name << " Mk" << elem.first
                   << "(const " << elem.second << " &vv) {" << Eol
                   << "  " << class_name << " out;" << Eol
                   << "  out.Which = " << idx << ";" << Eol
@@ -755,7 +762,7 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
             << "      State::TOpt::TPin::TWrapper opin(opt->Pin(opt_pin_alloc));" << Eol
             << "      if (opin->GetElemCount() != 1) { THROW_ERROR(TInvalidConversion); }" << Eol
             << "      State::TAny::TWrapper payload_state(opin->NewElem(0, payload_alloc));" << Eol
-            << "      Out = Rt::Variants::" << class_name << "::" << elem.first
+            << "      Out = Rt::Variants::" << class_name << "::Mk" << elem.first
             << "(AsNative<" << elem.second << ">(*payload_state));" << Eol
             << "    }" << Eol;
         ++idx;

--- a/orly/code_gen/variant_ctor.cc
+++ b/orly/code_gen/variant_ctor.cc
@@ -29,6 +29,8 @@ TVariantCtor::TVariantCtor(const L0::TPackage *package,
 
 void TVariantCtor::WriteExpr(TCppPrinter &out) const {
   /* GetReturnType() prints `Orly::Rt::Variants::TVariant<mangled>`; the
-     per-arm static factory is named after the tag and takes the payload. */
-  out << GetReturnType() << "::" << Tag << '(' << Payload << ')';
+     per-arm static factory is `Mk<Tag>` (the `Mk` prefix avoids macro
+     collisions on the bare tag name, e.g. an arm named `S`; see #119 and
+     orly/code_gen/variant.cc) and takes the payload. */
+  out << GetReturnType() << "::Mk" << Tag << '(' << Payload << ')';
 }

--- a/orly/code_gen/variant_emit.test.cc
+++ b/orly/code_gen/variant_emit.test.cc
@@ -45,10 +45,10 @@ using TV = Orly::Rt::Variants::TVariantV2O07Deletedi7Integer;
 FIXTURE(EmittedVariantRoundTrips) {
   Type::TTypeCzar type_czar;
 
-  TV i  = TV::Integer(int64_t(-384));
-  TV i2 = TV::Integer(int64_t(-384));
-  TV i3 = TV::Integer(int64_t(7));
-  TV d  = TV::Deleted(Rt::Objects::TObjO0());
+  TV i  = TV::MkInteger(int64_t(-384));
+  TV i2 = TV::MkInteger(int64_t(-384));
+  TV i3 = TV::MkInteger(int64_t(7));
+  TV d  = TV::MkDeleted(Rt::Objects::TObjO0());
 
   /* GetType(): the declared 2-arm variant type. */
   auto declared = Type::TVariant::Get(
@@ -77,8 +77,8 @@ FIXTURE(EmittedVariantRoundTrips) {
 FIXTURE(EmittedVariantAsVar) {
   Type::TTypeCzar type_czar;
 
-  TV i = TV::Integer(int64_t(-384));
-  TV d = TV::Deleted(Rt::Objects::TObjO0());
+  TV i = TV::MkInteger(int64_t(-384));
+  TV d = TV::MkDeleted(Rt::Objects::TObjO0());
 
   Var::TVar v_i = i.AsVar();
   Var::TVar v_d = d.AsVar();
@@ -93,8 +93,8 @@ FIXTURE(EmittedVariantAsVar) {
   EXPECT_TRUE(v_d.GetType() == declared);
 
   /* Var-level equality is consistent with native EqEq. */
-  TV i2 = TV::Integer(int64_t(-384));
-  TV i3 = TV::Integer(int64_t(7));
+  TV i2 = TV::MkInteger(int64_t(-384));
+  TV i3 = TV::MkInteger(int64_t(7));
   EXPECT_TRUE(i.AsVar() == i2.AsVar());
   EXPECT_FALSE(i.AsVar() == i3.AsVar());
   EXPECT_FALSE(i.AsVar() == d.AsVar());

--- a/orly/code_gen/variant_emit_test/variant.frozen.h
+++ b/orly/code_gen/variant_emit_test/variant.frozen.h
@@ -34,13 +34,13 @@ namespace Orly {
         public:
         TVariantV2O07Deletedi7Integer() : Which(0) {}
 
-        static TVariantV2O07Deletedi7Integer Deleted(const Orly::Rt::Objects::TObjO0 &vv) {
+        static TVariantV2O07Deletedi7Integer MkDeleted(const Orly::Rt::Objects::TObjO0 &vv) {
           TVariantV2O07Deletedi7Integer out;
           out.Which = 0;
           out.VDeleted = vv;
           return out;
         }
-        static TVariantV2O07Deletedi7Integer Integer(const int64_t &vv) {
+        static TVariantV2O07Deletedi7Integer MkInteger(const int64_t &vv) {
           TVariantV2O07Deletedi7Integer out;
           out.Which = 1;
           out.VInteger = vv;
@@ -240,8 +240,8 @@ namespace Orly {
         Type::TAny::TWrapper(tpin->NewElem(0, tag, etype_alloc));
         void *estate_alloc = alloca(State::GetMaxStateSize());
         State::TAny::TWrapper elem_state(spin->NewElem(0, estate_alloc));
-        if (tag == "Deleted") { Out = Rt::Variants::TVariantV2O07Deletedi7Integer::Deleted(AsNative<Orly::Rt::Objects::TObjO0>(*elem_state)); }
-        else if (tag == "Integer") { Out = Rt::Variants::TVariantV2O07Deletedi7Integer::Integer(AsNative<int64_t>(*elem_state)); }
+        if (tag == "Deleted") { Out = Rt::Variants::TVariantV2O07Deletedi7Integer::MkDeleted(AsNative<Orly::Rt::Objects::TObjO0>(*elem_state)); }
+        else if (tag == "Integer") { Out = Rt::Variants::TVariantV2O07Deletedi7Integer::MkInteger(AsNative<int64_t>(*elem_state)); }
         else { THROW_ERROR(TInvalidConversion); }
       }
       private:

--- a/tests/lang_tests/general/.variants_arm_names.orly.test.state
+++ b/tests/lang_tests/general/.variants_arm_names.orly.test.state
@@ -1,0 +1,21 @@
+[
+  0,
+  [
+    [],
+    [
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++"
+    ],
+    [
+      "Running tests"
+    ],
+    [
+      "Tests done"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/variants_arm_names.orly
+++ b/tests/lang_tests/general/variants_arm_names.orly
@@ -1,0 +1,52 @@
+/* <orly/lang_tests/general/variants_arm_names.orly>
+
+   Regression test for issue #119: a variant arm whose tag spells a
+   function-like macro broke the generated C++. The per-arm static
+   factory used to be named after the bare tag, so an arm named `S`
+   emitted `static ... S(const std::string &vv)`, which the preprocessor
+   expanded against the `S(x)` stringize macro in <base/code_location.h>
+   ("expected unqualified-id before string constant"); `HERE` would have
+   collided the same way. Factories are now `Mk<Tag>`, so any tag spelling
+   is safe. (The other tag-derived names -- GetV<Tag>, V<Tag> storage,
+   <class>_Boxed<Tag> -- were already prefixed.)
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+/* `S` and `HERE` are macros in <base/code_location.h>; `A` is innocuous
+   but kept for variety. */
+j is <| N(int) | S(str) | A | HERE(int) |>;
+
+classify = ((v) when {
+  N(n): n;
+  S(s): length_of s;
+  A: -1;
+  HERE(h): h * 10;
+}) where {
+  v = given::(j);
+};
+
+test {
+  /* Construct (Mk<Tag> factory) and match each macro-spelled arm. */
+  t1: classify(.v: j.N(7)) == 7;
+  t2: classify(.v: j.S("abcd")) == 4;
+  t3: classify(.v: j.A()) == -1;
+  t4: classify(.v: j.HERE(3)) == 30;
+
+  /* Equality and the .<Tag> accessor on a macro-spelled arm. */
+  t5: j.S("x") == j.S("x");
+  t6: j.S("x") != j.N(1);
+  t7: (j.S("hi")).S == "hi";
+  t8: (j.HERE(5)).HERE == 5;
+};


### PR DESCRIPTION
Closes #119.

## Problem

A variant arm whose tag spells a function-like macro broke the generated C++. The per-arm static factory was named after the bare tag, so:

```orly
j is <| N(int) | S(str) |>;
```

emitted `static ... S(const std::string &vv)`, which the preprocessor expanded against the `S(x)` stringize macro in `<base/code_location.h>` → *"expected unqualified-id before string constant"*. A tag named `HERE` would have collided the same way.

## Fix

Factories are now emitted as `Mk<Tag>`. This mirrors the `V` prefix the record/variant generators already use on field/payload storage for exactly this reason; the other tag-derived names (`GetV<Tag>`, `V<Tag>` storage, `<class>_Boxed<Tag>`) were already prefixed and safe. Three emission sites updated (two factory definitions + the read-back call in `variant.cc`, plus the ctor lowering in `variant_ctor.cc`), and the frozen-snapshot unit test (`variant.frozen.h` + `variant_emit.test` calls).

## Testing

- New `tests/lang_tests/general/variants_arm_names.orly`: a variant with arms named `S`, `A`, and `HERE` — construct, exhaustive `when`, equality, `.<Tag>` accessor.
- Full lang suite: **0 unexpected, 135 passed, 2 tracked xfails (#74/#75), exit 0**.
- `make test` passes.

## Side note (not fixed here)

While updating the frozen snapshot I noticed it is *also* stale relative to #96 — it still carries the pre-#96 single-key-record read-back rather than the `$which` form. That's orthogonal to this macro fix (the snapshot is a curated copy, not a live golden, so it silently drifts). Left as-is; worth converting to a live golden in a follow-up so it can't drift again.