### PR TITLE
test: make the variant frozen snapshot a live golden (#123)

### DIFF
--- a/orly/code_gen/variant.test.cc
+++ b/orly/code_gen/variant.test.cc
@@ -2,11 +2,29 @@
 
    Unit test for <orly/code_gen/variant.h>.
 
-   This exercises the *emitter* (it runs GenVariantHeader and confirms it
-   produces a file without throwing). It does NOT compile the emitted C++;
-   that validation is performed out-of-band in Phase 2 (see the emitted
-   /tmp/VO7Deletedi7Integer.h compiled against the runtime headers). The
-   emitter is otherwise dead code until the Phase-3 language surface exists.
+   Exercises the *emitter* (`GenVariantHeader`) two ways:
+
+     1. Generates a couple of variant headers and confirms it produces a
+        file without throwing.
+
+     2. Pins the emitter's output as a LIVE GOLDEN: the generated header
+        for `{ Integer(int) | Deleted }` is compared, byte for byte, to
+        the committed snapshot in variant_emit_test/variant.frozen.h that
+        orly/code_gen/variant_emit.test.cc compiles and runs against the
+        real runtime. Because the snapshot is a curated copy (not produced
+        at build time), it used to drift silently from the emitter -- it
+        carried a pre-#96 read-back for two releases (#123). This golden
+        check fails CI the moment the emitter's output and the snapshot
+        diverge.
+
+   The snapshot is curated in exactly two deterministic ways, which this
+   test reproduces before comparing: its leading auto-generated comment is
+   replaced (so we compare from `#pragma once` on), and the generated
+   `<orly/rt/objects/O0.h>` payload include is redirected to the
+   co-located O0.frozen.h. To refresh the snapshot after an intentional
+   emitter change, run this test with REGEN_VARIANT_GOLDEN=1 in the
+   environment; it rewrites variant.frozen.h in place (preserving the
+   snapshot's leading comment) and passes.
 
    Copyright 2010-2026 Atomic Kismet Company
 
@@ -24,15 +42,55 @@
 
 #include <orly/code_gen/variant.h>
 
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include <base/source_root.h>
 #include <orly/type.h>
 #include <orly/type/type_czar.h>
 #include <orly/type/variant.h>
 
 #include <base/test/kit.h>
 
+using namespace std;
 using namespace Orly;
 using namespace Orly::CodeGen;
 using namespace Orly::Type;
+
+/* The committed snapshot the emit test compiles, relative to the source root. */
+static const char *const GoldenRelPath =
+    "orly/code_gen/variant_emit_test/variant.frozen.h";
+
+/* Read an entire file into a string (empty if it does not exist). */
+static string Slurp(const string &path) {
+  ifstream in(path, ios::binary);
+  ostringstream ss;
+  ss << in.rdbuf();
+  return ss.str();
+}
+
+/* The portion of a generated header from the first `#pragma once` on --
+   i.e. everything but the leading comment, which the snapshot replaces. */
+static string BodyFromPragma(const string &s) {
+  auto pos = s.find("#pragma once");
+  return pos == string::npos ? s : s.substr(pos);
+}
+
+/* Apply the snapshot's one content edit: the generated payload include
+   points into the build-artifact objects dir; the snapshot redirects it
+   to the co-located frozen copy so the emit test is self-contained. */
+static string RedirectO0Include(string body) {
+  const string from = "#include <orly/rt/objects/O0.h>";
+  const string to   = "#include <orly/code_gen/variant_emit_test/O0.frozen.h>";
+  auto pos = body.find(from);
+  if (pos != string::npos) {
+    body.replace(pos, from.size(), to);
+  }
+  return body;
+}
 
 FIXTURE(GenVariantHeader) {
   TTypeCzar type_czar;
@@ -48,4 +106,42 @@ FIXTURE(GenVariantHeader) {
   auto rec = TObj::Get({{"x", TInt::Get()}, {"y", TBool::Get()}});
   auto variant2 = TVariant::Get({{"Point", rec}, {"None", deleted_payload}});
   GenVariantHeader("/tmp/", variant2);
+}
+
+/* The live-golden check (#123): the emitter's output for variant1 must
+   match the committed snapshot the emit test compiles. */
+FIXTURE(VariantGoldenMatchesEmitter) {
+  TTypeCzar type_czar;
+
+  auto deleted_payload = TObj::Get({});
+  auto variant1 = TVariant::Get({{"Integer", TInt::Get()}, {"Deleted", deleted_payload}});
+  GenVariantHeader("/tmp/", variant1);
+
+  const string live = RedirectO0Include(BodyFromPragma(Slurp("/tmp/V2O07Deletedi7Integer.h")));
+  const string golden_path = Base::GetSrcRoot() + GoldenRelPath;
+  const string golden_full = Slurp(golden_path);
+  const string golden = BodyFromPragma(golden_full);
+
+  if (getenv("REGEN_VARIANT_GOLDEN")) {
+    /* Preserve the snapshot's leading comment; replace the body. */
+    const string comment = golden_full.substr(0, golden_full.find("#pragma once"));
+    ofstream out(golden_path, ios::binary | ios::trunc);
+    out << comment << live;
+    cout << "REGEN_VARIANT_GOLDEN: rewrote " << golden_path << endl;
+    return;
+  }
+
+  if (live != golden) {
+    /* Write a refreshed candidate for inspection and point at the regen path. */
+    const string comment = golden_full.substr(0, golden_full.find("#pragma once"));
+    ofstream out("/tmp/variant.frozen.h.new", ios::binary | ios::trunc);
+    out << comment << live;
+    cerr << "\nGenVariantHeader output has drifted from " << GoldenRelPath << ".\n"
+         << "A refreshed candidate was written to /tmp/variant.frozen.h.new.\n"
+         << "If the change is intentional, regenerate with:\n"
+         << "  REGEN_VARIANT_GOLDEN=1 <this test binary>\n"
+         << "and rebuild so orly/code_gen/variant_emit.test.cc compiles the new snapshot.\n"
+         << endl;
+  }
+  EXPECT_TRUE(live == golden);
 }

--- a/orly/code_gen/variant_emit_test/variant.frozen.h
+++ b/orly/code_gen/variant_emit_test/variant.frozen.h
@@ -11,6 +11,8 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
+#include <string>
 
 #include <orly/rt/tuple.h>
 #include <orly/rt/containers.h>
@@ -20,6 +22,8 @@
 #include <orly/var/obj.h>
 #include <orly/var/new_sabot.h>
 #include <orly/sabot/to_native.h>
+#include <orly/native/type.h>
+#include <orly/type/new_sabot.h>
 
 /* Needed payload objects */
 #include <orly/code_gen/variant_emit_test/O0.frozen.h>
@@ -234,14 +238,44 @@ namespace Orly {
         Type::TRecord::TPin::TWrapper tpin(rtype->Pin(type_pin_alloc));
         void *state_pin_alloc = alloca(State::GetMaxStatePinSize());
         State::TRecord::TPin::TWrapper spin(state.Pin(state_pin_alloc));
-        if (tpin->GetElemCount() != 1) { THROW_ERROR(TInvalidConversion); }
-        std::string tag;
+        const size_t elem_count = tpin->GetElemCount();
         void *etype_alloc = alloca(Type::GetMaxTypeSize());
-        Type::TAny::TWrapper(tpin->NewElem(0, tag, etype_alloc));
         void *estate_alloc = alloca(State::GetMaxStateSize());
-        State::TAny::TWrapper elem_state(spin->NewElem(0, estate_alloc));
-        if (tag == "Deleted") { Out = Rt::Variants::TVariantV2O07Deletedi7Integer::MkDeleted(AsNative<Orly::Rt::Objects::TObjO0>(*elem_state)); }
-        else if (tag == "Integer") { Out = Rt::Variants::TVariantV2O07Deletedi7Integer::MkInteger(AsNative<int64_t>(*elem_state)); }
+        std::string field_name;
+        size_t which = static_cast<size_t>(-1);
+        size_t idx_Deleted = static_cast<size_t>(-1);
+        size_t idx_Integer = static_cast<size_t>(-1);
+        for (size_t i = 0; i < elem_count; ++i) {
+          Type::TAny::TWrapper(tpin->NewElem(i, field_name, etype_alloc));
+          if (field_name == "$which") {
+            State::TAny::TWrapper which_state(spin->NewElem(i, estate_alloc));
+            which = static_cast<size_t>(AsNative<int64_t>(*which_state));
+          }
+          else if (field_name == "Deleted") { idx_Deleted = i; }
+          else if (field_name == "Integer") { idx_Integer = i; }
+        }
+        void *opt_pin_alloc = alloca(State::GetMaxStatePinSize());
+        void *payload_alloc = alloca(State::GetMaxStateSize());
+        if (which == 0) {
+          if (idx_Deleted == static_cast<size_t>(-1)) { THROW_ERROR(TInvalidConversion); }
+          State::TAny::TWrapper arm_state(spin->NewElem(idx_Deleted, estate_alloc));
+          const State::TOpt *opt = dynamic_cast<const State::TOpt *>(arm_state.get());
+          if (!opt) { THROW_ERROR(TInvalidConversion); }
+          State::TOpt::TPin::TWrapper opin(opt->Pin(opt_pin_alloc));
+          if (opin->GetElemCount() != 1) { THROW_ERROR(TInvalidConversion); }
+          State::TAny::TWrapper payload_state(opin->NewElem(0, payload_alloc));
+          Out = Rt::Variants::TVariantV2O07Deletedi7Integer::MkDeleted(AsNative<Orly::Rt::Objects::TObjO0>(*payload_state));
+        }
+        else if (which == 1) {
+          if (idx_Integer == static_cast<size_t>(-1)) { THROW_ERROR(TInvalidConversion); }
+          State::TAny::TWrapper arm_state(spin->NewElem(idx_Integer, estate_alloc));
+          const State::TOpt *opt = dynamic_cast<const State::TOpt *>(arm_state.get());
+          if (!opt) { THROW_ERROR(TInvalidConversion); }
+          State::TOpt::TPin::TWrapper opin(opt->Pin(opt_pin_alloc));
+          if (opin->GetElemCount() != 1) { THROW_ERROR(TInvalidConversion); }
+          State::TAny::TWrapper payload_state(opin->NewElem(0, payload_alloc));
+          Out = Rt::Variants::TVariantV2O07Deletedi7Integer::MkInteger(AsNative<int64_t>(*payload_state));
+        }
         else { THROW_ERROR(TInvalidConversion); }
       }
       private:
@@ -264,6 +298,18 @@ namespace Orly {
         return State::Factory<Var::TVar>::New(val.AsVar(), state_alloc);
       }
     }; // State::Factory<TVariantV2O07Deletedi7Integer>
+
+    template <>
+    class Type::For<Rt::Variants::TVariantV2O07Deletedi7Integer> final {
+      NO_CONSTRUCTION(For);
+      public:
+      static Sabot::Type::TAny *GetType(void *type_alloc) {
+        return Orly::Type::NewSabot(type_alloc, Orly::Type::TDt<Rt::Variants::TVariantV2O07Deletedi7Integer>::GetType());
+      }
+      static Sabot::Type::TRecord *GetRecordType(void *type_alloc) {
+        return dynamic_cast<Sabot::Type::TRecord *>(GetType(type_alloc));
+      }
+    }; // Type::For<TVariantV2O07Deletedi7Integer>
 
   } // Orly
 


### PR DESCRIPTION
Closes #123.

## Problem

`variant_emit.test.cc` compiles a curated, committed snapshot of `GenVariantHeader`'s output (`variant_emit_test/variant.frozen.h`) to prove the emitted C++ compiles and round-trips against the real runtime (the #90 trap). But the snapshot was a hand-curated copy, not a golden checked against live output, so it drifted silently:

- it carried the **pre-#96** single-key-record read-back for two releases;
- #119 had to hand-edit it for the `Mk<Tag>` factory rename.

A passing test therefore proved only that *some past* emitter output worked, not the current one.

## Fix

`variant.test.cc` now pins the snapshot as a **live golden**: it generates the `{ Integer(int) | Deleted }` header and compares it byte-for-byte to the committed snapshot, reproducing the snapshot's two deterministic curation edits first:
- the leading auto-gen comment is replaced (compare from `#pragma once` on);
- the `<orly/rt/objects/O0.h>` payload include is redirected to the co-located `O0.frozen.h`.

Any divergence now **fails CI**, writing a refreshed candidate to `/tmp/variant.frozen.h.new` and printing the regen command. To refresh after an intentional emitter change:

```
REGEN_VARIANT_GOLDEN=1 <variant.test binary>
```

which rewrites the snapshot in place (preserving its leading comment) via `Base::GetSrcRoot()`.

Also **regenerated `variant.frozen.h` to current emitter output** in the same change — bringing it up to date with the #96 `$which` read-back, the `native/type.h` + `type/new_sabot.h` includes, and the `Mk<Tag>` factories.

## Verification

- The drift check **fires** on the stale snapshot (confirmed before regenerating).
- After `REGEN_VARIANT_GOLDEN=1`, the golden test passes.
- `variant_emit.test.cc` still compiles and round-trips against the refreshed snapshot.
- `make test` passes.

The emitter (`variant.cc`) itself is untouched, so the lang suite is unaffected.

## Note (deliberate scope)

The co-located `O0.frozen.h` payload fixture is still a plain frozen copy (not golden-checked). `GenObjHeader` is far more stable, and a drift there would surface as an emit-test *compile* failure rather than silently. Could get the same treatment later if needed.