### PR TITLE
lang: nested-variant back-references (#116 Phase 1)

### DIFF
--- a/orly/code_gen/variant.cc
+++ b/orly/code_gen/variant.cc
@@ -103,7 +103,10 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
      no methods and goes through the Rt:: machinery, which resolves fine
      in the variant's member bodies (complete-class context). */
   auto arm_has_methods = [](const Type::TType &payload) {
-    return payload.Is<Type::TSelfRef>() || payload.Is<Type::TObj>();
+    /* A self-ref boxes to TBox (methods), a record/open-variant payload to
+       an inline struct (methods). A container of boxes has none. */
+    return payload.Is<Type::TSelfRef>() || payload.Is<Type::TObj>()
+        || (payload.Is<Type::TVariant>() && Type::HasFreeSelfRef(payload));
   };
   bool is_recursive = false;
   for (const auto &elem : elems) {
@@ -114,6 +117,21 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
   }
   auto boxed_name = [&class_name](const string &tag) {
     return class_name + "_Boxed" + tag;
+  };
+  /* The name of the inline struct that stores an open nested-variant arm
+     payload (#116 Phase 1). Keyed by the open variant's mangled name and
+     qualified by the outer class, so it is unique within this header and
+     dedups across arms with the same nested shape. */
+  auto inline_name = [&class_name](const Type::TType &open_variant) {
+    return class_name + "_NV" + open_variant.GetMangledName();
+  };
+  /* True for an arm payload that is an open nested variant -- a variant
+     (transitively) holding a free self-reference bound by an enclosing
+     variant. Stored as an inline struct (see inline_name) rather than a
+     standalone header, since its native shape depends on the binder.
+     v1 (Phase 1) supports this only as a direct arm payload. */
+  auto arm_is_nested_variant = [](const Type::TType &payload) {
+    return payload.Is<Type::TVariant>() && Type::HasFreeSelfRef(payload);
   };
   /* Prints a type with every free self-reference replaced by its boxed
      storage, elementwise through the containers the placement rules
@@ -152,6 +170,9 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
   auto storage_type = [&](const string &tag, const Type::TType &payload) {
     if (Type::HasFreeSelfRef(payload) && payload.Is<Type::TObj>()) {
       return boxed_name(tag);
+    }
+    if (arm_is_nested_variant(payload)) {
+      return inline_name(payload);
     }
     return subst_storage(payload);
   };
@@ -285,6 +306,80 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
           }
           out << "}; // " << bname << Eol
               << Eol;
+        }
+        /* Inline structs for open nested-variant arm payloads (#116 Phase 1):
+           a variant arm whose payload is itself a variant holding a free
+           self-reference. The nested variant's native shape depends on its
+           binder (the outer), so it cannot get a standalone header keyed by
+           its binder-agnostic mangled name -- it is emitted inline here,
+           mirroring the _Boxed record structs. v1 supports a single nesting
+           level: the nested variant's arms are tag-only, scalar, or a self-
+           reference to the outer (depth 1 -> Rt::TBox<outer>). */
+        {
+          unordered_set<string> emitted_nv;
+          for (const auto &elem : elems) {
+            if (!arm_is_nested_variant(elem.second)) { continue; }
+            auto nvname = inline_name(elem.second);
+            if (!emitted_nv.insert(nvname).second) { continue; }
+            const auto &nv_elems = elem.second.As<Type::TVariant>()->GetElems();
+            auto nv_field = [&class_name](const Type::TType &p) {
+              return p.Is<Type::TSelfRef>() ? Base::AsStr("Rt::TBox<", class_name, '>')
+                                            : Base::AsStr(p);
+            };
+            out << "/* Inline storage for the open nested-variant payload of arm `"
+                << elem.first << "` (#116). */" << Eol
+                << "class " << nvname << " {" << Eol
+                << "  public:" << Eol
+                << "  " << nvname << "() : Which(0) {}" << Eol
+                << Eol
+                << "  /* From the unrolled closed nested variant (deduced); self arms box. */" << Eol
+                << "  template <typename TClosed>" << Eol
+                << "  explicit " << nvname << "(const TClosed &c) : Which(c.GetWhich()) {" << Eol
+                << "    switch (c.GetWhich()) {" << Eol;
+            {
+              size_t i = 0;
+              for (const auto &ne : nv_elems) {
+                out << "      case " << i << ": V" << ne.first << " = Rt::DeepBox<"
+                    << nv_field(ne.second) << ">(c.GetV" << ne.first << "()); break;" << Eol;
+                ++i;
+              }
+            }
+            out << "    }" << Eol
+                << "  }" << Eol
+                << Eol
+                << "  /* Back to the unrolled closed nested variant. */" << Eol
+                << "  template <typename TRet>" << Eol
+                << "  TRet ToUnrolled() const {" << Eol
+                << "    switch (Which) {" << Eol;
+            {
+              size_t i = 0;
+              for (const auto &ne : nv_elems) {
+                out << "      case " << i << ": return TRet::Mk" << ne.first
+                    << "(Rt::DeepUnbox<decltype(std::declval<TRet>().GetV" << ne.first
+                    << "())>(V" << ne.first << "));" << Eol;
+                ++i;
+              }
+            }
+            out << "    }" << Eol
+                << "    assert(false);" << Eol
+                << "    throw Rt::TSystemError(HERE, \"nested variant has no active arm\");" << Eol
+                << "  }" << Eol
+                << Eol
+                << "  /* Structural comparisons; defined after " << class_name
+                << " (they deref TBox<" << class_name << "> fields). */" << Eol
+                << "  bool EqEq(const " << nvname << " &that) const;" << Eol
+                << "  bool Match(const " << nvname << " &that) const;" << Eol
+                << "  bool MatchLess(const " << nvname << " &that) const;" << Eol
+                << "  size_t GetHash() const;" << Eol
+                << Eol
+                << "  private:" << Eol
+                << "  size_t Which;" << Eol;
+            for (const auto &ne : nv_elems) {
+              out << "  " << nv_field(ne.second) << " V" << ne.first << ";" << Eol;
+            }
+            out << "}; // " << nvname << Eol
+                << Eol;
+          }
         }
       }
       out << "class " << class_name << " {" << Eol;
@@ -484,14 +579,18 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
             if (arm_is_recursive(elem.second)) {
               /* TRet is the UNROLLED payload type; the code generator
                  supplies it explicitly at the access site
-                 (orly/code_gen/variant_access.cc). */
-              const bool record_payload = elem.second.Is<Type::TObj>();
+                 (orly/code_gen/variant_access.cc). A record or open-variant
+                 payload is stored in an inline struct that converts via
+                 ToUnrolled; a self-ref / container of boxes unboxes via
+                 Rt::DeepUnbox. */
+              const bool uses_inline_struct =
+                  elem.second.Is<Type::TObj>() || arm_is_nested_variant(elem.second);
               out << "template <typename TRet>" << Eol
                   << "TRet GetV" << elem.first << "() const {" << Eol
                   << "  assert(this);" << Eol
                   << "  assert(Which == " << idx << ");" << Eol
                   << "  return "
-                  << (record_payload
+                  << (uses_inline_struct
                           ? Base::AsStr('V', elem.first, ".template ToUnrolled<TRet>()")
                           : Base::AsStr("Rt::DeepUnbox<TRet>(V", elem.first, ')'))
                   << ";" << Eol
@@ -594,6 +693,68 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
                             })
               << ';' << Eol
               << "}" << Eol;
+        }
+        /* Inline nested-variant structs' comparison bodies (deferred: they
+           deref TBox<outer> fields, so the outer must be complete). */
+        {
+          unordered_set<string> done_nv;
+          for (const auto &elem : elems) {
+            if (!arm_is_nested_variant(elem.second)) { continue; }
+            auto nvname = inline_name(elem.second);
+            if (!done_nv.insert(nvname).second) { continue; }
+            const auto &nv_elems = elem.second.As<Type::TVariant>()->GetElems();
+            auto nv_field = [&class_name](const Type::TType &p) {
+              return p.Is<Type::TSelfRef>() ? Base::AsStr("Rt::TBox<", class_name, '>')
+                                            : Base::AsStr(p);
+            };
+            out << Eol
+                << "inline bool " << nvname << "::EqEq(const " << nvname
+                << " &that) const { return Match(that); }" << Eol
+                << "inline bool " << nvname << "::Match(const " << nvname << " &that) const {" << Eol
+                << "  if (Which != that.Which) { return false; }" << Eol
+                << "  switch (Which) {" << Eol;
+            {
+              size_t i = 0;
+              for (const auto &ne : nv_elems) {
+                out << "    case " << i << ": return Rt::Match(V" << ne.first
+                    << ", that.V" << ne.first << ");" << Eol;
+                ++i;
+              }
+            }
+            out << "  }" << Eol
+                << "  assert(false);" << Eol
+                << "  return false;" << Eol
+                << "}" << Eol
+                << "inline bool " << nvname << "::MatchLess(const " << nvname << " &that) const {" << Eol
+                << "  if (Which != that.Which) { return Which < that.Which; }" << Eol
+                << "  switch (Which) {" << Eol;
+            {
+              size_t i = 0;
+              for (const auto &ne : nv_elems) {
+                out << "    case " << i << ": return Rt::MatchLess(V" << ne.first
+                    << ", that.V" << ne.first << ");" << Eol;
+                ++i;
+              }
+            }
+            out << "  }" << Eol
+                << "  assert(false);" << Eol
+                << "  return false;" << Eol
+                << "}" << Eol
+                << "inline size_t " << nvname << "::GetHash() const {" << Eol
+                << "  switch (Which) {" << Eol;
+            {
+              size_t i = 0;
+              for (const auto &ne : nv_elems) {
+                out << "    case " << i << ": return std::hash<size_t>()(" << i
+                    << ") ^ std::hash<" << nv_field(ne.second) << ">()(V" << ne.first << ");" << Eol;
+                ++i;
+              }
+            }
+            out << "  }" << Eol
+                << "  assert(false);" << Eol
+                << "  return 0;" << Eol
+                << "}" << Eol;
+          }
         }
       }
     } // namespace Variants

--- a/orly/synth/type_def.cc
+++ b/orly/synth/type_def.cc
@@ -143,6 +143,30 @@ static void ValidateSelfRefPlacement(const TTypeDef *def, const Type::TType &typ
   }
   for (const auto &arm : variant->GetElems()) {
     const Type::TType &payload = arm.second;
+    /* An open nested variant directly as an arm payload (#116 Phase 1).
+       v1 supports a single nesting level: the nested variant's own arms
+       must be tag-only / scalar / self-free, or a *direct* self-reference
+       to an enclosing variant -- not a record, container, or further
+       nested variant carrying a free self-reference. */
+    if (const Type::TVariant *nested = payload.TryAs<Type::TVariant>()) {
+      if (Type::HasFreeSelfRef(payload)) {
+        bool ok = true;
+        for (const auto &nv_arm : nested->GetElems()) {
+          if (Type::HasFreeSelfRef(nv_arm.second) && !nv_arm.second.Is<Type::TSelfRef>()) {
+            ok = false;
+            break;
+          }
+        }
+        if (!ok) {
+          GetContext().AddError(pos_range,
+              Base::AsStr("in arm \"", arm.first,
+                          "\": a nested variant may currently recurse only via a direct "
+                          "self-reference arm; records, containers, and deeper nested "
+                          "variants holding a self-reference are not yet supported (#116)"));
+        }
+        continue;
+      }
+    }
     bool ok;
     /* One record layer is allowed at the payload root only. */
     const Type::TObj *rec = payload.TryAs<Type::TObj>();

--- a/orly/type/object_collector.cc
+++ b/orly/type/object_collector.cc
@@ -71,7 +71,13 @@ void Orly::Type::CollectObjects(const TType &type, unordered_set<TType> &object_
       }
     }
     virtual void operator()(const TVariant *that) const {
-      ObjectSet.insert(that->AsType());
+      /* An OPEN variant -- one with a free self-reference, e.g. a nested
+         variant bound by an enclosing one (#116) -- has no standalone
+         header (its native shape depends on the binder); it is emitted
+         inline at its binding site. A closed variant is a normal type. */
+      if (!HasFreeSelfRef(that->AsType())) {
+        ObjectSet.insert(that->AsType());
+      }
       for (auto iter : that->GetElems()) {
         iter.second.Accept(*this);
       }

--- a/tests/lang_tests/general/.variants_nested.orly.test.state
+++ b/tests/lang_tests/general/.variants_nested.orly.test.state
@@ -1,0 +1,21 @@
+[
+  0,
+  [
+    [],
+    [
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++"
+    ],
+    [
+      "Running tests"
+    ],
+    [
+      "Tests done"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/variants_nested.orly
+++ b/tests/lang_tests/general/variants_nested.orly
@@ -1,0 +1,100 @@
+/* <orly/lang_tests/general/variants_nested.orly>
+
+   End-to-end test for issue #116 Phase 1: a variant arm whose payload is
+   itself a variant that refers back to the enclosing (outer) variant -- a
+   nested self-reference (`TSelfRef` depth 1):
+
+     tree is <| Leaf(int) | Branch(<| Un(tree) | Nil |>) |>;
+
+   The nested variant `<| Un(tree) | Nil |>` has no standalone native
+   header (its shape depends on its binder, the outer `tree`), so the
+   code generator emits it as an inline struct inside `tree`'s header,
+   boxing the back-reference as `Rt::TBox<tree>` and converting to/from
+   the unrolled closed form the expression layer uses. Construction is
+   through the literal nested-variant ctor (`<| Un(tree) | Nil |>.Un(..)`,
+   tag-only `<| ... |>.Nil` takes no parens), and everything composes:
+   `is`/`.<Tag>` destructuring across both levels, deep `==`, set
+   membership, and recursive folds.
+
+   v1 scope: the nested variant must appear as a *direct* arm payload and
+   its own arms must be tag-only / scalar / a direct self-reference (not a
+   record, container, or further nested variant carrying a self-ref) --
+   those are clean compile errors for now. Deeper nesting and mutual
+   recursion are the remaining #116 work.
+
+   Fold limitation (pre-existing, not specific to nesting): a `when` or
+   if-else *all* of whose arms are recursive calls cannot have its result
+   type inferred -- it needs a concrete (non-recursive) arm to anchor
+   inference, exactly as the outer `Leaf` arm and the inner `Nil` arm do
+   below. A nested variant whose arms are *all* recursive (e.g.
+   `<| L(tree) | R(tree) |>`) can be constructed, compared, and stored,
+   but not yet folded for that reason.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+tree is <| Leaf(int) | Branch(<| Un(tree) | Nil |>) |>;
+
+/* Recursive fold: the outer `Leaf` arm and the inner `Nil` arm are the
+   concrete anchors; the `Un` arm recurses into the boxed child. */
+val = ((t) when {
+  Leaf(n): n;
+  Branch(b): ((b) when { Un(c): val(.t: c); Nil: 0; });
+}) where {
+  t = given::(tree);
+};
+
+depth = ((t) when {
+  Leaf: 0;
+  Branch(b): ((b) when { Un(c): 1 + depth(.t: c); Nil: 1; });
+}) where {
+  t = given::(tree);
+};
+
+/* Fixtures. */
+leaf  = (tree.Leaf(7)) where {};
+un5   = (tree.Branch(<| Un(tree) | Nil |>.Un(tree.Leaf(5)))) where {};
+un5b  = (tree.Branch(<| Un(tree) | Nil |>.Un(tree.Leaf(5)))) where {};
+un9   = (tree.Branch(<| Un(tree) | Nil |>.Un(tree.Leaf(9)))) where {};
+nil   = (tree.Branch(<| Un(tree) | Nil |>.Nil)) where {};
+deep  = (tree.Branch(<| Un(tree) | Nil |>.Un(
+         tree.Branch(<| Un(tree) | Nil |>.Un(tree.Leaf(8)))))) where {};
+
+test {
+  /* Recursive folds through the nested variant and the boxed back-ref. */
+  t1: val(.t: leaf) == 7;
+  t2: val(.t: un5) == 5;
+  t3: val(.t: nil) == 0;
+  t4: val(.t: deep) == 8;
+  t5: depth(.t: leaf) == 0;
+  t6: depth(.t: un5) == 1;
+  t7: depth(.t: deep) == 2;
+
+  /* Deep structural equality through the inline struct + boxed child. */
+  t8: un5 == un5b;
+  t9: un5 != un9;
+  t10: un5 != nil;
+
+  /* Destructuring across both levels. */
+  t11: un5 is Branch;
+  t12: not (un5 is Leaf);
+  t13: (un5.Branch) is Un;
+  t14: (nil.Branch) is Nil;
+  t15: (un5.Branch).Un is Leaf;
+  t16: (un5.Branch).Un.Leaf == 5;
+
+  /* Set membership: hashing/ordering reach through the inline struct and
+     the boxed child, so the duplicate collapses. */
+  t17: length_of {un5, un5b, un9, nil} == 3;
+};


### PR DESCRIPTION
Phase 1 of #116 (per the [planning pass](https://github.com/orlyatomics/orly/issues/116#issuecomment-4703683427), Path A / structural). A variant arm whose payload is itself a variant may now refer back to the enclosing variant:

```orly
tree is <| Leaf(int) | Branch(<| Un(tree) | Nil |>) |>;
```

## How

The nested variant `<| Un(tree) | Nil |>` has no standalone native header — its shape depends on its binder (the outer `tree`), which de Bruijn abstracts out of the mangled name. So the generator emits it as an **inline struct in the outer's header**, the variant analog of the `_Boxed` record structs from #103/#120: the back-reference boxes as `Rt::TBox<tree>`, and the struct converts to/from the unrolled closed form via templated ctor / `ToUnrolled`. Open nested-variant arms thus **reuse the existing recursive-arm code paths** (by-value storage, `DeepBox` factory, `ToUnrolled` getter, method comparison) — the only new code is the inline-struct emitter + its deferred comparison bodies.

- `orly/type/object_collector.cc`: an open variant is no longer collected as a standalone object (it has no header).
- `orly/synth/type_def.cc`: placement allows an open nested variant as a direct arm payload.

## v1 scope

The nested variant must be a **direct arm payload**, and its own arms must be tag-only / scalar / a direct self-reference. Records, containers, and deeper nested variants carrying a self-reference — and nested variants under containers — are clean compile errors. Deeper nesting and **mutual recursion** are the remaining #116 work.

## Composition + a fold caveat

Construction, `is`/`.<Tag>` destructuring across both levels, deep `==`, set membership, and recursive folds all compose. Pre-existing caveat (not specific to nesting): a `when`/if-else **all** of whose arms are recursive calls can't have its result type inferred — it needs a concrete arm to anchor it (the outer `Leaf` and inner `Nil` arms do). A nested variant whose arms are *all* recursive (`<| L(tree) | R(tree) |>`) can be built/compared/stored but not folded for that reason.

## Testing

- New `tests/lang_tests/general/variants_nested.orly`: recursive folds (`val`, `depth`), deep equality, two-level destructuring, set membership, v1 bounds.
- Full lang suite: **0 unexpected, 136 passed, 2 tracked xfails (#74/#75), exit 0**.
- `make test` passes; the #123 variant golden confirms non-recursive output is byte-unchanged.

Storage of recursive values remains out of scope (#115).