### PR TITLE
lang: fold ergonomics -- recursive when/if-else result typing (#126)

### DIFF
--- a/orly/expr/if_else.cc
+++ b/orly/expr/if_else.cc
@@ -24,6 +24,7 @@
 #include <orly/type/impl.h>
 #include <orly/type/equal_visitor.h>
 #include <orly/type/unwrap.h>
+#include <orly/type/variant.h>
 
 using namespace Orly;
 using namespace Orly::Expr;
@@ -66,12 +67,26 @@ Type::TType TIfElse::GetTypeImpl() const {
     NO_COPY(TIfElseVisitor);
     public:
     TIfElseVisitor(Type::TType &type, const TPosRange &pos_range) : TEqualVisitor(type, pos_range) {}
-    virtual void operator()(const Type::TAny *, const Type::TAny *) const {
-      throw TExprError(
-          HERE,
-          PosRange,
-          "Unable to resolve return type for if else expression. Are you missing a base case for a recursive function?");
+    virtual void operator()(const Type::TAny *lhs, const Type::TAny *) const {
+      /* Both branches are unresolved recursive calls. Defer rather than
+         throw: the node's type is anchored higher in the same function (a
+         concrete arm elsewhere), and the genuine "no base case" case is
+         caught once at the function level (TFunction::GetReturnType). See
+         #126. */
+      Type = lhs->AsType();
     }
+    /* A variant branch joins with an equal variant (variants are invariant
+       in v1, #95) or anchors an unresolved (TAny) branch. Mirrors
+       TEqCompVisitor; the base TEqualVisitor would otherwise throw (#126). */
+    virtual void operator()(const Type::TVariant *lhs, const Type::TVariant *rhs) const {
+      if (lhs != rhs) {
+        throw TExprError(HERE, PosRange,
+            "the branches of an if/else expression are different variant types");
+      }
+      Type = lhs->AsType();
+    }
+    virtual void operator()(const Type::TAny     *, const Type::TVariant  *rhs) const { Type = rhs->AsType(); }
+    virtual void operator()(const Type::TVariant *lhs, const Type::TAny    *) const final { Type = lhs->AsType(); }
     virtual void operator()(const Type::TAny      *, const Type::TAddr     *rhs) const { Type = rhs->AsType(); }
     virtual void operator()(const Type::TAny      *, const Type::TBool     *rhs) const { Type = rhs->AsType(); }
     virtual void operator()(const Type::TAny      *, const Type::TDict     *rhs) const { Type = rhs->AsType(); }

--- a/orly/expr/when.cc
+++ b/orly/expr/when.cc
@@ -117,9 +117,22 @@ Type::TType TWhen::GetTypeImpl() const {
     NO_COPY(TWhenJoinVisitor);
     public:
     TWhenJoinVisitor(Type::TType &type, const TPosRange &pos_range) : TEqualVisitor(type, pos_range) {}
-    virtual void operator()(const Type::TAny *, const Type::TAny *) const {
-      throw TExprError(HERE, PosRange, "`when` arms do not resolve to a single result type");
+    virtual void operator()(const Type::TAny *lhs, const Type::TAny *) const {
+      /* Both arms are unresolved recursive calls; defer (the node's type is
+         anchored higher in the same function, and genuine "no base case" is
+         caught at the function level -- TFunction::GetReturnType). See #126. */
+      Type = lhs->AsType();
     }
+    /* A variant arm joins with an equal variant (invariant in v1) or anchors
+       an unresolved (TAny) arm; the base TEqualVisitor would throw (#126). */
+    virtual void operator()(const Type::TVariant *lhs, const Type::TVariant *rhs) const {
+      if (lhs != rhs) {
+        throw TExprError(HERE, PosRange, "`when` arms resolve to different variant types");
+      }
+      Type = lhs->AsType();
+    }
+    virtual void operator()(const Type::TAny     *, const Type::TVariant  *rhs) const { Type = rhs->AsType(); }
+    virtual void operator()(const Type::TVariant *lhs, const Type::TAny    *) const final { Type = lhs->AsType(); }
     virtual void operator()(const Type::TAny *, const Type::TAddr     *rhs) const { Type = rhs->AsType(); }
     virtual void operator()(const Type::TAny *, const Type::TBool     *rhs) const { Type = rhs->AsType(); }
     virtual void operator()(const Type::TAny *, const Type::TDict     *rhs) const { Type = rhs->AsType(); }

--- a/orly/symbol/function.cc
+++ b/orly/symbol/function.cc
@@ -19,6 +19,7 @@
 #include <orly/symbol/function.h>
 
 #include <base/assert_true.h>
+#include <orly/error.h>
 #include <orly/symbol/scope.h>
 #include <orly/type/any.h>
 
@@ -77,11 +78,22 @@ const TPosRange &TFunction::GetPosRange() const {
 Type::TType TFunction::GetReturnType() const {
   Type::TType type;
   if (IsRecursive) {
+    /* Re-entered through a recursive call: the return type is not yet known.
+       TAny is the placeholder; a `when`/if-else with a concrete arm anchors
+       it, and an all-recursive node now defers rather than throwing (#126). */
     type = Type::TAny::Get();
   } else {
     IsRecursive = true;
     type = GetExpr()->GetType();
     IsRecursive = false;
+    /* If the whole body still resolves to TAny, every return path is a
+       recursive call -- a genuine missing base case. No expression produces
+       TAny except the recursive placeholder, so this is the one place the
+       diagnostic belongs (moved here from the per-node join, #126). */
+    if (type.Is<Type::TAny>()) {
+      throw TExprError(HERE, PosRange,
+          "this recursive function has no base case: every path is a recursive call");
+    }
   }
   return type;
 }

--- a/tests/lang_tests/general/.recursive_fold.orly.test.state
+++ b/tests/lang_tests/general/.recursive_fold.orly.test.state
@@ -1,0 +1,21 @@
+[
+  0,
+  [
+    [],
+    [
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++"
+    ],
+    [
+      "Running tests"
+    ],
+    [
+      "Tests done"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/recursive_fold.orly
+++ b/tests/lang_tests/general/recursive_fold.orly
@@ -1,0 +1,84 @@
+/* <orly/lang_tests/general/recursive_fold.orly>
+
+   Tests two fold-ergonomics fixes for `when` / if-else result typing
+   (issue #126), both of which make recursive variants foldable.
+
+   1. A `when` / if-else *all* of whose arms are recursive calls now types
+      correctly. A recursive call returns the `TAny` placeholder while the
+      function's return type is being computed; the join of two `TAny`
+      arms used to throw ("missing base case"), even when the node's type
+      is anchored by a concrete arm higher up. It now defers, and the
+      genuine missing-base-case case is reported once at the function
+      level. So a nested-variant fold whose inner `when` has only recursive
+      arms (`<| L(tree) | R(tree) |>`) works, anchored by the outer `Leaf`.
+
+   2. A `when` / if-else may now have *variant-typed* result branches.
+      The join visitors previously inherited a throwing default for
+      (variant, variant); they now join equal variants (and anchor an
+      unresolved arm), mirroring `==` / `!=`. So a fold can return a
+      variant.
+
+   Still limited (a broader, separate issue): a recursive function that
+   *constructs* with its own recursive-call result -- e.g. a tree-to-tree
+   transform `Branch(b): tree.Branch(... map(child) ...)` -- is rejected,
+   because the recursive result is the `TAny` placeholder where a concrete
+   payload is expected, and accepting it there would mask real type errors
+   without a fixpoint. Folds that return a variant built from non-recursive
+   parts (below) do work.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+/* (1) All-recursive inner `when`, anchored by the outer concrete arm. */
+tree is <| Leaf(int) | Branch(<| L(tree) | R(tree) |>) |>;
+
+val = ((t) when {
+  Leaf(n): n;
+  Branch(b): ((b) when { L(x): val(.t: x); R(y): val(.t: y); });
+}) where {
+  t = given::(tree);
+};
+
+a    = (tree.Branch(<| L(tree) | R(tree) |>.L(tree.Leaf(5)))) where {};
+deep = (tree.Branch(<| L(tree) | R(tree) |>.R(
+        tree.Branch(<| L(tree) | R(tree) |>.L(tree.Leaf(8)))))) where {};
+
+/* (2) Variant-typed results from if-else and `when`. */
+op is <| A(int) | B(int) |>;
+
+flip = ((op.B(x.A) if (x is A) else op.A(x.B))) where {
+  x = given::(op);
+};
+
+swap = ((x) when {
+  A(n): op.B(n);
+  B(n): op.A(n);
+}) where {
+  x = given::(op);
+};
+
+test {
+  /* (1) folds with an all-recursive inner `when`. */
+  t1: val(.t: tree.Leaf(7)) == 7;
+  t2: val(.t: a) == 5;
+  t3: val(.t: deep) == 8;
+
+  /* (2) variant-returning if-else. */
+  t4: flip(.x: op.A(5)) == op.B(5);
+  t5: flip(.x: op.B(9)) == op.A(9);
+
+  /* (2) variant-returning `when`. */
+  t6: swap(.x: op.A(3)) == op.B(3);
+  t7: swap(.x: op.B(4)) == op.A(4);
+};


### PR DESCRIPTION
Closes #126. Two fixes to `when` / if-else result typing that make recursive variants (and recursive functions generally) foldable.

## 1. All-recursive arms

A recursive call returns the `TAny` placeholder while a function's return type is being computed (the re-entrancy guard in `orly/symbol/function.cc`). The join visitors threw on `(TAny, TAny)` — wrong when the node's type is anchored by a concrete arm higher up:

```orly
val = ((t) when {
  Leaf(n): n;
  Branch(b): ((b) when { L(x): val(.t: x); R(y): val(.t: y); });  /* both arms recurse */
}) where { t = given::(tree); };
```

The join now defers `(TAny, TAny) -> TAny`, and the genuine missing-base-case diagnostic moves to the function level (if the *whole body* resolves to `TAny`, every path is recursive). Safe because no expression produces `TAny` except the recursive placeholder.

## 2. Variant-typed results

The join visitors inherited `TEqualVisitor`'s throwing `(TVariant, TVariant)` default; only `==`/`!=` overrode it. They now join equal variants (different variants → error; invariant in v1) and anchor an unresolved arm, mirroring `TEqCompVisitor`. So a fold can return a variant:

```orly
swap = ((x) when { A(n): op.B(n); B(n): op.A(n); }) where { x = given::(op); };
flip = ((op.B(x.A) if (x is A) else op.A(x.B))) where { x = given::(op); };
```

## Soundness / scope

Both fixes are sound: joining `TAny` with a concrete type yields that type (the recursive path really is that type); joining equal variants is identity. A separate, broader limitation remains and is **deliberately not** addressed here — a recursive function that *constructs* with its own recursive-call result (a tree-to-tree transform) is still rejected, because accepting the `TAny` placeholder in a concrete payload position would mask real type errors (e.g. `tree.Leaf(tree)`) without a proper fixpoint. Folds returning a variant built from non-recursive parts work.

## Testing

- New `tests/lang_tests/general/recursive_fold.orly`: an all-recursive inner `when` anchored by an outer concrete arm, plus variant-returning if-else and `when`.
- Genuine no-base-case still errors cleanly (now at the function level).
- Full lang suite: **0 unexpected, 137 passed, 2 tracked xfails (#74/#75), exit 0**; `make test` passes.