### PR TITLE
lang: defer TAny in variant-ctor payload and call args (#128 Option A)

### DIFF
--- a/orly/expr/function_app.cc
+++ b/orly/expr/function_app.cc
@@ -24,6 +24,8 @@
 #include <orly/error.h>
 #include <orly/expr/ref.h>
 #include <orly/expr/util.h>
+#include <orly/type/any.h>
+#include <orly/type/opt.h>
 #include <orly/type/unwrap.h>
 #include <orly/type/unwrap_visitor.h>
 #include <orly/symbol/function.h>
@@ -126,7 +128,13 @@ Type::TType TFunctionApp::GetTypeImpl() const {
     auto param_type = param.second;
     auto unwrapped_arg_type = Type::Unwrap(arg_type);
     is_sequence |= arg_type.Is<Type::TSeq>();
-    if (unwrapped_arg_type != param_type && Type::TOpt::Get(unwrapped_arg_type) != param_type) {
+    /* A TAny argument is an as-yet-unresolved recursive call (the
+       placeholder from TFunction::GetReturnType); defer rather than reject,
+       so a recursive call's result can be passed as an argument. Matches
+       how operators already propagate TAny -- the argument is not verified
+       in this position (#128 Option A). */
+    if (!unwrapped_arg_type.Is<Type::TAny>()
+        && unwrapped_arg_type != param_type && Type::TOpt::Get(unwrapped_arg_type) != param_type) {
       throw TExprError(HERE, GetPosRange(), "Function call with parameter type mismatch");
     }
     function_app_args.erase(arg);

--- a/orly/expr/variant.cc
+++ b/orly/expr/variant.cc
@@ -20,6 +20,7 @@
 
 #include <base/as_str.h>
 #include <orly/error.h>
+#include <orly/type/any.h>
 #include <orly/type/unroll.h>
 #include <orly/type/unwrap.h>
 #include <orly/type/util.h>
@@ -63,7 +64,13 @@ Type::TType TVariantCtor::GetTypeImpl() const {
      empty object and the synth layer supplies an empty-object payload
      expression, so this check covers both cases uniformly.) */
   Type::TType payload_type = Type::Unwrap(GetExpr()->GetType());
-  if (payload_type != Type::Unroll(iter->second, VariantType)) {
+  /* A TAny payload is an as-yet-unresolved recursive call (the placeholder
+     from TFunction::GetReturnType); defer rather than reject, so a function
+     can construct with its own recursive result (e.g. a tree-to-tree
+     transform). This matches how operators already propagate TAny -- a
+     recursive result is not verified in this position (#128 Option A). The
+     ctor's own type is the variant regardless of the payload. */
+  if (!payload_type.Is<Type::TAny>() && payload_type != Type::Unroll(iter->second, VariantType)) {
     std::string msg = Base::AsStr("variant constructor payload type does not match the declared type of arm \"", Tag, "\"");
     throw TExprError(HERE, GetPosRange(), msg.c_str());
   }

--- a/tests/lang_tests/general/.recursive_transform.orly.test.state
+++ b/tests/lang_tests/general/.recursive_transform.orly.test.state
@@ -1,0 +1,21 @@
+[
+  0,
+  [
+    [],
+    [
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++"
+    ],
+    [
+      "Running tests"
+    ],
+    [
+      "Tests done"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/recursive_transform.orly
+++ b/tests/lang_tests/general/recursive_transform.orly
@@ -1,0 +1,76 @@
+/* <orly/lang_tests/general/recursive_transform.orly>
+
+   Tests #128 Option A: a recursive call's result (the `TAny` placeholder
+   while the function's return type is being inferred) may now be used in
+   the two concrete positions that previously rejected it -- a variant
+   constructor payload and a function-call argument. Both now defer on
+   `TAny` instead of throwing, matching how operators and `when`/if-else
+   joins already propagate it. This unlocks recursive functions that
+   *construct with* their own result -- e.g. a tree-to-tree transform --
+   and that pass their result as an argument.
+
+   Soundness note: as with operators today, a recursive result is not
+   verified in these positions (the function's return type is fixed by its
+   base cases). Non-recursive type errors are still caught strictly; only
+   the recursive-placeholder case is deferred.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+tree is <| Leaf(int) | Branch(<| Un(tree) | Nil |>) |>;
+
+/* A tree-to-tree transform: negate every leaf. The `Un` arm constructs a
+   nested-variant payload from the recursive result `neg(c)` -- the case
+   that used to be rejected at the variant-ctor payload check. */
+neg = ((t) when {
+  Leaf(n): tree.Leaf(0 - n);
+  Branch(b): tree.Branch(((b) when {
+    Un(c): <| Un(tree) | Nil |>.Un(neg(.t: c));
+    Nil:  <| Un(tree) | Nil |>.Nil;
+  }));
+}) where {
+  t = given::(tree);
+};
+
+/* A recursive result passed as a function argument (`sz(c)` into max2),
+   the case that used to be rejected at the function-call argument check. */
+max2 = ((a if a > b else b)) where {
+  a = given::(int);
+  b = given::(int);
+};
+
+sz = ((t) when {
+  Leaf: 1;
+  Branch(b): ((b) when { Un(c): 1 + max2(.a: sz(.t: c), .b: 0); Nil: 1; });
+}) where {
+  t = given::(tree);
+};
+
+leaf = (tree.Leaf(5)) where {};
+one  = (tree.Branch(<| Un(tree) | Nil |>.Un(tree.Leaf(5)))) where {};
+two  = (tree.Branch(<| Un(tree) | Nil |>.Un(
+        tree.Branch(<| Un(tree) | Nil |>.Un(tree.Leaf(5)))))) where {};
+
+test {
+  /* Transform: construct with the recursive result. */
+  t1: neg(.t: leaf) == tree.Leaf(0 - 5);
+  t2: neg(.t: one) == tree.Branch(<| Un(tree) | Nil |>.Un(tree.Leaf(0 - 5)));
+  t3: neg(.t: neg(.t: one)) == one;        /* involution */
+  t4: neg(.t: neg(.t: two)) == two;
+
+  /* Recursive result as an argument. */
+  t5: sz(.t: leaf) == 1;
+  t6: sz(.t: one) == 2;
+  t7: sz(.t: two) == 3;
+};


### PR DESCRIPTION
Implements **Option A** from the [#128 planning pass](https://github.com/orlyatomics/orly/issues/128) — the small consistency fix that unlocks recursive functions which *construct with* or *pass as an argument* their own result (AST-rewriting / tree-to-tree transforms).

## Background

A recursive call returns the `TAny` placeholder while a function's return type is being inferred (`TFunction::GetReturnType`). Operators and (since #127) `when`/if-else joins already **propagate** `TAny` — so a recursive result flows through them and is anchored by the base cases. But two concrete-position checks **threw** on `TAny`, which was the entire blockage:

- variant constructor payload (`orly/expr/variant.cc`);
- function-call arguments (`orly/expr/function_app.cc`).

## Change

Both now skip the type check when the operand is `TAny`, matching operators. This unlocks:

```orly
/* construct with the recursive result -- a tree-to-tree transform */
neg = ((t) when {
  Leaf(n): tree.Leaf(0 - n);
  Branch(b): tree.Branch(((b) when { Un(c): <| Un(tree) | Nil |>.Un(neg(.t: c)); Nil: <| Un(tree) | Nil |>.Nil; }));
}) where { t = given::(tree); };

/* recursive result as an argument */
sz = ((t) when { Leaf: 1; Branch(b): ((b) when { Un(c): 1 + max2(.a: sz(.t: c), .b: 0); Nil: 1; }); }) where { t = given::(tree); };
```

## Soundness

This is a **consistency** fix, not new unsoundness: as with operators today, a recursive result is not *verified* in these positions (the return type is fixed by the base cases, and the no-base-case case is still caught at the function level, #126). `TAny` arises only from the recursive placeholder, so **non-recursive type errors are still rejected strictly** — verified that passing a `str` to an `int` param / `int` arm still errors. Full verification of recursive results (a real two-phase fixpoint) and its SCC form for mutual recursion remain **#128 Option B / #116**.

## Testing

- New `tests/lang_tests/general/recursive_transform.orly`: a leaf-negating tree transform (including involution `neg(neg(t)) == t`) and a size fold passing the recursive result to `max2`.
- Non-recursive type errors confirmed still caught.
- Full lang suite: **0 unexpected, 138 passed, 2 tracked xfails (#74/#75), exit 0**; `make test` passes.