### PR TITLE
type: equirecursive canonicalization of recursive types (#116 Phase 1)

### DIFF
--- a/orly/type/canon.cc
+++ b/orly/type/canon.cc
@@ -1,0 +1,181 @@
+/* <orly/type/canon.cc>
+
+   Implements <orly/type/canon.h>.
+
+   Both walks descend only into CLOSED states: a closed variant's arm,
+   unrolled against that variant (orly/type/unroll.h), is itself closed
+   (a closed variant has no free self-references, so its arms reference
+   only it or variants nested within them). So a single `Unroll` per
+   variant level produces the closed child -- no binder stack needed for
+   substitution; the stack in `Canon` is only for the fold check.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <orly/type/canon.h>
+
+#include <algorithm>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include <orly/type.h>
+#include <orly/type/unroll.h>
+
+using namespace Orly;
+using namespace Orly::Type;
+
+namespace {
+
+  /* A pair of types assumed equal during the coinductive Equiv check,
+     keyed by interned-pointer identity (TType::GetHash is the pointer). */
+  typedef std::set<std::pair<size_t, size_t>> TAssumed;
+
+  std::pair<size_t, size_t> Key(const TType &s, const TType &t) {
+    size_t a = s.GetHash(), b = t.GetHash();
+    return a < b ? std::make_pair(a, b) : std::make_pair(b, a);
+  }
+
+  /* The closed child reached by following arm `tag`'s payload of the
+     closed variant `v`. */
+  TType ArmChild(const TVariant *v, const std::string &tag) {
+    return Unroll(v->GetElems().at(tag), v->AsType());
+  }
+
+  bool EqHelp(const TType &s, const TType &t, TAssumed &assumed) {
+    if (s == t) {
+      return true;  // same interned type (covers all leaves: int, str, ...)
+    }
+    const std::pair<size_t, size_t> key = Key(s, t);
+    if (assumed.count(key)) {
+      return true;  // coinductive hypothesis
+    }
+
+    if (const TVariant *sv = s.TryAs<TVariant>()) {
+      const TVariant *tv = t.TryAs<TVariant>();
+      if (!tv) { return false; }
+      const TVariantElems &se = sv->GetElems();
+      const TVariantElems &te = tv->GetElems();
+      if (se.size() != te.size()) { return false; }
+      for (const auto &p : se) {
+        if (!te.count(p.first)) { return false; }
+      }
+      assumed.insert(key);
+      for (const auto &p : se) {
+        if (!EqHelp(ArmChild(sv, p.first), ArmChild(tv, p.first), assumed)) {
+          return false;
+        }
+      }
+      return true;
+    }
+    if (const TObj *so = s.TryAs<TObj>()) {
+      const TObj *to = t.TryAs<TObj>();
+      if (!to) { return false; }
+      const TObjElems &se = so->GetElems();
+      const TObjElems &te = to->GetElems();
+      if (se.size() != te.size()) { return false; }
+      for (const auto &p : se) {
+        if (!te.count(p.first)) { return false; }
+      }
+      assumed.insert(key);
+      for (const auto &p : se) {
+        if (!EqHelp(p.second, te.at(p.first), assumed)) { return false; }
+      }
+      return true;
+    }
+    if (const TList *sl = s.TryAs<TList>()) {
+      const TList *tl = t.TryAs<TList>();
+      if (!tl) { return false; }
+      assumed.insert(key);
+      return EqHelp(sl->GetElem(), tl->GetElem(), assumed);
+    }
+    if (const TSet *ss = s.TryAs<TSet>()) {
+      const TSet *ts = t.TryAs<TSet>();
+      if (!ts) { return false; }
+      assumed.insert(key);
+      return EqHelp(ss->GetElem(), ts->GetElem(), assumed);
+    }
+    if (const TOpt *so = s.TryAs<TOpt>()) {
+      const TOpt *to = t.TryAs<TOpt>();
+      if (!to) { return false; }
+      assumed.insert(key);
+      return EqHelp(so->GetElem(), to->GetElem(), assumed);
+    }
+    if (const TDict *sd = s.TryAs<TDict>()) {
+      const TDict *td = t.TryAs<TDict>();
+      if (!td) { return false; }
+      assumed.insert(key);
+      return EqHelp(sd->GetKey(), td->GetKey(), assumed)
+          && EqHelp(sd->GetVal(), td->GetVal(), assumed);
+    }
+    /* Other kinds (scalars, ids, self-refs, ...) are leaves: equality is
+       interned-pointer identity, already handled at the top. Anything
+       reaching here is a kind mismatch or two distinct leaves. */
+    return false;
+  }
+
+  TType CanonHelp(const TType &s, std::vector<TType> &stack) {
+    /* Fold: if s repeats an enclosing binder (a variant we are inside),
+       emit a back-reference instead of re-expanding. Innermost binder is
+       depth 0. */
+    for (size_t d = 0; d < stack.size(); ++d) {
+      if (Equiv(s, stack[stack.size() - 1 - d])) {
+        return TSelfRef::Get(d);
+      }
+    }
+    if (const TVariant *v = s.TryAs<TVariant>()) {
+      stack.push_back(s);
+      TVariantElems elems;
+      for (const auto &p : v->GetElems()) {
+        elems[p.first] = CanonHelp(ArmChild(v, p.first), stack);
+      }
+      stack.pop_back();
+      return TVariant::Get(elems);
+    }
+    /* Non-binders: recurse into children with the same binder stack and
+       no unrolling (a closed state's record fields / container elements
+       are themselves closed). */
+    if (const TObj *o = s.TryAs<TObj>()) {
+      TObjElems elems;
+      for (const auto &p : o->GetElems()) {
+        elems[p.first] = CanonHelp(p.second, stack);
+      }
+      return TObj::Get(elems);
+    }
+    if (const TList *l = s.TryAs<TList>()) {
+      return TList::Get(CanonHelp(l->GetElem(), stack));
+    }
+    if (const TSet *st = s.TryAs<TSet>()) {
+      return TSet::Get(CanonHelp(st->GetElem(), stack));
+    }
+    if (const TOpt *o = s.TryAs<TOpt>()) {
+      return TOpt::Get(CanonHelp(o->GetElem(), stack));
+    }
+    if (const TDict *d = s.TryAs<TDict>()) {
+      return TDict::Get(CanonHelp(d->GetKey(), stack), CanonHelp(d->GetVal(), stack));
+    }
+    return s;  // leaf
+  }
+
+}  // namespace
+
+bool Orly::Type::Equiv(const TType &s, const TType &t) {
+  TAssumed assumed;
+  return EqHelp(s, t, assumed);
+}
+
+TType Orly::Type::Canon(const TType &type) {
+  std::vector<TType> stack;
+  return CanonHelp(type, stack);
+}

--- a/orly/type/canon.h
+++ b/orly/type/canon.h
@@ -1,0 +1,65 @@
+/* <orly/type/canon.h>
+
+   Equirecursive equality and canonicalization for recursive types
+   (issue #116, mutual recursion, Path A).
+
+   A recursive type is a finite de Bruijn term with `TSelfRef` back-edges
+   (orly/type/self_ref.h). The same infinite ("unfolded") type can be
+   written as several distinct finite terms -- most importantly, the same
+   mutually-recursive cycle entered at different members:
+
+     a = <| X(<| Y(self@1) |>) |>     b = <| Y(<| X(self@1) |>) |>
+
+   Here `Unroll(a.X)` yields `<| Y(a) |>`, which is the *same* type as `b`
+   but a different finite term (the loop closes at a different node). Since
+   the type system interns structurally and compares by pointer, the two
+   would be unequal, breaking the accessor's result type.
+
+   `Equiv(s, t)` decides equirecursive equality (same infinite unfolding),
+   coinductively. `Canon(t)` rewrites a (closed) recursive type to a
+   canonical minimal de Bruijn form by folding at the first equirecursively-
+   equivalent enclosing binder -- so `Canon(<| Y(a) |>)` and `Canon(b)` are
+   the identical interned type. A single self-recursive type is already
+   minimal, so `Canon` is the identity on it (the #103/#120/#121/#125
+   shapes are unaffected); only mutual cycles are rewritten.
+
+   This is the standalone, unit-tested core (#116 Phase 1). It is not yet
+   wired into interning; that is a later phase.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#pragma once
+
+#include <orly/type/impl.h>
+
+namespace Orly {
+
+  namespace Type {
+
+    /* True iff s and t are equirecursively equal -- i.e. they have the same
+       infinite unfolding. Both should be closed (every TSelfRef bound by an
+       enclosing variant within the type). Reduces to pointer equality for
+       non-recursive types. */
+    bool Equiv(const TType &s, const TType &t);
+
+    /* The canonical minimal de Bruijn form of a closed recursive type:
+       equirecursively-equal inputs produce the identical interned TType.
+       The identity on non-recursive types and on already-minimal self-
+       recursive types. */
+    TType Canon(const TType &type);
+
+  }  // Type
+
+}  // Orly

--- a/orly/type/canon.test.cc
+++ b/orly/type/canon.test.cc
@@ -1,0 +1,112 @@
+/* <orly/type/canon.test.cc>
+
+   Unit test for <orly/type/canon.h> -- equirecursive equality and
+   canonicalization of de Bruijn recursive types (#116 Phase 1), exercised
+   directly on hand-built mu-terms with no language surface.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <orly/type/canon.h>
+
+#include <orly/type.h>
+#include <orly/type/type_czar.h>
+
+#include <base/test/kit.h>
+
+using namespace Orly;
+using namespace Orly::Type;
+
+/* Helpers to build mu-terms tersely. */
+static TType Vt(const TVariantElems &e) { return TVariant::Get(e); }
+static TType Self(size_t d) { return TSelfRef::Get(d); }
+
+/* `t is <| A(t) |>` -- the minimal self-recursive form. */
+FIXTURE(SelfRecursiveIsCanonical) {
+  TTypeCzar czar;
+  TType t = Vt({{"A", Self(0)}});
+  EXPECT_TRUE(Equiv(t, t));
+  EXPECT_TRUE(Canon(t) == t);  // already minimal -> identity
+}
+
+/* `<| A(<| A(self@1) |>) |>` unfolds to the same infinite tree as
+   `<| A(self@0) |>`; Canon must collapse the redundant level. */
+FIXTURE(NonMinimalSelfCollapses) {
+  TTypeCzar czar;
+  TType min = Vt({{"A", Self(0)}});
+  TType redundant = Vt({{"A", Vt({{"A", Self(1)}})}});
+  EXPECT_TRUE(Equiv(redundant, min));
+  EXPECT_TRUE(Canon(redundant) == min);
+  EXPECT_TRUE(Canon(redundant) == Canon(min));
+}
+
+/* Mutual recursion: a = <| X(<| Y(self@1) |>) |>, b = <| Y(<| X(self@1) |>) |>.
+   The accessor a.X unrolls to <| Y(a) |>, which is b -- but a different
+   finite term. Canon must reconcile them. */
+FIXTURE(MutualRecursionCanonicalizes) {
+  TTypeCzar czar;
+  TType a = Vt({{"X", Vt({{"Y", Self(1)}})}});
+  TType b = Vt({{"Y", Vt({{"X", Self(1)}})}});
+
+  /* `Unroll(a.X)` = <| Y(a) |>. */
+  TType ya = Vt({{"Y", a}});
+
+  EXPECT_TRUE(Equiv(ya, b));       // same infinite tree
+  EXPECT_FALSE(Equiv(a, b));       // genuinely different types (X- vs Y-headed)
+  EXPECT_FALSE(ya == b);           // ... but distinct finite terms before canon
+
+  EXPECT_TRUE(Canon(b) == b);            // b is already minimal
+  EXPECT_TRUE(Canon(ya) == Canon(b));    // the crux: a.X canonicalizes to b
+  EXPECT_TRUE(Canon(ya) == b);
+  EXPECT_FALSE(Canon(a) == Canon(b));    // a and b stay distinct
+}
+
+/* A finite, non-recursive type is unchanged, and distinct nested levels
+   that are NOT equirecursively equal are not folded. */
+FIXTURE(NonRecursiveUnchanged) {
+  TTypeCzar czar;
+  TType flat = Vt({{"A", TInt::Get()}, {"B", TStr::Get()}});
+  EXPECT_TRUE(Canon(flat) == flat);
+
+  TType nested = Vt({{"A", Vt({{"A", TInt::Get()}})}});  // outer A-child != inner
+  EXPECT_TRUE(Canon(nested) == nested);
+  EXPECT_FALSE(Equiv(nested, Vt({{"A", TInt::Get()}})));
+}
+
+/* Recursion through a record payload (the tree shape from #103): a
+   redundant unfolding still collapses, and equality holds across forms. */
+FIXTURE(RecursionThroughRecord) {
+  TTypeCzar czar;
+  /* tree = <| Leaf(int) | Node(<{.l: self@0, .r: self@0}>) |> */
+  auto node_rec = [](const TType &child) {
+    return TObj::Get({{"l", child}, {"r", child}});
+  };
+  TType tree = Vt({{"Leaf", TInt::Get()}, {"Node", node_rec(Self(0))}});
+
+  /* A once-unrolled form: Node's children are the whole tree spelled out
+     one level, with self@1 closing the loop. */
+  TType inner = Vt({{"Leaf", TInt::Get()}, {"Node", node_rec(Self(1))}});
+  TType unrolled = Vt({{"Leaf", TInt::Get()}, {"Node", node_rec(inner)}});
+
+  EXPECT_TRUE(Equiv(unrolled, tree));
+  EXPECT_TRUE(Canon(tree) == tree);
+  EXPECT_TRUE(Canon(unrolled) == tree);
+}
+
+/* Basic Equiv sanity on leaves. */
+FIXTURE(EquivLeaves) {
+  TTypeCzar czar;
+  EXPECT_TRUE(Equiv(TInt::Get(), TInt::Get()));
+  EXPECT_FALSE(Equiv(TInt::Get(), TStr::Get()));
+}


### PR DESCRIPTION
Phase 1 of mutual recursion (Path A, per the [implementation plan](https://github.com/orlyatomics/orly/issues/116#issuecomment-4710814386)): the **standalone, unit-tested canonicalization core** — the single hardest piece — built and verified in isolation before any language surface, exactly as the plan recommended.

## Why

The same infinite recursive type can be written as different finite de Bruijn terms — most importantly a mutual cycle entered at different members:

```
a = <| X(<| Y(self@1) |>) |>     b = <| Y(<| X(self@1) |>) |>
```

The accessor `a.X` unrolls to `<| Y(a) |>`, which is the *same* type as `b` but a structurally different term. Since types intern structurally and compare by pointer, they'd be unequal — the core blocker for mutual recursive type defs.

## What

`orly/type/canon.{h,cc}`:
- **`Equiv(s, t)`** — equirecursive equality (same infinite unfolding), coinductive with an assumed-equal-pair set keyed by interned identity. Closed children are reached by a single `Unroll` per variant level (a closed variant's arm, unrolled against it, is itself closed — so no binder stack is needed for substitution).
- **`Canon(type)`** — the canonical minimal de Bruijn form: fold at the first equirecursively-equivalent enclosing binder (regular-tree minimization expressed as folding). Equirecursively-equal inputs produce the *identical interned* `TType`.

A single self-recursive type is already minimal, so `Canon` is the **identity** on it — #103/#120/#121/#125 are untouched; only mutual cycles and redundant unfoldings are rewritten. Equality stays pointer-equality (canonicalize-then-intern); `==` is not changed.

**Not yet wired into interning** — that's the next phase (synth SCC handling + the `TVariant::Get` hook). This PR is purely the algorithm + its tests.

## Testing

`orly/type/canon.test.cc` — 6 fixtures, all pass:
- self-recursion is already canonical (`Canon(t) == t`);
- a redundant unfolding `<| A(<| A(self@1) |>) |>` collapses to `<| A(self@0) |>`;
- **the mutual crux**: `Equiv(<|Y(a)|>, b)`, `Canon(<|Y(a)|>) == b`, while `a` and `b` stay distinct;
- non-recursive types unchanged (and non-equal nested levels not folded);
- recursion through a record payload (the #103 tree shape);
- `Equiv` leaf sanity.

`make test` green.