### PR TITLE
type: recursive-group representation for mutual recursion (#116 Phase 2a)

### DIFF
--- a/orly/type.h
+++ b/orly/type.h
@@ -30,6 +30,7 @@
 #include <orly/type/dict.h>
 #include <orly/type/err.h>
 #include <orly/type/func.h>
+#include <orly/type/group_ref.h>
 #include <orly/type/id.h>
 #include <orly/type/int.h>
 #include <orly/type/list.h>

--- a/orly/type/group_ref.cc
+++ b/orly/type/group_ref.cc
@@ -1,0 +1,32 @@
+/* <orly/type/group_ref.cc>
+
+   Implements <orly/type/group_ref.h>.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <orly/type/group_ref.h>
+
+using namespace Orly::Type;
+
+IMPL_INTERNED_TYPE(TGroupRef, TGroupId, size_t);
+
+TGroupRef::~TGroupRef() {}
+
+void TGroupRef::Write(std::ostream &out) const {
+  /* Like TSelfRef, not a C++ type name -- a group reference resolves to a
+     member type (orly/type/rec_group.h) before any native use, so reaching
+     a generated file means a resolution was missed. Diagnostic form only. */
+  out << "groupref@" << GetIndex();
+}

--- a/orly/type/group_ref.h
+++ b/orly/type/group_ref.h
@@ -1,0 +1,87 @@
+/* <orly/type/group_ref.h>
+
+   The group-reference leaf: a reference from one member of a mutually-
+   recursive type group to another member (issue #116, Path A / A2).
+
+   A mutually-recursive SCC of variant defs -- `a is <| X(b) |>;
+   b is <| Y(a) |>;` -- is represented WITHOUT inlining: each member is a
+   normal `TVariant` whose arms reference sibling members through this
+   leaf, `TGroupRef(group, index)`, rather than expanding them. The leaf
+   breaks the otherwise-cyclic intern graph the way `TSelfRef` does for
+   single-def recursion, but it preserves type *sharing* (members stay
+   distinct, separately-emittable types) -- which the de Bruijn inlining
+   approach destroyed.
+
+   `Group` is the group's canonical identity (orly/type/rec_group.h): the
+   ordered vector of the members' canonicalized inlined forms, so that
+   structurally-isomorphic groups share one identity and their members
+   intern equal. `Index` selects the member within that identity.
+   Resolving a `TGroupRef` to the member `TVariant` it denotes is a
+   registry lookup (rec_group.h), not a structural reconstruction.
+
+   Like `TSelfRef`, this leaf appears only inside a group member's
+   payload map; it never surfaces as an expression type (the accessor
+   navigates it to the member type). Its `TVisitor` overload therefore
+   inherits the throwing default, except in the structural walkers.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include <base/class_traits.h>
+#include <orly/type/managed_type.h>
+
+namespace Orly {
+
+  namespace Type {
+
+    /* The canonical identity of a recursive group: the ordered vector of
+       its members' canonicalized inlined forms. */
+    typedef std::vector<TType> TGroupId;
+
+    /* The group-reference leaf. Interned by (group identity, member index). */
+    class TGroupRef : public TInternedType<TGroupRef, TGroupId, size_t> {
+      NO_COPY(TGroupRef);
+      public:
+
+      /* The group this reference belongs to. */
+      const TGroupId &GetGroup() const {
+        return std::get<0>(GetKey());
+      }
+
+      /* The referenced member's index within the group identity. */
+      size_t GetIndex() const {
+        return std::get<1>(GetKey());
+      }
+
+      static TType Get(const TGroupId &group, size_t index) {
+        return TInternedType::Get(group, index);
+      }
+
+      private:
+      TGroupRef(const TGroupId &group, size_t index) : TInternedType(group, index) {}
+      virtual ~TGroupRef();
+
+      virtual void Write(std::ostream &) const;
+
+      friend class TInternedType;
+    };  // TGroupRef
+
+  }  // Type
+
+}  // Orly

--- a/orly/type/impl.cc
+++ b/orly/type/impl.cc
@@ -28,6 +28,7 @@
 #include <orly/type/list.h>
 #include <orly/type/mutable.h>
 #include <orly/type/obj.h>
+#include <orly/type/group_ref.h>
 #include <orly/type/opt.h>
 #include <orly/type/self_ref.h>
 #include <orly/type/seq.h>
@@ -308,6 +309,18 @@ std::string TType::GetMangledName() const {
     virtual void operator()(const TSelfRef *that) const {
       std::ostringstream strm;
       strm << 'X' << that->GetDepth();
+      Name = strm.str();
+    }
+    /* A group reference mangles by its member index and the group identity
+       (the members' canonicalized inlined forms, which are pure de Bruijn --
+       no group refs -- so this is finite). Isomorphic groups share an
+       identity and therefore a mangled name (#116). */
+    virtual void operator()(const TGroupRef *that) const {
+      std::ostringstream strm;
+      strm << 'Y' << that->GetIndex() << 'g' << that->GetGroup().size();
+      for (const auto &member : that->GetGroup()) {
+        strm << member.GetMangledName();
+      }
       Name = strm.str();
     }
     virtual void operator()(const TOpt *that) const {

--- a/orly/type/impl.h
+++ b/orly/type/impl.h
@@ -43,6 +43,7 @@ namespace Orly {
     class TDict;
     class TErr;
     class TFunc;
+    class TGroupRef;
     class TId;
     class TInt;
     class TList;
@@ -255,6 +256,11 @@ namespace Orly {
          (mangling, gen_code, orlyify, has_optional, object_collector, unroll)
          override this. */
       virtual void operator()(const TSelfRef  *) const {throw Base::TImpossibleError(HERE);}
+      /* TGroupRef (mutual-recursion member reference, #116) is treated like
+         TSelfRef: a leaf that lives only inside a group member's payload map
+         and is navigated to the member type before surfacing, so only the
+         structural walkers override it. */
+      virtual void operator()(const TGroupRef  *) const {throw Base::TImpossibleError(HERE);}
       virtual void operator()(const TOpt      *that) const = 0;
       virtual void operator()(const TReal     *that) const = 0;
       virtual void operator()(const TSeq      *that) const = 0;

--- a/orly/type/rec_group.cc
+++ b/orly/type/rec_group.cc
@@ -1,0 +1,209 @@
+/* <orly/type/rec_group.cc>
+
+   Implements <orly/type/rec_group.h>.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <orly/type/rec_group.h>
+
+#include <algorithm>
+#include <cassert>
+#include <map>
+#include <numeric>
+#include <string>
+#include <unordered_map>
+
+#include <base/hash.h>
+#include <orly/type.h>
+#include <orly/type/canon.h>
+
+using namespace std;
+using namespace Orly;
+using namespace Orly::Type;
+
+namespace {
+
+  /* The registry: a group's canonical identity -> its member types, in
+     canonical (group-identity) order. Populated by MakeRecGroup, read by
+     ResolveGroupRef. Single-process compiler; isomorphic groups share an
+     entry because the identity is canonical. */
+  unordered_map<TGroupId, vector<TType>> &Registry() {
+    static unordered_map<TGroupId, vector<TType>> registry;
+    return registry;
+  }
+
+  /* A placeholder sibling reference in an input equation: TGroupRef with
+     the empty (not-yet-known) group identity, carrying only the member
+     index. */
+  const TGroupRef *AsPlaceholder(const TType &t) {
+    const TGroupRef *gr = t.TryAs<TGroupRef>();
+    return (gr && gr->GetGroup().empty()) ? gr : nullptr;
+  }
+
+  /* --- Inlining: a member's de Bruijn form (siblings expanded, back-edges
+         minted as TSelfRef), used only to compute the canonical identity. --- */
+
+  TType InlineType(const TType &t, const vector<TVariantElems> &members,
+                   size_t cur_depth, map<size_t, size_t> &binder_depth);
+
+  /* Inline a variant whose binder sits at `depth`. */
+  TType InlineVariant(const TVariantElems &elems, const vector<TVariantElems> &members,
+                      size_t depth, map<size_t, size_t> &binder_depth) {
+    TVariantElems out;
+    for (const auto &arm : elems) {
+      out[arm.first] = InlineType(arm.second, members, depth, binder_depth);
+    }
+    return TVariant::Get(out);
+  }
+
+  TType InlineType(const TType &t, const vector<TVariantElems> &members,
+                   size_t cur_depth, map<size_t, size_t> &binder_depth) {
+    if (const TGroupRef *gr = AsPlaceholder(t)) {
+      size_t m = gr->GetIndex();
+      auto it = binder_depth.find(m);
+      if (it != binder_depth.end()) {
+        return TSelfRef::Get(cur_depth - it->second);  // back-edge
+      }
+      /* Expand member m: entering its variant adds a binder. */
+      binder_depth[m] = cur_depth + 1;
+      TType result = InlineVariant(members[m], members, cur_depth + 1, binder_depth);
+      binder_depth.erase(m);
+      return result;
+    }
+    if (const TVariant *v = t.TryAs<TVariant>()) {
+      return InlineVariant(v->GetElems(), members, cur_depth + 1, binder_depth);
+    }
+    if (const TObj *o = t.TryAs<TObj>()) {
+      TObjElems out;
+      for (const auto &f : o->GetElems()) {
+        out[f.first] = InlineType(f.second, members, cur_depth, binder_depth);
+      }
+      return TObj::Get(out);
+    }
+    if (const TList *l = t.TryAs<TList>()) {
+      return TList::Get(InlineType(l->GetElem(), members, cur_depth, binder_depth));
+    }
+    if (const TSet *s = t.TryAs<TSet>()) {
+      return TSet::Get(InlineType(s->GetElem(), members, cur_depth, binder_depth));
+    }
+    if (const TOpt *o = t.TryAs<TOpt>()) {
+      return TOpt::Get(InlineType(o->GetElem(), members, cur_depth, binder_depth));
+    }
+    if (const TDict *d = t.TryAs<TDict>()) {
+      return TDict::Get(InlineType(d->GetKey(), members, cur_depth, binder_depth),
+                        InlineType(d->GetVal(), members, cur_depth, binder_depth));
+    }
+    return t;  // scalar / intra-member TSelfRef -- copied as-is
+  }
+
+  /* Member k's canonical inlined form (its de Bruijn type, minimized). */
+  TType MemberCanonInlined(const vector<TVariantElems> &members, size_t k) {
+    map<size_t, size_t> binder_depth{{k, 1}};
+    return Canon(InlineVariant(members[k], members, 1, binder_depth));
+  }
+
+  /* --- Reindexing: replace placeholder sibling refs with real TGroupRefs
+         into the canonical group identity. --- */
+
+  TType Reindex(const TType &t, const TGroupId &gid, const vector<size_t> &pos) {
+    if (const TGroupRef *gr = AsPlaceholder(t)) {
+      return TGroupRef::Get(gid, pos[gr->GetIndex()]);
+    }
+    if (const TVariant *v = t.TryAs<TVariant>()) {
+      TVariantElems out;
+      for (const auto &arm : v->GetElems()) {
+        out[arm.first] = Reindex(arm.second, gid, pos);
+      }
+      return TVariant::Get(out);
+    }
+    if (const TObj *o = t.TryAs<TObj>()) {
+      TObjElems out;
+      for (const auto &f : o->GetElems()) {
+        out[f.first] = Reindex(f.second, gid, pos);
+      }
+      return TObj::Get(out);
+    }
+    if (const TList *l = t.TryAs<TList>()) {
+      return TList::Get(Reindex(l->GetElem(), gid, pos));
+    }
+    if (const TSet *s = t.TryAs<TSet>()) {
+      return TSet::Get(Reindex(s->GetElem(), gid, pos));
+    }
+    if (const TOpt *o = t.TryAs<TOpt>()) {
+      return TOpt::Get(Reindex(o->GetElem(), gid, pos));
+    }
+    if (const TDict *d = t.TryAs<TDict>()) {
+      return TDict::Get(Reindex(d->GetKey(), gid, pos), Reindex(d->GetVal(), gid, pos));
+    }
+    return t;
+  }
+
+}  // namespace
+
+vector<TType> Orly::Type::MakeRecGroup(const vector<TVariantElems> &members) {
+  const size_t n = members.size();
+  assert(n > 0);
+
+  /* 1. Each member's canonical inlined form. */
+  vector<TType> canon_inlined(n);
+  for (size_t i = 0; i < n; ++i) {
+    canon_inlined[i] = MemberCanonInlined(members, i);
+  }
+
+  /* 2. Canonical order: sort member indices by their inlined form's mangled
+     name (structural and run-stable), so isomorphic groups -- regardless of
+     the order their members are supplied -- yield the same identity. */
+  vector<size_t> order(n);
+  iota(order.begin(), order.end(), 0);
+  sort(order.begin(), order.end(), [&](size_t a, size_t b) {
+    return canon_inlined[a].GetMangledName() < canon_inlined[b].GetMangledName();
+  });
+
+  /* group identity = inlined forms in canonical order; pos[k] = member k's
+     position in that order. */
+  TGroupId gid(n);
+  vector<size_t> pos(n);
+  for (size_t r = 0; r < n; ++r) {
+    gid[r] = canon_inlined[order[r]];
+    pos[order[r]] = r;
+  }
+
+  /* 3. Member types: real TGroupRefs into the canonical identity. */
+  vector<TType> result(n);
+  for (size_t i = 0; i < n; ++i) {
+    TVariantElems arms;
+    for (const auto &arm : members[i]) {
+      arms[arm.first] = Reindex(arm.second, gid, pos);
+    }
+    result[i] = TVariant::Get(arms);
+  }
+
+  /* 4. Register, indexed by canonical position, for navigation. */
+  vector<TType> by_pos(n);
+  for (size_t i = 0; i < n; ++i) {
+    by_pos[pos[i]] = result[i];
+  }
+  Registry()[gid] = by_pos;
+
+  return result;
+}
+
+TType Orly::Type::ResolveGroupRef(const TGroupRef *group_ref) {
+  assert(group_ref);
+  const auto it = Registry().find(group_ref->GetGroup());
+  assert(it != Registry().end());
+  assert(group_ref->GetIndex() < it->second.size());
+  return it->second[group_ref->GetIndex()];
+}

--- a/orly/type/rec_group.h
+++ b/orly/type/rec_group.h
@@ -1,0 +1,58 @@
+/* <orly/type/rec_group.h>
+
+   Construction and navigation of mutually-recursive type groups
+   (issue #116, Path A / A2). The type-layer core, independent of synth
+   and codegen.
+
+   `MakeRecGroup` takes a strongly-connected group of variant defs as
+   member "equations" -- a `TVariant`'s arm map per member, with a
+   reference to sibling member `k` written as the placeholder
+   `TGroupRef::Get({}, k)` (an empty group identity). It returns the
+   members' interned `TType`s (normal `TVariant`s whose sibling references
+   are real `TGroupRef`s into the group). Structurally-isomorphic groups
+   produce equal member types: the group identity is canonical -- the
+   members' inlined forms, canonicalized via orly/type/canon.h and ordered
+   by mangled name, independent of the order the members are supplied in.
+
+   `ResolveGroupRef` maps a `TGroupRef` back to the member `TType` it
+   denotes -- a registry lookup, used by the accessor.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#pragma once
+
+#include <vector>
+
+#include <orly/type/group_ref.h>
+#include <orly/type/impl.h>
+#include <orly/type/variant.h>
+
+namespace Orly {
+
+  namespace Type {
+
+    /* Build a mutually-recursive group from member equations (each a
+       variant arm map; sibling refs are TGroupRef::Get({}, k) placeholders
+       keyed only by member index). Returns the interned member types, in
+       the same order as the input equations. */
+    std::vector<TType> MakeRecGroup(const std::vector<TVariantElems> &members);
+
+    /* The member type a group reference denotes (registry lookup). The
+       group must have been built by MakeRecGroup. */
+    TType ResolveGroupRef(const TGroupRef *group_ref);
+
+  }  // Type
+
+}  // Orly

--- a/orly/type/rec_group.test.cc
+++ b/orly/type/rec_group.test.cc
@@ -1,0 +1,111 @@
+/* <orly/type/rec_group.test.cc>
+
+   Unit test for <orly/type/rec_group.h> -- building and navigating
+   mutually-recursive type groups (#116 Phase 2a), in the type layer with
+   no synth/codegen.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <orly/type/rec_group.h>
+
+#include <orly/type.h>
+#include <orly/type/type_czar.h>
+
+#include <base/test/kit.h>
+
+using namespace Orly;
+using namespace Orly::Type;
+
+/* A sibling placeholder: reference member `k` within the group. */
+static TType Ref(size_t k) { return TGroupRef::Get({}, k); }
+
+/* The member type a group ref resolves to. */
+static TType Nav(const TType &arm) { return ResolveGroupRef(arm.As<TGroupRef>()); }
+
+/* `a is <| X(b) |>; b is <| Y(a) |>;` -- member 0 = a, member 1 = b. */
+FIXTURE(MutualPair) {
+  TTypeCzar czar;
+  auto m = MakeRecGroup({ {{"X", Ref(1)}}, {{"Y", Ref(0)}} });
+  TType a = m[0], b = m[1];
+
+  /* Distinct members. */
+  EXPECT_FALSE(a == b);
+
+  /* The arms hold group refs that navigate to the sibling. */
+  TType ax = a.As<TVariant>()->GetElems().at("X");
+  TType by = b.As<TVariant>()->GetElems().at("Y");
+  EXPECT_TRUE(ax.Is<TGroupRef>());
+  EXPECT_TRUE(by.Is<TGroupRef>());
+  EXPECT_TRUE(Nav(ax) == b);   // a.X -> b
+  EXPECT_TRUE(Nav(by) == a);   // b.Y -> a
+}
+
+/* Building the same group again yields the same interned member types. */
+FIXTURE(SameGroupDedups) {
+  TTypeCzar czar;
+  auto m1 = MakeRecGroup({ {{"X", Ref(1)}}, {{"Y", Ref(0)}} });
+  auto m2 = MakeRecGroup({ {{"X", Ref(1)}}, {{"Y", Ref(0)}} });
+  EXPECT_TRUE(m1[0] == m2[0]);
+  EXPECT_TRUE(m1[1] == m2[1]);
+}
+
+/* The identity is canonical: supplying the same group with its members in
+   the opposite order yields the same member types (structural coherence). */
+FIXTURE(MemberOrderIndependent) {
+  TTypeCzar czar;
+  auto m = MakeRecGroup({ {{"X", Ref(1)}}, {{"Y", Ref(0)}} });   // 0=a(X->b), 1=b(Y->a)
+  /* Same group, members swapped: 0=b(Y->a@1), 1=a(X->b@0). */
+  auto swapped = MakeRecGroup({ {{"Y", Ref(1)}}, {{"X", Ref(0)}} });
+  EXPECT_TRUE(swapped[0] == m[1]);  // the Y-member equals b
+  EXPECT_TRUE(swapped[1] == m[0]);  // the X-member equals a
+}
+
+/* A structurally different group does not collide. */
+FIXTURE(DistinctGroups) {
+  TTypeCzar czar;
+  auto m  = MakeRecGroup({ {{"X", Ref(1)}}, {{"Y", Ref(0)}} });
+  auto ot = MakeRecGroup({ {{"P", Ref(1)}}, {{"Q", Ref(0)}} });
+  EXPECT_FALSE(ot[0] == m[0]);
+  EXPECT_FALSE(ot[0] == m[1]);
+}
+
+/* A three-member cycle a -> b -> c -> a navigates all the way around. */
+FIXTURE(ThreeCycle) {
+  TTypeCzar czar;
+  auto m = MakeRecGroup({ {{"A", Ref(1)}}, {{"B", Ref(2)}}, {{"C", Ref(0)}} });
+  TType a = m[0], b = m[1], c = m[2];
+  EXPECT_TRUE(Nav(a.As<TVariant>()->GetElems().at("A")) == b);
+  EXPECT_TRUE(Nav(b.As<TVariant>()->GetElems().at("B")) == c);
+  EXPECT_TRUE(Nav(c.As<TVariant>()->GetElems().at("C")) == a);
+}
+
+/* A member may also carry a non-recursive arm and a record payload. */
+FIXTURE(MixedArms) {
+  TTypeCzar czar;
+  /* expr = <| Lit(int) | Neg(expr) | Pair(<{.l: stmt, .r: stmt}>) |>
+     stmt = <| Done | Step(expr) |>  -- members 0=expr, 1=stmt */
+  TType pair_rec = TObj::Get({{"l", Ref(1)}, {"r", Ref(1)}});
+  auto m = MakeRecGroup({
+      {{"Lit", TInt::Get()}, {"Neg", Ref(0)}, {"Pair", pair_rec}},
+      {{"Done", TObj::Get({})}, {"Step", Ref(0)}},
+  });
+  TType expr = m[0], stmt = m[1];
+  EXPECT_FALSE(expr == stmt);
+  /* expr.Neg -> expr; expr.Pair.l -> stmt; stmt.Step -> expr. */
+  EXPECT_TRUE(Nav(expr.As<TVariant>()->GetElems().at("Neg")) == expr);
+  TType pair = expr.As<TVariant>()->GetElems().at("Pair");
+  EXPECT_TRUE(Nav(pair.As<TObj>()->GetElems().at("l")) == stmt);
+  EXPECT_TRUE(Nav(stmt.As<TVariant>()->GetElems().at("Step")) == expr);
+}

--- a/orly/type/type_czar.cc
+++ b/orly/type/type_czar.cc
@@ -37,6 +37,7 @@ TTypeCzar::TTypeCzar() {
   TOpt::New();
   TReal::New();
   TSelfRef::New();
+  TGroupRef::New();
   TSeq::New();
   TSet::New();
   TStr::New();
@@ -54,6 +55,7 @@ TTypeCzar::~TTypeCzar() {
   TStr::Delete();
   TSet::Delete();
   TSeq::Delete();
+  TGroupRef::Delete();
   TSelfRef::Delete();
   TReal::Delete();
   TOpt::Delete();


### PR DESCRIPTION
Phase 2a of mutual recursion (A2, structural — per the [design](https://github.com/orlyatomics/orly/issues/116#issuecomment-4711733322)): the **type-layer core, built and unit-tested in isolation** (no synth or codegen yet), exactly the way Phase 1's canonicalization was de-risked.

## What

A mutually-recursive SCC is represented **without inlining**: each member is a normal `TVariant` whose sibling references are a new leaf `TGroupRef(groupId, index)`, not expanded structure. This breaks the cyclic intern graph like `TSelfRef` does for self-recursion, but **preserves type sharing** — members stay distinct, separately-emittable types — which is what the naive de-Bruijn-inline approach destroyed (it inlined shared types, turned non-recursive arms recursive, and broke the #125 codegen).

- `orly/type/group_ref.{h,cc}` — the `TGroupRef` leaf, interned by `(group identity, member index)`, wired into the type layer like `TSelfRef` (forward decl + throwing `TVisitor` default + mangling + czar).
- `orly/type/rec_group.{h,cc}` — `MakeRecGroup` builds member types from member "equations" (arm maps with `TGroupRef::Get({}, k)` placeholders); the group identity is **canonical** — each member's inlined form, canonicalized via **#130's `Canon`** and ordered by mangled name — so structurally-isomorphic groups (regardless of member order) intern equal. `ResolveGroupRef` navigates a `TGroupRef` to its member type via a registry keyed by the canonical identity.

This is precisely where #130's `Canon` earns its keep: on the **group identity only**, never to represent the member types — so the inlining that breaks codegen is confined to computing a key.

The shipped self/nested/container/opt recursion (#103/#120/#121/#125) is **untouched** (stays de Bruijn `TSelfRef`); the group machinery is additive, for genuine multi-def SCCs.

## Testing

`orly/type/rec_group.test.cc` — 6 fixtures, all pass:
- a mutual pair: `a.X` navigates to `b`, `b.Y` to `a`;
- same group built twice → identical interned member types;
- **member-order independence** (the canonical-identity / structural-coherence guarantee);
- a structurally different group doesn't collide;
- a three-member cycle navigates all the way around;
- a mixed `expr`/`stmt` shape with a record payload and a non-recursive arm.

`make test` green; full lang suite **0 unexpected, 138 passed, 2 tracked xfails (#74/#75)**.

## Next

Phase 2b: synth SCC detection + group construction + cycle-detector relaxation. Phase 2c: per-SCC-header codegen. Phase 2d: the `expr`/`stmt` AST lang tests.