### PR TITLE
synth: resolve mutually-recursive type defs as a group (#116 phase 2b)

### DIFF
--- a/orly/synth/ref_type.cc
+++ b/orly/synth/ref_type.cc
@@ -21,6 +21,7 @@
 #include <base/assert_true.h>
 #include <orly/synth/context.h>
 #include <orly/type/any.h>
+#include <orly/type/group_ref.h>
 #include <orly/type/self_ref.h>
 
 using namespace Orly;
@@ -39,6 +40,15 @@ Type::TType TRefType::ComputeSymbolicType() const {
      by the nearest enclosing variant instead of recursing forever. Only
      direct recursion through a variant arm is supported in v1. */
   TTypeDef *def = *TypeDef;
+  /* A reference to a member of the mutually-recursive group currently being
+     resolved (issue #116): mint a TGroupRef placeholder keyed by the
+     member's index. MakeRecGroup reindexes these into the canonical group.
+     Checked before the in-flight path: during group resolution no def is
+     pushed in-flight, so the two never overlap. */
+  size_t group_index;
+  if (def && TTypeDef::InCurrentScc(def, group_index)) {
+    return Type::TGroupRef::Get({}, group_index);
+  }
   if (def && TTypeDef::IsInFlight(def)) {
     const TPosRange &pos_range = TypeDef.GetName().GetPosRange();
     if (def != TTypeDef::GetInnermostInFlight()) {

--- a/orly/synth/type_def.cc
+++ b/orly/synth/type_def.cc
@@ -18,6 +18,9 @@
 
 #include <orly/synth/type_def.h>
 
+#include <algorithm>
+#include <map>
+#include <set>
 #include <vector>
 
 #include <base/as_str.h>
@@ -25,7 +28,10 @@
 #include <base/no_default_case.h>
 #include <orly/synth/context.h>
 #include <orly/synth/new_type.h>
+#include <orly/type/group_ref.h>
+#include <orly/type/rec_group.h>
 #include <orly/type/unroll.h>
+#include <orly/type/variant.h>
 
 using namespace Orly;
 using namespace Orly::Synth;
@@ -39,6 +45,22 @@ struct TInFlightEntry {
   size_t VariantDepth;
 };  // TInFlightEntry
 static thread_local std::vector<TInFlightEntry> InFlightStack;
+
+/* The mutually-recursive group currently being resolved (issue #116):
+   maps each member def to its placeholder index. While set, a TRefType
+   naming a member resolves to a TGroupRef placeholder. Saved/restored
+   around each ResolveScc so nested group resolution (a member that uses a
+   *different* recursive group) works. */
+static thread_local std::map<const TTypeDef *, size_t> CurrentScc;
+
+bool TTypeDef::InCurrentScc(const TTypeDef *def, size_t &index) {
+  auto iter = CurrentScc.find(def);
+  if (iter == CurrentScc.end()) {
+    return false;
+  }
+  index = iter->second;
+  return true;
+}
 
 TTypeDef::TTypeDef(TScope *scope, const Package::Syntax::TTypeDef *type_def)
     : TDef(scope, Base::AssertTrue(type_def)->GetName()),
@@ -82,7 +104,111 @@ void TTypeDef::NoteSelfRefMinted() {
   InFlightStack.back().Def->SelfRefMinted = true;
 }
 
+void TTypeDef::ForwardReach(TTypeDef *start, std::set<TTypeDef *> &out) {
+  std::vector<TTypeDef *> stack;
+  start->ForEachRef([&stack](TAnyRef &ref) {
+    if (TTypeDef *td = dynamic_cast<TTypeDef *>(ref.GetDef())) {
+      stack.push_back(td);
+    }
+  });
+  while (!stack.empty()) {
+    TTypeDef *def = stack.back();
+    stack.pop_back();
+    if (!out.insert(def).second) {
+      continue;
+    }
+    def->ForEachRef([&stack](TAnyRef &ref) {
+      if (TTypeDef *td = dynamic_cast<TTypeDef *>(ref.GetDef())) {
+        stack.push_back(td);
+      }
+    });
+  }
+}
+
+const std::vector<TTypeDef *> &TTypeDef::GetScc() const {
+  if (!SccComputed) {
+    TTypeDef *self = const_cast<TTypeDef *>(this);
+    /* SCC = members reachable from self that can also reach self. */
+    std::set<TTypeDef *> fwd;
+    ForwardReach(self, fwd);
+    std::vector<TTypeDef *> scc;
+    for (TTypeDef *def : fwd) {
+      std::set<TTypeDef *> def_fwd;
+      ForwardReach(def, def_fwd);
+      if (def_fwd.count(self)) {
+        scc.push_back(def);
+      }
+    }
+    /* A non-recursive def reaches neither itself nor anything that reaches
+       it; ensure self is always present so the SCC is never empty. */
+    if (std::find(scc.begin(), scc.end(), self) == scc.end()) {
+      scc.push_back(self);
+    }
+    /* Stable order (cosmetic: the group identity is canonical regardless). */
+    std::sort(scc.begin(), scc.end(), [](TTypeDef *a, TTypeDef *b) {
+      return a->GetName().GetText() < b->GetName().GetText();
+    });
+    Scc = std::move(scc);
+    SccComputed = true;
+  }
+  return Scc;
+}
+
+void TTypeDef::ResolveScc() const {
+  if (GroupType) {
+    return;
+  }
+  const std::vector<TTypeDef *> &scc = GetScc();
+  assert(scc.size() > 1);
+
+  /* Activate placeholder mode for every member, then read each member's
+     equation: its variant arms with sibling references replaced by
+     TGroupRef placeholders (done in TRefType via InCurrentScc). */
+  std::map<const TTypeDef *, size_t> saved;
+  saved.swap(CurrentScc);
+  for (size_t i = 0; i < scc.size(); ++i) {
+    CurrentScc[scc[i]] = i;
+  }
+  std::vector<Type::TVariantElems> equations;
+  try {
+    for (TTypeDef *member : scc) {
+      const Type::TType &t = member->Type->GetSymbolicType();
+      const Type::TVariant *variant = t.TryAs<Type::TVariant>();
+      if (!variant) {
+        GetContext().AddError(member->GetName().GetPosRange(),
+            "a member of a mutually-recursive type group must be a variant "
+            "at its top level (issue #116)");
+        CurrentScc.swap(saved);
+        return;
+      }
+      equations.push_back(variant->GetElems());
+    }
+  } catch (...) {
+    CurrentScc.swap(saved);
+    throw;
+  }
+  CurrentScc.swap(saved);
+
+  /* Intern the group and cache each member's resolved type. */
+  std::vector<Type::TType> members = Type::MakeRecGroup(equations);
+  for (size_t i = 0; i < scc.size(); ++i) {
+    scc[i]->GroupType = members[i];
+  }
+}
+
 const Type::TType &TTypeDef::GetSymbolicType() const {
+  /* A member of a mutually-recursive group resolves through MakeRecGroup
+     (issue #116); resolve the whole group once and serve the cached type. */
+  if (GroupType) {
+    return *GroupType;
+  }
+  if (GetScc().size() > 1) {
+    ResolveScc();
+    assert(GroupType);
+    return *GroupType;
+  }
+
+  /* Single def: direct recursion via de Bruijn TSelfRef (issue #103). */
   InFlightStack.push_back(TInFlightEntry{this, 0});
   try {
     const Type::TType &result = Type->GetSymbolicType();
@@ -210,11 +336,16 @@ TAction TTypeDef::Build(int pass) {
 void TTypeDef::ForEachPred(int pass, const std::function<bool (TDef *)> &cb) {
   switch (pass) {
     case 1: {
-      Type->ForEachRef([this, cb](TAnyRef &ref) -> bool {
-        /* A def may depend on itself (direct recursion, #103); skip the
-           self-edge so the build driver's cycle detector doesn't fire. */
+      const std::vector<TTypeDef *> &scc = GetScc();
+      Type->ForEachRef([this, &scc, cb](TAnyRef &ref) -> bool {
+        /* A def may depend on itself (direct recursion, #103) or on a
+           sibling in its mutually-recursive group (#116); skip every
+           intra-group edge so the build driver's cycle detector doesn't
+           fire -- the group is resolved as a unit by GetSymbolicType. */
         TDef *def = ref.GetDef();
-        if (def != this) {
+        TTypeDef *td = dynamic_cast<TTypeDef *>(def);
+        bool in_scc = td && std::find(scc.begin(), scc.end(), td) != scc.end();
+        if (!in_scc) {
           cb(def);
         }
         return true;

--- a/orly/synth/type_def.h
+++ b/orly/synth/type_def.h
@@ -22,6 +22,9 @@
 #pragma once
 
 #include <cassert>
+#include <optional>
+#include <set>
+#include <vector>
 
 #include <orly/orly.package.cst.h>
 #include <orly/type.h>
@@ -82,11 +85,42 @@ namespace Orly {
          exempt. */
       static void NoteSelfRefMinted();
 
+      /* While a mutually-recursive group (a type-def SCC of size > 1) is
+         being resolved, a TRefType naming a member of that group resolves
+         to a TGroupRef placeholder rather than recursing (#116). Returns
+         true and the member's placeholder index iff `def` is a member of
+         the group currently being resolved. */
+      static bool InCurrentScc(const TTypeDef *def, size_t &index);
+
       private:
 
       /* Sticky: set when computing this def's symbolic type minted at
          least one self-reference. */
       mutable bool SelfRefMinted = false;
+
+      /* For a member of a mutually-recursive group (SCC size > 1), its
+         resolved group type (orly/type/rec_group.h); single-def recursion
+         keeps using the de Bruijn TSelfRef path and leaves this empty. */
+      mutable std::optional<Type::TType> GroupType;
+
+      /* This def's strongly-connected component over the type-def reference
+         graph, computed once (Tarjan-free two-reachability). Always contains
+         this; size > 1 means mutual/transitive recursion. */
+      mutable std::vector<TTypeDef *> Scc;
+      mutable bool SccComputed = false;
+
+      /* The SCC of this def (computed and cached on first use). */
+      const std::vector<TTypeDef *> &GetScc() const;
+
+      /* Every type def reachable from `start` by following the references in
+         its type expression (transitive closure, `start` included only if it
+         lies on a cycle). Used to compute SCCs by two-way reachability. */
+      static void ForwardReach(TTypeDef *start, std::set<TTypeDef *> &out);
+
+      /* Resolve a whole mutually-recursive group at once: build each
+         member's equation (sibling refs as TGroupRef placeholders) and
+         intern the group via MakeRecGroup, caching every member's GroupType. */
+      void ResolveScc() const;
 
       /* TODO */
       virtual TAction Build(int pass);

--- a/tests/lang_tests/general/.variants_mutual.orly.test.state
+++ b/tests/lang_tests/general/.variants_mutual.orly.test.state
@@ -1,0 +1,21 @@
+[
+  0,
+  [
+    [],
+    [
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++"
+    ],
+    [
+      "Running tests"
+    ],
+    [
+      "Tests done"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/variants_mutual.orly
+++ b/tests/lang_tests/general/variants_mutual.orly
@@ -1,0 +1,57 @@
+/* <orly/lang_tests/general/variants_mutual.orly>
+
+   Synth-layer test for issue #116 Phase 2b: mutually-recursive type
+   definitions typecheck.
+
+   A group of type defs whose references form a cycle no longer trips the
+   build driver's "cycle in build dependencies" detector (which #103
+   documented as the limit). The whole strongly-connected component is
+   resolved as a unit: each member's symbolic type is a variant whose
+   cross-references to its siblings are interned group references
+   (orly/type/rec_group.h), so the group has a single canonical identity.
+
+   This test only DECLARES the groups -- it does not construct or consume
+   values of them. Constructing/using a mutually-recursive value needs the
+   per-group native representation (Phase 2c); until then these types are
+   resolvable in the type checker but have no runtime form, exactly as an
+   unused self-recursive type def is resolvable without codegen.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+/* The minimal mutual pair: a refers to b, b refers to a. */
+a is <| X(b) |>;
+b is <| Y(a) |>;
+
+/* A three-member cycle: c -> d -> e -> c. */
+c is <| C(d) |>;
+d is <| D(e) |>;
+e is <| E(c) |>;
+
+/* A realistic mutually-recursive AST: an expression that may contain a
+   statement and a statement that may contain an expression, with
+   non-recursive arms and a record payload mixed in. */
+expr is <| Lit(int) | Neg(expr) | Block(stmt) |>;
+stmt is <| Done | Eval(expr) | Seq(<{.fst: stmt, .snd: stmt}>) |>;
+
+/* A self-recursive type def still resolves via the de Bruijn path (#103)
+   when declared alongside mutual groups -- the SCC of `tree` is just
+   itself. */
+tree is <| Leaf(int) | Branch(<{.l: tree, .r: tree}>) |>;
+
+test {
+  /* Compilation reaching here means every type def above resolved its
+     symbolic type without a build-cycle error. */
+  t1: true;
+};


### PR DESCRIPTION
## Phase 2b of #116 — mutual-recursion synth wiring

Mutually-recursive type definitions now **typecheck**. A group of type defs whose references form a cycle no longer trips the build driver's *"cycle in build dependencies"* detector (the limit documented for #103):

```
a is <| X(b) |>;
b is <| Y(a) |>;          // resolves; both are variants over the group
```

### How
`TTypeDef` computes its **SCC** over the type-def reference graph (two-way reachability):

- **size-1 SCC** (non-recursive or self-recursive) → unchanged: the existing single-def de Bruijn `TSelfRef` path from #103.
- **larger SCC** → `GetSymbolicType` resolves the whole group once. It reads each member's variant arms under a *placeholder mode* in which a `TRefType` naming a sibling mints a `TGroupRef` placeholder (`InCurrentScc`), then interns the group via `MakeRecGroup` (#131, phase 2a) and caches each member's resolved type. `ForEachPred` drops every intra-SCC edge (generalizing the #103 self-edge skip) so the cycle detector stays quiet — the group builds as a unit.

The group identity is canonical (phase 2a / Canon #130), so member order and redundant unfoldings don't change it.

### Scope boundary
This is the **type-checker half**. Constructing or consuming a value of a mutually-recursive type still needs the per-group native representation — **phase 2c**. Until then a group member behaves exactly like an unused recursive type def: resolvable in the type checker, no codegen. (Attempting to construct one currently hits the standard not-yet-reachable `TGroupRef` codegen guard; 2c replaces that with real lowering.)

### Tests
- New `tests/lang_tests/general/variants_mutual.orly`: mutual pair, three-member cycle, a realistic mutually-recursive `expr`/`stmt` AST (non-recursive arms + record payload), and a self-recursive `tree` declared alongside to confirm the single-def path is untouched.
- Full lang suite: **139 passed, 0 unexpected**, 2 pre-existing xfails (#74/#75).
- `make test`: green.