### PR TITLE
codegen: record / container of a sibling inside a mutual group (closes #116)

### DIFF
--- a/orly/code_gen/variant.cc
+++ b/orly/code_gen/variant.cc
@@ -1011,9 +1011,10 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
 }
 
 /* True iff `t` contains a TGroupRef anywhere (a reference into a mutually-
-   recursive group). A direct arm payload that IS a group ref is supported in
-   v1; a group ref buried in a record/container/nested variant is a tracked
-   #116 follow-up, detected here so it is reported rather than mis-emitted. */
+   recursive group) -- i.e. the arm is recursive. Supported payload shapes:
+   a direct group ref, a record of group refs, and list/set/opt/dict-value of
+   them (subst_storage walks these); a group ref under any other compound
+   throws a clear #116 error there. */
 static bool HasGroupRefDeep(const Type::TType &t) {
   if (t.Is<Type::TGroupRef>()) {
     return true;
@@ -1065,25 +1066,64 @@ void Orly::CodeGen::GenVariantGroupHeader(const std::string &out_dir, const Type
   }
 
   /* Primary member: emit the combined header defining every member class.
-     A recursive arm (its payload is a direct sibling/self reference, a
-     TGroupRef) is stored boxed as Rt::TBox<TVariant<sibling>> -- a concrete,
-     statically-known class, so no unrolling/decltype is needed (every
-     recursive edge in a group, even a self-edge, is a group ref). */
-  auto is_rec_arm = [](const Type::TType &payload) { return payload.Is<Type::TGroupRef>(); };
-  auto sibling_of = [](const Type::TType &payload) {
-    return Type::ResolveGroupRef(payload.As<Type::TGroupRef>());
+     A recursive arm holds a reference into the group -- a TGroupRef leaf,
+     which (#116) may be a direct sibling/self payload, a field of the
+     payload record, or under list/set/opt/dict-value within those. Because
+     a group ref resolves to a CONCRETE statically-known sibling class, it
+     boxes to Rt::TBox<sibling>; the rest reuses the #103 machinery (boxed
+     payload-record struct, DeepBox/DeepUnbox, member-template factory and
+     getter over the unrolled payload type) -- here the getter's TRet has
+     concrete sibling fields, so the decltype deduction is well-formed. */
+  auto is_rec_arm = [](const Type::TType &payload) { return HasGroupRefDeep(payload); };
+  auto sibling_of = [](const Type::TType &gr) {
+    return Type::ResolveGroupRef(gr.As<Type::TGroupRef>());
   };
-  auto storage_type = [&](const Type::TType &payload) -> string {
-    if (is_rec_arm(payload)) {
-      return Base::AsStr("Rt::TBox<", class_of(sibling_of(payload)), '>');
+  auto boxed_name = [&class_of](const Type::TType &m, const string &tag) {
+    return class_of(m) + "_Boxed" + tag;
+  };
+  /* Print a type with every group ref replaced by its boxed sibling storage,
+     elementwise through the containers placement allows. */
+  std::function<string (const Type::TType &)> subst_storage =
+      [&](const Type::TType &t) -> string {
+    if (!HasGroupRefDeep(t)) {
+      return Base::AsStr(t);
     }
-    /* v1 supports only direct sibling payloads and self-free payloads; a
-       group ref buried in a record/container is a #116 follow-up. */
-    if (HasGroupRefDeep(payload)) {
-      throw Orly::Rt::TSystemError(HERE, "a record/container/nested payload referencing a "
-                                         "mutually-recursive group member is not yet supported (#116)");
+    if (t.Is<Type::TGroupRef>()) {
+      return Base::AsStr("Rt::TBox<", class_of(sibling_of(t)), '>');
     }
-    return Base::AsStr(payload);
+    if (const auto *list = t.TryAs<Type::TList>()) {
+      return Base::AsStr("std::vector<", subst_storage(list->GetElem()), '>');
+    }
+    if (const auto *set = t.TryAs<Type::TSet>()) {
+      return Base::AsStr("Orly::Rt::TSet<", subst_storage(set->GetElem()), '>');
+    }
+    if (const auto *opt = t.TryAs<Type::TOpt>()) {
+      return Base::AsStr("Orly::Rt::TOpt<", subst_storage(opt->GetElem()), '>');
+    }
+    if (const auto *dict = t.TryAs<Type::TDict>()) {
+      return Base::AsStr("Orly::Rt::TDict<", Base::AsStr(dict->GetKey()), ", ",
+                         subst_storage(dict->GetVal()), '>');
+    }
+    /* A group ref nested in a record-within-a-container or a nested variant
+       has no native shape yet (the #116 remainder). */
+    throw Orly::Rt::TSystemError(HERE, "this mutually-recursive payload shape is not yet "
+                                       "supported (#116): a group reference may appear as an "
+                                       "arm payload, a payload-record field, or under "
+                                       "list/set/opt/dict-value within those");
+  };
+  /* An arm whose payload record holds group refs is stored as an adjacent
+     boxed struct (the variant analog of #103's _Boxed record storage). */
+  auto arm_is_record = [&is_rec_arm](const Type::TType &payload) {
+    return payload.Is<Type::TObj>() && is_rec_arm(payload);
+  };
+  /* The C++ type an arm's payload is stored in. */
+  auto storage_type = [&](const Type::TType &m, const string &tag, const Type::TType &payload) {
+    return arm_is_record(payload) ? boxed_name(m, tag) : subst_storage(payload);
+  };
+  /* A box or boxed-struct payload compares via direct method calls; a
+     CONTAINER of boxes has no methods and routes through Rt:: dispatch. */
+  auto arm_has_methods = [&arm_is_record](const Type::TType &payload) {
+    return payload.Is<Type::TGroupRef>() || arm_is_record(payload);
   };
 
   Base::TPath path(out_dir, prim_name, vector<string>{"h"});
@@ -1104,12 +1144,17 @@ void Orly::CodeGen::GenVariantGroupHeader(const std::string &out_dir, const Type
       << "#include <cstddef>" << Eol
       << "#include <cstdint>" << Eol
       << "#include <string>" << Eol
+      << "#include <utility>" << Eol
       << Eol
       << "#include <orly/rt/tuple.h>" << Eol
       << "#include <orly/rt/containers.h>" << Eol
       << "#include <orly/rt/obj.h>" << Eol
       << "#include <orly/rt/box.h>" << Eol
       << "#include <orly/type/variant.h>" << Eol
+      // MakeRecGroup, for the runtime TType reconstruction GenCode emits for a
+      // member (e.g. in a payload record's TDt::GetType) -- reachable from any
+      // file that includes a member via its shim header (#116).
+      << "#include <orly/type/rec_group.h>" << Eol
       << "#include <orly/var/impl.h>" << Eol
       << "#include <orly/var/obj.h>" << Eol;
 
@@ -1152,6 +1197,48 @@ void Orly::CodeGen::GenVariantGroupHeader(const std::string &out_dir, const Type
       }
       out << Eol;
 
+      /* Boxed payload-record structs (one per record arm, any member): each
+         group-ref field stored boxed, with templated ctor-from-unrolled and
+         ToUnrolled, comparison bodies deferred until the members complete. */
+      for (const auto &m : members) {
+        for (const auto &elem : m.As<Type::TVariant>()->GetElems()) {
+          if (!arm_is_record(elem.second)) { continue; }
+          auto bname = boxed_name(m, elem.first);
+          const auto &fields = elem.second.As<Type::TObj>()->GetElems();
+          out << "class " << bname << " {" << Eol
+              << "  public:" << Eol
+              << "  " << bname << "() {}" << Eol
+              << "  template <typename TRec>" << Eol
+              << "  explicit " << bname << "(const TRec &rec)";
+          if (!fields.empty()) { out << " : "; }
+          out << Base::Join(fields, ", ",
+                            [&subst_storage](TCppPrinter &strm, const Type::TObj::TElems::value_type &it) {
+                              strm << 'V' << it.first << "(Rt::DeepBox<" << subst_storage(it.second)
+                                   << ">(rec.GetV" << it.first << "()))";
+                            })
+              << " {}" << Eol
+              << "  template <typename TRet>" << Eol
+              << "  TRet ToUnrolled() const {" << Eol
+              << "    return TRet("
+              << Base::Join(fields, ", ",
+                            [](TCppPrinter &strm, const Type::TObj::TElems::value_type &it) {
+                              strm << "Rt::DeepUnbox<decltype(std::declval<TRet>().GetV"
+                                   << it.first << "())>(V" << it.first << ')';
+                            })
+              << ");" << Eol
+              << "  }" << Eol
+              << "  bool EqEq(const " << bname << " &that) const;" << Eol
+              << "  bool Match(const " << bname << " &that) const;" << Eol
+              << "  bool MatchLess(const " << bname << " &that) const;" << Eol
+              << "  size_t GetHash() const;" << Eol
+              << "  private:" << Eol;
+          for (const auto &field : fields) {
+            out << "  " << subst_storage(field.second) << " V" << field.first << ";" << Eol;
+          }
+          out << "}; // " << bname << Eol << Eol;
+        }
+      }
+
       /* One class per member. */
       for (const auto &m : members) {
         auto cm = class_of(m);
@@ -1162,15 +1249,17 @@ void Orly::CodeGen::GenVariantGroupHeader(const std::string &out_dir, const Type
           out << "public:" << Eol;
           out << cm << "() : Which(0) {}" << Eol << Eol;
 
-          /* Static per-arm factories. */
+          /* Static per-arm factories. A recursive arm takes the UNROLLED
+             payload (deduced at the call site) and stores it boxed. */
           { size_t idx = 0;
             for (const auto &elem : elems) {
               if (is_rec_arm(elem.second)) {
-                auto sib = class_of(sibling_of(elem.second));
-                out << "static " << cm << " Mk" << elem.first << "(const " << sib << " &vv) {" << Eol
+                out << "template <typename TPayload>" << Eol
+                    << "static " << cm << " Mk" << elem.first << "(const TPayload &vv) {" << Eol
                     << "  " << cm << " out;" << Eol
                     << "  out.Which = " << idx << ";" << Eol
-                    << "  out.V" << elem.first << " = Rt::TBox<" << sib << ">(vv);" << Eol
+                    << "  out.V" << elem.first << " = Rt::DeepBox<"
+                    << storage_type(m, elem.first, elem.second) << ">(vv);" << Eol
                     << "  return out;" << Eol
                     << "}" << Eol;
               } else {
@@ -1203,12 +1292,13 @@ void Orly::CodeGen::GenVariantGroupHeader(const std::string &out_dir, const Type
               << "  switch (Which) {" << Eol;
           { size_t idx = 0;
             for (const auto &elem : elems) {
-              if (is_rec_arm(elem.second)) {
+              if (is_rec_arm(elem.second) && arm_has_methods(elem.second)) {
                 out << "    case " << idx << ": return std::hash<size_t>()(" << idx
                     << ") ^ V" << elem.first << ".GetHash();" << Eol;
               } else {
                 out << "    case " << idx << ": return std::hash<size_t>()(" << idx
-                    << ") ^ std::hash<" << storage_type(elem.second) << ">()(V" << elem.first << ");" << Eol;
+                    << ") ^ std::hash<" << storage_type(m, elem.first, elem.second)
+                    << ">()(V" << elem.first << ");" << Eol;
               }
               ++idx;
             }
@@ -1223,7 +1313,11 @@ void Orly::CodeGen::GenVariantGroupHeader(const std::string &out_dir, const Type
           { size_t idx = 0;
             for (const auto &elem : elems) {
               if (is_rec_arm(elem.second)) {
-                out << "    case " << idx << ": return V" << elem.first << ".EqEq(that.V" << elem.first << ");" << Eol;
+                if (arm_has_methods(elem.second)) {
+                  out << "    case " << idx << ": return V" << elem.first << ".EqEq(that.V" << elem.first << ");" << Eol;
+                } else {
+                  out << "    case " << idx << ": return Rt::Match(V" << elem.first << ", that.V" << elem.first << ");" << Eol;
+                }
               } else {
                 out << "    case " << idx << ": return Rt::EqEq(V" << elem.first << ", that.V" << elem.first << ");" << Eol;
               }
@@ -1241,7 +1335,7 @@ void Orly::CodeGen::GenVariantGroupHeader(const std::string &out_dir, const Type
               << "  switch (Which) {" << Eol;
           { size_t idx = 0;
             for (const auto &elem : elems) {
-              if (is_rec_arm(elem.second)) {
+              if (is_rec_arm(elem.second) && arm_has_methods(elem.second)) {
                 out << "    case " << idx << ": return V" << elem.first << ".Match(that.V" << elem.first << ");" << Eol;
               } else {
                 out << "    case " << idx << ": return Rt::Match(V" << elem.first << ", that.V" << elem.first << ");" << Eol;
@@ -1257,7 +1351,7 @@ void Orly::CodeGen::GenVariantGroupHeader(const std::string &out_dir, const Type
               << "  switch (Which) {" << Eol;
           { size_t idx = 0;
             for (const auto &elem : elems) {
-              if (is_rec_arm(elem.second)) {
+              if (is_rec_arm(elem.second) && arm_has_methods(elem.second)) {
                 out << "    case " << idx << ": return V" << elem.first << ".MatchLess(that.V" << elem.first << ");" << Eol;
               } else {
                 out << "    case " << idx << ": return Rt::MatchLess(V" << elem.first << ", that.V" << elem.first << ");" << Eol;
@@ -1267,16 +1361,24 @@ void Orly::CodeGen::GenVariantGroupHeader(const std::string &out_dir, const Type
           }
           out << "  }" << Eol << "  assert(false);" << Eol << "  return false;" << Eol << "}" << Eol << Eol;
 
-          /* Accessors. A cross/self-member arm returns a sibling class that
-             may still be incomplete here (the group is a C++ cycle), so its
-             by-value getter is only DECLARED in-class and defined out-of-line
-             below, once every member class is complete. */
+          /* Accessors. A recursive arm's getter is a member template over the
+             UNROLLED payload type (supplied by variant_access.cc): a record
+             payload converts via the boxed struct's ToUnrolled; a direct
+             group ref / container of group refs unboxes via Rt::DeepUnbox. */
           out << "size_t GetWhich() const { assert(this); return Which; }" << Eol;
           { size_t idx = 0;
             for (const auto &elem : elems) {
               if (is_rec_arm(elem.second)) {
-                auto sib = class_of(sibling_of(elem.second));
-                out << sib << " GetV" << elem.first << "() const;" << Eol;
+                const bool uses_inline_struct = arm_is_record(elem.second);
+                out << "template <typename TRet>" << Eol
+                    << "TRet GetV" << elem.first << "() const {" << Eol
+                    << "  assert(this); assert(Which == " << idx << ");" << Eol
+                    << "  return "
+                    << (uses_inline_struct
+                            ? Base::AsStr('V', elem.first, ".template ToUnrolled<TRet>()")
+                            : Base::AsStr("Rt::DeepUnbox<TRet>(V", elem.first, ')'))
+                    << ";" << Eol
+                    << "}" << Eol;
               } else {
                 out << elem.second << " GetV" << elem.first << "() const {" << Eol
                     << "  assert(this); assert(Which == " << idx << ");" << Eol
@@ -1289,27 +1391,74 @@ void Orly::CodeGen::GenVariantGroupHeader(const std::string &out_dir, const Type
 
           out << Eol << "private:" << Eol << "size_t Which;" << Eol;
           for (const auto &elem : elems) {
-            out << storage_type(elem.second) << " V" << elem.first << ";" << Eol;
+            out << storage_type(m, elem.first, elem.second) << " V" << elem.first << ";" << Eol;
           }
         } // class body
         out << "}; // " << cm << Eol << Eol;
       }
 
-      /* Out-of-line cross/self-member accessors, now that every member class
-         is complete (each returns a sibling by value). */
+      /* Deferred boxed-record comparison bodies (need the member classes
+         complete: they deref the TBox<sibling> fields). */
       for (const auto &m : members) {
-        auto cm = class_of(m);
-        const auto &elems = m.As<Type::TVariant>()->GetElems();
-        size_t idx = 0;
-        for (const auto &elem : elems) {
-          if (is_rec_arm(elem.second)) {
-            auto sib = class_of(sibling_of(elem.second));
-            out << "inline " << sib << " " << cm << "::GetV" << elem.first << "() const {" << Eol
-                << "  assert(this); assert(Which == " << idx << ");" << Eol
-                << "  return V" << elem.first << ".Get();" << Eol
-                << "}" << Eol;
+        for (const auto &elem : m.As<Type::TVariant>()->GetElems()) {
+          if (!arm_is_record(elem.second)) { continue; }
+          auto bname = boxed_name(m, elem.first);
+          const auto &fields = elem.second.As<Type::TObj>()->GetElems();
+          auto match_term = [](TCppPrinter &strm, const Type::TObj::TElems::value_type &it) {
+            if (it.second.Is<Type::TGroupRef>()) {
+              strm << 'V' << it.first << ".Match(that.V" << it.first << ')';
+            } else {
+              strm << "Rt::Match(V" << it.first << ", that.V" << it.first << ')';
+            }
+          };
+          auto less_term = [](TCppPrinter &strm, const Type::TObj::TElems::value_type &it) {
+            if (it.second.Is<Type::TGroupRef>()) {
+              strm << 'V' << it.first << ".MatchLess(that.V" << it.first << ')';
+            } else {
+              strm << "Rt::MatchLess(V" << it.first << ", that.V" << it.first << ')';
+            }
+          };
+          out << "inline bool " << bname << "::EqEq(const " << bname << " &that) const { return Match(that); }" << Eol
+              << "inline bool " << bname << "::Match(const " << bname << " &that) const {" << Eol
+              << "  return ";
+          if (fields.empty()) { out << "true"; }
+          out << Base::Join(fields, " && ", match_term) << ';' << Eol
+              << "}" << Eol
+              << "inline bool " << bname << "::MatchLess(const " << bname << " &that) const {" << Eol
+              << "  return ";
+          if (fields.empty()) {
+            out << "false";
+          } else {
+            size_t emitted = 0;
+            for (auto iter = fields.begin(); iter != fields.end(); ++iter) {
+              if (std::next(iter) == fields.end()) {
+                less_term(out, *iter);
+              } else {
+                less_term(out, *iter);
+                out << " || (";
+                match_term(out, *iter);
+                out << " && (";
+                ++emitted;
+              }
+            }
+            out << string(2 * emitted, ')');
           }
-          ++idx;
+          out << ';' << Eol
+              << "}" << Eol
+              << "inline size_t " << bname << "::GetHash() const {" << Eol
+              << "  return ";
+          if (fields.empty()) { out << "0"; }
+          out << Base::Join(fields, " ^ ",
+                            [&subst_storage](TCppPrinter &strm, const Type::TObj::TElems::value_type &it) {
+                              if (it.second.Is<Type::TGroupRef>()) {
+                                strm << 'V' << it.first << ".GetHash()";
+                              } else {
+                                strm << "std::hash<" << subst_storage(it.second)
+                                     << ">()(V" << it.first << ')';
+                              }
+                            })
+              << ';' << Eol
+              << "}" << Eol;
         }
       }
       out << Eol;

--- a/orly/code_gen/variant_access.cc
+++ b/orly/code_gen/variant_access.cc
@@ -45,16 +45,18 @@ TVariantMember::TVariantMember(const L0::TPackage *package,
 
 void TVariantMember::WriteExpr(TCppPrinter &out) const {
   /* GetV<Tag>() returns the active arm's payload and asserts the arm is
-     active -- callers gate this with `is <Tag>`. For a RECURSIVE arm
-     (#103) the generated getter is a member template over the unrolled
-     payload type (which is this inline's own result type), supplied
-     explicitly here. */
+     active -- callers gate this with `is <Tag>`. For a RECURSIVE arm the
+     generated getter is a member template over the unrolled payload type
+     (which is this inline's own result type), supplied explicitly here.
+     "Recursive" covers self-references (#103) and references into a
+     mutually-recursive group (#116). */
   const Type::TVariant *variant =
       Type::Unwrap(Operand->GetReturnType()).TryAs<Type::TVariant>();
   bool recursive_arm = false;
   if (variant) {
     auto iter = variant->GetElems().find(Tag);
-    recursive_arm = iter != variant->GetElems().end() && Type::HasFreeSelfRef(iter->second);
+    recursive_arm = iter != variant->GetElems().end()
+        && (Type::HasFreeSelfRef(iter->second) || Type::HasGroupRef(iter->second));
   }
   out << '(' << Operand << ").GetV" << Tag;
   if (recursive_arm) {

--- a/orly/type/impl.cc
+++ b/orly/type/impl.cc
@@ -311,16 +311,25 @@ std::string TType::GetMangledName() const {
       strm << 'X' << that->GetDepth();
       Name = strm.str();
     }
-    /* A group reference mangles by its member index and the group identity
-       (the members' canonicalized inlined forms, which are pure de Bruijn --
-       no group refs -- so this is finite). Isomorphic groups share an
-       identity and therefore a mangled name (#116). */
+    /* A group reference mangles by its member index and a stable hash of the
+       group identity (the members' canonicalized inlined forms -- pure de
+       Bruijn, no group refs, so finite and order-canonical). Hashing rather
+       than inlining the whole identity keeps a member's name (and any record
+       that embeds members) within filesystem name limits -- the full forms
+       repeated at every group ref are quadratic and overflow 255 chars.
+       Isomorphic groups share the identity, hence the hash and name (#116).
+       FNV-1a over the concatenated member mangles; a collision would surface
+       as a duplicate C++ class name at compile, never silent corruption. */
     virtual void operator()(const TGroupRef *that) const {
-      std::ostringstream strm;
-      strm << 'Y' << that->GetIndex() << 'g' << that->GetGroup().size();
+      uint64_t h = 1469598103934665603ull;  // FNV-1a 64-bit offset basis
       for (const auto &member : that->GetGroup()) {
-        strm << member.GetMangledName();
+        for (char c : member.GetMangledName()) {
+          h = (h ^ static_cast<unsigned char>(c)) * 1099511628211ull;
+        }
+        h = (h ^ '|') * 1099511628211ull;  // member separator
       }
+      std::ostringstream strm;
+      strm << 'Y' << that->GetIndex() << 'g' << std::hex << h;
       Name = strm.str();
     }
     virtual void operator()(const TOpt *that) const {

--- a/orly/type/object_collector.cc
+++ b/orly/type/object_collector.cc
@@ -64,7 +64,7 @@ void Orly::Type::CollectObjects(const TType &type, unordered_set<TType> &object_
          so don't collect it. A record that merely embeds a complete
          recursive variant (bound refs only, e.g. the unrolled payload)
          is a normal record. */
-      if (!HasFreeSelfRef(that->AsType())) {
+      if (!HasFreeSelfRef(that->AsType()) && !HasFreeGroupRef(that->AsType())) {
         ObjectSet.insert(that->AsType());
       }
       for (auto iter : that->GetElems()) {

--- a/orly/type/unroll.cc
+++ b/orly/type/unroll.cc
@@ -218,6 +218,61 @@ bool Type::HasGroupRef(const TType &type) {
   return found;
 }
 
+bool Type::HasFreeGroupRef(const TType &type) {
+  class TVisitor
+      : public TType::TVisitor {
+    public:
+    TVisitor(bool &found) : Found(found) {}
+    virtual void operator()(const TGroupRef *) const { Found = true; }
+    virtual void operator()(const TSelfRef *) const {}
+    /* A variant is a binder boundary: group refs inside it are owned by that
+       variant (a complete sibling member), not free in `type`. Do not descend. */
+    virtual void operator()(const TVariant *) const {}
+    virtual void operator()(const TObj *that) const {
+      for (const auto &elem : that->GetElems()) {
+        if (Found) { return; }
+        elem.second.Accept(*this);
+      }
+    }
+    virtual void operator()(const TAddr *that) const {
+      for (const auto &elem : that->GetElems()) {
+        if (Found) { return; }
+        elem.second.Accept(*this);
+      }
+    }
+    virtual void operator()(const TDict *that) const {
+      that->GetKey().Accept(*this);
+      if (!Found) { that->GetVal().Accept(*this); }
+    }
+    virtual void operator()(const TErr *that) const { that->GetElem().Accept(*this); }
+    virtual void operator()(const TList *that) const { that->GetElem().Accept(*this); }
+    virtual void operator()(const TOpt *that) const { that->GetElem().Accept(*this); }
+    virtual void operator()(const TSeq *that) const { that->GetElem().Accept(*this); }
+    virtual void operator()(const TSet *that) const { that->GetElem().Accept(*this); }
+    virtual void operator()(const TFunc *that) const {
+      that->GetParamObject().Accept(*this);
+      if (!Found) { that->GetReturnType().Accept(*this); }
+    }
+    virtual void operator()(const TMutable *that) const {
+      that->GetAddr().Accept(*this);
+      if (!Found) { that->GetVal().Accept(*this); }
+    }
+    virtual void operator()(const TAny *) const {}
+    virtual void operator()(const TBool *) const {}
+    virtual void operator()(const TId *) const {}
+    virtual void operator()(const TInt *) const {}
+    virtual void operator()(const TReal *) const {}
+    virtual void operator()(const TStr *) const {}
+    virtual void operator()(const TTimeDiff *) const {}
+    virtual void operator()(const TTimePnt *) const {}
+    private:
+    bool &Found;
+  };  // TVisitor
+  bool found = false;
+  type.Accept(TVisitor(found));
+  return found;
+}
+
 /* The depth-tracking rewrite behind Unroll(). */
 static TType UnrollAtDepth(const TType &type, const TType &binder, size_t depth) {
   class TVisitor

--- a/orly/type/unroll.h
+++ b/orly/type/unroll.h
@@ -49,6 +49,15 @@ namespace Orly {
        mutual analogue of HasSelfRef. */
     bool HasGroupRef(const TType &type);
 
+    /* True iff the type contains a FREE group reference: one not nested
+       inside a TVariant. A group member's raw arm payload (`<{.head: ref}>`)
+       has free group refs (the refs are the member's recursive edges); the
+       UNROLLED payload, whose fields are complete sibling variants, has none
+       (their internal group refs are owned by those variants). The mutual
+       analogue of HasFreeSelfRef -- used to decide whether a payload needs
+       the boxed representation vs. is a normal standalone record/type. */
+    bool HasFreeGroupRef(const TType &type);
+
     /* True iff the type contains a FREE self-reference: one whose de
        Bruijn depth reaches past the variants nested inside `type` itself.
        A recursive variant's raw arm payload has free self-references (they

--- a/tests/lang_tests/general/.variants_mutual_record.orly.test.state
+++ b/tests/lang_tests/general/.variants_mutual_record.orly.test.state
@@ -1,0 +1,21 @@
+[
+  0,
+  [
+    [],
+    [
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++"
+    ],
+    [
+      "Running tests"
+    ],
+    [
+      "Tests done"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/variants_mutual_record.orly
+++ b/tests/lang_tests/general/variants_mutual_record.orly
@@ -1,0 +1,89 @@
+/* <orly/lang_tests/general/variants_mutual_record.orly>
+
+   Issue #116, final placement relaxation: a mutually-recursive group arm
+   whose payload is a RECORD of siblings, or a CONTAINER of siblings.
+
+   `tree` and `forest` are mutually recursive. `forest`'s `Cons` arm carries
+   a record `<{.head: tree, .tail: forest}>` (two different sibling members
+   in one record); its `Group` arm carries `[tree]` (a list of a sibling).
+   Each group reference inside those payloads is stored boxed as the concrete
+   sibling class (`Rt::TBox<tree>` / `std::vector<Rt::TBox<tree>>`), through
+   the same `_Boxed` / `DeepBox` machinery #103 uses for self-recursion —
+   here the unrolled payload's fields are concrete sibling classes, so the
+   getter's `decltype` deduction is well-formed.
+
+   Folds across the member boundary (`tsum`/`fsum`) descend through the
+   record arm; the list arm is exercised structurally (construct, `==`,
+   accessor, indexing, nested access).
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+tree is <| Leaf(int) | Node(forest) |>;
+forest is <| Empty | Cons(<{.head: tree, .tail: forest}>) | Group([tree]) |>;
+
+/* Mutually-recursive folds descending through the record arm. */
+tsum = ((t) when {
+  Leaf(n): n;
+  Node(f): fsum(.f: f);
+}) where {
+  t = given::(tree);
+};
+
+fsum = ((f) when {
+  Empty: 0;
+  Cons(c): tsum(.t: c.head) + fsum(.f: c.tail);
+  Group(ts): 0;
+}) where {
+  f = given::(forest);
+};
+
+/* A forest of two leaves built through the record (Cons) arm. */
+f12 = (forest.Cons(<{.head: tree.Leaf(1), .tail:
+        forest.Cons(<{.head: tree.Leaf(2), .tail: forest.Empty()}>)}>)) where {};
+t12 = (tree.Node(f12)) where {};
+t12b = (tree.Node(f12)) where {};
+t9 = (tree.Leaf(9)) where {};
+
+/* A forest built through the container (Group) arm. */
+g = (forest.Group([tree.Leaf(3), tree.Node(forest.Empty())])) where {};
+g2 = (forest.Group([tree.Leaf(3), tree.Node(forest.Empty())])) where {};
+
+test {
+  /* Folds through the record payload, across the member boundary. */
+  t1: tsum(.t: tree.Leaf(7)) == 7;
+  t2: tsum(.t: t12) == 3;
+  t3: fsum(.f: f12) == 3;
+
+  /* Deep structural equality reaches through boxed record fields. */
+  t4: t12 == t12b;
+  t5: t12 != t9;
+
+  /* is / .Tag / record-field / chained access across members. */
+  t6: t12 is Node;
+  t7: (t12.Node) is Cons;
+  t8: ((t12.Node).Cons).head.Leaf == 1;
+  t9: ((t12.Node).Cons).tail is Cons;
+
+  /* Container-of-sibling arm: construct, equality, accessor, indexing. */
+  t10: g == g2;
+  t11: g is Group;
+  t12: length_of (g.Group) == 2;
+  t13: (g.Group)[0].Leaf == 3;
+  t14: (g.Group)[1] is Node;
+
+  /* Recursive group values (record and container shapes) in a local set. */
+  t15: length_of {t12, t12b, t9} == 2;
+  t16: length_of {g, g2} == 1;
+};


### PR DESCRIPTION
## Closes #116 — the last recursive-variant placement gap

A mutually-recursive group arm whose payload is a **record of siblings** or a **container of siblings** now works end-to-end (package-internal): construct, fold, compare, hash, destructure.

```
tree   is <| Leaf(int) | Node(forest) |>;
forest is <| Empty | Cons(<{.head: tree, .tail: forest}>) | Group([tree]) |>;

forest.Cons(<{.head: tree.Leaf(1), .tail: forest.Empty()}>)   // record of two different siblings
forest.Group([tree.Leaf(3), tree.Node(forest.Empty())])        // list of a sibling
```

Previously these were *declarable* (Phase 2b) but rejected at codegen with "not yet supported (#116)".

### How
The group emitter now reuses the **#103 `_Boxed` machinery** for these shapes:
- A **record** arm is stored as an adjacent boxed struct — each group-ref field boxed via `subst_storage` (`tree` → `Rt::TBox<tree>`, `[tree]` → `std::vector<Rt::TBox<tree>>`, etc.), with a templated ctor-from-unrolled, `ToUnrolled`, and `DeepBox`/`DeepUnbox`.
- Factories and the `.Tag` getter become **member templates** over the unrolled payload, unifying the direct / record / container cases; `variant_access` treats a group-ref arm as recursive (template getter).
- Because **A2 never inlines**, a group ref resolves to a *concrete* sibling class, so the getter's `decltype(std::declval<TRet>().GetV<f>())` deduction is well-formed — the trap that blocked the inline approach simply doesn't arise here.

### Supporting type-layer work
- **`unroll`**: `HasFreeGroupRef` (a group ref not under a variant binder) — the mutual analogue of `HasFreeSelfRef`. `object_collector` skips the *raw* boxed payload record but **collects the unrolled record** (concrete sibling fields) so its standalone header is generated.
- **Mangling** (`impl.cc`): a `TGroupRef` now mangles by member index + a stable **FNV-1a hash** of the group identity, not the full inlined member forms. Repeating the whole identity at every group ref is quadratic and overflowed the **255-char filename limit** for a record-of-members; a hash collision would surface as a duplicate class name at compile, never silent corruption.
- The combined group header now includes `rec_group.h`, so any file using a member (via its shim) can compile the `MakeRecGroup` type reconstruction `GenCode` emits.

### Tests
- New `variants_mutual_record.orly`: `tree`/`forest` with a record-of-sibling arm (mutual `tsum`/`fsum` folds across the member boundary) **and** a list-of-sibling arm (construct, `==`, accessor, indexing, nested access, set dedup).
- Full lang suite: **141 passed, 0 unexpected**, 2 pre-existing xfails (#74/#75).
- `make test`: green — single-variant frozen snapshot unchanged.

With this, #116's remaining item is done; storage of recursive values stays scoped to #115.