### PR TITLE
sabot: recursive type leaf + atom codec + bridges (#115 phase 1)

### DIFF
--- a/orly/atom/kit2.cc
+++ b/orly/atom/kit2.cc
@@ -99,6 +99,11 @@ bool TCore::TOrderedArenaCompare::operator()(const TCore &lhs, const TCore &rhs)
         assert(lhs.Tycon == rhs.Tycon);
         return lhs.ForceAs<Base::TUuid>() < rhs.ForceAs<Base::TUuid>();
       }
+      case TTycon::SelfRef: {
+        /* Recursive back-reference leaf (issue #115): order by de Bruijn depth. */
+        assert(lhs.Tycon == rhs.Tycon);
+        return lhs.ForceAs<uint64_t>() < rhs.ForceAs<uint64_t>();
+      }
       default: {
         assert(lhs.Tycon != TTycon::Str);
         assert(lhs.Tycon != TTycon::Blob);
@@ -255,6 +260,7 @@ TCore::TCore(TExtensibleArena *arena, const Type::TAny &type) {
     virtual void operator()(const Type::TMap       &type) const override { Core->InitIndirectCoreArray(TTycon::Map,    Arena, type, true ); }
     virtual void operator()(const Type::TRecord    &type) const override { Core->InitIndirectCoreArray(Arena, type, false); }
     virtual void operator()(const Type::TTuple     &type) const override { Core->InitIndirectCoreArray(Arena, type, false); }
+    virtual void operator()(const Type::TSelfRef   &type) const override { Core->InitSelfRef(type.GetDepth()); }
     private:
     TExtensibleArena *Arena;
     TCore *Core;
@@ -393,6 +399,7 @@ TCore::Type::TAny *TCore::GetType(TArena *arena, void *type_alloc) const {
     case TTycon::Str      : { result = new (type_alloc) Sabot::Type::TStr      ();            break; }
     case TTycon::Tombstone: { result = new (type_alloc) Sabot::Type::TTombstone();            break; }
     case TTycon::Void     : { result = new (type_alloc) Sabot::Type::TVoid     ();            break; }
+    case TTycon::SelfRef  : { result = new (type_alloc) Sabot::Type::TSelfRef  (ForceAs<uint64_t>()); break; }
     case TTycon::Desc     : { result = new (type_alloc) ST::TDesc              (arena, this); break; }
     case TTycon::Free     : { result = new (type_alloc) ST::TFree              (arena, this); break; }
     case TTycon::Opt      : { result = new (type_alloc) ST::TOpt               (arena, this); break; }
@@ -551,7 +558,10 @@ const TCore::TOffset *TCore::TryGetOffset() const {
     case TTycon::TimePoint:
     case TTycon::Uuid:
     case TTycon::Tombstone:
-    case TTycon::Void: {
+    case TTycon::Void:
+    /* Recursive back-reference leaf (issue #115): a direct scalar -- no
+       indirection offset. */
+    case TTycon::SelfRef: {
       break;
     }
     case TTycon::Blob:

--- a/orly/atom/kit2.h
+++ b/orly/atom/kit2.h
@@ -306,7 +306,14 @@ namespace Orly {
         /* And then everybody else. */
         Int8 = MaxDirectBlob + 1, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64, Bool, Char,
         Float, Double, Duration, TimePoint, Uuid, Blob, Str, Tombstone, Void,
-        Desc, Free, Opt, Set, Vector, Map, Record, Tuple
+        Desc, Free, Opt, Set, Vector, Map, Record, Tuple,
+
+        /* The recursive back-reference leaf of a recursive sum type's #96
+           fixed-shape record encoding (issue #115).  Appended last so every
+           existing tycon keeps its numeric value (on-disk-compatible).  Stored
+           like a direct scalar -- its de Bruijn depth lives in DirectBlob -- so
+           it only ever appears nested inside a TYPE core, never as a value. */
+        SelfRef
 
       };  // TTycon
 
@@ -352,6 +359,10 @@ namespace Orly {
       void InitDuration (const TStdDuration  &val = TStdDuration() ) { InitDirect(TTycon::Duration,  val); }
       void InitTimePoint(const TStdTimePoint &val = TStdTimePoint()) { InitDirect(TTycon::TimePoint, val); }
       void InitUuid     (const TUuid         &val = TUuid()        ) { InitDirect(TTycon::Uuid,      val); }
+
+      /* The recursive back-reference leaf (issue #115): a direct scalar holding
+         the de Bruijn depth of the enclosing variant binder it refers to. */
+      void InitSelfRef  (uint64_t             val = 0              ) { InitDirect(TTycon::SelfRef,   val); }
 
       /* If the blob is small enough, store it directly; otherwise, propose an array of bytes and take it as our state. */
       void InitBlob(TExtensibleArena *arena, const uint8_t *start, const uint8_t *limit);
@@ -963,6 +974,12 @@ namespace Orly {
             comp = QuickCompare(ForceAs<Base::TUuid>(), that_core.ForceAs<Base::TUuid>());
             return true;
           }
+          case TTycon::SelfRef: {
+            /* Recursive back-reference leaf (issue #115): order by de Bruijn
+               depth.  Only meaningful nested inside a type core. */
+            comp = QuickCompare(ForceAs<uint64_t>(), that_core.ForceAs<uint64_t>());
+            return true;
+          }
           case TTycon::Tuple: {
             void *lhs_pin_alloc = alloca(sizeof(TArena::TFinalPin) * 2);
             void *rhs_pin_alloc = reinterpret_cast<uint8_t *>(lhs_pin_alloc) + sizeof(TArena::TFinalPin);
@@ -1124,7 +1141,10 @@ namespace Orly {
           case TTycon::Double:
           case TTycon::Duration:
           case TTycon::TimePoint:
-          case TTycon::Uuid: {
+          case TTycon::Uuid:
+          /* Recursive back-reference leaf (issue #115): same-tycon leaves are a
+             type match for key purposes, like any other direct scalar. */
+          case TTycon::SelfRef: {
             return true;
           }
           case TTycon::Tombstone: {
@@ -1374,6 +1394,11 @@ namespace Orly {
         }
         case TTycon::Uuid: {
           out_hash = std::hash<Base::TUuid>()(ForceAs<Base::TUuid>());
+          return true;
+        }
+        case TTycon::SelfRef: {
+          /* Recursive back-reference leaf (issue #115): hash its de Bruijn depth. */
+          out_hash = std::hash<uint64_t>()(ForceAs<uint64_t>());
           return true;
         }
         default: {

--- a/orly/atom/kit2.test.cc
+++ b/orly/atom/kit2.test.cc
@@ -25,9 +25,15 @@
 
 #include <orly/native/all.h>
 #include <orly/native/point.h>
+#include <orly/sabot/compare_types.h>
 #include <orly/sabot/get_hash.h>
 #include <orly/sabot/state_dumper.h>
 #include <orly/sabot/type_dumper.h>
+#include <orly/type/new_sabot.h>
+#include <orly/type/sabot_to_type.h>
+#include <orly/type/self_ref.h>
+#include <orly/type/type_czar.h>
+#include <orly/type/variant.h>
 #include <base/test/kit.h>
 
 using namespace std;
@@ -260,6 +266,37 @@ FIXTURE(Typical) {
   EXPECT_EQ(ToString<Native::TTombstone>(), "tombstone");
   EXPECT_EQ(ToString<void>(), "void");
   EXPECT_EQ(ToString<Native::TFree<bool>>(), "free(bool)");
+}
+
+/* A recursive sum type's #96 fixed-shape record survives the on-disk atom
+   codec (issue #115): the SelfRef tycon round-trips through TCore as a direct
+   scalar carrying its de Bruijn depth.  This is the on-disk half of the
+   new_sabot.test bridge round-trip. */
+FIXTURE(RecursiveType) {
+  static Type::TTypeCzar type_czar;
+  /* tree is <| Leaf(int) | Branch(<{ .l: tree, .r: tree }>) |> */
+  Type::TVariantElems arms;
+  arms["Leaf"] = Type::TInt::Get();
+  arms["Branch"] = Type::TObj::Get({ { "l", Type::TSelfRef::Get(0) }, { "r", Type::TSelfRef::Get(0) } });
+  const Type::TType tree = Type::TVariant::Get(arms);
+
+  TTestArena arena;
+  void *sabot_alloc = alloca(1000);
+  void *back_alloc = alloca(1000);
+  Sabot::Type::TAny::TWrapper sabot(Type::NewSabot(sabot_alloc, tree));
+
+  /* Encode the type to a core tree, then decode it back to a sabot type. */
+  TCore core(&arena, *sabot);
+  Sabot::Type::TAny::TWrapper back(core.GetType(&arena, back_alloc));
+
+  /* The decoded type compares equal to the original, and reverses all the way
+     back to the identical interned orly type. */
+  EXPECT_TRUE(Atom::IsEq(Sabot::CompareTypes(*sabot, *back)));
+  EXPECT_TRUE(Type::ToType(*back) == tree);
+
+  ostringstream strm;
+  back->Accept(Sabot::TTypeDumper(strm));
+  EXPECT_TRUE(strm.str().find("self_ref(0)") != string::npos);
 }
 
 FIXTURE(PinnedLongStr) {

--- a/orly/sabot/compare_types.cc
+++ b/orly/sabot/compare_types.cc
@@ -792,6 +792,9 @@ class TCompareTypesVisitor final
   virtual void operator()(const Type::TTuple &lhs, const Type::TRecord &rhs   ) const override;
   virtual void operator()(const Type::TTuple &lhs, const Type::TTuple &rhs    ) const override;
 
+  /* The recursive back-reference leaf (issue #115). */
+  virtual void OnSelfRef(const Type::TAny &lhs, const Type::TAny &rhs) const override;
+
   private:
 
   /* TODO */
@@ -809,6 +812,25 @@ Atom::TComparison Orly::Sabot::CompareTypes(const Type::TAny &lhs, const Type::T
   Atom::TComparison comp;
   AcceptDouble(lhs, rhs, TCompareTypesVisitor(comp));
   return comp;
+}
+
+/* Two recursive leaves at structurally-corresponding positions are equal iff
+   they refer back to the same binder (same de Bruijn depth); the surrounding
+   structure has already been matched in lock-step to reach here.  A leaf versus
+   a non-leaf are different types -- the leaf sorts first, consistently with
+   OrderTypes. */
+void TCompareTypesVisitor::OnSelfRef(const Type::TAny &lhs, const Type::TAny &rhs) const {
+  const bool lhs_is_ref = lhs.IsRecursiveRef();
+  const bool rhs_is_ref = rhs.IsRecursiveRef();
+  if (lhs_is_ref && rhs_is_ref) {
+    const uint64_t lhs_depth = static_cast<const Type::TSelfRef &>(lhs).GetDepth();
+    const uint64_t rhs_depth = static_cast<const Type::TSelfRef &>(rhs).GetDepth();
+    Comparison = (lhs_depth == rhs_depth)
+        ? TComparison::Eq
+        : (lhs_depth < rhs_depth ? TComparison::Lt : TComparison::Gt);
+    return;
+  }
+  Comparison = lhs_is_ref ? TComparison::Lt : TComparison::Gt;
 }
 
 void TCompareTypesVisitor::operator()(const Type::TInt8 &/*lhs*/, const Type::TInt8 &/*rhs*/     ) const { Comparison = TComparison::Eq; }

--- a/orly/sabot/get_depth.cc
+++ b/orly/sabot/get_depth.cc
@@ -60,6 +60,7 @@ class TDepthVisitor final
   virtual void operator()(const Type::TMap &type) const override;
   virtual void operator()(const Type::TRecord &type) const override;
   virtual void operator()(const Type::TTuple &type) const override;
+  virtual void operator()(const Type::TSelfRef &type) const override;
 
   private:
 
@@ -117,6 +118,10 @@ void TDepthVisitor::operator()(const Type::TRecord &type) const {
   }
   Depth = max_child_depth + 1UL;
 }
+/* The recursive leaf (issue #115) is finite and childless -- it is exactly the
+   device that keeps a recursive type's depth bounded, so it contributes 0.  The
+   enclosing record/variant adds its own +1 as usual. */
+void TDepthVisitor::operator()(const Type::TSelfRef & ) const { Depth = 0UL; }
 void TDepthVisitor::operator()(const Type::TTuple &type ) const {
   size_t max_child_depth = 0UL;
   size_t elem_count = type.GetElemCount();

--- a/orly/sabot/order_types.cc
+++ b/orly/sabot/order_types.cc
@@ -791,6 +791,9 @@ class TOrderTypesVisitor final
   virtual void operator()(const Type::TTuple &lhs, const Type::TRecord &rhs   ) const override;
   virtual void operator()(const Type::TTuple &lhs, const Type::TTuple &rhs    ) const override;
 
+  /* The recursive back-reference leaf (issue #115). */
+  virtual void OnSelfRef(const Type::TAny &lhs, const Type::TAny &rhs) const override;
+
   private:
 
   /* TODO */
@@ -814,6 +817,22 @@ class TOrderTypesVisitor final
 };  // TOrderTypesVisitor
 
 /* TODO */
+/* See the matching note in compare_types.cc: equal de Bruijn depth => equal
+   recursive leaves; a leaf orders before any non-leaf, consistently. */
+void TOrderTypesVisitor::OnSelfRef(const Type::TAny &lhs, const Type::TAny &rhs) const {
+  const bool lhs_is_ref = lhs.IsRecursiveRef();
+  const bool rhs_is_ref = rhs.IsRecursiveRef();
+  if (lhs_is_ref && rhs_is_ref) {
+    const uint64_t lhs_depth = static_cast<const Type::TSelfRef &>(lhs).GetDepth();
+    const uint64_t rhs_depth = static_cast<const Type::TSelfRef &>(rhs).GetDepth();
+    Comparison = (lhs_depth == rhs_depth)
+        ? TComparison::Eq
+        : (lhs_depth < rhs_depth ? TComparison::Lt : TComparison::Gt);
+    return;
+  }
+  Comparison = lhs_is_ref ? TComparison::Lt : TComparison::Gt;
+}
+
 Atom::TComparison Orly::Sabot::OrderTypes(const Type::TAny &lhs, const Type::TAny &rhs) {
   Atom::TComparison comp;
   AcceptDouble(lhs, rhs, TOrderTypesVisitor(comp));

--- a/orly/sabot/type.cc
+++ b/orly/sabot/type.cc
@@ -19,6 +19,7 @@
 #include <orly/sabot/type.h>
 
 #include <cassert>
+#include <stdexcept>
 
 using namespace Orly::Sabot;
 
@@ -80,7 +81,20 @@ ACCEPT(Vector)
 ACCEPT(Map)
 ACCEPT(Record)
 ACCEPT(Tuple)
+ACCEPT(SelfRef)
 #undef ACCEPT
+
+/* The recursive back-reference leaf (issue #115) is not part of the N*N
+   double-dispatch matrix and most visitors never meet it, so both hooks below
+   default to throwing.  Consumers that genuinely handle recursive types
+   override them. */
+void TTypeVisitor::operator()(const Type::TSelfRef &) const {
+  throw std::logic_error("this sabot type visitor does not handle the recursive (TSelfRef) leaf");
+}
+
+void TTypeDoubleVisitor::OnSelfRef(const Type::TAny &, const Type::TAny &) const {
+  throw std::logic_error("this sabot type double-visitor does not handle the recursive (TSelfRef) leaf");
+}
 
 namespace Orly {
 
@@ -190,5 +204,12 @@ namespace Orly {
 }  // Orly
 
 void Orly::Sabot::AcceptDouble(const Type::TAny &lhs, const Type::TAny &rhs, const TTypeDoubleVisitor &double_visitor) {
+  /* Intercept the recursive back-reference leaf (issue #115) at this single
+     chokepoint -- through which both top-level and recursive-descent
+     comparisons flow -- so it stays out of the N*N matrix. */
+  if (lhs.IsRecursiveRef() || rhs.IsRecursiveRef()) {
+    double_visitor.OnSelfRef(lhs, rhs);
+    return;
+  }
   lhs.Accept(TLhsVisitor(rhs, double_visitor));
 }

--- a/orly/sabot/type.h
+++ b/orly/sabot/type.h
@@ -60,6 +60,16 @@ namespace Orly {
       class TTombstone;
       class TVoid;
 
+      /* A recursive back-reference leaf (issue #115).  This is how a recursive
+         sum-type's #96 fixed-shape record stops being infinitely deep: at the
+         point where the record would contain itself, we emit this finite leaf
+         instead, carrying the de Bruijn depth of the enclosing variant binder
+         it refers back to.  It is deliberately kept OUT of the N*N
+         TTypeDoubleVisitor matrix (see TTypeDoubleVisitor::OnSelfRef and
+         AcceptDouble) -- mirroring how the orly type layer keeps its own
+         Type::TSelfRef / Type::TGroupRef out of its TDoubleVisitor. */
+      class TSelfRef;
+
       /* Unary types.  These are base classes which the sabot implementer must finalize. */
       class TDesc;
       class TFree;
@@ -145,6 +155,15 @@ namespace Orly {
 
         /* TODO */
         virtual void Accept(const TTypeVisitor &vistor) const = 0;
+
+        /* True iff this is the recursive back-reference leaf (Type::TSelfRef,
+           issue #115).  Lets AcceptDouble intercept the leaf at the single
+           double-dispatch chokepoint instead of paying for a row+column in the
+           N*N TTypeDoubleVisitor.  A cheap virtual, no dynamic_cast in the hot
+           comparison path. */
+        virtual bool IsRecursiveRef() const {
+          return false;
+        }
 
         protected:
 
@@ -298,6 +317,39 @@ namespace Orly {
       NULLARY_TYPE(Tombstone)
       NULLARY_TYPE(Void)
       #undef NULLARY_TYPE
+
+      /* The recursive back-reference leaf (issue #115).  Like a nullary type --
+         no children, so no TPin -- but it carries a de Bruijn depth payload
+         identifying which enclosing variant binder it refers back to.  Built by
+         the orly->sabot bridge (orly/type/new_sabot.cc) from Type::TSelfRef /
+         Type::TGroupRef, and by the atom layer from a TTycon::SelfRef core. */
+      class TSelfRef final
+          : public TAny {
+        public:
+
+        /* Cache the de Bruijn depth this leaf refers back to. */
+        TSelfRef(uint64_t depth)
+            : Depth(depth) {}
+
+        /* See TAny. */
+        virtual void Accept(const TTypeVisitor &vistor) const override;
+
+        /* See TAny -- this is the recursive leaf. */
+        virtual bool IsRecursiveRef() const override {
+          return true;
+        }
+
+        /* The de Bruijn depth of the enclosing variant binder we refer to. */
+        uint64_t GetDepth() const {
+          return Depth;
+        }
+
+        private:
+
+        /* See accessor. */
+        uint64_t Depth;
+
+      };  // TSelfRef
 
       /* Unary types. */
       #define UNARY_TYPE(name)  \
@@ -483,6 +535,13 @@ namespace Orly {
       virtual void operator()(const Type::TMap &rhs      ) const = 0;
       virtual void operator()(const Type::TRecord &rhs   ) const = 0;
       virtual void operator()(const Type::TTuple &rhs    ) const = 0;
+
+      /* The recursive back-reference leaf (issue #115).  Deliberately NOT pure:
+         it has a default that throws, so the many existing TTypeVisitor
+         subclasses (which never encounter a recursive type) need no change.
+         The handful that do -- the orly<->sabot bridges, get_depth, the atom
+         type encoder, type_dumper -- override it. */
+      virtual void operator()(const Type::TSelfRef &rhs) const;
 
       protected:
 
@@ -1256,6 +1315,13 @@ namespace Orly {
       virtual void operator()(const Type::TTuple &lhs, const Type::TMap &rhs      ) const = 0;
       virtual void operator()(const Type::TTuple &lhs, const Type::TRecord &rhs   ) const = 0;
       virtual void operator()(const Type::TTuple &lhs, const Type::TTuple &rhs    ) const = 0;
+
+      /* The recursive back-reference leaf (issue #115).  AcceptDouble routes
+         here whenever EITHER side is a Type::TSelfRef, so the leaf never needs
+         a row or column in the N*N matrix above.  Not pure: the default throws,
+         so only the consumers that can actually meet a recursive type
+         (CompareTypes, OrderTypes) override it; the rest inherit the throw. */
+      virtual void OnSelfRef(const Type::TAny &lhs, const Type::TAny &rhs) const;
 
       protected:
 

--- a/orly/sabot/type_dumper.cc
+++ b/orly/sabot/type_dumper.cc
@@ -143,6 +143,10 @@ void TTypeDumper::operator()(const Type::TRecord &type) const {
   Strm << ')';
 }
 
+void TTypeDumper::operator()(const Type::TSelfRef &type) const {
+  Strm << "self_ref(" << type.GetDepth() << ')';
+}
+
 void TTypeDumper::operator()(const Type::TTuple &type) const {
   Strm << "tuple(";
   size_t elem_count = type.GetElemCount();

--- a/orly/sabot/type_dumper.h
+++ b/orly/sabot/type_dumper.h
@@ -67,6 +67,7 @@ namespace Orly {
       virtual void operator()(const Type::TMap &type) const override;
       virtual void operator()(const Type::TRecord &type) const override;
       virtual void operator()(const Type::TTuple &type) const override;
+      virtual void operator()(const Type::TSelfRef &type) const override;
 
       private:
 

--- a/orly/type/new_sabot.cc
+++ b/orly/type/new_sabot.cc
@@ -87,11 +87,17 @@ Sabot::Type::TAny *Orly::Type::TryNewSabot(void *buf, const Type::TType &type) {
        reverses the mapping (the `$which` sentinel field, un-expressible in
        orlyscript, marks the record as a variant). */
     virtual void operator()(const TVariant *type) const override {
-      /* A RECURSIVE variant (issue #103) has no translation: its fixed-shape
-         record encoding would contain itself, and the sabot type vocabulary
-         cannot express the cycle. Storing (or returning to a client) a
-         recursive variant value is a v1 limitation; see issue #103. */
-      if (HasSelfRef(type->AsType())) {
+      /* A self-recursive variant (issue #103/#115) encodes to the same #96
+         fixed-shape record; the cycle is broken by emitting a finite
+         Sabot::Type::TSelfRef leaf at each recursion point (the TSelfRef case
+         below), so the record is no longer infinitely deep.
+
+         A MUTUAL-group variant (its arms carry Type::TGroupRef, #116) is not
+         yet storable: lowering it would require inlining the group to its de
+         Bruijn form first. Those still return no translation (the TGroupRef
+         case below), so MakeRecGroup members keep failing translation cleanly
+         until that follow-on lands. */
+      if (HasGroupRef(type->AsType())) {
         return;
       }
       TObjElems rec;
@@ -101,10 +107,14 @@ Sabot::Type::TAny *Orly::Type::TryNewSabot(void *buf, const Type::TType &type) {
       }
       Result = new (Buf) ST::TRecord(TObj::Get(rec).As<TObj>());
     }
-    /* Reachable only through a recursive variant's payload map, which the
-       TVariant case above already rejects -- but be explicit anyway. */
-    virtual void operator()(const TSelfRef */*type*/) const override {}
-    /* Likewise reachable only through a mutual group's payload map (#116). */
+    /* The recursion point of a self-recursive variant (issue #115): emit the
+       finite sabot back-reference leaf carrying the de Bruijn depth.  This is
+       what stops the fixed-shape record encoding from being infinitely deep. */
+    virtual void operator()(const TSelfRef *type) const override {
+      Result = new (Buf) Sabot::Type::TSelfRef(type->GetDepth());
+    }
+    /* A mutual group's cross/self reference (#116) -- not yet translatable;
+       see the TVariant case above. */
     virtual void operator()(const TGroupRef */*type*/) const override {}
     private:
     Sabot::Type::TAny *&Result;

--- a/orly/type/new_sabot.test.cc
+++ b/orly/type/new_sabot.test.cc
@@ -23,9 +23,13 @@
 #include <sstream>
 #include <string>
 
+#include <orly/sabot/compare_types.h>
 #include <orly/sabot/type_dumper.h>
 #include <orly/native/all.h>
+#include <orly/type/sabot_to_type.h>
+#include <orly/type/self_ref.h>
 #include <orly/type/type_czar.h>
+#include <orly/type/variant.h>
 #include <base/test/kit.h>
 
 using namespace std;
@@ -56,4 +60,70 @@ FIXTURE(Typical) {
   EXPECT_EQ(ToString(Type::TAddr::Get({ { TAddrDir::Asc, Type::TReal::Get() } })), "tuple(double)");
   EXPECT_EQ(ToString(Type::TAddr::Get({ { TAddrDir::Desc, Type::TReal::Get() } })), "tuple(desc(double))");
   EXPECT_EQ(ToString(Type::TObj::Get({ { "x", Type::TReal::Get() }, { "y", Type::TReal::Get() } })), "record(x: double, y: double)");
+}
+
+/* Recursive sum types (issue #115).  A self-recursive variant translates to its
+   #96 fixed-shape record with a finite self_ref leaf at each recursion point,
+   and round-trips back to the identical interned orly type. */
+
+/* tree is <| Leaf(int) | Branch(<{ .l: tree, .r: tree }>) |> */
+static Type::TType MakeTree() {
+  Type::TVariantElems arms;
+  arms["Leaf"] = Type::TInt::Get();
+  arms["Branch"] = Type::TObj::Get({ { "l", Type::TSelfRef::Get(0) }, { "r", Type::TSelfRef::Get(0) } });
+  return Type::TVariant::Get(arms);
+}
+
+/* json is <| Null | N(int) | Arr([json]) | Obj({str: json}) |> -- self-ref under
+   a list and under a dict value (the #120 container family). */
+static Type::TType MakeJson() {
+  Type::TVariantElems arms;
+  arms["Null"] = Type::TObj::Get({});
+  arms["N"] = Type::TInt::Get();
+  arms["Arr"] = Type::TList::Get(Type::TSelfRef::Get(0));
+  arms["Obj"] = Type::TDict::Get(Type::TStr::Get(), Type::TSelfRef::Get(0));
+  return Type::TVariant::Get(arms);
+}
+
+static Type::TType RoundTrip(const Type::TType &type) {
+  return Type::ToType(*Sabot::Type::TAny::TWrapper(NewSabot(alloca(1000), type)));
+}
+
+FIXTURE(RecursiveVariantTranslates) {
+  /* The cycle becomes a finite self_ref leaf -- no infinite materialization. */
+  const string dump = ToString(MakeTree());
+  EXPECT_TRUE(dump.find("$which") != string::npos);
+  EXPECT_TRUE(dump.find("self_ref(0)") != string::npos);
+}
+
+FIXTURE(RecursiveVariantRoundTrips) {
+  /* orly type -> sabot -> orly type is the identity on the interned type. */
+  const Type::TType tree = MakeTree();
+  EXPECT_TRUE(RoundTrip(tree) == tree);
+
+  const Type::TType json = MakeJson();
+  EXPECT_TRUE(RoundTrip(json) == json);
+
+  /* Distinct recursive types stay distinct through translation. */
+  EXPECT_FALSE(RoundTrip(tree) == json);
+
+  /* A back-reference at de Bruijn depth 1 -- an inner variant whose arm refers
+     to the OUTER variant (the #125 nested-variant shape) -- carries its depth
+     through translation too. */
+  Type::TVariantElems outer;
+  outer["X"] = Type::TVariant::Get({ { "Y", Type::TSelfRef::Get(1) } });
+  const Type::TType nested = Type::TVariant::Get(outer);
+  EXPECT_TRUE(RoundTrip(nested) == nested);
+}
+
+FIXTURE(RecursiveVariantCompareTypes) {
+  /* The sabot-level CompareTypes agrees with orly-type identity for recursive
+     types (set homogeneity / key ordering rides on this). */
+  void *a = alloca(1000), *b = alloca(1000), *c = alloca(1000);
+  Sabot::Type::TAny::TWrapper tree_a(NewSabot(a, MakeTree()));
+  Sabot::Type::TAny::TWrapper tree_b(NewSabot(b, MakeTree()));
+  EXPECT_TRUE(Atom::IsEq(Sabot::CompareTypes(*tree_a, *tree_b)));
+
+  Sabot::Type::TAny::TWrapper json_c(NewSabot(c, MakeJson()));
+  EXPECT_FALSE(Atom::IsEq(Sabot::CompareTypes(*tree_a, *json_c)));
 }

--- a/orly/type/sabot_to_type.cc
+++ b/orly/type/sabot_to_type.cc
@@ -20,6 +20,7 @@
 
 #include <orly/type/obj.h>
 #include <orly/type/opt.h>
+#include <orly/type/self_ref.h>
 #include <orly/type/util.h>
 #include <orly/type/variant.h>
 
@@ -104,6 +105,14 @@ void Type::TToTypeVisitor::operator()(const Sabot::Type::TRecord &type) const   
     return;
   }
   Type = TObj::Get(obj_elem_map);
+}
+/* The recursive back-reference leaf (issue #115): the dual of the TSelfRef
+   case in orly/type/new_sabot.cc.  Reconstruct the orly de Bruijn self-ref at
+   the same depth; the enclosing TVariant::Get re-interns the whole recursive
+   variant (variants are the binders -- issue #103), so the round-tripped type
+   is pointer-equal to the original. */
+void Type::TToTypeVisitor::operator()(const Sabot::Type::TSelfRef &type) const       {
+  Type = Type::TSelfRef::Get(type.GetDepth());
 }
 void Type::TToTypeVisitor::operator()(const Sabot::Type::TTuple &type) const          {
   size_t elem_count = type.GetElemCount();

--- a/orly/type/sabot_to_type.h
+++ b/orly/type/sabot_to_type.h
@@ -77,6 +77,7 @@ namespace Orly {
       virtual void operator()(const Sabot::Type::TMap &type) const override;
       virtual void operator()(const Sabot::Type::TRecord &type) const override;
       virtual void operator()(const Sabot::Type::TTuple &type) const override;
+      virtual void operator()(const Sabot::Type::TSelfRef &type) const override;
 
       private:
 


### PR DESCRIPTION
First phase of **issue #115** (storage & client marshaling of recursive variants), following the planning pass's **Option B** and the de-risk-in-isolation approach that worked for #130.

## What this does

Teaches the **sabot type vocabulary** to express the cycle in a recursive sum type's #96 fixed-shape record. Until now a recursive variant's record contained itself (every arm's optional payload needs its element type), so the sabot type would be infinitely deep — which is exactly why storing one was a compile error.

A single finite leaf, `Sabot::Type::TSelfRef`, carries the **de Bruijn depth** of the enclosing variant binder it refers back to. At each recursion point the `orly -> sabot` bridge emits this leaf instead of recursing forever.

Per Option B, the leaf is kept **out of the N×N `TTypeDoubleVisitor`** (`compare_types` / `order_types`, ~780 hand-written cases each). It is intercepted at the single double-dispatch chokepoint, `AcceptDouble`, via a cheap `TAny::IsRecursiveRef()` virtual and a non-pure `TTypeDoubleVisitor::OnSelfRef` hook — mirroring how the orly type layer keeps *its* `TSelfRef`/`TGroupRef` out of *its* `TDoubleVisitor`. The `TTypeVisitor` hook is likewise non-pure (default throws), so the many existing visitors that never meet a recursive type need no change.

## Layers wired

- `sabot/type.{h,cc}` — the leaf, `IsRecursiveRef`, `OnSelfRef`, `AcceptDouble` interception.
- `sabot/get_depth`, `compare_types`, `order_types`, `type_dumper` — leaf handling (bounded depth; equal de Bruijn depth ⇒ equal leaves; a leaf orders before any non-leaf, consistently).
- `atom/kit2` — a `TTycon::SelfRef` **appended last** (on-disk-compatible), stored like a direct scalar holding the depth: `InitSelfRef`, the type encoder, `GetType`, `TryGetOffset`, and the quick compare/order/hash/match paths.
- `type/new_sabot.cc` — drop the recursive-variant rejection; `TSelfRef -> leaf`. Mutual groups (`TGroupRef` arms) still return no translation — a documented follow-on.
- `type/sabot_to_type.cc` — `leaf -> orly TSelfRef`; the enclosing `TVariant::Get` re-interns the whole recursive type.

## Tests

Unit-tested in isolation:
- `type/new_sabot.test` — `tree`, `json` (list/dict of self), and a depth-1 nested back-reference round-trip `orly type -> sabot -> orly type` to the **identical interned type**; `CompareTypes` agrees with orly-type identity.
- `atom/kit2.test` — the same recursive type survives the on-disk `TCore` codec (the `SelfRef` tycon round-trips as a direct scalar).

Full sabot/atom/type test suites pass; `orlyi` and `orlyc` build clean.

## Scope / what's next

The `<-` store guard and the `AsVar()` / read-back stubs are **untouched**, so end-to-end storage stays blocked. This PR is purely the type machinery. Follow-ons:
- **phase 3** — value read-back (real `TToNativeVisitor` / `State::Factory` reconstructing boxed payloads), `var/sabot_to_var`.
- **phase 4** — lift the guards (`new_and_delete.cc`, the two `AsVar` throws); WS marshaling rides along.
- **phase 5** — lang tests (store/retrieve/return single-recursive values + stored set).
- mutual-recursion storage (`TGroupRef`) — needs inlining the group to its de Bruijn form first.