### PR TITLE
code_gen: store & read back recursive variant values (#115 phase 3+4)

### DIFF
--- a/orly/code_gen/package.cc
+++ b/orly/code_gen/package.cc
@@ -34,6 +34,7 @@
 #include <orly/type/impl.h>
 #include <orly/type/object_collector.h> //TODO: This header should be renamed
 #include <orly/type/orlyify.h>
+#include <orly/type/self_ref.h>
 #include <orly/type/util.h>
 #include <orly/type/variant.h>
 #include <orly/expr/util.h>
@@ -544,6 +545,12 @@ void TPackage::WriteLink(TCppPrinter &out, const TRelPath &path) const {
                                 out << "}";
                               })
                       << "})";
+                  };
+                  virtual void operator()(const Type::TSelfRef  *that) const {
+                    /* The recursion point of a stored recursive variant
+                       (#115): reconstruct the de Bruijn self-reference so the
+                       enclosing TVariant::Get re-interns the recursive type. */
+                    Out << "Orly::Type::TSelfRef::Get(" << that->GetDepth() << ")";
                   };
                   virtual void operator()(const Type::TOpt      *that) const {
                     Out << "Orly::Type::TOpt::Get(";

--- a/orly/code_gen/variant.cc
+++ b/orly/code_gen/variant.cc
@@ -181,6 +181,43 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
     assert(false);
     return Base::AsStr(t);
   };
+  /* Like subst_storage, but maps a free self-reference to the variant itself
+     (`class_name`) rather than to its boxed storage -- i.e. the UNROLLED type,
+     expressed through containers WITHOUT ever naming a separate unrolled
+     record/variant class. This is the device that lets the read-back
+     (Sabot::TToNativeVisitor) and write-back (AsVar) name only the variant and
+     self-free types: naming the unrolled payload record directly would pull in
+     its header, which includes this one back -- exactly the cycle the boxed
+     member-template getter/factory design avoids (#115). A self-free subtree
+     prints verbatim; a record/variant payload is handled field-by-field by the
+     boxed struct's own AsVar/FromState, never through this helper. */
+  std::function<string (const Type::TType &)> unrolled_over_self =
+      [&](const Type::TType &t) -> string {
+    if (!Type::HasFreeSelfRef(t)) {
+      return Base::AsStr(t);
+    }
+    if (t.Is<Type::TSelfRef>()) {
+      /* Fully qualified: this string is used both in namespace
+         Orly::Rt::Variants (AsVar/FromState) and Orly::Sabot
+         (TToNativeVisitor), where the bare class name is not in scope. */
+      return Base::AsStr("Orly::Rt::Variants::", class_name);
+    }
+    if (const auto *list = t.TryAs<Type::TList>()) {
+      return Base::AsStr("std::vector<", unrolled_over_self(list->GetElem()), '>');
+    }
+    if (const auto *set = t.TryAs<Type::TSet>()) {
+      return Base::AsStr("Orly::Rt::TSet<", unrolled_over_self(set->GetElem()), '>');
+    }
+    if (const auto *opt = t.TryAs<Type::TOpt>()) {
+      return Base::AsStr("Orly::Rt::TOpt<", unrolled_over_self(opt->GetElem()), '>');
+    }
+    if (const auto *dict = t.TryAs<Type::TDict>()) {
+      return Base::AsStr("Orly::Rt::TDict<", Base::AsStr(dict->GetKey()), ", ",
+                         unrolled_over_self(dict->GetVal()), '>');
+    }
+    assert(false);
+    return Base::AsStr(t);
+  };
   /* The C++ type in which an arm's payload is stored. */
   auto storage_type = [&](const string &tag, const Type::TType &payload) {
     if (Type::HasFreeSelfRef(payload) && payload.Is<Type::TObj>()) {
@@ -315,6 +352,14 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
               << "  bool MatchLess(const " << bname << " &that) const;" << Eol
               << "  size_t GetHash() const;" << Eol
               << Eol
+              << "  /* Storage read/write (#115). Defined after " << class_name << " (they" << Eol
+              << "     recurse through it). AsVar builds a dynamic Var::TObj from the" << Eol
+              << "     fields (self fields unbox + recurse); FromState rebuilds the boxed" << Eol
+              << "     record from a stored sabot record. Both name only " << class_name << " and" << Eol
+              << "     self-free field types -- never the unrolled record (no header cycle). */" << Eol
+              << "  Var::TVar AsVar() const;" << Eol
+              << "  static " << bname << " FromState(const Orly::Sabot::State::TRecord &state);" << Eol
+              << Eol
               << "  private:" << Eol;
           for (const auto &field : fields) {
             out << "  " << subst_storage(field.second) << " V" << field.first << ";" << Eol;
@@ -438,6 +483,26 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
             } else {
               out << "static " << class_name << " Mk" << elem.first
                   << "(const " << elem.second << " &vv) {" << Eol
+                  << "  " << class_name << " out;" << Eol
+                  << "  out.Which = " << idx << ";" << Eol
+                  << "  out.V" << elem.first << " = vv;" << Eol
+                  << "  return out;" << Eol
+                  << "}" << Eol;
+            }
+            ++idx;
+          }
+        }
+
+        /* Read-back factory for a boxed-record arm (#115): construct directly
+           from the already-boxed payload struct (which the storage read path
+           rebuilds via <Boxed>::FromState), bypassing the unrolled-payload
+           Mk<Tag> above so the header never names the unrolled record. */
+        {
+          size_t idx = 0;
+          for (const auto &elem : elems) {
+            if (arm_is_recursive(elem.second) && elem.second.Is<Type::TObj>()) {
+              out << "static " << class_name << " MkBoxed" << elem.first
+                  << "(const " << boxed_name(elem.first) << " &vv) {" << Eol
                   << "  " << class_name << " out;" << Eol
                   << "  out.Which = " << idx << ";" << Eol
                   << "  out.V" << elem.first << " = vv;" << Eol
@@ -708,6 +773,63 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
                             })
               << ';' << Eol
               << "}" << Eol;
+
+          /* AsVar (#115): build a dynamic Var::TObj from the fields. A self /
+             container-of-self field unboxes to its UNROLLED form (naming only
+             this variant) and Var::TVar recurses into it (records/variants have
+             AsVar); a self-free field converts directly. */
+          out << Eol
+              << "inline Var::TVar " << bname << "::AsVar() const {" << Eol
+              << "  return Var::TVar::Obj(std::unordered_map<std::string, Var::TVar>{"
+              << Base::Join(fields,
+                            ", ",
+                            [&](TCppPrinter &strm, const Type::TObj::TElems::value_type &it) {
+                              strm << "{\"" << it.first << "\", Var::TVar(";
+                              if (Type::HasFreeSelfRef(it.second)) {
+                                strm << "Rt::DeepUnbox<" << unrolled_over_self(it.second)
+                                     << ">(V" << it.first << ')';
+                              } else {
+                                strm << 'V' << it.first;
+                              }
+                              strm << ")}";
+                            })
+              << "});" << Eol
+              << "}" << Eol;
+
+          /* FromState (#115): rebuild this boxed record from a stored sabot
+             record. Walk the fields by name; a self / container-of-self field
+             is reconstructed in its UNROLLED form (AsNative recurses through
+             this variant) then re-boxed, a self-free field deserializes
+             directly. */
+          out << Eol
+              << "inline " << bname << " " << bname
+              << "::FromState(const Orly::Sabot::State::TRecord &state) {" << Eol
+              << "  " << bname << " out;" << Eol
+              << "  void *type_alloc = alloca(Sabot::Type::GetMaxTypeSize());" << Eol
+              << "  Sabot::Type::TRecord::TWrapper rtype(state.GetRecordType(type_alloc));" << Eol
+              << "  void *type_pin_alloc = alloca(Sabot::Type::GetMaxTypePinSize());" << Eol
+              << "  Sabot::Type::TRecord::TPin::TWrapper tpin(rtype->Pin(type_pin_alloc));" << Eol
+              << "  void *state_pin_alloc = alloca(Sabot::State::GetMaxStatePinSize());" << Eol
+              << "  Sabot::State::TRecord::TPin::TWrapper spin(state.Pin(state_pin_alloc));" << Eol
+              << "  const size_t elem_count = tpin->GetElemCount();" << Eol
+              << "  void *etype_alloc = alloca(Sabot::Type::GetMaxTypeSize());" << Eol
+              << "  void *estate_alloc = alloca(Sabot::State::GetMaxStateSize());" << Eol
+              << "  std::string field_name;" << Eol
+              << "  for (size_t i = 0; i < elem_count; ++i) {" << Eol
+              << "    Sabot::Type::TAny::TWrapper(tpin->NewElem(i, field_name, etype_alloc));" << Eol
+              << "    Sabot::State::TAny::TWrapper fstate(spin->NewElem(i, estate_alloc));" << Eol;
+          for (const auto &field : fields) {
+            out << "    if (field_name == \"" << field.first << "\") { out.V" << field.first << " = ";
+            if (Type::HasFreeSelfRef(field.second)) {
+              out << "Rt::DeepBox<" << subst_storage(field.second) << ">(Sabot::AsNative<"
+                  << unrolled_over_self(field.second) << ">(*fstate)); }" << Eol;
+            } else {
+              out << "Sabot::AsNative<" << field.second << ">(*fstate); }" << Eol;
+            }
+          }
+          out << "  }" << Eol
+              << "  return out;" << Eol
+              << "}" << Eol;
         }
         /* Inline nested-variant structs' comparison bodies (deferred: they
            deref TBox<outer> fields, so the outer must be complete). */
@@ -841,27 +963,46 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
      reported at runtime rather than silently mis-encoded. */ {
     TNamespacePrinter nsp(vector<string>{"Orly", "Rt", "Variants"}, out);
     out << "inline Var::TVar " << class_name << "::AsVar() const {" << Eol
-        << "  assert(this);" << Eol;
-    if (is_recursive) {
-      out << "  throw Rt::TSystemError(HERE, \"a recursive variant value cannot be stored or "
-             "returned from a package function; see issue #103\");" << Eol
-          << "}" << Eol;
-    } else {
-      out << "  switch (Which) {" << Eol;
-      {
-        size_t idx = 0;
-        for (const auto &elem : elems) {
-          out << "    case " << idx << ": return Var::TVar::Variant("
+        << "  assert(this);" << Eol
+        << "  switch (Which) {" << Eol;
+    {
+      size_t idx = 0;
+      for (const auto &elem : elems) {
+        const auto &payload = elem.second;
+        out << "    case " << idx << ": ";
+        if (arm_is_nested_variant(payload)) {
+          /* A nested-variant arm payload (#125) is stored as an inline struct;
+             its dynamic-var/sabot marshaling is a #115 follow-on. (Statement,
+             not `return throw` -- the latter is ill-formed.) */
+          out << "throw Rt::TSystemError(HERE, \"storing a variant with a "
+                 "nested-variant arm is not yet supported; see issue #115\")";
+        } else {
+          out << "return Var::TVar::Variant("
               << "Type::TDt<Rt::Variants::" << class_name << ">::GetType(), \""
-              << elem.first << "\", Var::TVar(V" << elem.first << "));" << Eol;
-          ++idx;
+              << elem.first << "\", ";
+          if (arm_is_recursive(payload) && payload.Is<Type::TObj>()) {
+            /* Boxed-record arm: the boxed struct builds its own Var::TObj,
+               recursing into self fields -- without naming the unrolled record. */
+            out << "V" << elem.first << ".AsVar()";
+          } else if (arm_is_recursive(payload)) {
+            /* Self-ref / container-of-self / opt-of-self arm: unbox to the
+               unrolled value (naming only this variant) and let Var::TVar
+               recurse into it. */
+            out << "Var::TVar(Rt::DeepUnbox<" << unrolled_over_self(payload)
+                << ">(V" << elem.first << "))";
+          } else {
+            out << "Var::TVar(V" << elem.first << ")";
+          }
+          out << ")";
         }
+        out << ";" << Eol;
+        ++idx;
       }
-      out << "  }" << Eol
-          << "  assert(false);" << Eol
-          << "  throw Rt::TSystemError(HERE, \"variant has no active arm\");" << Eol
-          << "}" << Eol;
     }
+    out << "  }" << Eol
+        << "  assert(false);" << Eol
+        << "  throw Rt::TSystemError(HERE, \"variant has no active arm\");" << Eol
+        << "}" << Eol;
   } // namespace Orly::Rt::Variants
 
   out << Eol;
@@ -891,12 +1032,7 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
             << " &) const override { THROW_ERROR(TInvalidConversion); }" << Eol;
       }
     }
-    if (is_recursive) {
-      /* A recursive variant is never stored (#103: its fixed-shape record
-         type would be infinitely deep), so there is nothing to read back. */
-      out << "  virtual void operator()(const State::TRecord &) const override {"
-          << " THROW_ERROR(TInvalidConversion); }" << Eol;
-    } else {
+    {
     out << "  virtual void operator()(const State::TRecord &state) const override {" << Eol
         << "    void *type_alloc = alloca(Type::GetMaxTypeSize());" << Eol
         << "    Type::TRecord::TWrapper rtype(state.GetRecordType(type_alloc));" << Eol
@@ -937,10 +1073,29 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
             << "      if (!opt) { THROW_ERROR(TInvalidConversion); }" << Eol
             << "      State::TOpt::TPin::TWrapper opin(opt->Pin(opt_pin_alloc));" << Eol
             << "      if (opin->GetElemCount() != 1) { THROW_ERROR(TInvalidConversion); }" << Eol
-            << "      State::TAny::TWrapper payload_state(opin->NewElem(0, payload_alloc));" << Eol
-            << "      Out = Rt::Variants::" << class_name << "::Mk" << elem.first
-            << "(AsNative<" << elem.second << ">(*payload_state));" << Eol
-            << "    }" << Eol;
+            << "      State::TAny::TWrapper payload_state(opin->NewElem(0, payload_alloc));" << Eol;
+        const auto &payload = elem.second;
+        if (arm_is_nested_variant(payload)) {
+          /* Reading a stored nested-variant arm (#125) is a #115 follow-on. */
+          out << "      THROW_ERROR(TInvalidConversion);" << Eol;
+        } else if (arm_is_recursive(payload) && payload.Is<Type::TObj>()) {
+          /* Boxed-record arm: rebuild the boxed struct from the stored sabot
+             record (recursing through this variant), then construct the arm --
+             without the header ever naming the unrolled record. */
+          out << "      const State::TRecord *prec = dynamic_cast<const State::TRecord *>(payload_state.get());" << Eol
+              << "      if (!prec) { THROW_ERROR(TInvalidConversion); }" << Eol
+              << "      Out = Rt::Variants::" << class_name << "::MkBoxed" << elem.first
+              << "(Rt::Variants::" << boxed_name(elem.first) << "::FromState(*prec));" << Eol;
+        } else if (arm_is_recursive(payload)) {
+          /* Self-ref / container-of-self / opt-of-self arm: reconstruct the
+             unrolled payload (naming only this variant) and box it via Mk<Tag>. */
+          out << "      Out = Rt::Variants::" << class_name << "::Mk" << elem.first
+              << "(AsNative<" << unrolled_over_self(payload) << ">(*payload_state));" << Eol;
+        } else {
+          out << "      Out = Rt::Variants::" << class_name << "::Mk" << elem.first
+              << "(AsNative<" << payload << ">(*payload_state));" << Eol;
+        }
+        out << "    }" << Eol;
         ++idx;
       }
     }

--- a/orly/symbol/stmt/new_and_delete.cc
+++ b/orly/symbol/stmt/new_and_delete.cc
@@ -80,13 +80,16 @@ void TNew::TypeCheck() const {
   /* NOTE: Maybe this should be type check rather than get type. But for now,
            GetType() calls ComputeType() which does the type check. */
   Type::TType value_type = GetRhs()->GetExpr()->GetType();
-  /* A recursive variant has no storage encoding in v1 (the sabot type
-     vocabulary cannot express the recursion); reject the write here with
-     a real message rather than letting a downstream visitor choke on the
-     self-reference. See issue #103. */
-  if (Type::HasSelfRef(value_type)) {
+  /* Self-recursive variants are now storable: their #96 fixed-shape record
+     encoding closes the cycle with a finite Sabot::Type::TSelfRef leaf, and the
+     value read/write round-trips through the boxed payload representation
+     (issue #115). A MUTUALLY-recursive variant (Type::TGroupRef) is not yet --
+     its sabot encoding needs the group inlined to de Bruijn form first -- so
+     reject that write here with a clear message rather than letting
+     orly/type/new_sabot.cc fail translation at runtime. */
+  if (Type::HasGroupRef(value_type)) {
     throw TExprError(HERE, GetPosRange(),
-        "a value containing a recursive variant cannot be stored (issue #103)");
+        "a value containing a mutually-recursive variant cannot be stored yet (issue #116/#115)");
   }
 }
 

--- a/tests/lang_tests/general/.variants_recursive_storage.orly.test.state
+++ b/tests/lang_tests/general/.variants_recursive_storage.orly.test.state
@@ -1,0 +1,21 @@
+[
+  0,
+  [
+    [],
+    [
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++"
+    ],
+    [
+      "Running tests"
+    ],
+    [
+      "Tests done"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/variants_recursive_storage.orly
+++ b/tests/lang_tests/general/variants_recursive_storage.orly
@@ -1,0 +1,104 @@
+/* <orly/lang_tests/general/variants_recursive_storage.orly>
+
+   End-to-end test for issue #115: a RECURSIVE sum-type value round-trips
+   through storage (`<-` / `*`).
+
+   Recursion is closed at the sabot type layer by a finite TSelfRef leaf
+   carrying the de Bruijn depth (#115 phase 1), so a recursive variant's
+   #96 fixed-shape record is no longer infinitely deep. The VALUE is a
+   finite tree of those records; the generated AsVar walks the boxed
+   payload down to the recursion points and the Sabot::TToNativeVisitor
+   rebuilds it on read-back, re-boxing each self field (#115 phase 3).
+
+   This covers the shapes the storage path supports: a record arm with
+   self fields (`tree`, `intlist`), a tag-only base arm, and a
+   container-of-self arm (`json`'s `JArr([json])`). Mutually-recursive
+   variants (#116) are still rejected at the `<-` typecheck.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+tree is <| Leaf(int) | Branch(<{.l: tree, .r: tree}>) |>;
+intlist is <| Nil | Cons(<{.head: int, .tail: intlist}>) |>;
+json is <| JNull | JNum(int) | JArr([json]) |>;
+
+read_tree = (*<[n]>::(tree)) where {
+  n = given::(int);
+};
+
+read_list = (*<[n]>::(intlist)) where {
+  n = given::(int);
+};
+
+read_json = (*<[n]>::(json)) where {
+  n = given::(int);
+};
+
+read_tree_set = (*<[n]>::({tree})) where {
+  n = given::(int);
+};
+
+/* A binary tree (record arm with two self fields) round-trips. */
+with {
+  <[500]> <- tree.Branch(<{.l: tree.Leaf(1), .r:
+             tree.Branch(<{.l: tree.Leaf(2), .r: tree.Leaf(3)}>)}>);
+} test {
+  t1: read_tree(.n: 500) == tree.Branch(<{.l: tree.Leaf(1), .r:
+        tree.Branch(<{.l: tree.Leaf(2), .r: tree.Leaf(3)}>)}>);
+  /* A structurally different tree is not equal. */
+  t2: read_tree(.n: 500) != tree.Leaf(1);
+  t3: read_tree(.n: 500) != tree.Branch(<{.l: tree.Leaf(1), .r:
+        tree.Branch(<{.l: tree.Leaf(2), .r: tree.Leaf(9)}>)}>);
+  /* Read-back is destructurable like any variant. */
+  t4: read_tree(.n: 500) is Branch;
+  t5: (read_tree(.n: 500).Branch).l.Leaf == 1;
+};
+
+/* A tag-only base arm (`Leaf` here is the non-recursive arm). */
+with {
+  <[501]> <- tree.Leaf(42);
+} test {
+  t6: read_tree(.n: 501) == tree.Leaf(42);
+  t7: read_tree(.n: 501) != tree.Leaf(43);
+};
+
+/* A linked list (record arm + tag-only `Nil` base). */
+with {
+  <[502]> <- intlist.Cons(<{.head: 1, .tail:
+             intlist.Cons(<{.head: 2, .tail:
+             intlist.Cons(<{.head: 3, .tail: intlist.Nil()}>)}>)}>);
+} test {
+  t8: read_list(.n: 502) == intlist.Cons(<{.head: 1, .tail:
+        intlist.Cons(<{.head: 2, .tail:
+        intlist.Cons(<{.head: 3, .tail: intlist.Nil()}>)}>)}>);
+  t9: read_list(.n: 502) != intlist.Nil();
+};
+
+/* A container-of-self arm: `JArr([json])` (#120 family). */
+with {
+  <[503]> <- json.JArr([json.JNum(1), json.JNull(), json.JArr([json.JNum(2)])]);
+} test {
+  t10: read_json(.n: 503) == json.JArr([json.JNum(1), json.JNull(), json.JArr([json.JNum(2)])]);
+  t11: read_json(.n: 503) != json.JArr([json.JNum(1)]);
+  t12: read_json(.n: 503) is JArr;
+};
+
+/* A SET of recursive values stays homogeneous on disk (the #96 fixed-shape
+   record makes every variant value share one element type), and dedups. */
+with {
+  <[504]> <- {tree.Leaf(1), tree.Leaf(1), tree.Leaf(2),
+              tree.Branch(<{.l: tree.Leaf(1), .r: tree.Leaf(2)}>)};
+} test {
+  t13: length_of read_tree_set(.n: 504) == 3;
+};


### PR DESCRIPTION
Stacked on #135 (phase 1). Lifts the recursive-variant **storage boundary end to end**: a self-recursive variant value now round-trips through `<-` / `*`.

```
tree is <| Leaf(int) | Branch(<{.l: tree, .r: tree}>) |>;
<[500]> <- tree.Branch(<{.l: tree.Leaf(1), .r: tree.Leaf(2)}>);   // store
*<[500]>::(tree)                                                  // read it back
```

## The problem

The value is a finite tree of #96 fixed-shape records, but the in-memory payload is stored **boxed** (`Rt::TBox`), so `AsVar` (write) and `Sabot::TToNativeVisitor` (read) must cross between the boxed form and the dynamic-var/sabot world at every recursion point.

The hard constraint: those two live in the variant **header** and must **not name the unrolled payload record** of a boxed-record arm — that record's header includes the variant's back (the exact cycle the boxed member-template getter/factory design exists to avoid).

## The approach

- **`unrolled_over_self`** — expresses a payload's unrolled type naming only the variant itself (`self → the variant`, through containers), never a separate record. Self-ref / container-of-self / opt-of-self arms use it directly (`AsNative<unrolled>` / `DeepUnbox<unrolled>`).
- **Boxed-record arms** (tree, linked list — the common case) get deferred `AsVar()` + `FromState()` on the `_Boxed` struct (defined after the variant is complete, like its `EqEq`), walking fields and recursing through the variant for self fields. The header names only the variant + self-free field types.
- **`MkBoxed<Tag>`** reconstructs the arm from a rebuilt boxed struct.
- The `TToNativeVisitor` `TRecord` reader is **unified**: non-recursive arms emit byte-identical code to before; recursive arms dispatch by shape.

Recursion bottoms out naturally — nested values reconstruct via `AsNative<self>` (the same visitor, finite because the value is finite) and convert via the variant's own `AsVar`.

Also: `TPackage::WriteLink`'s type-link printer gains a `TSelfRef` case (so the package link table can describe a stored recursive type), and the `<-` typecheck now allows self-recursion while still rejecting **mutual** recursion (`TGroupRef`).

## Tests

`variants_recursive_storage.orly` stores/reads a binary tree (record arm), a linked list (record arm + tag-only base), a container-of-self `json` variant, and a deduped **set** of recursive values. Full lang suite: **0 unexpected, 142 passed** (the 3 package-internal recursive tests #103/#125 still green — the codegen change preserves their output). `orlyi`/`orlyc` build clean.

## Follow-ons (reported clearly, not silently broken)

- Nested-variant arms (#125) — `AsVar`/read-back throw a clear "not yet supported" at the arm.
- Mutual-group storage (#116, `TGroupRef`) — rejected at the `<-` typecheck; needs the group inlined to de Bruijn form at encode time.
- WS client marshaling rides on this same `AsVar` path; an explicit protocol test is worth adding.