### PR TITLE
var: accept equirecursive element types in dynamic containers (closes #137)

### DIFF
--- a/orly/var/dict.cc
+++ b/orly/var/dict.cc
@@ -18,6 +18,7 @@
 
 #include <orly/var/dict.h>
 
+#include <orly/type/canon.h>
 #include <orly/type/dict.h>
 #include <orly/var/set.h>
 
@@ -141,10 +142,10 @@ TDict &TDict::Xor(const TVar &) {
 
 TDict::TDict(const Rt::TDict<TVar, TVar> &that, const Type::TType &key_type, const Type::TType &val_type) : Val(that), KeyType(key_type), ValType(val_type) {
   for (auto iter = Val.begin(); iter != Val.end(); ++iter) {
-    if (iter->first.GetType() != KeyType) {
+    if (iter->first.GetType() != KeyType && !Type::Equiv(iter->first.GetType(), KeyType)) {
       throw Rt::TSystemError(HERE, "Dictionary constructor requires homogenous key type.");
     }
-    if (iter->second.GetType() != ValType) {
+    if (iter->second.GetType() != ValType && !Type::Equiv(iter->second.GetType(), ValType)) {
       throw Rt::TSystemError(HERE, "Dictionary constructor requires homogenous val type.");
     }
   }

--- a/orly/var/list.cc
+++ b/orly/var/list.cc
@@ -18,6 +18,7 @@
 
 #include <orly/var/list.h>
 
+#include <orly/type/canon.h>
 #include <orly/type/list.h>
 #include <orly/type/orlyify.h>
 #include <orly/var/int.h>
@@ -127,7 +128,7 @@ TList &TList::Xor(const TVar &) {
 
 TList::TList(const std::vector<TVar> &that, const Type::TType &type) : Val(that), Type(type) {
   for (auto iter = Val.begin(); iter != Val.end(); ++iter) {
-    if (iter->GetType() != Type) {
+    if (iter->GetType() != Type && !Type::Equiv(iter->GetType(), Type)) {
       std::ostringstream oss;
       oss << "List constructor requires homogenous element type. List type '";
       Orly::Type::Orlyify(oss, Type);

--- a/orly/var/set.cc
+++ b/orly/var/set.cc
@@ -18,6 +18,7 @@
 
 #include <orly/var/set.h>
 
+#include <orly/type/canon.h>
 #include <orly/type/set.h>
 
 using namespace Orly;
@@ -119,7 +120,7 @@ TSet &TSet::Xor(const TVar &) {
 
 TSet::TSet(const Rt::TSet<TVar> &that, const Type::TType &type) : Val(that), Type(type) {
   for (auto iter = Val.begin(); iter != Val.end(); ++iter) {
-    if (iter->GetType() != Type) {
+    if (iter->GetType() != Type && !Type::Equiv(iter->GetType(), Type)) {
       throw Rt::TSystemError(HERE, "Set constructor requires homogenous element type.");
     }
   }


### PR DESCRIPTION
Fixes #137.

Returning a recursive variant whose active arm is a **container of self** (a `[self]` / `{self}` / `{k: self}` arm — the #120 family) to a client failed with `List constructor requires homogeneous element type` (`orly/var/list.cc`).

## Root cause

The WS reply serializes the returned value through `Var::ToVar` (sabot → dynamic `Var`). A recursive-variant value's container-arm elements are stored with the *full* variant type at each level, so on read-back the container's declared element type (folded, `[self]`) and the element values' reconstructed types are **equirecursively equal but not pointer-equal** — they differ only in how the recursion is rolled. The dynamic-`Var` container constructors (`TList`/`TSet`/`TDict`) demanded *pointer*-equal element types and so rejected a perfectly homogeneous container.

(Storage of the same value works because it goes through native `AsVar`, where every level's type is the same interned `TDt<json>::GetType()`. Only the sabot→`Var` reconstruction path exposes the roll/unroll difference.)

## Fix

On a pointer inequality, fall back to equirecursive equality (`Type::Equiv`, the #130 primitive) before rejecting, in `TList`/`TSet`/`TDict`.

- Non-recursive types are unaffected: for interned non-recursive types equirecursive equality coincides with pointer equality, so a genuine mismatch still throws.
- The fast pointer-equal path (the overwhelmingly common case) short-circuits before `Equiv` is ever called — no cost on the hot path.

## Verification

Over the actual WS protocol, a method returning

```
json is <| JNull | JNum(int) | JArr([json]) |>;
build_json = (json.JArr([json.JNum(n), json.JNull(), json.JArr([json.JNum(n + 1)])])) where { n = given::(int); };
```

now marshals to `{"JArr": [{"JNum": 7.0}, {"JNull": {}}, {"JArr": [{"JNum": 8.0}]}]}`, alongside the already-working record-arm trees. Full lang suite: **0 unexpected, 142 passed**; `orlyi`/`orlyc` build clean.

(The fix is on the dynamic-`Var`/WS path, which `lang_test` — a native-read harness — doesn't exercise; verified manually with an `orlyi` + WebSocket round-trip. A committable WS smoke test would be a reasonable follow-up.)