### PR TITLE
code_gen: store & read back mutually-recursive variant values (#115/#116)

### DIFF
--- a/orly/code_gen/package.cc
+++ b/orly/code_gen/package.cc
@@ -34,7 +34,9 @@
 #include <orly/type/impl.h>
 #include <orly/type/object_collector.h> //TODO: This header should be renamed
 #include <orly/type/orlyify.h>
+#include <orly/type/rec_group.h>
 #include <orly/type/self_ref.h>
+#include <orly/type/unroll.h>
 #include <orly/type/util.h>
 #include <orly/type/variant.h>
 #include <orly/expr/util.h>
@@ -533,6 +535,14 @@ void TPackage::WriteLink(TCppPrinter &out, const TRelPath &path) const {
                       << "})";
                   };
                   virtual void operator()(const Type::TVariant  *that) const {
+                    /* A mutual-group member (its arms carry TGroupRef, #116) is
+                       stored as its inlined de Bruijn form (orly/type/new_sabot.cc
+                       does the same), so describe the link the same way -- the
+                       inlined form has only TSelfRef, handled below (#115). */
+                    if (Type::HasGroupRef(that->AsType())) {
+                      Type::InlinedMemberType(that->AsType()).Accept(*this);
+                      return;
+                    }
                     Out
                       << "Orly::Type::TVariant::Get(std::map<std::string, Orly::Type::TType> {"
                       << Join(that->GetElems(),

--- a/orly/code_gen/variant.cc
+++ b/orly/code_gen/variant.cc
@@ -1280,6 +1280,36 @@ void Orly::CodeGen::GenVariantGroupHeader(const std::string &out_dir, const Type
   auto arm_has_methods = [&arm_is_record](const Type::TType &payload) {
     return payload.Is<Type::TGroupRef>() || arm_is_record(payload);
   };
+  /* Like subst_storage but maps a group ref to the sibling member CLASS itself
+     (not its boxed storage) -- i.e. the UNROLLED payload, naming only concrete
+     sibling classes defined in this header. Storage read/write (#115) uses it:
+     read via Mk<Tag>(AsNative<unrolled>), write via Var::TVar(DeepUnbox<unrolled>).
+     A record-of-sibling arm is handled field-by-field by its boxed struct
+     instead, so this is only ever called on group refs and containers of them. */
+  std::function<string (const Type::TType &)> unrolled_over_group =
+      [&](const Type::TType &t) -> string {
+    if (!HasGroupRefDeep(t)) {
+      return Base::AsStr(t);
+    }
+    if (t.Is<Type::TGroupRef>()) {
+      return Base::AsStr("Orly::Rt::Variants::", class_of(sibling_of(t)));
+    }
+    if (const auto *list = t.TryAs<Type::TList>()) {
+      return Base::AsStr("std::vector<", unrolled_over_group(list->GetElem()), '>');
+    }
+    if (const auto *set = t.TryAs<Type::TSet>()) {
+      return Base::AsStr("Orly::Rt::TSet<", unrolled_over_group(set->GetElem()), '>');
+    }
+    if (const auto *opt = t.TryAs<Type::TOpt>()) {
+      return Base::AsStr("Orly::Rt::TOpt<", unrolled_over_group(opt->GetElem()), '>');
+    }
+    if (const auto *dict = t.TryAs<Type::TDict>()) {
+      return Base::AsStr("Orly::Rt::TDict<", Base::AsStr(dict->GetKey()), ", ",
+                         unrolled_over_group(dict->GetVal()), '>');
+    }
+    assert(false);
+    return Base::AsStr(t);
+  };
 
   Base::TPath path(out_dir, prim_name, vector<string>{"h"});
   TCppPrinter out(AsStr(path));
@@ -1311,7 +1341,13 @@ void Orly::CodeGen::GenVariantGroupHeader(const std::string &out_dir, const Type
       // file that includes a member via its shim header (#116).
       << "#include <orly/type/rec_group.h>" << Eol
       << "#include <orly/var/impl.h>" << Eol
-      << "#include <orly/var/obj.h>" << Eol;
+      << "#include <orly/var/obj.h>" << Eol
+      // Storage read/write (#115): Sabot::AsNative + the TToNativeVisitor and
+      // Native::State::Factory / Type::For specializations emitted per member.
+      << "#include <orly/var/new_sabot.h>" << Eol
+      << "#include <orly/sabot/to_native.h>" << Eol
+      << "#include <orly/native/type.h>" << Eol
+      << "#include <orly/type/new_sabot.h>" << Eol;
 
   /* Needed payload objects: scalar/closed-type arms only. Group-ref arms
      resolve to sibling member classes defined in this very file, so they
@@ -1386,6 +1422,10 @@ void Orly::CodeGen::GenVariantGroupHeader(const std::string &out_dir, const Type
               << "  bool Match(const " << bname << " &that) const;" << Eol
               << "  bool MatchLess(const " << bname << " &that) const;" << Eol
               << "  size_t GetHash() const;" << Eol
+              << "  /* Storage read/write (#115), deferred until the members are" << Eol
+              << "     complete (they recurse through sibling classes). */" << Eol
+              << "  Var::TVar AsVar() const;" << Eol
+              << "  static " << bname << " FromState(const Orly::Sabot::State::TRecord &state);" << Eol
               << "  private:" << Eol;
           for (const auto &field : fields) {
             out << "  " << subst_storage(field.second) << " V" << field.first << ";" << Eol;
@@ -1419,6 +1459,24 @@ void Orly::CodeGen::GenVariantGroupHeader(const std::string &out_dir, const Type
                     << "}" << Eol;
               } else {
                 out << "static " << cm << " Mk" << elem.first << "(const " << elem.second << " &vv) {" << Eol
+                    << "  " << cm << " out;" << Eol
+                    << "  out.Which = " << idx << ";" << Eol
+                    << "  out.V" << elem.first << " = vv;" << Eol
+                    << "  return out;" << Eol
+                    << "}" << Eol;
+              }
+              ++idx;
+            }
+          }
+
+          /* Read-back factory for a record-of-sibling arm (#115): build
+             directly from the already-boxed struct (rebuilt by <Boxed>::FromState
+             from a stored sabot record), bypassing the unrolled-record Mk<Tag>. */
+          { size_t idx = 0;
+            for (const auto &elem : elems) {
+              if (arm_is_record(elem.second)) {
+                out << "static " << cm << " MkBoxed" << elem.first
+                    << "(const " << boxed_name(m, elem.first) << " &vv) {" << Eol
                     << "  " << cm << " out;" << Eol
                     << "  out.Which = " << idx << ";" << Eol
                     << "  out.V" << elem.first << " = vv;" << Eol
@@ -1614,17 +1672,58 @@ void Orly::CodeGen::GenVariantGroupHeader(const std::string &out_dir, const Type
                             })
               << ';' << Eol
               << "}" << Eol;
-        }
-      }
-      out << Eol;
 
-      /* Out-of-line throwing AsVar for every member. */
-      for (const auto &m : members) {
-        auto cm = class_of(m);
-        out << "inline Var::TVar " << cm << "::AsVar() const {" << Eol
-            << "  throw Rt::TSystemError(HERE, \"a mutually-recursive variant value cannot yet be "
-               "stored or returned from a package function; see issue #116\");" << Eol
-            << "}" << Eol;
+          /* AsVar (#115): a dynamic Var::TObj of the fields; a sibling /
+             container-of-sibling field unboxes to its unrolled form (naming
+             concrete sibling classes) and Var::TVar recurses through it. */
+          out << "inline Var::TVar " << bname << "::AsVar() const {" << Eol
+              << "  return Var::TVar::Obj(std::unordered_map<std::string, Var::TVar>{"
+              << Base::Join(fields, ", ",
+                            [&](TCppPrinter &strm, const Type::TObj::TElems::value_type &it) {
+                              strm << "{\"" << it.first << "\", Var::TVar(";
+                              if (HasGroupRefDeep(it.second)) {
+                                strm << "Rt::DeepUnbox<" << unrolled_over_group(it.second)
+                                     << ">(V" << it.first << ')';
+                              } else {
+                                strm << 'V' << it.first;
+                              }
+                              strm << ")}";
+                            })
+              << "});" << Eol
+              << "}" << Eol;
+
+          /* FromState (#115): rebuild the boxed record from a stored sabot
+             record; a sibling field reconstructs via AsNative through the
+             sibling class, then re-boxes. */
+          out << "inline " << bname << " " << bname
+              << "::FromState(const Orly::Sabot::State::TRecord &state) {" << Eol
+              << "  " << bname << " out;" << Eol
+              << "  void *type_alloc = alloca(Sabot::Type::GetMaxTypeSize());" << Eol
+              << "  Sabot::Type::TRecord::TWrapper rtype(state.GetRecordType(type_alloc));" << Eol
+              << "  void *type_pin_alloc = alloca(Sabot::Type::GetMaxTypePinSize());" << Eol
+              << "  Sabot::Type::TRecord::TPin::TWrapper tpin(rtype->Pin(type_pin_alloc));" << Eol
+              << "  void *state_pin_alloc = alloca(Sabot::State::GetMaxStatePinSize());" << Eol
+              << "  Sabot::State::TRecord::TPin::TWrapper spin(state.Pin(state_pin_alloc));" << Eol
+              << "  const size_t elem_count = tpin->GetElemCount();" << Eol
+              << "  void *etype_alloc = alloca(Sabot::Type::GetMaxTypeSize());" << Eol
+              << "  void *estate_alloc = alloca(Sabot::State::GetMaxStateSize());" << Eol
+              << "  std::string field_name;" << Eol
+              << "  for (size_t i = 0; i < elem_count; ++i) {" << Eol
+              << "    Sabot::Type::TAny::TWrapper(tpin->NewElem(i, field_name, etype_alloc));" << Eol
+              << "    Sabot::State::TAny::TWrapper fstate(spin->NewElem(i, estate_alloc));" << Eol;
+          for (const auto &field : fields) {
+            out << "    if (field_name == \"" << field.first << "\") { out.V" << field.first << " = ";
+            if (HasGroupRefDeep(field.second)) {
+              out << "Rt::DeepBox<" << subst_storage(field.second) << ">(Sabot::AsNative<"
+                  << unrolled_over_group(field.second) << ">(*fstate)); }" << Eol;
+            } else {
+              out << "Sabot::AsNative<" << field.second << ">(*fstate); }" << Eol;
+            }
+          }
+          out << "  }" << Eol
+              << "  return out;" << Eol
+              << "}" << Eol;
+        }
       }
       out << Eol;
     } // namespace Variants
@@ -1643,6 +1742,193 @@ void Orly::CodeGen::GenVariantGroupHeader(const std::string &out_dir, const Type
           << "template <> inline bool MatchLess(const " << cm << " &lhs, const " << cm << " &rhs) { return lhs.MatchLess(rhs); }" << Eol;
     }
   } // namespace Orly::Rt
+
+  out << Eol;
+
+  /* TDt per member (#115): the runtime declared type. GenCode on a member
+     rebuilds the group (a MakeRecGroup IIFE) and returns this member, so a set
+     of mutual values is homogeneous at the var layer and AsVar can carry the
+     full declared type. */ {
+    TNamespacePrinter nsp(vector<string>{"Orly", "Type"}, out);
+    for (const auto &m : members) {
+      out << "template <>" << Eol
+          << "struct TDt<Rt::Variants::" << class_of(m) << "> {" << Eol
+          << "  static TType GetType() {" << Eol
+          << "    return ";
+      Type::GenCode(out.GetOstream(), m);
+      out << ";" << Eol
+          << "  }" << Eol
+          << "};" << Eol;
+    }
+  } // namespace Orly::Type
+
+  out << Eol;
+
+  /* Out-of-line AsVar for every member (#115): build a Var::TVariant for the
+     active arm, carrying the full declared (group) type from TDt above so a set
+     of mutual values stays homogeneous. A sibling / container-of-sibling
+     payload unboxes to its unrolled form and Var::TVar recurses; a
+     record-of-sibling payload delegates to its boxed struct's AsVar. */ {
+    TNamespacePrinter nsp(vector<string>{"Orly", "Rt", "Variants"}, out);
+    for (const auto &m : members) {
+      auto cm = class_of(m);
+      const auto &elems = m.As<Type::TVariant>()->GetElems();
+      out << "inline Var::TVar " << cm << "::AsVar() const {" << Eol
+          << "  assert(this);" << Eol
+          << "  switch (Which) {" << Eol;
+      { size_t idx = 0;
+        for (const auto &elem : elems) {
+          const auto &payload = elem.second;
+          /* Carry the member's INLINED de Bruijn type (TSelfRef arms, no group
+             refs) so the dynamic-var/sabot value encoder -- which reads the
+             variant's declared arm-payload types -- can translate it
+             (orly/type/new_sabot.cc rejects a raw TGroupRef). It is consistent
+             for every value of the member, matching the stored type. */
+          out << "    case " << idx << ": return Var::TVar::Variant("
+              << "Type::InlinedMemberType(Type::TDt<Rt::Variants::" << cm
+              << ">::GetType()), \"" << elem.first << "\", ";
+          if (arm_is_record(payload)) {
+            out << "V" << elem.first << ".AsVar()";
+          } else if (is_rec_arm(payload)) {
+            out << "Var::TVar(Rt::DeepUnbox<" << unrolled_over_group(payload)
+                << ">(V" << elem.first << "))";
+          } else {
+            out << "Var::TVar(V" << elem.first << ")";
+          }
+          out << ");" << Eol;
+          ++idx;
+        }
+      }
+      out << "  }" << Eol
+          << "  assert(false);" << Eol
+          << "  throw Rt::TSystemError(HERE, \"variant has no active arm\");" << Eol
+          << "}" << Eol;
+    }
+  } // namespace Orly::Rt::Variants
+
+  out << Eol;
+
+  /* Read-back (#115): each stored member is the fixed-shape #96 record
+     <{ .$which:int, .Tag:payload?, ... }> of its inlined de Bruijn form
+     (orly/type/new_sabot.cc inlines a group member). Specialize
+     TToNativeVisitor per member: read `$which`, read the active arm's payload,
+     and rebuild via the member's factory -- a sibling arm reconstructs through
+     the sibling class (AsNative<sibling>), a record-of-sibling arm through its
+     boxed struct's FromState. */ {
+    TNamespacePrinter nsp(vector<string>{"Orly", "Sabot"}, out);
+    for (const auto &m : members) {
+      auto cm = class_of(m);
+      const auto &elems = m.As<Type::TVariant>()->GetElems();
+      out << "template <>" << Eol
+          << "class TToNativeVisitor<Rt::Variants::" << cm << "> final : public TStateVisitor {" << Eol
+          << "  NO_COPY(TToNativeVisitor);" << Eol
+          << "  public:" << Eol
+          << "  TToNativeVisitor(Rt::Variants::" << cm << " &out) : Out(out) {}" << Eol;
+      {
+        static const char *const kNonRecord[] = {
+            "TFree", "TTombstone", "TVoid", "TInt8", "TInt16", "TInt32", "TInt64",
+            "TUInt8", "TUInt16", "TUInt32", "TUInt64", "TBool", "TChar", "TFloat",
+            "TDouble", "TDuration", "TTimePoint", "TUuid", "TBlob", "TStr", "TDesc",
+            "TOpt", "TSet", "TVector", "TMap", "TTuple"};
+        for (const char *const s : kNonRecord) {
+          out << "  virtual void operator()(const State::" << s
+              << " &) const override { THROW_ERROR(TInvalidConversion); }" << Eol;
+        }
+      }
+      out << "  virtual void operator()(const State::TRecord &state) const override {" << Eol
+          << "    void *type_alloc = alloca(Type::GetMaxTypeSize());" << Eol
+          << "    Type::TRecord::TWrapper rtype(state.GetRecordType(type_alloc));" << Eol
+          << "    void *type_pin_alloc = alloca(Type::GetMaxTypePinSize());" << Eol
+          << "    Type::TRecord::TPin::TWrapper tpin(rtype->Pin(type_pin_alloc));" << Eol
+          << "    void *state_pin_alloc = alloca(State::GetMaxStatePinSize());" << Eol
+          << "    State::TRecord::TPin::TWrapper spin(state.Pin(state_pin_alloc));" << Eol
+          << "    const size_t elem_count = tpin->GetElemCount();" << Eol
+          << "    void *etype_alloc = alloca(Type::GetMaxTypeSize());" << Eol
+          << "    void *estate_alloc = alloca(State::GetMaxStateSize());" << Eol
+          << "    std::string field_name;" << Eol
+          << "    size_t which = static_cast<size_t>(-1);" << Eol;
+      for (const auto &elem : elems) {
+        out << "    size_t idx_" << elem.first << " = static_cast<size_t>(-1);" << Eol;
+      }
+      out << "    for (size_t i = 0; i < elem_count; ++i) {" << Eol
+          << "      Type::TAny::TWrapper(tpin->NewElem(i, field_name, etype_alloc));" << Eol
+          << "      if (field_name == \"$which\") {" << Eol
+          << "        State::TAny::TWrapper which_state(spin->NewElem(i, estate_alloc));" << Eol
+          << "        which = static_cast<size_t>(AsNative<int64_t>(*which_state));" << Eol
+          << "      }" << Eol;
+      for (const auto &elem : elems) {
+        out << "      else if (field_name == \"" << elem.first << "\") { idx_"
+            << elem.first << " = i; }" << Eol;
+      }
+      out << "    }" << Eol
+          << "    void *opt_pin_alloc = alloca(State::GetMaxStatePinSize());" << Eol
+          << "    void *payload_alloc = alloca(State::GetMaxStateSize());" << Eol;
+      { size_t idx = 0;
+        for (const auto &elem : elems) {
+          out << "    " << (idx == 0 ? "if" : "else if") << " (which == " << idx << ") {" << Eol
+              << "      if (idx_" << elem.first << " == static_cast<size_t>(-1)) { THROW_ERROR(TInvalidConversion); }" << Eol
+              << "      State::TAny::TWrapper arm_state(spin->NewElem(idx_" << elem.first << ", estate_alloc));" << Eol
+              << "      const State::TOpt *opt = dynamic_cast<const State::TOpt *>(arm_state.get());" << Eol
+              << "      if (!opt) { THROW_ERROR(TInvalidConversion); }" << Eol
+              << "      State::TOpt::TPin::TWrapper opin(opt->Pin(opt_pin_alloc));" << Eol
+              << "      if (opin->GetElemCount() != 1) { THROW_ERROR(TInvalidConversion); }" << Eol
+              << "      State::TAny::TWrapper payload_state(opin->NewElem(0, payload_alloc));" << Eol;
+          const auto &payload = elem.second;
+          if (arm_is_record(payload)) {
+            out << "      const State::TRecord *prec = dynamic_cast<const State::TRecord *>(payload_state.get());" << Eol
+                << "      if (!prec) { THROW_ERROR(TInvalidConversion); }" << Eol
+                << "      Out = Rt::Variants::" << cm << "::MkBoxed" << elem.first
+                << "(Rt::Variants::" << boxed_name(m, elem.first) << "::FromState(*prec));" << Eol;
+          } else if (is_rec_arm(payload)) {
+            out << "      Out = Rt::Variants::" << cm << "::Mk" << elem.first
+                << "(AsNative<" << unrolled_over_group(payload) << ">(*payload_state));" << Eol;
+          } else {
+            out << "      Out = Rt::Variants::" << cm << "::Mk" << elem.first
+                << "(AsNative<" << payload << ">(*payload_state));" << Eol;
+          }
+          out << "    }" << Eol;
+          ++idx;
+        }
+      }
+      out << "    else { THROW_ERROR(TInvalidConversion); }" << Eol
+          << "  }" << Eol
+          << "  private:" << Eol
+          << "  Rt::Variants::" << cm << " &Out;" << Eol
+          << "}; // TToNativeVisitor" << Eol;
+    }
+  } // namespace Orly::Sabot
+
+  out << Eol;
+
+  /* Write-side serialization (#115/#96): route each member's VALUE through
+     AsVar() and its TYPE through Orly::Type::NewSabot (which inlines the group
+     member to its de Bruijn form), per member. */ {
+    TNamespacePrinter nsp(vector<string>{"Orly", "Native"}, out);
+    for (const auto &m : members) {
+      auto cm = class_of(m);
+      out << "template <>" << Eol
+          << "class State::Factory<Rt::Variants::" << cm << "> final {" << Eol
+          << "  NO_CONSTRUCTION(Factory);" << Eol
+          << "  public:" << Eol
+          << "  static Sabot::State::TAny *New(const Rt::Variants::" << cm
+          << " &val, void *state_alloc) {" << Eol
+          << "    return State::Factory<Var::TVar>::New(val.AsVar(), state_alloc);" << Eol
+          << "  }" << Eol
+          << "}; // State::Factory<" << cm << ">" << Eol
+          << "template <>" << Eol
+          << "class Type::For<Rt::Variants::" << cm << "> final {" << Eol
+          << "  NO_CONSTRUCTION(For);" << Eol
+          << "  public:" << Eol
+          << "  static Sabot::Type::TAny *GetType(void *type_alloc) {" << Eol
+          << "    return Orly::Type::NewSabot(type_alloc, Orly::Type::TDt<Rt::Variants::"
+          << cm << ">::GetType());" << Eol
+          << "  }" << Eol
+          << "  static Sabot::Type::TRecord *GetRecordType(void *type_alloc) {" << Eol
+          << "    return dynamic_cast<Sabot::Type::TRecord *>(GetType(type_alloc));" << Eol
+          << "  }" << Eol
+          << "}; // Type::For<" << cm << ">" << Eol;
+    }
+  } // namespace Orly::Native
 
   out << Eol;
 

--- a/orly/symbol/stmt/new_and_delete.cc
+++ b/orly/symbol/stmt/new_and_delete.cc
@@ -79,18 +79,15 @@ void TNew::TypeCheck() const {
   GetLhs()->GetExpr()->GetType().Accept(TAddressTypeVisitor(dummy, GetPosRange()));
   /* NOTE: Maybe this should be type check rather than get type. But for now,
            GetType() calls ComputeType() which does the type check. */
-  Type::TType value_type = GetRhs()->GetExpr()->GetType();
-  /* Self-recursive variants are now storable: their #96 fixed-shape record
-     encoding closes the cycle with a finite Sabot::Type::TSelfRef leaf, and the
-     value read/write round-trips through the boxed payload representation
-     (issue #115). A MUTUALLY-recursive variant (Type::TGroupRef) is not yet --
-     its sabot encoding needs the group inlined to de Bruijn form first -- so
-     reject that write here with a clear message rather than letting
-     orly/type/new_sabot.cc fail translation at runtime. */
-  if (Type::HasGroupRef(value_type)) {
-    throw TExprError(HERE, GetPosRange(),
-        "a value containing a mutually-recursive variant cannot be stored yet (issue #116/#115)");
-  }
+  GetRhs()->GetExpr()->GetType();
+  /* Recursive variants -- self-recursive (Type::TSelfRef) and mutually-recursive
+     (Type::TGroupRef) alike -- are storable (issue #115): a self-recursive value
+     closes the cycle with the finite sabot TSelfRef leaf, and a mutual-group
+     value is lowered by inlining the member to its de Bruijn form
+     (orly/type/new_sabot.cc), so it rides the same machinery. Either way the
+     value read/writes through the boxed payload representation. A mutual payload
+     shape codegen does not yet handle (a group ref under a nested variant, etc.)
+     is reported with a clear message at code generation. */
 }
 
 TNew::TNew(

--- a/orly/type/new_sabot.cc
+++ b/orly/type/new_sabot.cc
@@ -18,6 +18,7 @@
 
 #include <orly/type/new_sabot.h>
 
+#include <orly/type/rec_group.h>
 #include <orly/type/unroll.h>
 #include <orly/type/util.h>
 
@@ -92,12 +93,15 @@ Sabot::Type::TAny *Orly::Type::TryNewSabot(void *buf, const Type::TType &type) {
          Sabot::Type::TSelfRef leaf at each recursion point (the TSelfRef case
          below), so the record is no longer infinitely deep.
 
-         A MUTUAL-group variant (its arms carry Type::TGroupRef, #116) is not
-         yet storable: lowering it would require inlining the group to its de
-         Bruijn form first. Those still return no translation (the TGroupRef
-         case below), so MakeRecGroup members keep failing translation cleanly
-         until that follow-on lands. */
+         A MUTUAL-group variant (its arms carry Type::TGroupRef, #116) is
+         lowered for storage (issue #115) by first inlining the group member to
+         its canonical self-recursive de Bruijn form -- siblings expanded,
+         cycles minted as Type::TSelfRef -- which the TSelfRef path then encodes
+         as an ordinary recursive #96 record. The inlined form is the same for
+         every value of the member type, so a stored set stays homogeneous and
+         `::(member)` matches it on read-back. */
       if (HasGroupRef(type->AsType())) {
+        Result = TryNewSabot(Buf, InlinedMemberType(type->AsType()));
         return;
       }
       TObjElems rec;

--- a/orly/type/new_sabot.test.cc
+++ b/orly/type/new_sabot.test.cc
@@ -26,6 +26,8 @@
 #include <orly/sabot/compare_types.h>
 #include <orly/sabot/type_dumper.h>
 #include <orly/native/all.h>
+#include <orly/type/group_ref.h>
+#include <orly/type/rec_group.h>
 #include <orly/type/sabot_to_type.h>
 #include <orly/type/self_ref.h>
 #include <orly/type/type_czar.h>
@@ -114,6 +116,30 @@ FIXTURE(RecursiveVariantRoundTrips) {
   outer["X"] = Type::TVariant::Get({ { "Y", Type::TSelfRef::Get(1) } });
   const Type::TType nested = Type::TVariant::Get(outer);
   EXPECT_TRUE(RoundTrip(nested) == nested);
+}
+
+/* A MUTUALLY-recursive group (#116): `a is <|X(b)|>; b is <|Y(a)|>;`. Each
+   member translates for storage (issue #115) by inlining to its canonical
+   de Bruijn form -- so it no longer fails translation -- consistently (a stored
+   set stays homogeneous) and distinctly per member. */
+FIXTURE(MutualGroupTranslates) {
+  auto m = Type::MakeRecGroup({ { { "X", Type::TGroupRef::Get({}, 1) } },
+                                { { "Y", Type::TGroupRef::Get({}, 0) } } });
+  const Type::TType a = m[0], b = m[1];
+
+  void *ba = alloca(1000), *ba2 = alloca(1000), *bb = alloca(1000);
+  Sabot::Type::TAny::TWrapper a_sabot(NewSabot(ba, a));
+  Sabot::Type::TAny::TWrapper a_sabot2(NewSabot(ba2, a));
+  Sabot::Type::TAny::TWrapper b_sabot(NewSabot(bb, b));
+
+  /* Translates (no exception) and is finite/consistent for the same member. */
+  EXPECT_TRUE(Atom::IsEq(Sabot::CompareTypes(*a_sabot, *a_sabot2)));
+  /* Distinct members are distinct stored types. */
+  EXPECT_FALSE(Atom::IsEq(Sabot::CompareTypes(*a_sabot, *b_sabot)));
+
+  /* The stored type is the member's canonical inlined de Bruijn form, and
+     round-trips back to it. */
+  EXPECT_TRUE(RoundTrip(a) == Type::InlinedMemberType(a));
 }
 
 FIXTURE(RecursiveVariantCompareTypes) {

--- a/orly/type/rec_group.cc
+++ b/orly/type/rec_group.cc
@@ -229,3 +229,14 @@ bool Orly::Type::TryGetGroupMembers(const TType &member, vector<TType> &members,
   index = it->second.second;
   return true;
 }
+
+TType Orly::Type::InlinedMemberType(const TType &member) {
+  const auto it = MemberIndex().find(member);
+  assert(it != MemberIndex().end());
+  /* The group identity is exactly the members' canonical inlined de Bruijn
+     forms, in canonical order; this member sits at it->second.second. */
+  const TGroupId &gid = it->second.first;
+  const size_t pos = it->second.second;
+  assert(pos < gid.size());
+  return gid[pos];
+}

--- a/orly/type/rec_group.h
+++ b/orly/type/rec_group.h
@@ -61,6 +61,15 @@ namespace Orly {
     bool TryGetGroupMembers(const TType &member, std::vector<TType> &members,
                             size_t &index);
 
+    /* A group member's canonical inlined de Bruijn form: the self-recursive
+       TVariant (sibling refs expanded, cycles minted as Type::TSelfRef) that
+       MakeRecGroup already computed as the group identity. This is how a
+       mutual-group value is lowered for STORAGE (issue #115): inlining turns a
+       member into an ordinary self-recursive variant, so the sabot TSelfRef
+       leaf and the rest of the single-recursion machinery carry it. `member`
+       must be a type built by MakeRecGroup. */
+    TType InlinedMemberType(const TType &member);
+
   }  // Type
 
 }  // Orly

--- a/tests/lang_tests/general/.variants_mutual_storage.orly.test.state
+++ b/tests/lang_tests/general/.variants_mutual_storage.orly.test.state
@@ -1,0 +1,21 @@
+[
+  0,
+  [
+    [],
+    [
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++"
+    ],
+    [
+      "Running tests"
+    ],
+    [
+      "Tests done"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/variants_mutual_storage.orly
+++ b/tests/lang_tests/general/variants_mutual_storage.orly
@@ -1,0 +1,80 @@
+/* <orly/lang_tests/general/variants_mutual_storage.orly>
+
+   End-to-end test for issue #115 (mutual-recursion storage): a value of a
+   MUTUALLY-recursive variant group round-trips through storage (`<-` / `*`).
+
+   A group member is lowered for storage by inlining it to its canonical
+   self-recursive de Bruijn form (orly/type/new_sabot.cc), so it rides the
+   same #96 fixed-shape-record machinery as a single recursive variant. The
+   value reads back through the per-member Sabot::TToNativeVisitor, with each
+   cross-member edge reconstructed through the concrete sibling class and
+   re-boxed (#115/#116).
+
+   Covers the three group-arm shapes: a direct sibling ref (`Node(forest)`), a
+   record of siblings (`Cons(<{.head: tree, .tail: forest}>)`), and a container
+   of siblings (`Group([tree])`).
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+tree is <| Leaf(int) | Node(forest) |>;
+forest is <| Empty | Cons(<{.head: tree, .tail: forest}>) | Group([tree]) |>;
+
+read_tree = (*<[n]>::(tree)) where {
+  n = given::(int);
+};
+
+read_forest = (*<[n]>::(forest)) where {
+  n = given::(int);
+};
+
+/* A tree holding a forest (direct sibling ref + record-of-siblings arm). */
+with {
+  <[600]> <- tree.Node(forest.Cons(<{.head: tree.Leaf(1), .tail:
+             forest.Cons(<{.head: tree.Leaf(2), .tail: forest.Empty()}>)}>));
+} test {
+  t1: read_tree(.n: 600) == tree.Node(forest.Cons(<{.head: tree.Leaf(1), .tail:
+        forest.Cons(<{.head: tree.Leaf(2), .tail: forest.Empty()}>)}>));
+  /* A structurally different tree is not equal. */
+  t2: read_tree(.n: 600) != tree.Leaf(1);
+  t3: read_tree(.n: 600) != tree.Node(forest.Cons(<{.head: tree.Leaf(1), .tail:
+        forest.Cons(<{.head: tree.Leaf(9), .tail: forest.Empty()}>)}>));
+  /* Read-back destructures like any variant: Node's payload is a forest. */
+  t4: read_tree(.n: 600) is Node;
+};
+
+/* A tag-only base arm. */
+with {
+  <[601]> <- tree.Leaf(42);
+} test {
+  t5: read_tree(.n: 601) == tree.Leaf(42);
+  t6: read_tree(.n: 601) != tree.Leaf(43);
+};
+
+/* A forest with a container-of-sibling arm (`Group([tree])`). */
+with {
+  <[602]> <- forest.Group([tree.Leaf(3), tree.Node(forest.Empty()), tree.Leaf(5)]);
+} test {
+  t7: read_forest(.n: 602) == forest.Group([tree.Leaf(3), tree.Node(forest.Empty()), tree.Leaf(5)]);
+  t8: read_forest(.n: 602) != forest.Empty();
+  t9: read_forest(.n: 602) is Group;
+};
+
+/* The Empty base arm of the sibling member. */
+with {
+  <[603]> <- forest.Empty();
+} test {
+  t10: read_forest(.n: 603) == forest.Empty();
+  t11: read_forest(.n: 603) != forest.Group([tree.Leaf(1)]);
+};


### PR DESCRIPTION
Lifts the **last** recursive-variant storage boundary (issue #115): a value of a **mutually-recursive** variant group (#116) now round-trips through `<-` / `*`.

```
tree   is <| Leaf(int) | Node(forest) |>;
forest is <| Empty | Cons(<{.head: tree, .tail: forest}>) | Group([tree]) |>;

<[600]> <- tree.Node(forest.Cons(<{.head: tree.Leaf(1), .tail: forest.Empty()}>));
*<[600]>::(tree)   // reads back, structurally equal
```

## Approach — reuse single-recursion via inlining

A group member is lowered for storage by **inlining it to its canonical self-recursive de Bruijn form** (siblings expanded, cycles minted as `Type::TSelfRef`), which the sabot `TSelfRef` leaf and #96 fixed-shape record already handle (PR #135/#136). `MakeRecGroup` already computes that inlined form as the group identity, so exposing it is a lookup — no new walker.

- **`type/rec_group.{h,cc}`** — `InlinedMemberType(member)` returns the member's canonical inlined de Bruijn form.
- **`type/new_sabot.cc`** — a group-member variant inlines first, then takes the ordinary recursive path (no longer fails translation). Consistent for every value ⇒ stored sets stay homogeneous and `::(member)` matches on read-back.
- **`code_gen/variant.cc`** (`GenVariantGroupHeader`) — real value read/write, mirroring the single-variant emitter (#136) over the group. Here a recursive edge resolves to a **concrete sibling class**, so read-back names siblings directly (no unrolled-record cycle). Adds `unrolled_over_group`, deferred `AsVar`/`FromState` on boxed record structs, `MkBoxed<Tag>`, `TDt<member>` specializations, per-member out-of-line `AsVar` (carrying the member's *inlined* type so the value encoder can translate it), per-member `Sabot::TToNativeVisitor`, and per-member `State::Factory`/`Type::For`.
- **`code_gen/package.cc`** — the link-table type printer describes a group member by its inlined form (matching `new_sabot`), reusing the `TSelfRef` case.
- **`symbol/stmt/new_and_delete.cc`** — drop the `<-` rejection of mutual recursion; unsupported group-ref shapes (under a nested variant, etc.) still get a clear codegen error.

Builds on #137 (now merged): a mutual value's container-of-sibling arm reconstructs to `Var` element types that are equirecursively — not pointer — equal.

## Tests

`variants_mutual_storage.orly` stores/reads a tree-with-forest (direct sibling ref + record-of-siblings), a container-of-siblings forest, and the tag-only base arms. `type/new_sabot.test` gains a mutual-group type round-trip. Full lang suite: **0 unexpected, 143 passed**; `orlyi`/`orlyc` build clean.

## What this closes

With this, the **whole recursive-variant family stores and reads back**: self-recursion (trees, lists, JSON), single-def containers/opt/nested, and now mutual recursion. Remaining #115 tail: nested-variant arm (#125) marshaling and a committable WS smoke test.