### PR TITLE
code_gen: store & read back nested-variant arm values (#115/#125)

### DIFF
--- a/orly/code_gen/variant.cc
+++ b/orly/code_gen/variant.cc
@@ -432,6 +432,14 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
                 << "  bool MatchLess(const " << nvname << " &that) const;" << Eol
                 << "  size_t GetHash() const;" << Eol
                 << Eol
+                << "  /* Storage read/write (#115), deferred until " << class_name
+                << " is complete (they recurse through it via the self arm). The"
+                << " open nested variant is itself a variant value, so AsVar" << Eol
+                << "     builds a Var::TVariant; FromState rebuilds it from the"
+                << " stored #96 record. */" << Eol
+                << "  Var::TVar AsVar() const;" << Eol
+                << "  static " << nvname << " FromState(const Orly::Sabot::State::TRecord &state);" << Eol
+                << Eol
                 << "  private:" << Eol
                 << "  size_t Which;" << Eol;
             for (const auto &ne : nv_elems) {
@@ -503,6 +511,25 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
             if (arm_is_recursive(elem.second) && elem.second.Is<Type::TObj>()) {
               out << "static " << class_name << " MkBoxed" << elem.first
                   << "(const " << boxed_name(elem.first) << " &vv) {" << Eol
+                  << "  " << class_name << " out;" << Eol
+                  << "  out.Which = " << idx << ";" << Eol
+                  << "  out.V" << elem.first << " = vv;" << Eol
+                  << "  return out;" << Eol
+                  << "}" << Eol;
+            }
+            ++idx;
+          }
+        }
+        /* Read-back factory for a nested-variant arm (#115/#125): construct
+           directly from the already-built inline struct (rebuilt by its
+           FromState), bypassing the closed-payload Mk<Tag> so the header never
+           names the closed nested variant. */
+        {
+          size_t idx = 0;
+          for (const auto &elem : elems) {
+            if (arm_is_nested_variant(elem.second)) {
+              out << "static " << class_name << " MkNV" << elem.first
+                  << "(const " << inline_name(elem.second) << " &vv) {" << Eol
                   << "  " << class_name << " out;" << Eol
                   << "  out.Which = " << idx << ";" << Eol
                   << "  out.V" << elem.first << " = vv;" << Eol
@@ -891,6 +918,89 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
                 << "  assert(false);" << Eol
                 << "  return 0;" << Eol
                 << "}" << Eol;
+
+            /* AsVar (#115): the open nested variant is itself a variant value;
+               build a Var::TVariant for the active arm, carrying the nested
+               variant's (open, TSelfRef-bearing) type so it nests correctly
+               inside the outer's encoding. A self arm unboxes to the outer and
+               Var::TVar recurses. */
+            out << "inline Var::TVar " << nvname << "::AsVar() const {" << Eol
+                << "  switch (Which) {" << Eol;
+            { size_t i = 0;
+              for (const auto &ne : nv_elems) {
+                out << "    case " << i << ": return Var::TVar::Variant(";
+                Type::GenCode(out.GetOstream(), elem.second);
+                out << ", \"" << ne.first << "\", Var::TVar(";
+                if (ne.second.Is<Type::TSelfRef>()) {
+                  out << "Rt::DeepUnbox<" << class_name << ">(V" << ne.first << ')';
+                } else {
+                  out << 'V' << ne.first;
+                }
+                out << "));" << Eol;
+                ++i;
+              }
+            }
+            out << "  }" << Eol
+                << "  assert(false);" << Eol
+                << "  throw Rt::TSystemError(HERE, \"nested variant has no active arm\");" << Eol
+                << "}" << Eol;
+
+            /* FromState (#115): rebuild the inline struct from the nested
+               variant's stored #96 record -- read `$which`, read the active
+               arm's payload, box a self arm. */
+            out << "inline " << nvname << " " << nvname
+                << "::FromState(const Orly::Sabot::State::TRecord &state) {" << Eol
+                << "  " << nvname << " out;" << Eol
+                << "  void *type_alloc = alloca(Sabot::Type::GetMaxTypeSize());" << Eol
+                << "  Sabot::Type::TRecord::TWrapper rtype(state.GetRecordType(type_alloc));" << Eol
+                << "  void *type_pin_alloc = alloca(Sabot::Type::GetMaxTypePinSize());" << Eol
+                << "  Sabot::Type::TRecord::TPin::TWrapper tpin(rtype->Pin(type_pin_alloc));" << Eol
+                << "  void *state_pin_alloc = alloca(Sabot::State::GetMaxStatePinSize());" << Eol
+                << "  Sabot::State::TRecord::TPin::TWrapper spin(state.Pin(state_pin_alloc));" << Eol
+                << "  const size_t elem_count = tpin->GetElemCount();" << Eol
+                << "  void *etype_alloc = alloca(Sabot::Type::GetMaxTypeSize());" << Eol
+                << "  void *estate_alloc = alloca(Sabot::State::GetMaxStateSize());" << Eol
+                << "  std::string field_name;" << Eol
+                << "  size_t which = static_cast<size_t>(-1);" << Eol;
+            for (const auto &ne : nv_elems) {
+              out << "  size_t idx_" << ne.first << " = static_cast<size_t>(-1);" << Eol;
+            }
+            out << "  for (size_t i = 0; i < elem_count; ++i) {" << Eol
+                << "    Sabot::Type::TAny::TWrapper(tpin->NewElem(i, field_name, etype_alloc));" << Eol
+                << "    if (field_name == \"$which\") {" << Eol
+                << "      Sabot::State::TAny::TWrapper ws(spin->NewElem(i, estate_alloc));" << Eol
+                << "      which = static_cast<size_t>(Sabot::AsNative<int64_t>(*ws));" << Eol
+                << "    }" << Eol;
+            for (const auto &ne : nv_elems) {
+              out << "    else if (field_name == \"" << ne.first << "\") { idx_"
+                  << ne.first << " = i; }" << Eol;
+            }
+            out << "  }" << Eol
+                << "  void *opt_pin_alloc = alloca(Sabot::State::GetMaxStatePinSize());" << Eol
+                << "  void *payload_alloc = alloca(Sabot::State::GetMaxStateSize());" << Eol;
+            { size_t i = 0;
+              for (const auto &ne : nv_elems) {
+                out << "  if (which == " << i << ") {" << Eol
+                    << "    out.Which = " << i << ";" << Eol
+                    << "    Sabot::State::TAny::TWrapper arm_state(spin->NewElem(idx_" << ne.first << ", estate_alloc));" << Eol
+                    << "    const Sabot::State::TOpt *opt = dynamic_cast<const Sabot::State::TOpt *>(arm_state.get());" << Eol
+                    << "    if (opt) {" << Eol
+                    << "      Sabot::State::TOpt::TPin::TWrapper opin(opt->Pin(opt_pin_alloc));" << Eol
+                    << "      Sabot::State::TAny::TWrapper payload_state(opin->NewElem(0, payload_alloc));" << Eol
+                    << "      out.V" << ne.first << " = ";
+                if (ne.second.Is<Type::TSelfRef>()) {
+                  out << "Rt::DeepBox<" << nv_field(ne.second) << ">(Sabot::AsNative<"
+                      << class_name << ">(*payload_state));" << Eol;
+                } else {
+                  out << "Sabot::AsNative<" << nv_field(ne.second) << ">(*payload_state);" << Eol;
+                }
+                out << "    }" << Eol
+                    << "  }" << Eol;
+                ++i;
+              }
+            }
+            out << "  return out;" << Eol
+                << "}" << Eol;
           }
         }
       }
@@ -970,17 +1080,15 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
       for (const auto &elem : elems) {
         const auto &payload = elem.second;
         out << "    case " << idx << ": ";
-        if (arm_is_nested_variant(payload)) {
-          /* A nested-variant arm payload (#125) is stored as an inline struct;
-             its dynamic-var/sabot marshaling is a #115 follow-on. (Statement,
-             not `return throw` -- the latter is ill-formed.) */
-          out << "throw Rt::TSystemError(HERE, \"storing a variant with a "
-                 "nested-variant arm is not yet supported; see issue #115\")";
-        } else {
+        {
           out << "return Var::TVar::Variant("
               << "Type::TDt<Rt::Variants::" << class_name << ">::GetType(), \""
               << elem.first << "\", ";
-          if (arm_is_recursive(payload) && payload.Is<Type::TObj>()) {
+          if (arm_is_nested_variant(payload)) {
+            /* Nested-variant arm (#125): the inline struct is itself a variant
+               value and builds its own Var::TVariant. */
+            out << "V" << elem.first << ".AsVar()";
+          } else if (arm_is_recursive(payload) && payload.Is<Type::TObj>()) {
             /* Boxed-record arm: the boxed struct builds its own Var::TObj,
                recursing into self fields -- without naming the unrolled record. */
             out << "V" << elem.first << ".AsVar()";
@@ -1076,8 +1184,13 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
             << "      State::TAny::TWrapper payload_state(opin->NewElem(0, payload_alloc));" << Eol;
         const auto &payload = elem.second;
         if (arm_is_nested_variant(payload)) {
-          /* Reading a stored nested-variant arm (#125) is a #115 follow-on. */
-          out << "      THROW_ERROR(TInvalidConversion);" << Eol;
+          /* Nested-variant arm (#125): rebuild the inline struct from the
+             stored nested #96 record, then construct the arm -- without naming
+             the closed nested variant. */
+          out << "      const State::TRecord *prec = dynamic_cast<const State::TRecord *>(payload_state.get());" << Eol
+              << "      if (!prec) { THROW_ERROR(TInvalidConversion); }" << Eol
+              << "      Out = Rt::Variants::" << class_name << "::MkNV" << elem.first
+              << "(Rt::Variants::" << inline_name(payload) << "::FromState(*prec));" << Eol;
         } else if (arm_is_recursive(payload) && payload.Is<Type::TObj>()) {
           /* Boxed-record arm: rebuild the boxed struct from the stored sabot
              record (recursing through this variant), then construct the arm --

--- a/tests/lang_tests/general/.variants_nested_storage.orly.test.state
+++ b/tests/lang_tests/general/.variants_nested_storage.orly.test.state
@@ -1,0 +1,21 @@
+[
+  0,
+  [
+    [],
+    [
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++"
+    ],
+    [
+      "Running tests"
+    ],
+    [
+      "Tests done"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/variants_nested_storage.orly
+++ b/tests/lang_tests/general/variants_nested_storage.orly
@@ -1,0 +1,66 @@
+/* <orly/lang_tests/general/variants_nested_storage.orly>
+
+   End-to-end test for issue #115: a recursive variant with a NESTED-variant
+   arm (#125) round-trips through storage (`<-` / `*`).
+
+   `tree is <| Leaf(int) | Branch(<| Un(tree) | Nil |>) |>;` -- the Branch arm's
+   payload is an anonymous open nested variant that refers back to the outer
+   `tree`. It is stored as an inline struct in the outer's header; that struct
+   is itself a variant value, so it grows its own AsVar / read-back (#115),
+   nesting inside the outer's #96 fixed-shape record.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+tree is <| Leaf(int) | Branch(<| Un(tree) | Nil |>) |>;
+
+read_tree = (*<[n]>::(tree)) where {
+  n = given::(int);
+};
+
+/* Branch carrying a nested `Un(tree)` (the self arm of the nested variant). */
+with {
+  <[700]> <- tree.Branch(<| Un(tree) | Nil |>.Un(tree.Leaf(5)));
+} test {
+  t1: read_tree(.n: 700) == tree.Branch(<| Un(tree) | Nil |>.Un(tree.Leaf(5)));
+  t2: read_tree(.n: 700) != tree.Branch(<| Un(tree) | Nil |>.Un(tree.Leaf(9)));
+  t3: read_tree(.n: 700) != tree.Leaf(5);
+  t4: read_tree(.n: 700) is Branch;
+};
+
+/* Branch carrying the nested tag-only `Nil`. */
+with {
+  <[701]> <- tree.Branch(<| Un(tree) | Nil |>.Nil);
+} test {
+  t5: read_tree(.n: 701) == tree.Branch(<| Un(tree) | Nil |>.Nil);
+  t6: read_tree(.n: 701) != tree.Branch(<| Un(tree) | Nil |>.Un(tree.Leaf(0)));
+};
+
+/* A deeply-nested value: Branch(Un(Branch(Un(Leaf 8)))). */
+with {
+  <[702]> <- tree.Branch(<| Un(tree) | Nil |>.Un(
+             tree.Branch(<| Un(tree) | Nil |>.Un(tree.Leaf(8)))));
+} test {
+  t7: read_tree(.n: 702) == tree.Branch(<| Un(tree) | Nil |>.Un(
+        tree.Branch(<| Un(tree) | Nil |>.Un(tree.Leaf(8)))));
+  t8: read_tree(.n: 702) != tree.Branch(<| Un(tree) | Nil |>.Un(
+        tree.Branch(<| Un(tree) | Nil |>.Un(tree.Leaf(7)))));
+};
+
+/* The plain (non-nested) base arm still round-trips alongside. */
+with {
+  <[703]> <- tree.Leaf(42);
+} test {
+  t9: read_tree(.n: 703) == tree.Leaf(42);
+};


### PR DESCRIPTION
Completes recursive-variant storage (issue #115): a value whose arm payload is an open **nested** variant (#125) now round-trips through `<-` / `*`.

```
tree is <| Leaf(int) | Branch(<| Un(tree) | Nil |>) |>;
<[700]> <- tree.Branch(<| Un(tree) | Nil |>.Un(tree.Leaf(5)));
*<[700]>::(tree)   // round-trips
```

## Approach

The nested variant has no standalone header (its shape depends on the binder), so it's stored as an inline `_NV` struct in the outer's header. That struct is itself a variant value, so it grows storage read/write of its own, nesting inside the outer's #96 fixed-shape record:

- The inline struct gains deferred **`AsVar()`** (builds a `Var::TVariant` for the active arm, carrying the open nested variant's own type via `GenCode` so it nests correctly inside the outer's encoding; a self arm unboxes to the outer and `Var::TVar` recurses) and **`FromState()`** (rebuilds the struct from the nested #96 record, boxing a self arm) — defined after the outer class completes, like its `EqEq`.
- The outer gains an **`MkNV<Tag>`** factory that builds the arm directly from a rebuilt inline struct, so the header never names the *closed* nested variant (which would reintroduce the include cycle).
- The outer's `AsVar` nested-arm case now delegates to the inline struct's `AsVar` (was a throw); its read-back rebuilds via `MkNV` + `FromState` (was `THROW_ERROR`).

The type side already worked — `new_sabot` sees the nested variant as an ordinary `TVariant` and encodes its #96 record, with the back-reference as the sabot `TSelfRef` leaf.

## Test

`variants_nested_storage.orly` stores/reads `Branch(Un(tree))`, the nested tag-only `Nil`, a deeply-nested value, and the plain base arm. Full lang suite: **0 unexpected, 143 passed**; `orlyi`/`orlyc` build clean.

## #115 status

With this (and #140, mutual storage), the **entire recursive-variant family stores and reads back**: self-recursion (trees, linked lists, JSON), containers/opt of self, nested-variant arms, and mutual recursion. The last open item is a committable **WS smoke test** to guard the dynamic-`Var` marshaling path in CI (the `lang_test` native-read harness doesn't reach it).