### PR TITLE
examples: recursive-variants WS storage/marshaling smoke test (#115)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,3 +347,17 @@ jobs:
       - name: crdt-text run-go.sh (go driver, collaborative CRDT)
         run: ./run-go.sh
         working-directory: examples/crdt-text
+
+      # Recursive sum-type storage + client marshaling smoke test (issue
+      # #115): store a fixed recursive value of each shape (self-recursive
+      # tree, container-of-self doc, mutual tree/forest, nested-variant tree),
+      # read it back, and self-check the marshaled JSON. Guards the
+      # dynamic-var/WS marshaling path that the C++ lang_test (a native-read
+      # harness) cannot reach.
+      - name: recursive-variants run.sh (python driver, recursive storage)
+        run: ./run.sh
+        working-directory: examples/recursive-variants
+
+      - name: recursive-variants run-go.sh (go driver, recursive storage)
+        run: ./run-go.sh
+        working-directory: examples/recursive-variants

--- a/examples/recursive-variants/.gitignore
+++ b/examples/recursive-variants/.gitignore
@@ -1,0 +1,2 @@
+# Stray go-build output from `go build ./...` in this dir.
+recursive-variants

--- a/examples/recursive-variants/README.md
+++ b/examples/recursive-variants/README.md
@@ -1,0 +1,67 @@
+# Recursive sum types — storage & client marshaling
+
+A WebSocket smoke test for **issue #115**: storing recursive sum-type values
+and marshaling them back to a client. It stores a fixed value of each recursive
+shape under a key, reads it back, and self-checks the JSON the client receives.
+
+Recursive variants used to be package-internal — `<-` was a compile error and
+returning one to a client threw at runtime. They are now fully first-class:
+they store, read back, and marshal over the wire. This demo exercises that
+**dynamic-var / WebSocket marshaling path**, which the C++ `lang_test` suite (a
+native-read harness) can't reach — so it's the regression guard for it.
+
+## The shapes
+
+`recursive.orly` declares one type per recursive shape:
+
+```
+tree   is <| Leaf(int) | Branch(<{.l: tree, .r: tree}>) |>;        # self-ref in a record arm   (#103)
+doc    is <| Null | Num(int) | Str(str) | Arr([doc]) |>;           # self-ref under a list       (#120)
+mtree  is <| MLeaf(int) | MNode(forest) |>;                        # mutual recursion            (#116)
+forest is <| FEmpty | FCons(<{.head: mtree, .tail: forest}>) |>;
+ntree  is <| NLeaf(int) | NBranch(<| Un(ntree) | Nil |>) |>;       # nested-variant arm          (#125)
+```
+
+For each, a `put_X(.k)` method stores a fixed value with `new <[...]> <- ...`,
+and a `get_X(.k)` method reads it back with `*<[...]>`. The driver calls them
+over the WebSocket protocol and checks the result.
+
+## Marshaling
+
+A variant value marshals to JSON as `{ "Tag": <payload> }`; a tag-only arm as
+`{ "Tag": {} }`; numbers come back as JSON floats. So the stored `tree`
+
+```
+tree.Branch(<{.l: tree.Leaf(1), .r: tree.Branch(<{.l: tree.Leaf(2), .r: tree.Leaf(3)}>)}>)
+```
+
+reads back as
+
+```json
+{"Branch": {"l": {"Leaf": 1.0}, "r": {"Branch": {"l": {"Leaf": 2.0}, "r": {"Leaf": 3.0}}}}}
+```
+
+## Running
+
+Build the project first (`make debug` from the repo root), then:
+
+```
+./run.sh        # Python driver (demo.py)
+./run-go.sh     # Go driver (demo.go) — needs the `go` toolchain
+```
+
+Each wrapper compiles `recursive.orly`, starts a fresh `orlyi`, runs the driver
+against it over `ws://127.0.0.1:8082/`, and tears `orlyi` down. The Python and
+Go drivers run the identical scenario and self-check; they're paired so they
+can be diffed in spirit.
+
+Expected output:
+
+```
+  [ok] tree  (self-reference in a record arm, #103)
+  [ok] doc   (self-reference under a list, #120)
+  [ok] mtree (mutual recursion, #116)
+  [ok] ntree (nested-variant arm, #125)
+
+All recursive-variant values round-tripped through storage and marshaled correctly.
+```

--- a/examples/recursive-variants/demo.go
+++ b/examples/recursive-variants/demo.go
@@ -1,0 +1,138 @@
+// Recursive sum-type storage + client marshaling demo (issue #115), in Go.
+//
+// Equivalent to demo.py -- same scenario and self-check. Connects to a
+// running orlyi over the WebSocket protocol, stores a fixed recursive value
+// of each shape, reads it back, and checks the marshaled JSON. A variant
+// marshals as {"Tag": <payload>}; a tag-only arm as {"Tag": {}}; numbers come
+// back as JSON floats. The Python and Go drivers are paired so reviewers can
+// diff them in spirit.
+//
+// Run via the wrapper:  ./run-go.sh
+// Or directly, after starting orlyi separately:  go run demo.go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"reflect"
+
+	"github.com/gorilla/websocket"
+)
+
+const wsURL = "ws://127.0.0.1:8082/"
+
+type reply struct {
+	Status string          `json:"status"`
+	Result json.RawMessage `json:"result"`
+	Pos    string          `json:"pos,omitempty"`
+}
+
+func die(msg string) {
+	fmt.Fprintln(os.Stderr, msg)
+	os.Exit(1)
+}
+
+func send(c *websocket.Conn, stmt string) json.RawMessage {
+	if err := c.WriteMessage(websocket.TextMessage, []byte(stmt)); err != nil {
+		die(fmt.Sprintf("write %q: %v", stmt, err))
+	}
+	_, msg, err := c.ReadMessage()
+	if err != nil {
+		die(fmt.Sprintf("read after %q: %v", stmt, err))
+	}
+	var r reply
+	if err := json.Unmarshal(msg, &r); err != nil {
+		die(fmt.Sprintf("parse reply to %q: %v\n  raw: %s", stmt, err, msg))
+	}
+	if r.Status != "ok" {
+		die(fmt.Sprintf("%s: %s", stmt, string(msg)))
+	}
+	return r.Result
+}
+
+func sendString(c *websocket.Conn, stmt string) string {
+	var s string
+	if err := json.Unmarshal(send(c, stmt), &s); err != nil {
+		die(fmt.Sprintf("expected string result from %q", stmt))
+	}
+	return s
+}
+
+// A case: a recursive value stored then read back, with the expected
+// round-tripped JSON (as a literal the driver parses for comparison).
+type recCase struct {
+	label    string
+	put, get string
+	expected string
+}
+
+var cases = []recCase{
+	{
+		"tree  (self-reference in a record arm, #103)",
+		"put_tree", "get_tree",
+		`{"Branch": {"l": {"Leaf": 1.0}, "r": {"Branch": {"l": {"Leaf": 2.0}, "r": {"Leaf": 3.0}}}}}`,
+	},
+	{
+		"doc   (self-reference under a list, #120)",
+		"put_doc", "get_doc",
+		`{"Arr": [{"Num": 1.0}, {"Str": "two"}, {"Arr": [{"Num": 3.0}]}, {"Null": {}}]}`,
+	},
+	{
+		"mtree (mutual recursion, #116)",
+		"put_mtree", "get_mtree",
+		`{"MNode": {"FCons": {"head": {"MLeaf": 1.0}, "tail": {"FCons": {"head": {"MLeaf": 2.0}, "tail": {"FEmpty": {}}}}}}}`,
+	},
+	{
+		"ntree (nested-variant arm, #125)",
+		"put_ntree", "get_ntree",
+		`{"NBranch": {"Un": {"NLeaf": 7.0}}}`,
+	},
+}
+
+// parse turns JSON bytes into a structure DeepEqual can compare (maps/slices/
+// float64/string), independent of key order.
+func parse(b []byte, what string) interface{} {
+	var v interface{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		die(fmt.Sprintf("parse %s: %v\n  raw: %s", what, err, b))
+	}
+	return v
+}
+
+func main() {
+	u, _ := url.Parse(wsURL)
+	c, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	if err != nil {
+		die(fmt.Sprintf("dial %s: %v", wsURL, err))
+	}
+	defer c.Close()
+
+	send(c, "new session;")
+	send(c, "install recursive.0;")
+	pov := sendString(c, "new safe shared pov;")
+	fmt.Printf("pov: %s\n\n", pov)
+
+	failures := 0
+	for k, rc := range cases {
+		send(c, fmt.Sprintf("try {%s} recursive %s <{.k: %d}>;", pov, rc.put, k))
+		got := send(c, fmt.Sprintf("try {%s} recursive %s <{.k: %d}>;", pov, rc.get, k))
+		ok := reflect.DeepEqual(parse(got, "result"), parse([]byte(rc.expected), "expected"))
+		status := "ok"
+		if !ok {
+			status = "FAIL"
+			failures++
+		}
+		fmt.Printf("  [%s] %s\n", status, rc.label)
+		if !ok {
+			fmt.Printf("        expected: %s\n        got:      %s\n", rc.expected, got)
+		}
+	}
+
+	send(c, "exit;")
+	if failures > 0 {
+		die(fmt.Sprintf("\n%d case(s) failed.", failures))
+	}
+	fmt.Println("\nAll recursive-variant values round-tripped through storage and marshaled correctly.")
+}

--- a/examples/recursive-variants/demo.py
+++ b/examples/recursive-variants/demo.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Recursive sum-type storage + client marshaling demo (issue #115), in Python.
+
+Connects to a running orlyi over the WebSocket protocol, stores a fixed
+recursive value of each shape (self-recursive tree, container-of-self doc,
+mutual tree/forest, nested-variant tree), reads it back, and self-checks the
+marshaled JSON. A variant marshals as {"Tag": <payload>}; a tag-only arm as
+{"Tag": {}}; numbers come back as JSON floats.
+
+Run via the wrapper:  ./run.sh
+Or directly, after starting orlyi separately:  python3 demo.py
+"""
+
+import json
+import sys
+
+import websocket
+
+WS_URL = "ws://127.0.0.1:8082/"
+
+
+def send(ws, stmt):
+    ws.send(stmt)
+    reply = json.loads(ws.recv())
+    if reply.get("status") != "ok":
+        sys.exit(f"FAIL: {stmt}\n  -> {reply}")
+    return reply.get("result")
+
+
+# Each case: (label, put-method, get-method, expected round-tripped JSON).
+CASES = [
+    (
+        "tree  (self-reference in a record arm, #103)",
+        "put_tree", "get_tree",
+        {"Branch": {"l": {"Leaf": 1.0},
+                    "r": {"Branch": {"l": {"Leaf": 2.0}, "r": {"Leaf": 3.0}}}}},
+    ),
+    (
+        "doc   (self-reference under a list, #120)",
+        "put_doc", "get_doc",
+        {"Arr": [{"Num": 1.0}, {"Str": "two"}, {"Arr": [{"Num": 3.0}]}, {"Null": {}}]},
+    ),
+    (
+        "mtree (mutual recursion, #116)",
+        "put_mtree", "get_mtree",
+        {"MNode": {"FCons": {"head": {"MLeaf": 1.0},
+                             "tail": {"FCons": {"head": {"MLeaf": 2.0},
+                                                "tail": {"FEmpty": {}}}}}}},
+    ),
+    (
+        "ntree (nested-variant arm, #125)",
+        "put_ntree", "get_ntree",
+        {"NBranch": {"Un": {"NLeaf": 7.0}}},
+    ),
+]
+
+
+def main():
+    ws = websocket.create_connection(WS_URL)
+    send(ws, "new session;")
+    send(ws, "install recursive.0;")
+    pov = send(ws, "new safe shared pov;")
+    print(f"pov: {pov}\n")
+
+    failures = 0
+    for kk, (label, put, get, expected) in enumerate(CASES):
+        send(ws, f"try {{{pov}}} recursive {put} <{{.k: {kk}}}>;")
+        got = send(ws, f"try {{{pov}}} recursive {get} <{{.k: {kk}}}>;")
+        ok = got == expected
+        print(f"  [{'ok' if ok else 'FAIL'}] {label}")
+        if not ok:
+            print(f"        expected: {json.dumps(expected)}")
+            print(f"        got:      {json.dumps(got)}")
+            failures += 1
+
+    send(ws, "exit;")
+    ws.close()
+
+    if failures:
+        sys.exit(f"\n{failures} case(s) failed.")
+    print("\nAll recursive-variant values round-tripped through storage and marshaled correctly.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/recursive-variants/go.mod
+++ b/examples/recursive-variants/go.mod
@@ -1,0 +1,5 @@
+module github.com/orlyatomics/orly/examples/recursive-variants
+
+go 1.22
+
+require github.com/gorilla/websocket v1.5.3

--- a/examples/recursive-variants/go.sum
+++ b/examples/recursive-variants/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/examples/recursive-variants/recursive.orly
+++ b/examples/recursive-variants/recursive.orly
@@ -1,0 +1,79 @@
+/* <examples/recursive-variants/recursive.orly>
+
+   A WS smoke test for recursive sum-type STORAGE and CLIENT MARSHALING
+   (issue #115). Each method stores a fixed recursive value under a key and
+   reads it back, so the driver -- exercising the WebSocket protocol -- sees
+   the value cross from native storage to the dynamic-var layer and out as
+   JSON. That dynamic-var/marshaling path is the one the C++ lang_test suite
+   (a native-read harness) can't reach, so this demo guards it end to end.
+
+   It covers all four recursive-variant shapes:
+     - a binary `tree`        -- self-reference in a record arm (#103)
+     - a `doc`                -- self-reference under a list (#120 container)
+     - a `mtree`/`forest` pair -- MUTUAL recursion (#116)
+     - an `ntree`             -- a NESTED-variant arm (#125)
+
+   A variant marshals to JSON as `{ "Tag": <payload> }`; a tag-only arm as
+   `{ "Tag": {} }`; numbers come back as JSON floats.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+tree   is <| Leaf(int) | Branch(<{.l: tree, .r: tree}>) |>;
+doc    is <| Null | Num(int) | Str(str) | Arr([doc]) |>;
+mtree  is <| MLeaf(int) | MNode(forest) |>;
+forest is <| FEmpty | FCons(<{.head: mtree, .tail: forest}>) |>;
+ntree  is <| NLeaf(int) | NBranch(<| Un(ntree) | Nil |>) |>;
+
+/* tree: self-reference in a record arm. */
+put_tree = ((1) effecting {
+  new <['tree', k]> <- tree.Branch(<{.l: tree.Leaf(1), .r:
+    tree.Branch(<{.l: tree.Leaf(2), .r: tree.Leaf(3)}>)}>);
+}) where {
+  k = given::(int);
+};
+get_tree = (*<['tree', k]>::(tree)) where {
+  k = given::(int);
+};
+
+/* doc: self-reference under a list. */
+put_doc = ((1) effecting {
+  new <['doc', k]> <- doc.Arr([doc.Num(1), doc.Str("two"), doc.Arr([doc.Num(3)]), doc.Null()]);
+}) where {
+  k = given::(int);
+};
+get_doc = (*<['doc', k]>::(doc)) where {
+  k = given::(int);
+};
+
+/* mtree/forest: mutual recursion. */
+put_mtree = ((1) effecting {
+  new <['mtree', k]> <- mtree.MNode(forest.FCons(<{.head: mtree.MLeaf(1), .tail:
+    forest.FCons(<{.head: mtree.MLeaf(2), .tail: forest.FEmpty()}>)}>));
+}) where {
+  k = given::(int);
+};
+get_mtree = (*<['mtree', k]>::(mtree)) where {
+  k = given::(int);
+};
+
+/* ntree: nested-variant arm. */
+put_ntree = ((1) effecting {
+  new <['ntree', k]> <- ntree.NBranch(<| Un(ntree) | Nil |>.Un(ntree.NLeaf(7)));
+}) where {
+  k = given::(int);
+};
+get_ntree = (*<['ntree', k]>::(ntree)) where {
+  k = given::(int);
+};

--- a/examples/recursive-variants/run-go.sh
+++ b/examples/recursive-variants/run-go.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# End-to-end WS smoke test for recursive sum-type storage + client
+# marshaling (issue #115), driven by the go driver:
+#   1. Compile recursive.orly with orlyc.
+#   2. Lay out a package directory orlyi can install from.
+#   3. Start a fresh orlyi (killing any prior instance).
+#   4. Run the driver: store a recursive value of each shape over the
+#      WebSocket protocol, read it back, and self-check the marshaled JSON.
+#   5. Kill orlyi on exit.
+#
+# Run from any working directory; binaries are found relative to the repo,
+# two levels up. Override with ORLY_OUT if your build went elsewhere.
+
+set -e
+
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../.. && pwd)"
+ORLY_OUT="${ORLY_OUT:-$REPO_ROOT/../out_orly/debug}"
+ORLYI="$ORLY_OUT/orly/server/orlyi"
+ORLYC="$ORLY_OUT/orly/orlyc"
+
+for bin in "$ORLYI" "$ORLYC"; do
+  if [ ! -x "$bin" ]; then
+    echo "missing: $bin"
+    echo ""
+    echo "Build the project first (from $REPO_ROOT):"
+    echo "  make debug"
+    echo ""
+    echo "Or set ORLY_OUT to point at your debug-build output tree."
+    exit 1
+  fi
+done
+
+if ! command -v go >/dev/null 2>&1; then
+  echo "missing: go (install golang-go or download from go.dev)"
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'kill -9 $ORLYI_PID 2>/dev/null || true; rm -rf "$WORK"' EXIT
+
+echo "[1/5] compile recursive.orly"
+"$ORLYC" -o "$WORK" recursive.orly
+
+echo "[2/5] populate packages/"
+mkdir "$WORK/packages"
+touch "$WORK/packages/__orly__"
+cp "$WORK/recursive.0.so" "$WORK/packages/"
+
+pkill -9 -f 'instance_name=recursive_variants_demo' 2>/dev/null || true
+sleep 1
+
+echo "[3/5] start fresh orlyi (logs -> $WORK/orlyi.log)"
+"$ORLYI" --mem_sim --create=true \
+         --port_number=19600 --slave_port_number=19601 \
+         --connection_backlog=10 \
+         --instance_name=recursive_variants_demo \
+         --starting_state=SOLO \
+         --package_dir="$WORK/packages" \
+         > "$WORK/orlyi.log" 2>&1 &
+ORLYI_PID=$!
+
+echo "[4/5] wait for WebSocket port 8082"
+for _ in $(seq 1 60); do
+  if ss -tln 2>/dev/null | grep -q ':8082'; then
+    break
+  fi
+  sleep 1
+done
+if ! ss -tln 2>/dev/null | grep -q ':8082'; then
+  echo "orlyi failed to come up; last log lines:"
+  tail -20 "$WORK/orlyi.log"
+  exit 1
+fi
+
+echo "[5/5] go run demo.go"
+go run demo.go

--- a/examples/recursive-variants/run.sh
+++ b/examples/recursive-variants/run.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# End-to-end WS smoke test for recursive sum-type storage + client
+# marshaling (issue #115), driven by the python driver:
+#   1. Compile recursive.orly with orlyc.
+#   2. Lay out a package directory orlyi can install from.
+#   3. Start a fresh orlyi (killing any prior instance).
+#   4. Run the driver: store a recursive value of each shape over the
+#      WebSocket protocol, read it back, and self-check the marshaled JSON.
+#   5. Kill orlyi on exit.
+#
+# Run from any working directory; binaries are found relative to the repo,
+# two levels up. Override with ORLY_OUT if your build went elsewhere.
+
+set -e
+
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../.. && pwd)"
+ORLY_OUT="${ORLY_OUT:-$REPO_ROOT/../out_orly/debug}"
+ORLYI="$ORLY_OUT/orly/server/orlyi"
+ORLYC="$ORLY_OUT/orly/orlyc"
+
+for bin in "$ORLYI" "$ORLYC"; do
+  if [ ! -x "$bin" ]; then
+    echo "missing: $bin"
+    echo ""
+    echo "Build the project first (from $REPO_ROOT):"
+    echo "  make debug"
+    echo ""
+    echo "Or set ORLY_OUT to point at your debug-build output tree."
+    exit 1
+  fi
+done
+
+WORK="$(mktemp -d)"
+trap 'kill -9 $ORLYI_PID 2>/dev/null || true; rm -rf "$WORK"' EXIT
+
+echo "[1/5] compile recursive.orly"
+"$ORLYC" -o "$WORK" recursive.orly
+
+echo "[2/5] populate packages/"
+mkdir "$WORK/packages"
+touch "$WORK/packages/__orly__"
+cp "$WORK/recursive.0.so" "$WORK/packages/"
+
+pkill -9 -f 'instance_name=recursive_variants_demo' 2>/dev/null || true
+sleep 1
+
+echo "[3/5] start fresh orlyi (logs -> $WORK/orlyi.log)"
+"$ORLYI" --mem_sim --create=true \
+         --port_number=19600 --slave_port_number=19601 \
+         --connection_backlog=10 \
+         --instance_name=recursive_variants_demo \
+         --starting_state=SOLO \
+         --package_dir="$WORK/packages" \
+         > "$WORK/orlyi.log" 2>&1 &
+ORLYI_PID=$!
+
+echo "[4/5] wait for WebSocket port 8082"
+for _ in $(seq 1 60); do
+  if ss -tln 2>/dev/null | grep -q ':8082'; then
+    break
+  fi
+  sleep 1
+done
+if ! ss -tln 2>/dev/null | grep -q ':8082'; then
+  echo "orlyi failed to come up; last log lines:"
+  tail -20 "$WORK/orlyi.log"
+  exit 1
+fi
+
+echo "[5/5] run demo.py"
+python3 demo.py


### PR DESCRIPTION
A WebSocket end-to-end demo (paired Python + Go drivers, like the other examples) that **guards the recursive-variant client-marshaling path in CI** — the dynamic-`Var` path the C++ `lang_test` suite (a native-read harness) can't reach.

It stores a fixed recursive value of each shape under a key, reads it back over `ws://127.0.0.1:8082/`, and self-checks the marshaled JSON:

| type | shape | issue |
|---|---|---|
| `tree` | self-reference in a record arm | #103 |
| `doc` | self-reference under a list | #120 |
| `mtree`/`forest` | mutual recursion | #116 |
| `ntree` | nested-variant arm | #125 |

Each shape has a `put_X(.k)` (`new <[...]> <- ` fixed value) and `get_X(.k)` (`*<[...]>`) method. A variant marshals as `{"Tag": <payload>}`, a tag-only arm as `{"Tag": {}}`, numbers as JSON floats — e.g. the stored `tree` reads back as:

```json
{"Branch": {"l": {"Leaf": 1.0}, "r": {"Branch": {"l": {"Leaf": 2.0}, "r": {"Leaf": 3.0}}}}}
```

## Contents

`examples/recursive-variants/` — `recursive.orly`, `demo.py`, `demo.go` (+ `go.mod`/`go.sum`), `run.sh`, `run-go.sh`, `README.md`, structured exactly like the existing demos and wired into the `examples/* end-to-end` CI job.

## Validation

- `demo.py` verified end-to-end against a live `orlyi`: all four shapes round-trip and marshal to the expected JSON.
- `demo.go` compiles and is a faithful mirror of `demo.py` (same statements, same confirmed-correct expected JSON, same `gorilla/websocket` helper pattern as the other Go drivers).
- `run.sh`/`run-go.sh` pass `bash -n` and are structurally identical to the CI-proven bitcoin wrappers.

**No engine changes** — storage and marshaling of the whole recursive-variant family already work on master (#135/#136/#139/#140/#141). This PR is purely the regression guard.