### PR TITLE
indy: regression guard for Tetris promotion push/pop window (#143)

### DIFF
--- a/orly/indy/transaction_base.cc
+++ b/orly/indy/transaction_base.cc
@@ -28,6 +28,9 @@ using namespace Base;
 using namespace Orly::Atom;
 using namespace Orly::Indy::L1;
 
+/* Test-only; empty in production. See header. */
+std::function<void ()> TTransaction::OnCommitBetweenPushAndPopForTest;
+
 bool TTransaction::Push(const L0::TManager::TPtr<TRepo> &repo, const shared_ptr<TUpdate> &update, const std::optional<TSequenceNumber> &ensure_or_discard) {
   Prepared = false;
   EnsureOrDiscard = EnsureOrDiscard || ensure_or_discard;
@@ -406,6 +409,11 @@ TTransaction::~TTransaction() NO_THROW {
       if (my_mutation->GetKind() == TMutation::Pusher) {
         delete my_mutation;
       }
+    }
+
+    /* Test-only window between the push-apply and pop-apply passes. */
+    if (CommitFlag && OnCommitBetweenPushAndPopForTest) {
+      OnCommitBetweenPushAndPopForTest();
     }
 
     /* now delete the rest */

--- a/orly/indy/transaction_base.h
+++ b/orly/indy/transaction_base.h
@@ -77,6 +77,16 @@ namespace Orly {
         /* Discard the prepared action, if any. */
         void DiscardAction() NO_THROW;
 
+        /* Test-only instrumentation hook, invoked at commit time inside
+           ~TTransaction *between* the pusher-apply pass (which makes the
+           promoted update visible in the parent repo via AppendUpdate) and
+           the popper-apply pass (which removes it from the child repo). It
+           lets a unit test deterministically observe the cross-repo
+           transition and assert there is no "neither" transient. Defaults
+           to empty; never set in production, so it is a single null check
+           on the commit path. See orly/indy/transaction_base.cc. */
+        static std::function<void ()> OnCommitBetweenPushAndPopForTest;
+
         /* TODO */
         class TTransactionCompletion {
           NO_COPY(TTransactionCompletion);

--- a/orly/indy/transaction_base.test.cc
+++ b/orly/indy/transaction_base.test.cc
@@ -338,6 +338,104 @@ FIXTURE(Promoter) {
   });
 }
 
+/* Issue #143: a child repo's promotion to its parent (Tetris push-to-parent
+   + pop-from-child) must never present a "neither" transient to a reader that
+   spans child + parent (which is what a shared-POV read does, since the
+   shared POV's repo is a child of the global repo). At every instant during
+   commit the in-flight update must be visible in at least one of the two
+   repos -- otherwise a concurrent read drops it (the agent-swarm symptom).
+
+   We make the window deterministic with the test-only commit hook that fires
+   between the pusher-apply pass and the popper-apply pass. From inside the
+   window we present-walk the child snapshot then the parent snapshot (the
+   same child-first union TContext performs) and assert the key is present in
+   at least one of them -- never dropped from both. */
+FIXTURE(Issue143PromotionWindow) {
+  Fiber::TFiberTestRunner runner([](std::mutex &mut, std::condition_variable &cond, bool &fin, Fiber::TRunner::TRunnerCons &) {
+    TSuprena arena;
+    void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
+    const TScheduler::TPolicy scheduler_policy(10, 10, 10ms);
+    TScheduler scheduler;
+    scheduler.SetPolicy(scheduler_policy);
+    Orly::Indy::Disk::Sim::TMemEngine mem_engine(&scheduler,
+                                                 256, 64, 128, 1, 64, 1);
+    auto manager = make_unique<TMyManager>(mem_engine.GetEngine(), &scheduler, MemMergeCoreVec, DiskMergeCoreVec);
+    Base::TUuid global_id(TUuid::Twister);
+    Base::TUuid child_id(TUuid::Twister);
+    Base::TUuid idx_id(TUuid::Twister);
+
+    /* global repo (the promotion target / parent) and a child repo. In
+       production the child's repo is constructed with ParentRepo = global so
+       it auto-registers with the Tetris manager; here we drive the
+       child->parent promotion by hand (as TRepoTetrisManager::Play does) and
+       perform the cross-repo read by hand too, so we leave the child
+       parent-less to avoid pulling in a live Tetris player fiber. The
+       cross-repo read invariant under test is identical: a reader that unions
+       the child snapshot with the global snapshot must never see "neither". */
+    auto global_repo = manager->GetRepo(global_id, TTtl::max(), std::nullopt, false, true);
+    auto child_repo = manager->GetRepo(child_id, TTtl::max(), std::nullopt, false, true);
+
+    const TIndexKey from_key(idx_id, TKey(make_tuple(1L), &arena, state_alloc));
+    const TIndexKey to_key(idx_id, TKey(make_tuple(10L), &arena, state_alloc));
+
+    /* A reader that spans child -> parent finds the key iff a present-walk on
+       either repo's snapshot is valid. This mirrors TContext, which snapshots
+       the child view first, then each parent view (context.cc ctor), and
+       unions them. A "drop" is: found in NEITHER. */
+    auto found_in_child_or_parent = [&]() -> bool {
+      /* child snapshot first (matches TContext ctor order) */
+      auto child_view = make_unique<TRepo::TView>(child_repo);
+      auto child_walker_ptr = child_repo->NewPresentWalker(child_view, from_key, to_key);
+      bool in_child = static_cast<bool>(*child_walker_ptr);
+      /* parent snapshot second */
+      auto parent_view = make_unique<TRepo::TView>(global_repo);
+      auto parent_walker_ptr = global_repo->NewPresentWalker(parent_view, from_key, to_key);
+      bool in_parent = static_cast<bool>(*parent_walker_ptr);
+      return in_child || in_parent;
+    };
+
+    /* Push an update into the child. */
+    /* commit push to child */ {
+      auto transaction = manager->NewTransaction();
+      auto update = TUpdate::NewUpdate(TUpdate::TOpByKey{ { from_key, TKey(7L, &arena, state_alloc)} }, TKey(&arena), TKey(Base::TUuid(TUuid::Best), &arena, state_alloc));
+      transaction->Push(child_repo, update);
+      transaction->Prepare();
+      transaction->CommitAction();
+    }
+    EXPECT_TRUE(found_in_child_or_parent());
+
+    /* Install the test-only hook: fires inside the commit, between the
+       push-to-parent apply and the pop-from-child apply. */
+    bool window_saw_value = false;
+    L1::TTransaction::OnCommitBetweenPushAndPopForTest = [&]() {
+      window_saw_value = found_in_child_or_parent();
+    };
+
+    /* Promote: pop the lowest from the child and push it to the parent, all
+       in one transaction (this is what TRepoTetrisManager::Play registers). */
+    /* commit promotion */ {
+      auto transaction = manager->NewTransaction();
+      transaction->Pop(child_repo);
+      transaction->Push(global_repo, transaction->Peek(child_repo));
+      transaction->Prepare();
+      transaction->CommitAction();
+    }  // <-- ~TTransaction here applies push (parent), fires hook, then pop (child)
+
+    L1::TTransaction::OnCommitBetweenPushAndPopForTest = nullptr;
+
+    /* The whole point: mid-promotion the value must be observable in at least
+       one repo -- never dropped from both. */
+    EXPECT_TRUE(window_saw_value);
+
+    /* And after promotion the value lives in the parent and is still found. */
+    EXPECT_TRUE(found_in_child_or_parent());
+
+    std::lock_guard<std::mutex> lock(mut);
+    fin = true;
+    cond.notify_one();
+  });
+}
+
 FIXTURE(DiskPromoter) {
   Fiber::TFiberTestRunner runner([](std::mutex &mut, std::condition_variable &cond, bool &fin, Fiber::TRunner::TRunnerCons &) {
     TSuprena arena;


### PR DESCRIPTION
## Summary

Investigation of issue #143 (agent-swarm intermittently dropping concurrent
commutative writes), focused on the cross-repo Tetris push/pop window the
issue pinned as the root cause.

**Finding: the push/pop ordering window described in #143 is already closed.**
The cross-repo transition is applied in a single transaction's destructor
(`TTransaction::~TTransaction`), which deletes **all pushers before any
poppers** (the "first delete the pushers" pass). That means the parent push
(`AppendUpdate`, synchronously visible under the parent's `DataLock`) always
lands **before** the child pop (`PopLowest`). Combined with the reader side —
`TContext` always snapshots the child view **before** each parent view
(`context.cc` ctor) — the "neither" transient that would drop a write cannot
occur:

- A drop requires the child snapshot to miss the update (taken after the pop)
  AND the parent snapshot to miss it (taken before the push).
- Child-snapshotted-before-parent + push-applied-before-pop makes that
  ordering impossible; the only reachable transient is "seen in **both**"
  (parent push visible, child not yet popped), i.e. the double-count that
  PR #60's `UpdateId` fold-dedup already handles.

So this PR does **not** change engine behavior. Instead it converts the
implicit, comment-only "pushers first" invariant into an enforced, tested
contract, and adds a deterministic regression guard.

## What this PR adds

1. A **test-only** instrumentation hook,
   `TTransaction::OnCommitBetweenPushAndPopForTest`, invoked in
   `~TTransaction` between the pusher-apply pass and the popper-apply pass.
   It defaults to empty and is never set in production — a single null check
   on the commit path, zero cost otherwise.

2. A deterministic unit test, `transaction_base.test`
   `FIXTURE(Issue143PromotionWindow)`, that:
   - builds the shared-POV-over-global topology (a child repo promoting to a
     parent/global repo),
   - drives the child->parent promotion by hand exactly as
     `TRepoTetrisManager::Play` registers it (`Pop(child)` + `Push(parent,
     Peek(child))` in one transaction),
   - reads through the same child-first union a real `TContext` performs, and
   - asserts the in-flight update is visible in **at least one** of {child,
     parent} *inside* the commit window — never dropped from both.

   The test is **green on current `master`**. To confirm it has teeth, I
   temporarily inverted the destructor ordering to pop-first (simulating the
   bug the issue theorized): the fixture went **red** with the exact
   "neither" drop. Restoring the correct push-first ordering makes it green
   again. This locks the ordering in so a future refactor of the destructor
   can't silently reopen the window.

## On the agent-swarm flake

The intermittent agent-swarm self-check failure is real, but it is **not**
produced by this push/pop ordering window — that window is already correctly
ordered, as the test now demonstrates. The remaining suspect surface is the
read-time fold/dedup magnitude path (the `+= 1` counts, the #49/#60 lineage)
rather than wholesale presence, which this guard rules out for the
single-transaction promotion path. Narrowing the residual `+=`-count race is
left to a follow-up; this PR's value is removing the push/pop window from the
suspect list with a permanent, deterministic guard.

## Verification

- `transaction_base.test`: 4/4 pass (was 3/3; +1 new fixture).
- Inverted-ordering experiment: new fixture goes red (catches the drop),
  proving the guard is meaningful.
- `make test`: full unit suite green.
- `python3 tools/lang_test.py -d orly/data tests/lang_tests`: 0 unexpected
  (only the known xfails). `issue_49_fold.orly` still passes.

Refs #143.
