### PR TITLE
agent-swarm: read-back barrier before fan-out to close the create-race (#143)

### DIFF
--- a/examples/agent-swarm/demo.go
+++ b/examples/agent-swarm/demo.go
@@ -512,6 +512,55 @@ func main() {
 		expectedCooccurCount[k] = v + 1
 	}
 
+	// Read-back barrier (issue #143): the pre-init writes committed on the
+	// bootstrap session, but the agents are *different* sessions. If an agent's
+	// `is known` predicate read runs before a seed is visible to it, it takes
+	// the `new <- 1` create branch instead of the commutative `+= 1`, and that
+	// stray Assign masks the commutative run on read -> lost increments. To
+	// exclude that create-race (which the pre-init is meant to design out), open
+	// a FRESH session and confirm every seeded key is visible from it before
+	// fanning agents out; a fresh session seeing them means other fresh agent
+	// sessions will too. Poll briefly to absorb any promotion-visibility lag.
+	fmt.Println("read-back barrier: confirming all seeds are visible to a fresh session...")
+	{
+		vDialer := *websocket.DefaultDialer
+		vDialer.HandshakeTimeout = wsTimeout
+		verifier, _, err := vDialer.Dial(wsURL, nil)
+		if err != nil {
+			panic(err)
+		}
+		mustSend(verifier, "new session;")
+		deadline := time.Now().Add(30 * time.Second)
+		for {
+			pending := 0
+			for e := range expectedTagRecords {
+				if len(tagsForEntity(verifier, pov, e)) == 0 {
+					pending++
+				}
+			}
+			for mk := range expectedMentions {
+				if mentionCount(verifier, pov, mk.entity, mk.docID) < 1 {
+					pending++
+				}
+			}
+			for pk := range expectedCooccur {
+				if cooccurCount(verifier, pov, pk.a, pk.b) < 1 {
+					pending++
+				}
+			}
+			if pending == 0 {
+				break
+			}
+			if time.Now().After(deadline) {
+				verifier.Close()
+				fmt.Fprintf(os.Stderr, "read-back barrier timed out; %d seed(s) never became visible to a fresh session\n", pending)
+				os.Exit(1)
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		verifier.Close()
+	}
+
 	// Fan out: each agent on its own WS, all concurrent.
 	var wg sync.WaitGroup
 	t0 := time.Now()

--- a/examples/agent-swarm/demo.py
+++ b/examples/agent-swarm/demo.py
@@ -345,6 +345,7 @@ def main():
     print("read-back barrier: confirming all seeds are visible to a fresh session...")
     verifier = websocket.create_connection(WS_URL, timeout=WS_TIMEOUT_S)
     try:
+        send(verifier, "new session;")
         deadline = time.monotonic() + 30.0
         pending = (
             [("tag", e) for e in expected_tag_records]

--- a/examples/agent-swarm/demo.py
+++ b/examples/agent-swarm/demo.py
@@ -333,6 +333,44 @@ def main():
     expected_mention_count = {k: v + 1 for k, v in expected_mentions.items()}
     expected_cooccur_count = {k: v + 1 for k, v in expected_cooccur.items()}
 
+    # Read-back barrier (issue #143): the pre-init writes committed on the
+    # bootstrap session, but the agents are *different* sessions. If an agent's
+    # `is known` predicate read runs before a seed is visible to it, it takes
+    # the `new <- 1` create branch instead of the commutative `+= 1`, and that
+    # stray Assign masks the commutative run on read -> lost increments. To
+    # exclude that create-race (which the pre-init is meant to design out), open
+    # a FRESH session and confirm every seeded key is visible from it before
+    # fanning agents out; a fresh session seeing them means other fresh agent
+    # sessions will too. Poll briefly to absorb any promotion-visibility lag.
+    print("read-back barrier: confirming all seeds are visible to a fresh session...")
+    verifier = websocket.create_connection(WS_URL, timeout=WS_TIMEOUT_S)
+    try:
+        deadline = time.monotonic() + 30.0
+        pending = (
+            [("tag", e) for e in expected_tag_records]
+            + [("mention", k) for k in expected_mentions]
+            + [("cooccur", k) for k in expected_cooccur]
+        )
+        while pending:
+            still = []
+            for kind, key in pending:
+                if kind == "tag":
+                    visible = len(tags_for_entity(verifier, pov, key)) > 0
+                elif kind == "mention":
+                    visible = mention_count(verifier, pov, key[0], key[1]) >= 1
+                else:
+                    visible = cooccur_count(verifier, pov, key[0], key[1]) >= 1
+                if not visible:
+                    still.append((kind, key))
+            pending = still
+            if pending:
+                if time.monotonic() > deadline:
+                    sys.exit(f"read-back barrier timed out; {len(pending)} seed(s) "
+                             f"never became visible to a fresh session")
+                time.sleep(0.05)
+    finally:
+        verifier.close()
+
     # Fan out: each agent opens its own WS and runs concurrently.
     threads = []
     t0 = time.monotonic()


### PR DESCRIPTION
## What

Adds a **read-back barrier** to the agent-swarm demo (both `demo.py` and `demo.go`) between pre-init and the agent fan-out.

## Why (#143)

The demo pre-initialises every key on the bootstrap session so the concurrent agents all hit the commutative `+= 1` / `|=` branch instead of the `new <- 1` create branch. But the agents are *separate sessions*. If an agent's `is known` predicate read runs before a seed is visible to it, it takes the create branch — and that stray `Assign` masks the commutative fold on read (`ApplyDeferredFold` treats a newer `Assign` as a base and breaks on older different-mutator entries), dropping increments. That matches the intermittent `got 1 want 2` self-check failure in #143.

Pre-init commits on the bootstrap session, so a bootstrap-side read-back would only confirm *its own* read-your-writes. Instead the barrier opens a **fresh** session and polls until every seeded key is visible from it before fanning out — a fresh session seeing a key means the other fresh agent sessions will too. 30s deadline, then it bails loudly.

## Scope

- Demo-side only — no engine change. The underlying create-race is still worth fixing in the engine; this removes the demo's exposure to it.
- One bug fixed along the way: the Python verifier connection polled before sending `new session;` (the Go barrier already did this) — without it every query returned `session not yet established`.

## Verification

- **Run-verified locally, both drivers** (`DEMO_SCALE=small`): each passes its self-check end-to-end with the barrier in place — 92 tag-provenance records across 25 entities + 53 mention counters + 45 cooccurrence counters, 4 concurrent agents, zero lost updates.
- Since the original failure was intermittent, a single green run can't *prove* the flake is gone; CI's examples job over repeated runs is the ongoing signal. #144 ensures any future failure can't cascade-skip the other examples.
