### PR TITLE
indy: characterise the #143 create-race fold orderings (regression guard)

### DIFF
--- a/orly/indy/context_fold.test.cc
+++ b/orly/indy/context_fold.test.cc
@@ -200,3 +200,105 @@ FIXTURE(Issue143FoldUndercount) {
     cond.notify_one();
   });
 }
+
+/* Issue #143 create-race characterisation.
+
+   The agent-swarm `add_mention` is a check-then-act: it emits `+= 1`
+   (TMutator::Add) when the key `is known`, else `new <- 1` -- and `new`
+   lowers to a TMutator::Assign entry (session.cc routes TNew through the
+   op_by_key/Assign path, not the deferred-commutative path). Under
+   concurrency the two branches can BOTH fire for one key when a writer's
+   read snapshot predates a concurrent create: one session sees the key
+   known and emits Add(1); another sees it absent and emits Assign(1).
+   The SeqNum is assigned at AppendUpdate (commit) time
+   (transaction_base.cc ~637), independent of when each session read, so
+   the Assign can land at a HIGHER SeqNum than the Add.
+
+   This fixture commits each ordering by hand (commit order == SeqNum
+   order; the newest entry is the fold anchor) and pins the resulting
+   read. The key finding for #143:
+
+     * `Add(1)` against an absent key folds to 1 -- the commutative
+       mutator already treats "missing" as the monoid identity (0). So
+       the `new <-` create branch is not needed for correctness; an
+       unconditional `+= 1` works on a fresh key.
+
+     * A newer Assign MASKS older Add runs (Add(1) then Assign(1) reads
+       as 1, not 2). This is the agent-swarm "got 1 want 2" undercount.
+       It is NOT a fold bug: Assign is destructive/final by definition,
+       so `x += 1; x <- 1` MUST read as 1. The fold is behaving
+       correctly; the defect is that the racy check-then-act emits a
+       destructive Assign for what is logically an initialise. The
+       engine-clean idiom is unconditional `+= 1` (no `is known` / `new`
+       branch); a deeper fix (a distinct create/upsert mutator that does
+       not mask commutative history) is a separate, larger indy change.
+
+   We therefore pin the SEMANTICALLY CORRECT values (Assign is
+   destructive), so this guard fails if a future change "fixes" #143 by
+   making Assign non-destructive -- which would corrupt legitimate
+   assign-after-increment. */
+FIXTURE(Issue143CreateRaceSemantics) {
+  Fiber::TFiberTestRunner runner([](std::mutex &mut, std::condition_variable &cond, bool &fin, Fiber::TRunner::TRunnerCons &) {
+    TSuprena arena;
+    void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
+    const TScheduler::TPolicy scheduler_policy(10, 10, 10ms);
+    TScheduler scheduler;
+    scheduler.SetPolicy(scheduler_policy);
+
+    Base::TUuid idx_id(TUuid::Twister);
+    const TIndexKey counter_key(idx_id, TKey(make_tuple(1L), &arena, state_alloc));
+
+    /* Each scenario gets a FRESH repo so prior entries don't leak. The
+       order of `entries` is the COMMIT order: earliest first => lowest
+       SeqNum. At read time the heap delivers highest SeqNum (newest)
+       first, so the LAST entry committed is the fold anchor. */
+    auto run_scenario = [&](const char *name,
+                            const std::vector<std::pair<TMutator, int64_t>> &entries,
+                            int64_t want) {
+      Orly::Indy::Disk::Sim::TMemEngine mem_engine(&scheduler, 256, 64, 128, 1, 64, 1);
+      auto manager = make_unique<TMyManager>(mem_engine.GetEngine(), &scheduler, MemMergeCoreVec, DiskMergeCoreVec);
+      Base::TUuid repo_id(TUuid::Twister);
+      auto repo = manager->GetRepo(repo_id, TTtl::max(), std::nullopt, true, true);
+      for (const auto &e : entries) {
+        auto transaction = manager->NewTransaction();
+        auto update = TUpdate::NewUpdate(TUpdate::TOpByKey{}, TKey(&arena),
+                                         TKey(Base::TUuid(TUuid::Twister), &arena, state_alloc));
+        update->AddEntry(counter_key, TKey(e.second, &arena, state_alloc), e.first);
+        transaction->Push(repo, update);
+        transaction->Prepare();
+        transaction->CommitAction();
+      }
+      TSuprena ctx_arena;
+      TContext context(repo, &ctx_arena);
+      EXPECT_EQ(context[counter_key], TKey(want, &arena, state_alloc));
+    };
+
+    /* Commit order is oldest->newest (newest = anchor). `want` is the
+       SEMANTICALLY CORRECT value under destructive-Assign semantics. */
+
+    /* `+= 1` on a totally absent key already folds to 1 (identity 0):
+       the create branch is unnecessary for a fresh counter. */
+    run_scenario("Add1_only_absentkey",     {{TMutator::Add,1}},                        1);
+    /* Two blind creates of the same value: latest Assign wins -> 1.
+       (A genuine user-level lost update; both writers said "set to 1".) */
+    run_scenario("Assign1_then_Assign1",     {{TMutator::Assign,1},{TMutator::Assign,1}},1);
+    /* Add anchored above an Assign base: folds base + acc -> 2. */
+    run_scenario("Assign1_then_Add1",        {{TMutator::Assign,1},{TMutator::Add,1}},   2);
+    /* THE #143 ORDERING: Add then a newer Assign. Assign is destructive
+       and masks the older increment -> 1. Correct for assignment; the
+       agent-swarm undercount is this case, caused by `new <-` emitting a
+       destructive Assign rather than an initialise. */
+    run_scenario("Add1_then_Assign1",        {{TMutator::Add,1},{TMutator::Assign,1}},   1);
+    /* Two distinct deferred increments fold -> 2 (the happy path the
+       demo wants; achieved when both writers take the `+=` branch). */
+    run_scenario("Add1_then_Add1",           {{TMutator::Add,1},{TMutator::Add,1}},      2);
+    /* Assign base + two increments -> 3. */
+    run_scenario("Assign1_Add1_Add1",        {{TMutator::Assign,1},{TMutator::Add,1},{TMutator::Add,1}}, 3);
+    /* Newer Assign masks two older increments -> 1 (destructive). */
+    run_scenario("Add1_Add1_then_Assign1",   {{TMutator::Add,1},{TMutator::Add,1},{TMutator::Assign,1}}, 1);
+
+    std::lock_guard<std::mutex> lock(mut);
+    fin = true;
+    cond.notify_one();
+  });
+}


### PR DESCRIPTION
## What this is

A **deterministic, engine-level reproduction and characterisation** of the
agent-swarm "got 1 want 2" intermittent undercount (#143), landed as a
regression guard. It also settles what the true root cause is.

This is **test-only** (`orly/indy/context_fold.test.cc`). It does not
change engine behaviour, because the investigation concluded the fold is
already correct (see below). The prior three indy hypotheses (#145 Tetris
window, #146 read-time fold determinism, #148 cross-repo snapshot) were
each guarded and disproven; this PR closes the loop on the actual
mechanism.

## The mechanism (reproduced deterministically)

`add_mention` is a check-then-act:

```
add_mention = ((1) effecting { *<['mention',e,d]>::(int) += 1; }
               if *<['mention',e,d]>::(int?) is known
               else (0) effecting { new <['mention',e,d]> <- 1; })
```

- `+= 1` lowers to a **deferred** `TMutator::Add` entry (the #49 path).
- `new <- 1` lowers to a **destructive** `TMutator::Assign` entry (`TNew`
  goes through `session.cc`'s `op_by_key`/Assign path, not the
  deferred-commutative path).

Under concurrency both branches can fire for one key when a writer's read
snapshot predates a concurrent create: one session sees the key *known*
and emits `Add(1)`; another sees it *absent* and emits `Assign(1)`.
SeqNums are assigned at `AppendUpdate`/commit time
(`transaction_base.cc` ~637), **not** at read time, so the `Assign` can
land at a **higher** SeqNum than the `Add`. The fixture commits exactly
this ordering (`Add1_then_Assign1`) and reads back **1**, not 2 — the
undercount.

## Root cause: not a fold bug

A newer `Assign` masking an older `Add` is **correct**: `Assign` is
destructive/final by definition, so `x += 1; x <- 1` MUST read as 1. The
read-path fold (`ApplyDeferredFold`) and the disk-path fold
(`FoldOneKey`) are both behaving correctly. The defect is at the
language-pattern level: a check-then-act with a non-commutative
`is known` predicate emits a destructive `Assign` for what is logically
an *initialise*. That is inherently racy at the user level.

Two findings the fixture also pins:

- **`+= 1` on a totally absent key already folds to 1** — the commutative
  mutator treats "missing" as the monoid identity (0). So the create
  branch is unnecessary; the engine already supports the clean
  unconditional-`+=` idiom. The demo mitigation in #149 (read-back
  barrier that forces the `+=` branch) is consistent with this.
- A deeper engine fix — a distinct create/upsert mutator that does *not*
  mask commutative history the way a deliberate `Assign` does — is a
  separate, larger indy change (new mutator + fold rules + disk format +
  codegen) and is intentionally **out of scope** here.

## Why the guard asserts what it does

The fixture pins the **semantically correct** values (Assign
destructive). It therefore fails if a future change "fixes" #143 by
making `Assign` non-destructive — which would silently corrupt
legitimate assign-after-increment. It complements the #146 single-mutator
fold guard with the mixed `Assign`/`Add` orderings the create-race
actually produces.

## Tests

- `orly/indy/context_fold.test` — passed 2, failed 0 (the new
  `Issue143CreateRaceSemantics` fixture + the existing
  `Issue143FoldUndercount`).
- `make test` — exit 0, full suite green.

## Residual uncertainty

This bug is intermittent and prior confident diagnoses were wrong three
times. What's now solid: the *fold orderings* are deterministically
characterised and the Assign-masking is provably correct under
assignment semantics. What remains a judgement call: whether to ship the
deeper create/upsert mutator, or to treat the racy check-then-act as an
acknowledged language limitation (with `+=`-on-absent as the recommended
idiom). This PR documents the decision point; it does not pre-empt it.
