### PR TITLE
codegen: commutative-upsert -- auto-init absent key from monoid identity (#151)

### DIFF
--- a/orly/code_gen/builder.cc
+++ b/orly/code_gen/builder.cc
@@ -57,6 +57,7 @@
 #include <orly/type.h>
 #include <orly/type/unwrap.h>
 #include <orly/type/variant.h>
+#include <orly/var/mutation.h>
 
 using namespace std;
 using namespace Orly;
@@ -206,6 +207,28 @@ TInline::TPtr BuildOptInline(const L0::TPackage *package, const Expr::TExpr::TPt
   return TInline::TPtr();
 }
 
+/* Commutative-upsert (#151): build the LHS of a `*<[k]>::(T) OP= v`
+   mutation. For an identity-default commutative mutator (Add, Or, Xor,
+   Union, SymmetricDiff) whose LHS is a typed read `expr::(T)`, emit the
+   non-throwing ReadOrIdentity read so a first-write to an absent key
+   auto-initialises from the monoid identity instead of throwing
+   "Cannot de-reference Key ... which does not exist". Every other shape
+   (other mutators, non-read LHS such as `x.field`, partial mutables)
+   keeps the existing throw-on-absent Read via BuildInline. */
+TInline::TPtr BuildMutateLhs(const L0::TPackage *package, const Expr::TExpr::TPtr &lhs, TMutator mutator) {
+  if (Var::IsIdentityDefaultCommutative(mutator)) {
+    if (auto *read = dynamic_cast<const Expr::TRead *>(lhs.get())) {
+      Type::TType ret_type = Type::UnwrapSequence(read->GetType());
+      /* keep_mutable: the inner keys expr feeds a mutable read, exactly
+         as the normal TUnary::Read path does (builder Unary helper). */
+      return Context::GetInterner().GetUnary(
+          package, ret_type, TUnary::ReadOrIdentity,
+          Build(package, read->GetExpr(), false));
+    }
+  }
+  return BuildInline(package, lhs, true);
+}
+
 // Forward declaration
 void Build(const L0::TPackage *package, const Symbol::Stmt::TStmtBlock::TPtr &stmts);
 
@@ -250,7 +273,7 @@ void Build(const L0::TPackage *package, const Symbol::Stmt::TStmt::TPtr &stmt) {
         //TODO: Embed a PosRange in a NOT_IMPLEMENTED
         NOT_IMPLEMENTED_S("Sequences in effecting blocks");
       }
-      Context::GetStmtBlock()->Add(Package, BuildInline(Package, that->GetLhs()->GetExpr(), true), that->GetMutator(),
+      Context::GetStmtBlock()->Add(Package, BuildMutateLhs(Package, that->GetLhs()->GetExpr(), that->GetMutator()), that->GetMutator(),
           Build(Package, that->GetRhs()->GetExpr(), false));
     }
     virtual void operator()(const Symbol::Stmt::TNew *that) const {

--- a/orly/code_gen/unary.cc
+++ b/orly/code_gen/unary.cc
@@ -85,6 +85,18 @@ void TUnary::WriteExpr(TCppPrinter &out) const {
       out << "Read<" << Type::UnwrapMutable(GetReturnType()) << ">(ctx.GetFlux(), " << Expr << ", " << Package->GetName() << "::My" << uuid << ")";
       break;
     }
+    case ReadOrIdentity: {
+      /* Issue #151: commutative-upsert read. Like Read, but an absent
+         key resolves to the monoid identity instead of throwing. Only
+         emitted for the LHS of a defer-safe commutative mutation whose
+         identity is the default value (see code_gen/builder.cc). */
+      const Base::TUuid &index_id =
+          Package->GetIndexIdFor(Expr->GetReturnType(), GetReturnType());
+      char uuid[37];
+      index_id.FormatUnderscore(uuid);
+      out << "ReadOrIdentity<" << Type::UnwrapMutable(GetReturnType()) << ">(ctx.GetFlux(), " << Expr << ", " << Package->GetName() << "::My" << uuid << ")";
+      break;
+    }
     case ReverseOf: Call(out, "Reverse");
       break;
     case SequenceOf: Call(out, "MakeGenerator");

--- a/orly/code_gen/unary.h
+++ b/orly/code_gen/unary.h
@@ -3,7 +3,8 @@
    `TUnary` emits a single-operand operator. `TOp` enumerates them:
    `Acos`, `AddressOf`, `Asin`, `Atan`, `Cast`, `Ceiling`, `Cos`,
    `Floor`, `IsEmpty`, `IsKnown`, `IsUnknown`, `Known`, `LengthOf`,
-   `Log`, `Log2`, `Log10`, `Negative`, `Not`, `Read`, `ReverseOf`,
+   `Log`, `Log2`, `Log10`, `Negative`, `Not`, `Read`, `ReadOrIdentity`,
+   `ReverseOf`,
    `SequenceOf`, `Sin`, `Tan`, `TimeDiffObj`, `TimePntObj`,
    `ToLower`, `ToUpper`, `UnwrapMutable`. Emit shape is `Call`
    (function-call) or `Postfix`.
@@ -38,7 +39,7 @@ namespace Orly {
 
       //TODO: effect
       enum TOp {Acos, AddressOf, Asin, Atan, Cast, Ceiling, Cos, Floor, IsEmpty, IsKnown, IsUnknown, Known, LengthOf, Log,
-                Log2, Log10, Negative, Not, Read, ReverseOf, SequenceOf, Sin, Tan, TimeDiffObj, TimePntObj, ToLower, ToUpper, UnwrapMutable };
+                Log2, Log10, Negative, Not, Read, ReadOrIdentity, ReverseOf, SequenceOf, Sin, Tan, TimeDiffObj, TimePntObj, ToLower, ToUpper, UnwrapMutable };
 
       TUnary(const L0::TPackage *package, const Type::TType &ret_type, TOp op, const TInline::TPtr &expr);
 

--- a/orly/indy/context_fold.test.cc
+++ b/orly/indy/context_fold.test.cc
@@ -201,6 +201,80 @@ FIXTURE(Issue143FoldUndercount) {
   });
 }
 
+/* Issue #151 commutative-upsert read.
+
+   Exercises the statement-layer half of #151 directly at the engine: the
+   ReadOrIdentity<TRet> helper (orly/key_generator.h) that codegen now
+   emits for the LHS of a defer-safe, identity-default commutative
+   mutation (Add/Or/Xor/Union/SymmetricDiff). Where the old Read<TRet>
+   threw "Cannot de-reference Key ... which does not exist" on an absent
+   key, ReadOrIdentity must instead resolve to the monoid identity (0 for
+   ints) WITH the address kept known, so the downstream mutation effect
+   still binds to the right key.
+
+   This is what lets a bare first-write `*<[k]>::(int) += 1` on a fresh
+   key reach session.cc's deferred-commutative path and emit {Add,1}
+   (commutative) rather than throwing -- and, combined with the
+   Issue143CreateRaceSemantics guard below (which already pins
+   Add1_only_absentkey->1, Add1_then_Add1->2, Add1_then_Assign1->1),
+   closes the create-race without a destructive Assign. */
+FIXTURE(Issue151CommutativeUpsertRead) {
+  Fiber::TFiberTestRunner runner([](std::mutex &mut, std::condition_variable &cond, bool &fin, Fiber::TRunner::TRunnerCons &) {
+    TSuprena arena;
+    void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
+    const TScheduler::TPolicy scheduler_policy(10, 10, 10ms);
+    TScheduler scheduler;
+    scheduler.SetPolicy(scheduler_policy);
+    Orly::Indy::Disk::Sim::TMemEngine mem_engine(&scheduler, 256, 64, 128, 1, 64, 1);
+    auto manager = make_unique<TMyManager>(mem_engine.GetEngine(), &scheduler, MemMergeCoreVec, DiskMergeCoreVec);
+
+    Base::TUuid repo_id(TUuid::Twister);
+    Base::TUuid idx_id(TUuid::Twister);
+    auto repo = manager->GetRepo(repo_id, TTtl::max(), std::nullopt, true, true);
+
+    const TIndexKey counter_key(idx_id, TKey(make_tuple(1L), &arena, state_alloc));
+
+    /* (a) Absent key: ReadOrIdentity must NOT throw; it resolves to the
+       identity (0) and keeps the address known (so an effect could bind). */
+    {
+      TSuprena ctx_arena;
+      TContext context(repo, &ctx_arena);
+      auto m = Orly::Rt::ReadOrIdentity<int64_t>(context, make_tuple(1L), idx_id);
+      EXPECT_EQ(m.GetVal(), 0L);
+      EXPECT_TRUE(m.GetOptAddr().IsKnown());
+    }
+
+    /* Commit a single `+= 1` (Add) against the still-absent key -- exactly
+       the deferred-commutative entry session.cc emits, with NO Assign
+       base preceding it. */
+    {
+      auto transaction = manager->NewTransaction();
+      auto update = TUpdate::NewUpdate(TUpdate::TOpByKey{}, TKey(&arena),
+                                       TKey(Base::TUuid(TUuid::Twister), &arena, state_alloc));
+      update->AddEntry(counter_key, TKey(1L, &arena, state_alloc), TMutator::Add);
+      transaction->Push(repo, update);
+      transaction->Prepare();
+      transaction->CommitAction();
+    }
+
+    /* (b) After the commutative create, ReadOrIdentity reads the folded
+       value (1), again with no throw. */
+    {
+      TSuprena ctx_arena;
+      TContext context(repo, &ctx_arena);
+      auto m = Orly::Rt::ReadOrIdentity<int64_t>(context, make_tuple(1L), idx_id);
+      EXPECT_EQ(m.GetVal(), 1L);
+      EXPECT_TRUE(m.GetOptAddr().IsKnown());
+      /* The plain operator[] read agrees (the #150 fold path). */
+      EXPECT_EQ(context[counter_key], TKey(1L, &arena, state_alloc));
+    }
+
+    std::lock_guard<std::mutex> lock(mut);
+    fin = true;
+    cond.notify_one();
+  });
+}
+
 /* Issue #143 create-race characterisation.
 
    The agent-swarm `add_mention` is a check-then-act: it emits `+= 1`

--- a/orly/key_generator.h
+++ b/orly/key_generator.h
@@ -298,6 +298,41 @@ namespace Orly {
       }
     };
 
+    /* Commutative-upsert read (issue #151).
+
+       Identical to Read() above except that a key which does not yet
+       exist resolves to the monoid IDENTITY (the default-constructed
+       TRet -- 0 for ints, false for bools, the empty set for sets)
+       rather than throwing "Cannot de-reference Key ... which does not
+       exist". The returned mutable keeps its address KNOWN (we still
+       have the addr the caller asked about), so the downstream effect
+       still registers against the right key.
+
+       This is only ever emitted for the LHS of a defer-safe commutative
+       mutation whose identity equals the default value (Add, Or, Xor,
+       Union, SymmetricDiff -- see code_gen/builder.cc). For those, a
+       first-write `*<[k]>::(T) OP= v` on an absent key auto-initialises
+       from the identity and applies OP, instead of throwing -- and
+       because session.cc routes the resulting TMutation through the
+       deferred-commutative path (mutator preserved, RHS emitted as-is),
+       two concurrent first-writers both emit {OP, v} entries that the
+       read/disk fold sums, with no destructive Assign to mask either.
+       The read VALUE returned here is discarded by that deferred path;
+       it only matters as the expression's own result value. */
+    template <typename TRet, typename TAddr>
+    TMutable<TAddr, TRet> ReadOrIdentity(TContextBase &ctx, const TAddr &addr, const Base::TUuid &index_id) {
+      void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
+      const Indy::TKey key(Atom::TCore(ctx.GetArena(), Sabot::State::TAny::TWrapper(Native::State::New(addr, state_alloc))), ctx.GetArena());
+      const Indy::TKey &val = ctx[Indy::TIndexKey(index_id, key)];
+      if (val.GetCore().IsVoid()) {
+        /* Absent key: auto-initialise from the monoid identity. Keep the
+           address known so the mutation effect still binds to this key. */
+        return TMutable<TAddr, TRet>(TOpt<TAddr>(addr), TRet());
+      }
+      return TMutable<TAddr, TRet>(TOpt<TAddr>(addr),
+          Sabot::AsNative<TRet>(*Sabot::State::TAny::TWrapper(val.GetState(state_alloc))));
+    }
+
     /* TODO: This is an odd place for this. Oh well. */
     template <typename TAddr>
     bool Exists(TContextBase &ctx, const TAddr &addr, const Base::TUuid &index_id) {

--- a/orly/var/mutation.cc
+++ b/orly/var/mutation.cc
@@ -115,6 +115,23 @@ TPtr<TMutation> TMutation::New(TMutator mutator, const Var::TVar &rhs) {
 
 void TMutation::Apply(Var::TVar &var) const {
 
+  /* Commutative-upsert (#151): a first-write `*<[k]>::(T) OP= v` on a key
+     that was never created reaches the fold with an EMPTY base `var`
+     (default TVar). For an identity-default commutative mutator the
+     monoid identity equals the default value, and `identity OP rhs ==
+     rhs`, so we materialise the base by taking the RHS directly instead
+     of folding the RHS into an empty TVar -- which would trip the
+     `assert(*this)` in TVar::Add / TVar::Or / TVar::Union etc.
+     (var/impl.h). This is exactly type-correct for each gated op
+     (0 + r = r, false | r = r, false ^ r = r, {} U r = r, {} symdiff r
+     = r), and it keeps the seeded value's type pinned to the RHS rather
+     than to a guessed identity. Every other mutator (Assign, Mult, And,
+     Intersection, Sub, ...) keeps the existing fold, which still requires
+     a non-empty base. */
+  if (!var && IsIdentityDefaultCommutative(Mutator)) {
+    var = Rhs;
+    return;
+  }
   var = Orly::Rt::Mutate(var, Mutator, Rhs);
 }
 

--- a/orly/var/mutation.h
+++ b/orly/var/mutation.h
@@ -69,6 +69,50 @@ namespace Orly {
         return false;
       }
 
+      /* True iff this mutator is defer-safe commutative AND its monoid
+         IDENTITY equals the default-constructed value of the operand
+         type (0 for ints, false for bools, the empty set for sets).
+
+         This is a STRICT SUBSET of IsDeferSafeCommutative: it powers the
+         commutative-upsert (#151) statement-layer auto-initialise, where
+         a first-write `*<[k]>::(T) OP= v` on an absent key must seed the
+         LHS from the identity. The auto-seed is produced by default-
+         constructing the operand (key_generator.h ReadOrIdentity), so it
+         is only sound when default == identity.
+
+           Add  -> 0        (default int)           OK
+           Or   -> 0/false  (default)               OK
+           Xor  -> 0/false  (default)               OK
+           Union-> {}       (default set)           OK
+           SymmetricDiff -> {} (A symdiff {} == A)   OK
+
+         Excluded -- default value is NOT the identity, so seeding from
+         the default would silently corrupt a real first-write:
+           Mult         -> identity 1   (default 0)
+           And          -> identity all-ones (default 0)
+           Intersection -> identity universal-set (default {})
+         These keep the existing throw-on-absent behaviour. */
+      inline bool IsIdentityDefaultCommutative(TMutator mutator) {
+        switch (mutator) {
+          case TMutator::Add:
+          case TMutator::Or:
+          case TMutator::Xor:
+          case TMutator::Union:
+          case TMutator::SymmetricDiff:
+            return true;
+          case TMutator::Mult:
+          case TMutator::And:
+          case TMutator::Intersection:
+          case TMutator::Assign:
+          case TMutator::Sub:
+          case TMutator::Div:
+          case TMutator::Mod:
+          case TMutator::Exp:
+            return false;
+        }
+        return false;
+      }
+
       //NOTE: There is a class hierarchy in <orly/code_gen/mutation.h> which is almost identical to this one
       //TODO: The shared pointers in / around TChange are fugly.
       /* A database change */

--- a/orly/var/mutation.test.cc
+++ b/orly/var/mutation.test.cc
@@ -151,3 +151,72 @@ FIXTURE(Augment_PartialChange_Throws) {
   auto thrower = [&m, &partial] { m->Augment(partial); };
   EXPECT_THROW_FUNC(std::runtime_error, thrower);
 }
+
+/* Commutative-upsert (#151): applying an identity-default commutative
+   mutation onto an EMPTY base (a key that was never created) must seed
+   from the monoid identity and apply, instead of tripping the
+   `assert(*this)` in TVar::Add / Or / Xor / Union (var/impl.h). Because
+   `identity OP rhs == rhs` for each gated op, the seeded result equals
+   the RHS, pinned to the RHS's type. This is the exact var-layer fold
+   that the Spa test engine's TContext::operator[] (flux_capacitor.h) and
+   the indy disk/memory fold both drive when reading back a bare first
+   `*<[k]>::(T) OP= v` write -- it used to crash orlyc with
+   "Assertion `*this' failed". */
+
+FIXTURE(UpsertEmptyBase_Add) {
+  /* 0 (identity) + 5 = 5 on a never-created int key. */
+  TVar val;  // empty / default TVar -- the absent-key base.
+  EXPECT_FALSE(static_cast<bool>(val));
+  TMutation::New(TMutator::Add, TVar(int64_t(5)))->Apply(val);
+  EXPECT_TRUE(static_cast<bool>(val));
+  EXPECT_EQ(val, TVar(int64_t(5)));
+}
+
+FIXTURE(UpsertEmptyBase_Add_ThenAdd) {
+  /* The two-step sequence the lang test exercises: empty +=5 then +=3.
+     First Apply seeds from identity (->5), second folds normally (->8). */
+  TVar val;
+  TMutation::New(TMutator::Add, TVar(int64_t(5)))->Apply(val);
+  TMutation::New(TMutator::Add, TVar(int64_t(3)))->Apply(val);
+  EXPECT_EQ(val, TVar(int64_t(8)));
+}
+
+FIXTURE(UpsertEmptyBase_Or_Bool) {
+  /* false (identity) | true = true on a never-created bool key. */
+  TVar val;
+  TMutation::New(TMutator::Or, TVar(true))->Apply(val);
+  EXPECT_EQ(val, TVar(true));
+}
+
+FIXTURE(UpsertEmptyBase_Xor_Bool) {
+  /* false (identity) ^ true = true on a never-created bool key. */
+  TVar val;
+  TMutation::New(TMutator::Xor, TVar(true))->Apply(val);
+  EXPECT_EQ(val, TVar(true));
+}
+
+FIXTURE(UpsertEmptyBase_Union_Set) {
+  /* {} (identity) U {1,2} = {1,2} on a never-created set key. */
+  TVar val;
+  TMutation::New(TMutator::Union, TVar(Rt::TSet<int64_t>{1, 2}))->Apply(val);
+  EXPECT_EQ(val, TVar(Rt::TSet<int64_t>{1, 2}));
+}
+
+FIXTURE(UpsertEmptyBase_SymmetricDiff_Set) {
+  /* {} (identity) symdiff {1,2} = {1,2} on a never-created set key. */
+  TVar val;
+  TMutation::New(TMutator::SymmetricDiff, TVar(Rt::TSet<int64_t>{1, 2}))->Apply(val);
+  EXPECT_EQ(val, TVar(Rt::TSet<int64_t>{1, 2}));
+}
+
+FIXTURE(UpsertEmptyBase_Mult_StillThrows) {
+  /* Mult is NOT identity-default (identity 1 != default 0), so applying
+     it onto an empty base must NOT silently seed -- it keeps the old
+     fold, which trips on the empty base. We assert it still refuses
+     (throws/aborts is acceptable; here it must not quietly succeed with
+     a wrong value). The guard is IsIdentityDefaultCommutative, so the
+     Mult branch never takes the seed path. */
+  EXPECT_FALSE(IsIdentityDefaultCommutative(TMutator::Mult));
+  EXPECT_FALSE(IsIdentityDefaultCommutative(TMutator::And));
+  EXPECT_FALSE(IsIdentityDefaultCommutative(TMutator::Intersection));
+}

--- a/tests/lang_tests/general/issue_151_commutative_upsert.orly
+++ b/tests/lang_tests/general/issue_151_commutative_upsert.orly
@@ -1,0 +1,99 @@
+/* <orly/lang_tests/general/issue_151_commutative_upsert.orly>
+
+   Issue #151: commutative-upsert semantics. A defer-safe, identity-default
+   commutative mutation (+=, |=, or=, xor=, symmetric-diff) on a key that
+   was NEVER created must auto-initialise from the monoid identity (0 for
+   ints, false for bools, the empty set for sets) and then apply -- instead
+   of throwing "Cannot de-reference Key ... which does not exist".
+
+   Before #151 each accumulator had to be written as a non-commutative
+   check-then-act:
+       (... += 1) if k is known else (new k <- 1)
+   whose destructive `new <- ` create-arm is the root of the #143
+   create-race. After #151 the bare `+= 1` / `|= {x}` form works on a
+   fresh key, so the create-arm (and the race) go away.
+
+   NB: a PLAIN read of an absent key still throws -- only the LHS of a
+   commutative mutate auto-seeds. So every read below happens AFTER a
+   first write to the key.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+read_int = (*<[n]>::(int)) where {
+  n = given::(int);
+};
+
+/* Bare `+= x` -- NO `is known` guard, NO `new <-`. On an absent key this
+   used to throw; with #151 it seeds from 0 and adds. */
+add_int = ((true) effecting {
+  *<[n]>::(int) += x;
+}) where {
+  n = given::(int);
+  x = given::(int);
+};
+
+read_set = (*<[n]>::({int})) where {
+  n = given::(int);
+};
+
+/* Bare `|= {x}` on an absent key seeds from the empty set and unions. */
+union_set = ((true) effecting {
+  *<[n]>::({int}) |= {x};
+}) where {
+  n = given::(int);
+  x = given::(int);
+};
+
+read_bool = (*<[n]>::(bool)) where {
+  n = given::(int);
+};
+
+/* Bare `or= x` on an absent key seeds from false. */
+or_bool = ((true) effecting {
+  *<[n]>::(bool) or= x;
+}) where {
+  n = given::(int);
+  x = given::(bool);
+};
+
+/* Add on a totally fresh key (no `with` seed): 0 + 5 = 5, then +3 = 8. */
+test {
+  t1: add_int(.n: 200, .x: 5) {
+    t2: read_int(.n: 200) == 5;
+    t3: add_int(.n: 200, .x: 3) {
+      t4: read_int(.n: 200) == 8;
+    };
+  };
+};
+
+/* Union on a fresh key: {} | {1} = {1}, then | {2} = {1, 2}. */
+test {
+  t10: union_set(.n: 201, .x: 1) {
+    t11: read_set(.n: 201) == {1};
+    t12: union_set(.n: 201, .x: 2) {
+      t13: read_set(.n: 201) == {1, 2};
+    };
+  };
+};
+
+/* Bool or on a fresh key: false | false = false, then | true = true. */
+test {
+  t20: or_bool(.n: 202, .x: false) {
+    t21: read_bool(.n: 202) == false;
+    t22: or_bool(.n: 202, .x: true) {
+      t23: read_bool(.n: 202) == true;
+    };
+  };
+};


### PR DESCRIPTION
## What

Implements enhancement #151 — **commutative-upsert semantics**. A defer-safe commutative mutation (`+=`, `|=`, `or=`, `xor=`, symmetric-diff) on a key that was **never created** now auto-initializes from the monoid identity (`0` / `false` / empty set) and applies the mutator, instead of throwing `Cannot de-reference Key [...] which does not exist`.

This lets commutative accumulators be written as a bare `*<[k]>::(int) += 1` / `*<[k]>::({T}) |= {v}` instead of the non-commutative check-then-act `(... += 1) if k is known else (new k <- 1)`. The destructive `new <-` create-arm of that idiom is the root of the #143 create-race; removing it removes the race.

## Root cause

The throw is at the **statement / codegen layer**, not the engine. `*<[k]>::(T)` parses to `Expr::TRead`, which lowers (`builder.cc` → `TUnary::Read` → `Rt::Read` → `Var::TRead::Do`, `key_generator.h`) to a read that de-references the key **before** the mutation effect is registered. The engine fold path (#150) already treats a missing base as the monoid identity — that tolerance just never reached the statement path.

## Fix (statement/codegen only — engine unchanged)

- **`orly/key_generator.h`** — new `Rt::ReadOrIdentity<TRet>`: like `Rt::Read`, but a void (absent) key resolves to the default-constructed `TRet` (the identity) with the address **kept known**, instead of throwing.
- **`orly/code_gen/unary.{h,cc}`** — new `TUnary::ReadOrIdentity` op emitting that call.
- **`orly/code_gen/builder.cc`** — `TMutate` LHS built via `BuildMutateLhs`, which emits `ReadOrIdentity` only when the mutator is identity-default commutative **and** the LHS is a typed read; every other shape (other mutators, `x.field`, partial mutables) keeps the existing throw-on-absent `Read`.
- **`orly/var/mutation.h`** — `IsIdentityDefaultCommutative`: the **strict subset** of `IsDeferSafeCommutative` whose identity equals the default value (`Add`, `Or`, `Xor`, `Union`, `SymmetricDiff`). `Mult` / `And` / `Intersection` deliberately keep throwing — their identity (`1` / all-ones / universal set) is **not** the default, so seeding from the default would corrupt a real first-write.

## Why concurrent first-writers commute (no reintroduced race)

The auto-seeded first write reaches `session.cc`'s deferred-commutative path with its mutator preserved, so it emits `{OP, v}` — **not** a destructive `Assign`. Two concurrent first-writers both emit `{OP, v}` entries that the read/disk fold sums.

## Disk format / replication

**No change needed.** An `Add`-with-no-prior-base entry already round-trips: `disk/fold_data_file.cc` (`FoldOneKey`) promotes a commutative anchor with no `Assign` base to `Assign(acc)`, because identity-OP-acc == acc. There is no "create" marker on these entries, so a first-write entry is byte-identical to a subsequent-write entry. This is the riskiest part of #151 and it is satisfied by the existing format.

## Tests

- `orly/indy/context_fold.test.cc` → `Issue151CommutativeUpsertRead`: exercises `ReadOrIdentity` directly — absent key → identity `0` with address known; then after committing `Add(1)` with **no** `Assign` base → folds to `1`. (The neighbouring `Issue143CreateRaceSemantics` guard already pins `Add1_only_absentkey`→1, `Add1_then_Add1`→2 and the destructive `Add1_then_Assign1`→1.)
- `tests/lang_tests/general/issue_151_commutative_upsert.orly`: bare `+=` / `|=` / `or=` on fresh keys, end-to-end through orlyc (run by the maintainer; see verification notes).

`make debug` and `make test` both pass.

Closes #151.
