### PR TITLE
agent-swarm: bare commutative ops, retire the #143 pre-init/barrier

### DIFF
--- a/examples/agent-swarm/demo.go
+++ b/examples/agent-swarm/demo.go
@@ -384,15 +384,6 @@ func commaize(n int) string {
 	return string(out)
 }
 
-func sortedTagList(m map[string]bool) []string {
-	out := make([]string, 0, len(m))
-	for k := range m {
-		out = append(out, k)
-	}
-	sort.Strings(out)
-	return out
-}
-
 func recordSetsEqual(a, b map[tagRecord]bool) bool {
 	if len(a) != len(b) {
 		return false
@@ -481,85 +472,16 @@ func main() {
 		numAgents, numDocs, len(expectedTagRecords), len(expectedCooccur))
 	fmt.Printf("total writes from agents: %s\n", commaize(totalWrites))
 
-	// Pre-initialise every key so concurrent agents take the
-	// commutative |= / += branch (never the `new <-` create branch).
-	fmt.Println("\npre-initialising all keys via the bootstrap session...")
-	for entity, records := range expectedTagRecords {
-		// Seed with the lex-first tag for determinism, stamped with a
-		// dedicated "seed" agent; the agents union the rest.
-		tagset := map[string]bool{}
-		for rec := range records {
-			tagset[rec.tag] = true
-		}
-		first := sortedTagList(tagset)[0]
-		addTag(boot, pov, entity, first, "seed")
-		records[tagRecord{first, "seed"}] = true
-	}
-	for mk := range expectedMentions {
-		addMention(boot, pov, mk.entity, mk.docID)
-	}
-	for pk := range expectedCooccur {
-		addCooccur(boot, pov, pk.a, pk.b)
-	}
-
-	// Pre-init seeded each key with one of the agent ops; adjust expectations.
-	expectedMentionCount := map[mentionKey]int{}
-	for k, v := range expectedMentions {
-		expectedMentionCount[k] = v + 1
-	}
-	expectedCooccurCount := map[pairKey]int{}
-	for k, v := range expectedCooccur {
-		expectedCooccurCount[k] = v + 1
-	}
-
-	// Read-back barrier (issue #143): the pre-init writes committed on the
-	// bootstrap session, but the agents are *different* sessions. If an agent's
-	// `is known` predicate read runs before a seed is visible to it, it takes
-	// the `new <- 1` create branch instead of the commutative `+= 1`, and that
-	// stray Assign masks the commutative run on read -> lost increments. To
-	// exclude that create-race (which the pre-init is meant to design out), open
-	// a FRESH session and confirm every seeded key is visible from it before
-	// fanning agents out; a fresh session seeing them means other fresh agent
-	// sessions will too. Poll briefly to absorb any promotion-visibility lag.
-	fmt.Println("read-back barrier: confirming all seeds are visible to a fresh session...")
-	{
-		vDialer := *websocket.DefaultDialer
-		vDialer.HandshakeTimeout = wsTimeout
-		verifier, _, err := vDialer.Dial(wsURL, nil)
-		if err != nil {
-			panic(err)
-		}
-		mustSend(verifier, "new session;")
-		deadline := time.Now().Add(30 * time.Second)
-		for {
-			pending := 0
-			for e := range expectedTagRecords {
-				if len(tagsForEntity(verifier, pov, e)) == 0 {
-					pending++
-				}
-			}
-			for mk := range expectedMentions {
-				if mentionCount(verifier, pov, mk.entity, mk.docID) < 1 {
-					pending++
-				}
-			}
-			for pk := range expectedCooccur {
-				if cooccurCount(verifier, pov, pk.a, pk.b) < 1 {
-					pending++
-				}
-			}
-			if pending == 0 {
-				break
-			}
-			if time.Now().After(deadline) {
-				verifier.Close()
-				fmt.Fprintf(os.Stderr, "read-back barrier timed out; %d seed(s) never became visible to a fresh session\n", pending)
-				os.Exit(1)
-			}
-			time.Sleep(50 * time.Millisecond)
-		}
-		verifier.Close()
-	}
+	// No pre-init and no read-back barrier. With commutative-upsert
+	// (issue #151) the very first write to a key is the same bare += / |=
+	// the engine treats commutatively -- an absent key folds from the
+	// monoid identity (0 / empty set) -- so concurrent agents can *create*
+	// and aggregate brand-new keys with zero coordination, no seeding, and
+	// no create-race. The expected end-state is exactly the corpus rollup:
+	// every (entity, doc) mention is written once, and each pair's
+	// cooccurrence count is its number of docs.
+	expectedMentionCount := expectedMentions
+	expectedCooccurCount := expectedCooccur
 
 	// Fan out: each agent on its own WS, all concurrent.
 	var wg sync.WaitGroup

--- a/examples/agent-swarm/demo.py
+++ b/examples/agent-swarm/demo.py
@@ -308,69 +308,16 @@ def main():
           f"unordered pairs: {len(expected_cooccur)}")
     print(f"total writes from agents: {total_writes:,}")
 
-    # Pre-initialise every key so concurrent agents all take the
-    # commutative `+=` / `|=` branch (never the `new <-` create branch).
-    # Isolates whether lost updates come from the create-race or from
-    # the field-call itself -- if the demo passes, it's the field-call.
-    print("\npre-initialising all keys via the bootstrap session...")
-    for entity, records in expected_tag_records.items():
-        # Seed with one arbitrary tag so the set exists; the agents
-        # union the rest. Pick the lexicographically first tag for
-        # determinism, stamped with a dedicated "seed" agent so it's a
-        # distinct, predictable provenance record.
-        first_tag = sorted({tag for tag, _agent in records})[0]
-        add_tag(boot, pov, entity, first_tag, "seed")
-        records.add((first_tag, "seed"))
-    for (entity, doc_id) in expected_mentions:
-        # Seed with a count of 1, then the agent's add_mention bumps
-        # to the expected 2. Adjust ground truth accordingly.
-        add_mention(boot, pov, entity, doc_id)
-    for (a, b) in expected_cooccur:
-        add_cooccur(boot, pov, a, b)
-
-    # Pre-init seeded each key with exactly one of the agent ops, so
-    # the expected end-state per key bumps up by one.
-    expected_mention_count = {k: v + 1 for k, v in expected_mentions.items()}
-    expected_cooccur_count = {k: v + 1 for k, v in expected_cooccur.items()}
-
-    # Read-back barrier (issue #143): the pre-init writes committed on the
-    # bootstrap session, but the agents are *different* sessions. If an agent's
-    # `is known` predicate read runs before a seed is visible to it, it takes
-    # the `new <- 1` create branch instead of the commutative `+= 1`, and that
-    # stray Assign masks the commutative run on read -> lost increments. To
-    # exclude that create-race (which the pre-init is meant to design out), open
-    # a FRESH session and confirm every seeded key is visible from it before
-    # fanning agents out; a fresh session seeing them means other fresh agent
-    # sessions will too. Poll briefly to absorb any promotion-visibility lag.
-    print("read-back barrier: confirming all seeds are visible to a fresh session...")
-    verifier = websocket.create_connection(WS_URL, timeout=WS_TIMEOUT_S)
-    try:
-        send(verifier, "new session;")
-        deadline = time.monotonic() + 30.0
-        pending = (
-            [("tag", e) for e in expected_tag_records]
-            + [("mention", k) for k in expected_mentions]
-            + [("cooccur", k) for k in expected_cooccur]
-        )
-        while pending:
-            still = []
-            for kind, key in pending:
-                if kind == "tag":
-                    visible = len(tags_for_entity(verifier, pov, key)) > 0
-                elif kind == "mention":
-                    visible = mention_count(verifier, pov, key[0], key[1]) >= 1
-                else:
-                    visible = cooccur_count(verifier, pov, key[0], key[1]) >= 1
-                if not visible:
-                    still.append((kind, key))
-            pending = still
-            if pending:
-                if time.monotonic() > deadline:
-                    sys.exit(f"read-back barrier timed out; {len(pending)} seed(s) "
-                             f"never became visible to a fresh session")
-                time.sleep(0.05)
-    finally:
-        verifier.close()
+    # No pre-init and no read-back barrier. With commutative-upsert
+    # (issue #151) the very first write to a key is the same bare `+= 1`
+    # / `|=` the engine treats commutatively -- an absent key folds from
+    # the monoid identity (0 / empty set) -- so concurrent agents can
+    # *create* and aggregate brand-new keys with zero coordination, no
+    # seeding, and no create-race. The expected end-state is therefore
+    # exactly the corpus rollup: every (entity, doc) mention is written
+    # once, and each pair's cooccurrence count is its number of docs.
+    expected_mention_count = expected_mentions
+    expected_cooccur_count = expected_cooccur
 
     # Fan out: each agent opens its own WS and runs concurrently.
     threads = []

--- a/examples/agent-swarm/graph.orly
+++ b/examples/agent-swarm/graph.orly
@@ -23,13 +23,14 @@
    writers all land their contributions and the merge machinery
    aggregates correctly.
 
-   Each function below mirrors the pattern from
-   examples/wikipedia-pageviews/views.orly: a single function that
-   takes the `is known` branch for subsequent writes and the `new <-`
-   branch for the very first write at a key. The driver pre-initialises
-   every key before agents fan out so all concurrent writers take the
-   commutative branch (we want to isolate the +=/|= property, not the
-   create-race).
+   Each write function is a BARE commutative field call -- no `is known`
+   check, no `new <-` create branch. With commutative-upsert (issue #151)
+   a `+=` / `|=` on an absent key folds from the monoid identity (0 /
+   empty set), so the very first writer at a key needs no special-casing.
+   That is what makes this coordination-free: concurrent agents can both
+   *create* and aggregate the same brand-new key with no pre-init and no
+   read-back barrier -- the create-race that the old `is known` /
+   `new <-` pattern was prone to (issue #143) simply cannot arise.
 
    Copyright 2010-2026 Atomic Kismet Company
 
@@ -53,16 +54,15 @@ tags_for_entity = (((*<['entity', e]>::({<{.tag: str, .agent: str}>})) if *<['en
   e = given::(str);
 };
 
-/* Union one (tag, agent) record into the entity's set. First call
-   creates with the singleton; subsequent calls union -- both shapes
-   commute under concurrent callers writing different records at the
-   same key. Re-asserting the same (tag, agent) is idempotent; the same
-   tag from a different agent is a distinct provenance record. */
-add_tag = (((1) effecting {
+/* Union one (tag, agent) record into the entity's set. On an absent key
+   the set folds from empty, so the first union just yields the singleton
+   and subsequent calls accumulate -- all callers commute, so concurrent
+   agents writing different records at the same key all land. Re-asserting
+   the same (tag, agent) is idempotent; the same tag from a different
+   agent is a distinct provenance record. */
+add_tag = ((1) effecting {
   *<['entity', e]>::({<{.tag: str, .agent: str}>}) |= {<{.tag: t, .agent: agent}>};
-} if *<['entity', e]>::({<{.tag: str, .agent: str}>}?) is known else (0) effecting {
-  new <['entity', e]> <- {<{.tag: t, .agent: agent}>};
-})) where {
+}) where {
   e     = given::(str);
   t     = given::(str);
   agent = given::(str);
@@ -75,11 +75,9 @@ mention_count = (((*<['mention', e, d]>::(int)) if *<['mention', e, d]>::(int?) 
   d = given::(int);
 };
 
-add_mention = (((1) effecting {
+add_mention = ((1) effecting {
   *<['mention', e, d]>::(int) += 1;
-} if *<['mention', e, d]>::(int?) is known else (0) effecting {
-  new <['mention', e, d]> <- 1;
-})) where {
+}) where {
   e = given::(str);
   d = given::(int);
 };
@@ -101,11 +99,9 @@ cooccur_count = (((*<['cooccur', a, b]>::(int)) if *<['cooccur', a, b]>::(int?) 
   b = given::(str);
 };
 
-add_cooccur = (((1) effecting {
+add_cooccur = ((1) effecting {
   *<['cooccur', a, b]>::(int) += 1;
-} if *<['cooccur', a, b]>::(int?) is known else (0) effecting {
-  new <['cooccur', a, b]> <- 1;
-})) where {
+}) where {
   a = given::(str);
   b = given::(str);
 };
@@ -118,8 +114,9 @@ test {
   t2: mention_count(.e: "Python", .d: 0) == 0;
   t3: cooccur_count(.a: "Python", .b: "GPT-4") == 0;
 
-  /* First add_tag creates (returns 0); subsequent unions return 1. */
-  t4: add_tag(.e: "Python", .t: "language", .agent: "a1") == 0 {
+  /* Every add_tag returns 1 (the effecting branch's value); the first
+     union on an absent key just yields the singleton set. */
+  t4: add_tag(.e: "Python", .t: "language", .agent: "a1") == 1 {
     t5: tags_for_entity(.e: "Python") == {<{.tag: "language", .agent: "a1"}>};
     t6: add_tag(.e: "Python", .t: "popular", .agent: "a1") == 1 {
       t7: tags_for_entity(.e: "Python")
@@ -143,11 +140,11 @@ test {
 
   /* Mention counter accumulates across calls; per-doc keys are
      independent; the range-fold sums them all. */
-  t12: add_mention(.e: "GPT-4", .d: 0) == 0 {
+  t12: add_mention(.e: "GPT-4", .d: 0) == 1 {
     t13: mention_count(.e: "GPT-4", .d: 0) == 1;
     t14: add_mention(.e: "GPT-4", .d: 0) == 1 {
       t15: mention_count(.e: "GPT-4", .d: 0) == 2;
-      t16: add_mention(.e: "GPT-4", .d: 1) == 0 {
+      t16: add_mention(.e: "GPT-4", .d: 1) == 1 {
         t17: mention_count(.e: "GPT-4", .d: 0) == 2;
         t18: mention_count(.e: "GPT-4", .d: 1) == 1;
         t19: mentions_total(.e: "GPT-4", .d_start: 0, .d_end: 1) == 3;
@@ -157,7 +154,7 @@ test {
   };
 
   /* Cooccurrence counter, same shape as mention. */
-  t21: add_cooccur(.a: "Python", .b: "GPT-4") == 0 {
+  t21: add_cooccur(.a: "Python", .b: "GPT-4") == 1 {
     t22: cooccur_count(.a: "Python", .b: "GPT-4") == 1;
     t23: add_cooccur(.a: "Python", .b: "GPT-4") == 1 {
       t24: cooccur_count(.a: "Python", .b: "GPT-4") == 2;


### PR DESCRIPTION
## What

Simplifies the agent-swarm demo to use **bare commutative field calls**, removing the driver-side scaffolding that issue #143 needed before the engine could upsert.

- **graph.orly**: `add_tag` / `add_mention` / `add_cooccur` drop the `is known` / `new <-` check-then-act create arm — each is now a single `|=` / `+= 1`. Inline tests updated (first write returns `1`).
- **demo.py / demo.go**: remove the pre-init pass and the read-back barrier (the #143 mitigation from #149). Agents now **create and aggregate brand-new keys concurrently with zero coordination**; ground truth is the raw corpus rollup (no `+1` seed bumps). Dead seed/`sortedTagList` code removed.

Net −134 lines.

## Why

With commutative-upsert (#151, merged as #152), `+= 1` / `|=` on an absent key folds from the monoid identity, so the first writer at a key needs no special-casing and concurrent first-writers commute. The whole reason for the pre-init + barrier — avoiding the create-race from the non-commutative `is known` branch — is gone. This makes the demo:

- **match the README's existing claim** — "zero coordination: no locks, no per-agent partitioning, no merge-on-read logic in the driver" (previously the driver *did* pre-seed + barrier);
- **exercise the genuine concurrent-create path** #143 was actually about, instead of designing it out with pre-seeding.

## Verification

Run end-to-end on live `orlyi`, fresh instance per run, **both drivers**: Python 3×, Go 2× — all `self-check OK`, **67 tag provenance records / 53 mention counters / 45 cooccurrence counters across 4 concurrent agents** (67 = the old 92 minus the 25 now-removed seed records). `orlyc` compiles the bare-op `graph.orly` (inline tests pass).

Depends on #152 (merged).

Closes the demo half of #143 — the create-race is now fixed at the source, not mitigated.
