### PR TITLE
variant widening via `as`: narrow into a superset variant (#104)

### DIFF
--- a/orly/code_gen/builder.cc
+++ b/orly/code_gen/builder.cc
@@ -346,7 +346,25 @@ TInline::TPtr Orly::CodeGen::Build(const L0::TPackage *package, const Expr::TExp
     }
     //TODO: Cast should be able to maintain mutability of list elements, as well as when doing the no-op cast.
     virtual void operator()(const Expr::TAs *that) const {
-      if(that->GetExpr()->GetType().Is<Type::TSeq>()) {
+      /* A variant -> wider-variant widening (#104) is a value rebuild, not a
+         reinterpret cast: the two are distinct C++ structs with different
+         `Which` numbering. Detect it by source and result being DIFFERENT
+         variant types (the type checker has already proven the relation and
+         excluded the recursive / optional-target cases, so the result type
+         is the bare wide variant here) and lower to a TVariantWiden. */
+      const Type::TVariant *src_variant = Type::Unwrap(that->GetExpr()->GetType()).TryAs<Type::TVariant>();
+      const Type::TVariant *dst_variant = ReturnType.TryAs<Type::TVariant>();
+      if (src_variant && dst_variant && src_variant != dst_variant) {
+        TInline::TPtr operand = Build(Package, that->GetExpr(), false);
+        TVariantWiden::TArmVec arms;
+        size_t src_which = 0;
+        for (const auto &elem : src_variant->GetElems()) {
+          /* GetElems() iterates in asciibetical order, which is exactly the
+             source struct's `Which` numbering. */
+          arms.emplace_back(src_which++, elem.first);
+        }
+        Res = TInline::TPtr(new TVariantWiden(Package, ReturnType, operand, arms));
+      } else if(that->GetExpr()->GetType().Is<Type::TSeq>()) {
         Res = Interner.GetUnary(Package, ReturnType, TUnary::Cast, BuildInline(Package, that->GetExpr(), true));
       } else {
         Unary(Package, TUnary::Cast, that);

--- a/orly/code_gen/variant_access.cc
+++ b/orly/code_gen/variant_access.cc
@@ -81,3 +81,26 @@ void TVariantWhen::WriteExpr(TCppPrinter &out) const {
   }
   out << '(' << Arms.back().second << "))";
 }
+
+TVariantWiden::TVariantWiden(const L0::TPackage *package,
+                             const Type::TType &type,
+                             const TInline::TPtr &operand,
+                             const TArmVec &arms)
+    : TInline(package, type), Operand(operand), Arms(arms) {}
+
+void TVariantWiden::WriteExpr(TCppPrinter &out) const {
+  /* Nested ternary on the source's active arm, each branch rebuilding the
+     value via the destination (wide) struct's `Mk<Tag>` factory.
+     GetReturnType() prints the destination's mangled struct name (as in
+     TVariantCtor); `Mk` prefixes the tag to dodge macro collisions (#119).
+     The last arm is the unconditional fall-through (the source's arm set is
+     total, so one branch always applies). */
+  out << '(';
+  for (size_t arm_idx = 0; arm_idx + 1 < Arms.size(); ++arm_idx) {
+    out << "((" << Operand << ").GetWhich() == " << Arms[arm_idx].first << ") ? "
+        << GetReturnType() << "::Mk" << Arms[arm_idx].second
+        << "((" << Operand << ").GetV" << Arms[arm_idx].second << "()) : ";
+  }
+  out << GetReturnType() << "::Mk" << Arms.back().second
+      << "((" << Operand << ").GetV" << Arms.back().second << "()))";
+}

--- a/orly/code_gen/variant_access.h
+++ b/orly/code_gen/variant_access.h
@@ -120,6 +120,44 @@ namespace Orly {
         TArmVec Arms;
     }; // TVariantWhen
 
+    /* `narrow_val as wide_t` -- widening a narrow variant to a superset
+       variant (#104). The narrow and wide native structs have different
+       `Which` numbering (the asciibetical arm index shifts when arms are
+       inserted) and different field sets, so this is a value rebuild, not a
+       reinterpret: a nested ternary on the source's active arm calls the
+       DESTINATION struct's `Mk<Tag>` factory, which assigns the
+       destination's own `Which` -- so the `$which` remap falls out for free:
+         ((op).GetWhich()==sw0) ? Dst::Mk<t0>((op).GetV<t0>())
+           : ... : Dst::Mk<tN>((op).GetV<tN>())
+       where `sw*` are the SOURCE arm indices and `Dst` is this inline's
+       (wide) result type. v1 handles non-recursive, non-optional widening
+       only (the type checker rejects the other cases, see orly/expr/as.cc),
+       so every `GetV<Tag>()` is a plain accessor and every arm of the source
+       has a same-payload arm in the destination. */
+    class TVariantWiden : public TInline {
+      NO_COPY(TVariantWiden);
+      public:
+
+      /* (source arm `Which` index, tag name). */
+      typedef std::vector<std::pair<size_t, std::string>> TArmVec;
+
+      TVariantWiden(const L0::TPackage *package,
+                    const Type::TType &type,
+                    const TInline::TPtr &operand,
+                    const TArmVec &arms);
+
+      void WriteExpr(TCppPrinter &out) const;
+
+      virtual void AppendDependsOn(std::unordered_set<TInline::TPtr> &dependency_set) const override {
+        dependency_set.insert(Operand);
+        Operand->AppendDependsOn(dependency_set);
+      }
+
+      private:
+        TInline::TPtr Operand;
+        TArmVec Arms;
+    }; // TVariantWiden
+
   } // CodeGen
 
 } // Orly

--- a/orly/expr/as.cc
+++ b/orly/expr/as.cc
@@ -25,8 +25,10 @@
 #include <orly/pos_range.h>
 #include <orly/type.h>
 #include <orly/type/infix_visitor.h>
+#include <orly/type/unroll.h>
 #include <orly/type/unwrap.h>
 #include <orly/type/unwrap_visitor.h>
+#include <orly/type/variant.h>
 
 using namespace Orly;
 using namespace Orly::Expr;
@@ -175,14 +177,20 @@ Type::TType TAs::GetTypeImpl() const {
       }
       Type = rhs->AsType();
     }
-    /* Casting a variant is only an identity cast (variants are invariant
-       in v1, #95). Its real purpose is widening to an optional variant:
-       `v as op_t?` -- the infix machinery unwraps the optional target to
-       reach (variant, variant) here, then re-wraps the result, which is
-       the only way to build a KNOWN optional variant (#118). */
+    /* A variant cast is either an identity cast or a widening (#104):
+       `narrow as wide`, legal iff every arm of the source appears
+       identically in the target (TVariant::IsWidenableTo -- tag set widens,
+       payloads invariant). IsWidenableTo is reflexive, so it also covers the
+       identity cast, whose original purpose was widening to an optional
+       variant: `v as op_t?` -- the infix machinery unwraps the optional
+       target to reach (variant, variant) here, then re-wraps the result,
+       which is the only way to build a KNOWN optional variant (#118). The
+       v1-scope guards (recursive variants, optional-target widening) are
+       applied once, after the visitor, in GetTypeImpl. */
     virtual void operator()(const Type::TVariant  *lhs, const Type::TVariant  *rhs) const {
-      if (lhs != rhs) {
-        throw TExprError(HERE, PosRange, "A variant can only be cast to its own type.");
+      if (!lhs->IsWidenableTo(rhs)) {
+        throw TExprError(HERE, PosRange,
+            "a variant can only be cast to its own type or widened to a superset variant type");
       }
       Type = rhs->AsType();
     }
@@ -347,5 +355,44 @@ Type::TType TAs::GetTypeImpl() const {
   };  // TAsTypeVisitor
   Type::TType type;
   Type::TType::Accept(GetExpr()->GetType(), Type, TAsTypeVisitor(type, GetPosRange()));
+  /* v1-scope guards for variant widening (#104). A genuine widening is a
+     cast whose source and result both unwrap to a variant, but to DIFFERENT
+     variant types (an identity cast -- including `v as v_t?` -- has the same
+     unwrapped variant on both sides and is unaffected). Two corners are
+     deferred past v1 and rejected here with a clear message rather than
+     producing code that cannot be lowered:
+       - recursive / mutually-recursive variants (#103/#116/#125): widening
+         would have to rebuild through the boxed self-edge representation;
+       - widening to an optional target (`narrow as wide?`): the rebuild
+         produces the bare wide struct, with no optional-wrap path yet. */
+  const Type::TVariant *src_variant = Type::Unwrap(GetExpr()->GetType()).TryAs<Type::TVariant>();
+  /* The result is the bare wide variant, or `wide?` when the cast targeted
+     an optional (`narrow as wide?`); reach the variant through the optional
+     so the widen is detected either way. Unwrap (mutable/seq) does not strip
+     optional -- that needs UnwrapOptional. */
+  Type::TType result_inner = type.Is<Type::TOpt>() ? Type::UnwrapOptional(type) : type;
+  const Type::TVariant *dst_variant = Type::Unwrap(result_inner).TryAs<Type::TVariant>();
+  if (src_variant && dst_variant && src_variant != dst_variant) {
+    /* A variant's self-reference is bound by the variant itself, so it is
+       "free" only at the arm-payload level -- check each arm's payload, the
+       same level code_gen tests for the recursive `GetV<Tag>` template
+       (orly/code_gen/variant_access.cc). */
+    auto is_recursive = [](const Type::TVariant *v) {
+      for (const auto &arm : v->GetElems()) {
+        if (Type::HasFreeSelfRef(arm.second) || Type::HasGroupRef(arm.second)) {
+          return true;
+        }
+      }
+      return false;
+    };
+    if (is_recursive(src_variant) || is_recursive(dst_variant)) {
+      throw TExprError(HERE, GetPosRange(),
+          "widening of recursive variants is not yet supported (#104)");
+    }
+    if (type.Is<Type::TOpt>()) {
+      throw TExprError(HERE, GetPosRange(),
+          "widening to an optional variant type is not yet supported (#104)");
+    }
+  }
   return type;
 }

--- a/orly/type/variant.h
+++ b/orly/type/variant.h
@@ -69,6 +69,26 @@ namespace Orly {
         return TInternedType::Get(elems);
       }
 
+      /* The widening (subtype) relation `this ⊑ wide` (issue #104): true
+         iff every `(tag → payload)` arm of `this` appears identically (same
+         tag, same payload type) in `wide`. The tag set widens; payloads stay
+         invariant. A direct mirror of `TObj::IsSubsetOf` (orly/type/obj.h) --
+         a narrow variant's arms must be a subset of the wide one's. Reflexive
+         (a type is widenable to itself). Used by the explicit `as` cast
+         (orly/expr/as.cc) to permit a narrow value to flow into a wider
+         variant context. */
+      bool IsWidenableTo(const TVariant *wide) const {
+        assert(this);
+        assert(wide);
+        for (const auto &arm : GetElems()) {
+          auto pos = wide->GetElems().find(arm.first);
+          if (pos == wide->GetElems().end() || arm.second != pos->second) {
+            return false;
+          }
+        }
+        return true;
+      }
+
       private:
       TVariant(const TVariantElems &elems) : TInternedType(elems) {}
       virtual ~TVariant();

--- a/tests/lang_tests/.xfail
+++ b/tests/lang_tests/.xfail
@@ -13,3 +13,9 @@
 
 general/unsorted/multiple_sequences.orly #74
 general/unsorted/sequence_in_effecting.orly #75
+
+# Deferred v1 cases of variant widening (#104): rejected today with a clear
+# "not yet supported" diagnostic; each will xpass (and should be promoted to
+# a positive test) when the corresponding widening case is implemented.
+general/variants_widen_optional.orly #104
+general/variants_widen_recursive.orly #104

--- a/tests/lang_tests/general/.variants_widen.orly.test.state
+++ b/tests/lang_tests/general/.variants_widen.orly.test.state
@@ -1,0 +1,21 @@
+[
+  0,
+  [
+    [],
+    [
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++"
+    ],
+    [
+      "Running tests"
+    ],
+    [
+      "Tests done"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/.variants_widen_optional.orly.test.state
+++ b/tests/lang_tests/general/.variants_widen_optional.orly.test.state
@@ -1,0 +1,10 @@
+[
+  1,
+  [
+    [],
+    [
+      "Synth + Symbols",
+      "33:18-33:57 [orly/expr/as.cc, 393]widening to an optional variant type is not yet supported (#104)"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/.variants_widen_recursive.orly.test.state
+++ b/tests/lang_tests/general/.variants_widen_recursive.orly.test.state
@@ -1,0 +1,10 @@
+[
+  1,
+  [
+    [],
+    [
+      "Synth + Symbols",
+      "36:15-36:27 [orly/expr/as.cc, 389]widening of recursive variants is not yet supported (#104)"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/variants_widen.orly
+++ b/tests/lang_tests/general/variants_widen.orly
@@ -1,0 +1,113 @@
+/* <orly/lang_tests/general/variants_widen.orly>
+
+   Explicit variant widening via `as` (issue #104, v1).
+
+   A value of a narrow variant type may be cast to a wider (superset)
+   variant type: `narrow_val as wide_t`, legal iff every arm of the source
+   appears identically (same tag, same payload type) in the target. The tag
+   set widens; payloads stay invariant. This is the schema-evolution story
+   for sum types -- adding an arm does not force producers of the old type
+   to be rewritten.
+
+   Widening is NOT a reinterpret. The native `Which` discriminant is the
+   arm's asciibetical index, so inserting an arm shifts the indices of every
+   later arm: `<| Number | Text |>` has Number=0, Text=1, but the wider
+   `<| Deleted | Number | Text |>` has Number=1, Text=2. The cast therefore
+   rebuilds the value through the wide struct's `Mk<Tag>` factory (code_gen
+   TVariantWiden), which assigns the wide `Which` -- so the `$which` remap
+   falls out for free, on disk too.
+
+   v1 scope: explicit `as` only (no implicit widening or `when`-result LUB);
+   payloads invariant; non-recursive variants only. The deferred cases
+   (narrowing, recursive variants, optional targets) are rejected by the
+   type checker -- see variants_widen_bad_*.orly.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+/* The widened value, with its arm indices remapped, equals a value built
+   directly in the wide type. Number (source Which 0) remaps to wide Which 1;
+   Text (source Which 1) remaps to wide Which 2. */
+widen_num = ((<| Number(int) | Text(str) |>.Number(n)
+    as <| Deleted | Number(int) | Text(str) |>)) where {
+  n = given::(int);
+};
+widen_txt = ((<| Number(int) | Text(str) |>.Text(s)
+    as <| Deleted | Number(int) | Text(str) |>)) where {
+  s = given::(str);
+};
+
+with {
+} test {
+  /* Widened payload arm == directly-built wide value (the $which remap). */
+  t_num: widen_num(.n: 5) == <| Deleted | Number(int) | Text(str) |>.Number(5);
+  t_txt: widen_txt(.s: "hi") == <| Deleted | Number(int) | Text(str) |>.Text("hi");
+  /* Different arm / payload after widening are still unequal. */
+  t_neq_arm: widen_num(.n: 5) != <| Deleted | Number(int) | Text(str) |>.Deleted;
+  t_neq_pay: widen_num(.n: 5) != <| Deleted | Number(int) | Text(str) |>.Number(6);
+  /* The widened value reports the active arm and payload of the source. */
+  t_is_num:  widen_num(.n: 5) is Number == true;
+  t_is_del:  widen_num(.n: 5) is Deleted == false;
+  t_payload: (widen_num(.n: 5).Number if widen_num(.n: 5) is Number else 0) == 5;
+  /* `when` over the widened value is exhaustive over the static WIDE type
+     (all three arms), and dispatches on the remapped Which. */
+  t_when: ((widen_num(.n: 7)) when {
+    Deleted:    -1;
+    Number(k):  k;
+    Text(z):    0;
+  }) == 7;
+};
+
+/* Widening a tag-only arm: `<| Off | On |>` (Off=0, On=1) into
+   `<| Dim | Off | On |>` (Dim=0, Off=1, On=2) -- the empty-object payload
+   moves through the same rebuild. */
+widen_flag = ((<| Off | On |>.On as <| Dim | Off | On |>)) where {
+  ignored = given::(int);
+};
+
+with {
+} test {
+  t_flag_eq:  widen_flag(.ignored: 0) == <| Dim | Off | On |>.On;
+  t_flag_neq: widen_flag(.ignored: 0) != <| Dim | Off | On |>.Dim;
+  t_flag_is:  widen_flag(.ignored: 0) is On == true;
+};
+
+/* Storage round-trip of a WIDENED value: it serializes as the wide shape
+   (the rebuild already produced the wide struct), so it reads back as a
+   wide value. */
+read_wide = (*<[k]>::(<| Deleted | Number(int) | Text(str) |>)) where {
+  k = given::(int);
+};
+
+with {
+  <[500]> <- (<| Number(int) | Text(str) |>.Number(42)
+      as <| Deleted | Number(int) | Text(str) |>);
+} test {
+  t_store_widened: read_wide(.k: 500) == <| Deleted | Number(int) | Text(str) |>.Number(42);
+};
+
+/* Schema evolution without a migration pass: data written as the NARROW
+   type is read back with its original narrow annotation, then widened in
+   memory at the boundary -- equal to the same value built wide. */
+read_narrow = (*<[k]>::(<| Number(int) | Text(str) |>)) where {
+  k = given::(int);
+};
+
+with {
+  <[501]> <- <| Number(int) | Text(str) |>.Text("old");
+} test {
+  t_read_old_then_widen:
+      (read_narrow(.k: 501) as <| Deleted | Number(int) | Text(str) |>)
+      == <| Deleted | Number(int) | Text(str) |>.Text("old");
+};

--- a/tests/lang_tests/general/variants_widen_optional.orly
+++ b/tests/lang_tests/general/variants_widen_optional.orly
@@ -1,0 +1,41 @@
+/* <orly/lang_tests/general/variants_widen_optional.orly>
+
+   Deferred v1 case for variant widening (issue #104), tracked as an xfail.
+
+   Widening to an OPTIONAL target variant (`narrow as wide?`) -- building a
+   known-optional widened value, the variant analog of the existing
+   `v as v_t?` identity-to-optional cast -- is not implemented in v1: the
+   widening rebuild produces the bare wide struct, and there is no
+   optional-wrap path for it yet. The type checker rejects it with a clear
+   "not yet supported (#104)" rather than emitting code that cannot be
+   lowered, so this file currently FAILS to compile and is pinned in
+   tests/lang_tests/.xfail. (An IDENTITY cast to an optional variant,
+   `v as v_t?`, is unaffected and still works -- see variants_optional.orly.)
+
+   When optional-target widening lands, this test will compile and run
+   (xpass), prompting removal of the .xfail entry and promotion to a plain
+   positive test -- the assertion below is written to pass at that point.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+widen_to_opt = ((<| Number(int) | Text(str) |>.Number(n)
+    as <| Deleted | Number(int) | Text(str) |>?)) where {
+  n = given::(int);
+};
+
+with {
+} test {
+  t: widen_to_opt(.n: 1) is known;
+};

--- a/tests/lang_tests/general/variants_widen_recursive.orly
+++ b/tests/lang_tests/general/variants_widen_recursive.orly
@@ -1,0 +1,43 @@
+/* <orly/lang_tests/general/variants_widen_recursive.orly>
+
+   Deferred v1 case for variant widening (issue #104), tracked as an xfail.
+
+   Widening of RECURSIVE variants is not implemented in v1. A recursive
+   variant boxes its self-edges in the native representation
+   (#103/#116/#125), so widening would have to rebuild through that boxed
+   form -- a high-cost, low-value corner left out of v1. The shared arms of
+   `rnar` and `rwid` are structurally identical (`Leaf(int)` and the
+   self-referential `Node`), so the widening relation itself holds, but the
+   type checker rejects the cast with a clear "not yet supported (#104)"
+   because a self-reference is present. This file therefore currently FAILS
+   to compile and is pinned in tests/lang_tests/.xfail.
+
+   When recursive-variant widening lands, this test will compile and run
+   (xpass), prompting removal of the .xfail entry and promotion to a plain
+   positive test -- the assertion below is written to pass at that point.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+rnar is <| Leaf(int) | Node(<{.next: rnar}>) |>;
+rwid is <| Extra | Leaf(int) | Node(<{.next: rwid}>) |>;
+
+widen_rec = ((rnar.Leaf(n) as rwid)) where {
+  n = given::(int);
+};
+
+with {
+} test {
+  t: widen_rec(.n: 1) is Leaf;
+};


### PR DESCRIPTION
## What

Implements **issue #104** v1: explicit widening of a narrow variant value into a wider (superset) variant via `as`.

```orly
narrow is <| Number(int) | Text(str) |>;
wide   is <| Deleted | Number(int) | Text(str) |>;
/* a `narrow` value now flows into a `wide` context: */
some_narrow_value as <| Deleted | Number(int) | Text(str) |>
```

This is the schema-evolution story for sum types: adding an arm no longer forces every producer of the old type to be rewritten.

## How

- **Relation** (`TVariant::IsWidenableTo`, a mirror of `TObj::IsSubsetOf`): `narrow ⊑ wide` iff every `(tag → payload)` arm of the narrow type appears identically in the wide one. Tag set widens; payloads stay invariant.
- **Type-check** (`orly/expr/as.cc`): the `(TVariant, TVariant)` cast case, previously identity-only, now permits a widening (and still covers the identity-to-optional `v as v_t?` path, since the relation is reflexive).
- **Codegen** (`TVariantWiden` in `orly/code_gen/`): widening is a *value rebuild*, not a reinterpret — the native `Which` discriminant is the arm's asciibetical index, so inserting an arm shifts every later index. The cast lowers to a ternary on the source `GetWhich()` that calls the **destination** struct's `Mk<Tag>` factory, which assigns the wide `Which`. The `$which` remap falls out for free, on disk too.
- **Storage**: no change. A widened value serializes as the wide shape; data written narrow still reads back narrow and widens in memory at the boundary — **no migration pass**.

## v1 scope

Explicit `as` only — **no** implicit widening (assignment / param / branch-join) and **no** `when`-result LUB; the `when`/if-else variant-result joins are untouched. Two cases are deferred and rejected at type-check with a clear `not yet supported (#104)`:

- widening to an **optional** target (`narrow as wide?`);
- widening of **recursive** variants (would have to rebuild through the boxed self-edge representation, #103/#116/#125).

Both are pinned as **xfail** tests (`#104`) that will *xpass* — and should be promoted to positive tests — when implemented.

## Tests

- `variants_widen.orly` (passing): the asciibetical-index remap, tag-only arms, `is` / `.Tag` / exhaustive `when` over the widened static type, store-widened-then-read, and read-old-narrow-then-widen.
- `variants_widen_optional.orly`, `variants_widen_recursive.orly` (xfail `#104`): the deferred cases.

Full lang suite (`make test_lang`) green — `0 unexpected, 146 passed, 4 tracked failures (xfail)`. C++ unit suite (`make test`) green.