### PR TITLE
variant widening: optional target `narrow as wide?` (#104 phase 2)

### DIFF
--- a/orly/code_gen/builder.cc
+++ b/orly/code_gen/builder.cc
@@ -348,12 +348,14 @@ TInline::TPtr Orly::CodeGen::Build(const L0::TPackage *package, const Expr::TExp
     virtual void operator()(const Expr::TAs *that) const {
       /* A variant -> wider-variant widening (#104) is a value rebuild, not a
          reinterpret cast: the two are distinct C++ structs with different
-         `Which` numbering. Detect it by source and result being DIFFERENT
-         variant types (the type checker has already proven the relation and
-         excluded the recursive / optional-target cases, so the result type
-         is the bare wide variant here) and lower to a TVariantWiden. */
+         `Which` numbering. Detect it by source and result both unwrapping to
+         a variant but to DIFFERENT types (the type checker has proven the
+         relation and excluded the recursive case). The target may be the bare
+         wide variant or `wide?`; reach the destination through the optional
+         so both lower here. */
       const Type::TVariant *src_variant = Type::Unwrap(that->GetExpr()->GetType()).TryAs<Type::TVariant>();
-      const Type::TVariant *dst_variant = ReturnType.TryAs<Type::TVariant>();
+      Type::TType result_inner = ReturnType.Is<Type::TOpt>() ? Type::UnwrapOptional(ReturnType) : ReturnType;
+      const Type::TVariant *dst_variant = Type::Unwrap(result_inner).TryAs<Type::TVariant>();
       if (src_variant && dst_variant && src_variant != dst_variant) {
         TInline::TPtr operand = Build(Package, that->GetExpr(), false);
         TVariantWiden::TArmVec arms;
@@ -363,7 +365,14 @@ TInline::TPtr Orly::CodeGen::Build(const L0::TPackage *package, const Expr::TExp
              source struct's `Which` numbering. */
           arms.emplace_back(src_which++, elem.first);
         }
-        Res = TInline::TPtr(new TVariantWiden(Package, ReturnType, operand, arms));
+        /* The rebuild always produces the bare wide variant. When the target
+           is optional, wrap it: a Cast from the bare wide value to `wide?`
+           lowers to `Rt::TOpt<wide>(CastAs<wide,wide>::Do(v))` (the identity
+           inner cast), the same machinery the identity `v as v_t?` uses. */
+        TInline::TPtr widened(new TVariantWiden(Package, dst_variant->AsType(), operand, arms));
+        Res = ReturnType.Is<Type::TOpt>()
+            ? Interner.GetUnary(Package, ReturnType, TUnary::Cast, widened)
+            : widened;
       } else if(that->GetExpr()->GetType().Is<Type::TSeq>()) {
         Res = Interner.GetUnary(Package, ReturnType, TUnary::Cast, BuildInline(Package, that->GetExpr(), true));
       } else {

--- a/orly/expr/as.cc
+++ b/orly/expr/as.cc
@@ -355,21 +355,21 @@ Type::TType TAs::GetTypeImpl() const {
   };  // TAsTypeVisitor
   Type::TType type;
   Type::TType::Accept(GetExpr()->GetType(), Type, TAsTypeVisitor(type, GetPosRange()));
-  /* v1-scope guards for variant widening (#104). A genuine widening is a
-     cast whose source and result both unwrap to a variant, but to DIFFERENT
-     variant types (an identity cast -- including `v as v_t?` -- has the same
-     unwrapped variant on both sides and is unaffected). Two corners are
-     deferred past v1 and rejected here with a clear message rather than
-     producing code that cannot be lowered:
-       - recursive / mutually-recursive variants (#103/#116/#125): widening
-         would have to rebuild through the boxed self-edge representation;
-       - widening to an optional target (`narrow as wide?`): the rebuild
-         produces the bare wide struct, with no optional-wrap path yet. */
+  /* Remaining v1-scope guard for variant widening (#104). A genuine widening
+     is a cast whose source and result both unwrap to a variant, but to
+     DIFFERENT variant types (an identity cast -- including `v as v_t?` -- has
+     the same unwrapped variant on both sides and is unaffected). The target
+     may be bare or optional: `narrow as wide` yields the bare wide variant,
+     `narrow as wide?` yields `wide?` (codegen rebuilds the bare wide value
+     and wraps it in the optional). Recursive / mutually-recursive variants
+     (#103/#116/#125) are still deferred -- widening would have to rebuild
+     through the boxed self-edge representation -- and rejected here with a
+     clear message rather than producing code that cannot be lowered. */
   const Type::TVariant *src_variant = Type::Unwrap(GetExpr()->GetType()).TryAs<Type::TVariant>();
   /* The result is the bare wide variant, or `wide?` when the cast targeted
-     an optional (`narrow as wide?`); reach the variant through the optional
-     so the widen is detected either way. Unwrap (mutable/seq) does not strip
-     optional -- that needs UnwrapOptional. */
+     an optional; reach the variant through the optional so the widen is
+     detected either way. Unwrap (mutable/seq) does not strip optional -- that
+     needs UnwrapOptional. */
   Type::TType result_inner = type.Is<Type::TOpt>() ? Type::UnwrapOptional(type) : type;
   const Type::TVariant *dst_variant = Type::Unwrap(result_inner).TryAs<Type::TVariant>();
   if (src_variant && dst_variant && src_variant != dst_variant) {
@@ -388,10 +388,6 @@ Type::TType TAs::GetTypeImpl() const {
     if (is_recursive(src_variant) || is_recursive(dst_variant)) {
       throw TExprError(HERE, GetPosRange(),
           "widening of recursive variants is not yet supported (#104)");
-    }
-    if (type.Is<Type::TOpt>()) {
-      throw TExprError(HERE, GetPosRange(),
-          "widening to an optional variant type is not yet supported (#104)");
     }
   }
   return type;

--- a/tests/lang_tests/.xfail
+++ b/tests/lang_tests/.xfail
@@ -14,8 +14,8 @@
 general/unsorted/multiple_sequences.orly #74
 general/unsorted/sequence_in_effecting.orly #75
 
-# Deferred v1 cases of variant widening (#104): rejected today with a clear
-# "not yet supported" diagnostic; each will xpass (and should be promoted to
-# a positive test) when the corresponding widening case is implemented.
-general/variants_widen_optional.orly #104
+# Deferred case of variant widening (#104): rejected today with a clear
+# "not yet supported" diagnostic; will xpass (and should be promoted to a
+# positive test) when recursive-variant widening is implemented.
+# (Optional-target widening landed in phase 2; its test is now a positive.)
 general/variants_widen_recursive.orly #104

--- a/tests/lang_tests/general/.variants_widen_optional.orly.test.state
+++ b/tests/lang_tests/general/.variants_widen_optional.orly.test.state
@@ -1,10 +1,21 @@
 [
-  1,
+  0,
   [
     [],
     [
-      "Synth + Symbols",
-      "33:18-33:57 [orly/expr/as.cc, 393]widening to an optional variant type is not yet supported (#104)"
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++"
+    ],
+    [
+      "Running tests"
+    ],
+    [
+      "Tests done"
     ]
   ]
 ]

--- a/tests/lang_tests/general/variants_widen_optional.orly
+++ b/tests/lang_tests/general/variants_widen_optional.orly
@@ -1,20 +1,16 @@
 /* <orly/lang_tests/general/variants_widen_optional.orly>
 
-   Deferred v1 case for variant widening (issue #104), tracked as an xfail.
+   Widening to an OPTIONAL target variant (issue #104, phase 2).
 
-   Widening to an OPTIONAL target variant (`narrow as wide?`) -- building a
-   known-optional widened value, the variant analog of the existing
-   `v as v_t?` identity-to-optional cast -- is not implemented in v1: the
-   widening rebuild produces the bare wide struct, and there is no
-   optional-wrap path for it yet. The type checker rejects it with a clear
-   "not yet supported (#104)" rather than emitting code that cannot be
-   lowered, so this file currently FAILS to compile and is pinned in
-   tests/lang_tests/.xfail. (An IDENTITY cast to an optional variant,
-   `v as v_t?`, is unaffected and still works -- see variants_optional.orly.)
+   `narrow as wide?` widens a narrow variant value AND wraps it in a known
+   optional in one step -- the variant analog of the identity-to-optional
+   cast `v as v_t?` (#118), and the way to build a known-optional widened
+   value. Codegen rebuilds the bare wide value (TVariantWiden) and wraps it:
+   the cast from the bare wide value to `wide?` lowers to
+   `Rt::TOpt<wide>(CastAs<wide,wide>::Do(v))` (identity inner cast), reusing
+   the same optional-wrap machinery the identity cast uses.
 
-   When optional-target widening lands, this test will compile and run
-   (xpass), prompting removal of the .xfail entry and promotion to a plain
-   positive test -- the assertion below is written to pass at that point.
+   (Was an xfail under #104 until this phase landed.)
 
    Copyright 2010-2026 Atomic Kismet Company
 
@@ -30,12 +26,42 @@
    See the License for the specific language governing permissions and
    limitations under the License. */
 
-widen_to_opt = ((<| Number(int) | Text(str) |>.Number(n)
+widen_num_opt = ((<| Number(int) | Text(str) |>.Number(n)
     as <| Deleted | Number(int) | Text(str) |>?)) where {
   n = given::(int);
+};
+widen_txt_opt = ((<| Number(int) | Text(str) |>.Text(s)
+    as <| Deleted | Number(int) | Text(str) |>?)) where {
+  s = given::(str);
 };
 
 with {
 } test {
-  t: widen_to_opt(.n: 1) is known;
+  /* The widened value is a KNOWN optional. */
+  t_known: widen_num_opt(.n: 5) is known;
+  t_not_unknown: not (widen_num_opt(.n: 5) is unknown);
+  /* `known` peels to the (remapped) wide variant value. */
+  t_peel_num: known widen_num_opt(.n: 5) == <| Deleted | Number(int) | Text(str) |>.Number(5);
+  t_peel_txt: known widen_txt_opt(.s: "hi") == <| Deleted | Number(int) | Text(str) |>.Text("hi");
+  /* It equals an optional wide value built directly (both known, payloads
+     compare equal -> the comparison is a known true). */
+  t_eq_direct: known (widen_num_opt(.n: 5)
+      == (<| Deleted | Number(int) | Text(str) |>.Number(5) as <| Deleted | Number(int) | Text(str) |>?));
+  /* A different payload after widening is not equal. */
+  t_neq: known (widen_num_opt(.n: 5)
+      != (<| Deleted | Number(int) | Text(str) |>.Number(6) as <| Deleted | Number(int) | Text(str) |>?));
+};
+
+/* Stored read widened to an optional: the source is a TMutable<narrow> read,
+   deref'd, rebuilt wide, and wrapped. */
+read_narrow = (*<[k]>::(<| Number(int) | Text(str) |>)) where {
+  k = given::(int);
+};
+
+with {
+  <[600]> <- <| Number(int) | Text(str) |>.Text("old");
+} test {
+  t_read_widen_opt:
+      known (read_narrow(.k: 600) as <| Deleted | Number(int) | Text(str) |>?)
+      == <| Deleted | Number(int) | Text(str) |>.Text("old");
 };


### PR DESCRIPTION
## What

Next phase of **#104**: widening to an **optional** target variant.

```orly
narrow is <| Number(int) | Text(str) |>;
wide   is <| Deleted | Number(int) | Text(str) |>;
some_narrow_value as <| Deleted | Number(int) | Text(str) |>?   /* -> a known wide? */
```

`narrow as wide?` widens the value **and** wraps it in a known optional in one step — the variant analog of the identity-to-optional cast `v as v_t?` (#118), and the way to build a known-optional widened value. This was the optional-target case deferred (xfail) when v1 (#155) shipped.

## How

- **Type-check** (`orly/expr/as.cc`): drop the v1 "not yet supported" rejection for an optional target. The `(variant, variant)` widening case is reached through the infix machinery's optional unwrap/re-wrap exactly as the identity cast is, so `narrow as wide?` types to `wide?` with no further work.
- **Codegen** (`orly/code_gen/builder.cc`): the rebuild (`TVariantWiden`) always produces the **bare** wide value; when the target is optional, wrap it with a `Cast` to `wide?`, which lowers to `Rt::TOpt<wide>(CastAs<wide,wide>::Do(v))` — the identity inner cast, reusing the **same** optional-wrap machinery the identity `v as v_t?` cast already uses. No new runtime support needed.

## Tests

Promotes `variants_widen_optional.orly` from an **xfail** to a **positive** test: known/unknown discrimination, `known` peel to the remapped wide value, equality with a directly-built optional wide, a not-equal payload, and a stored-read source (`TMutable<narrow>`) widened to an optional.

**Recursive-variant widening remains the lone deferred case** under #104 (still xfail-pinned). Full lang suite green — `0 unexpected, 147 passed, 3 tracked failures (xfail)`. C++ unit suite green.