### PR TITLE
defer recursive results in compound ctor payloads: recursive widening folds (#104/#128)

### DIFF
--- a/orly/expr/expr.cc
+++ b/orly/expr/expr.cc
@@ -18,6 +18,7 @@
 
 #include <orly/expr/expr.h>
 
+#include <orly/type/unroll.h>
 #include <orly/type/util.h>
 
 using namespace Orly;
@@ -37,7 +38,16 @@ Type::TType TExpr::GetType() const {
   }
 
   auto type = GetTypeImpl();
-  if (!type.Is<Type::TAny>()) {
+  /* Don't memoize a type that still contains TAny anywhere -- TAny is the
+     unresolved recursive-call placeholder (TFunction::GetReturnType), so such
+     a type is provisional. Caching it would freeze the placeholder in (e.g. a
+     record `<{.next: TAny}>` built from a recursive result), and codegen would
+     later read the stale TAny and fail to emit it. Leaving it uncached makes
+     the expression recompute once the recursion resolves to a concrete type
+     (by codegen). Generalizes the old `!Is<TAny>` guard to compound types
+     (#128 Option A's caching note; needed for #104 recursive-variant widening
+     folds). */
+  if (!Type::HasAny(type)) {
     assert (!CachedType || *CachedType == type);
     CachedType = type;
   }

--- a/orly/expr/variant.cc
+++ b/orly/expr/variant.cc
@@ -21,6 +21,12 @@
 #include <base/as_str.h>
 #include <orly/error.h>
 #include <orly/type/any.h>
+#include <orly/type/dict.h>
+#include <orly/type/list.h>
+#include <orly/type/obj.h>
+#include <orly/type/opt.h>
+#include <orly/type/seq.h>
+#include <orly/type/set.h>
 #include <orly/type/unroll.h>
 #include <orly/type/unwrap.h>
 #include <orly/type/util.h>
@@ -28,6 +34,79 @@
 
 using namespace Orly;
 using namespace Orly::Expr;
+
+namespace {
+
+  /* True iff `actual` matches `expected` structurally, treating any `TAny`
+     in `actual` as a wildcard matching the corresponding subterm of
+     `expected`. `TAny` arises only from an as-yet-unresolved recursive-call
+     result (TFunction::GetReturnType), so this defers verification of a
+     recursive result nested ANYWHERE in a compound payload while still
+     strictly checking the non-recursive parts -- the compound generalization
+     of the shallow `Is<TAny>` deferral (#128 Option A). It is what lets a
+     recursive variant be rebuilt by a fold, e.g. widening
+     `Node(<{.next: rnar}>)` to `Node(<{.next: rwid}>)` where the `.next`
+     field holds the recursive call's (TAny) result (#104).
+
+     Recurses through the recursive-variant payload shapes (#116/#125):
+     record, list/set/seq, dict value/key, opt, and nested variant. Any other
+     kind falls to the interned-equality fast path -- a conservative reject if
+     it isn't pointer-equal, never a false accept. */
+  bool MatchesModuloAny(const Type::TType &actual, const Type::TType &expected) {
+    if (actual == expected) {
+      return true;  // interned: structurally identical (covers the no-TAny case)
+    }
+    if (actual.Is<Type::TAny>()) {
+      return true;  // a recursive result -- the wildcard hole we defer on
+    }
+    /* Same-kind compound: recurse on children. A map-keyed compound (obj /
+       variant) must have the same key set with each field matching. */
+    auto match_map = [](const auto &a_elems, const auto &e_elems) {
+      if (a_elems.size() != e_elems.size()) {
+        return false;
+      }
+      auto ai = a_elems.begin();
+      auto ei = e_elems.begin();
+      for (; ai != a_elems.end(); ++ai, ++ei) {
+        if (ai->first != ei->first || !MatchesModuloAny(ai->second, ei->second)) {
+          return false;
+        }
+      }
+      return true;
+    };
+    if (const auto *a = actual.TryAs<Type::TObj>()) {
+      const auto *e = expected.TryAs<Type::TObj>();
+      return e && match_map(a->GetElems(), e->GetElems());
+    }
+    if (const auto *a = actual.TryAs<Type::TVariant>()) {
+      const auto *e = expected.TryAs<Type::TVariant>();
+      return e && match_map(a->GetElems(), e->GetElems());
+    }
+    if (const auto *a = actual.TryAs<Type::TList>()) {
+      const auto *e = expected.TryAs<Type::TList>();
+      return e && MatchesModuloAny(a->GetElem(), e->GetElem());
+    }
+    if (const auto *a = actual.TryAs<Type::TSet>()) {
+      const auto *e = expected.TryAs<Type::TSet>();
+      return e && MatchesModuloAny(a->GetElem(), e->GetElem());
+    }
+    if (const auto *a = actual.TryAs<Type::TSeq>()) {
+      const auto *e = expected.TryAs<Type::TSeq>();
+      return e && MatchesModuloAny(a->GetElem(), e->GetElem());
+    }
+    if (const auto *a = actual.TryAs<Type::TOpt>()) {
+      const auto *e = expected.TryAs<Type::TOpt>();
+      return e && MatchesModuloAny(a->GetElem(), e->GetElem());
+    }
+    if (const auto *a = actual.TryAs<Type::TDict>()) {
+      const auto *e = expected.TryAs<Type::TDict>();
+      return e && MatchesModuloAny(a->GetKey(), e->GetKey())
+               && MatchesModuloAny(a->GetVal(), e->GetVal());
+    }
+    return false;
+  }
+
+}  // namespace
 
 TVariantCtor::TPtr TVariantCtor::New(const std::string &tag,
                                      const TExpr::TPtr &payload,
@@ -64,13 +143,19 @@ Type::TType TVariantCtor::GetTypeImpl() const {
      empty object and the synth layer supplies an empty-object payload
      expression, so this check covers both cases uniformly.) */
   Type::TType payload_type = Type::Unwrap(GetExpr()->GetType());
-  /* A TAny payload is an as-yet-unresolved recursive call (the placeholder
-     from TFunction::GetReturnType); defer rather than reject, so a function
-     can construct with its own recursive result (e.g. a tree-to-tree
-     transform). This matches how operators already propagate TAny -- a
-     recursive result is not verified in this position (#128 Option A). The
-     ctor's own type is the variant regardless of the payload. */
-  if (!payload_type.Is<Type::TAny>() && payload_type != Type::Unroll(iter->second, VariantType)) {
+  /* The payload must match the declared (unrolled) arm type, but a TAny --
+     an as-yet-unresolved recursive call (the placeholder from
+     TFunction::GetReturnType) -- is deferred rather than rejected, so a
+     function can construct with its own recursive result (e.g. a tree-to-tree
+     transform or a recursive widening fold). MatchesModuloAny treats TAny as
+     a wildcard ANYWHERE in the payload, so a recursive result nested in a
+     record/container (the common `Node(<{.next: self}>)` shape) is deferred
+     while the non-recursive parts stay strictly checked. This matches how
+     operators already propagate TAny -- a recursive result is not verified in
+     this position (#128 Option A, extended to compound payloads for #104
+     recursive-variant widening). The ctor's own type is the variant
+     regardless of the payload. */
+  if (!MatchesModuloAny(payload_type, Type::Unroll(iter->second, VariantType))) {
     std::string msg = Base::AsStr("variant constructor payload type does not match the declared type of arm \"", Tag, "\"");
     throw TExprError(HERE, GetPosRange(), msg.c_str());
   }

--- a/orly/type/unroll.cc
+++ b/orly/type/unroll.cc
@@ -31,6 +31,64 @@
 using namespace Orly;
 using namespace Orly::Type;
 
+bool Type::HasAny(const TType &type) {
+  class TVisitor
+      : public TType::TVisitor {
+    public:
+    TVisitor(bool &found) : Found(found) {}
+    virtual void operator()(const TAny *) const { Found = true; }
+    virtual void operator()(const TSelfRef *) const {}
+    virtual void operator()(const TGroupRef *) const {}
+    virtual void operator()(const TVariant *that) const {
+      for (const auto &elem : that->GetElems()) {
+        if (Found) { return; }
+        elem.second.Accept(*this);
+      }
+    }
+    virtual void operator()(const TObj *that) const {
+      for (const auto &elem : that->GetElems()) {
+        if (Found) { return; }
+        elem.second.Accept(*this);
+      }
+    }
+    virtual void operator()(const TAddr *that) const {
+      for (const auto &elem : that->GetElems()) {
+        if (Found) { return; }
+        elem.second.Accept(*this);
+      }
+    }
+    virtual void operator()(const TDict *that) const {
+      that->GetKey().Accept(*this);
+      if (!Found) { that->GetVal().Accept(*this); }
+    }
+    virtual void operator()(const TErr *that) const { that->GetElem().Accept(*this); }
+    virtual void operator()(const TList *that) const { that->GetElem().Accept(*this); }
+    virtual void operator()(const TOpt *that) const { that->GetElem().Accept(*this); }
+    virtual void operator()(const TSeq *that) const { that->GetElem().Accept(*this); }
+    virtual void operator()(const TSet *that) const { that->GetElem().Accept(*this); }
+    virtual void operator()(const TFunc *that) const {
+      that->GetParamObject().Accept(*this);
+      if (!Found) { that->GetReturnType().Accept(*this); }
+    }
+    virtual void operator()(const TMutable *that) const {
+      that->GetAddr().Accept(*this);
+      if (!Found) { that->GetVal().Accept(*this); }
+    }
+    virtual void operator()(const TBool *) const {}
+    virtual void operator()(const TId *) const {}
+    virtual void operator()(const TInt *) const {}
+    virtual void operator()(const TReal *) const {}
+    virtual void operator()(const TStr *) const {}
+    virtual void operator()(const TTimeDiff *) const {}
+    virtual void operator()(const TTimePnt *) const {}
+    private:
+    bool &Found;
+  };  // TVisitor
+  bool found = false;
+  type.Accept(TVisitor(found));
+  return found;
+}
+
 bool Type::HasSelfRef(const TType &type) {
   class TVisitor
       : public TType::TVisitor {

--- a/orly/type/unroll.h
+++ b/orly/type/unroll.h
@@ -37,6 +37,15 @@ namespace Orly {
 
   namespace Type {
 
+    /* True iff the type structurally contains a TAny leaf (at any depth).
+       TAny arises only from an as-yet-unresolved recursive-call result
+       (TFunction::GetReturnType), so a type for which this holds is not yet
+       fully resolved and must not be memoized: TExpr::GetType refuses to
+       cache it, so the expression recomputes (and the recursion resolves to a
+       concrete type) by codegen time. The compound generalization of the
+       shallow `Is<TAny>` check (#128 / #104 recursive-variant widening). */
+    bool HasAny(const TType &type);
+
     /* True iff the type structurally contains a TSelfRef leaf (at any
        depth, bound or free). True both for a recursive variant itself and
        for any type that embeds one (e.g. a record with a recursive-variant

--- a/tests/lang_tests/general/.variants_widen_recursive.orly.test.state
+++ b/tests/lang_tests/general/.variants_widen_recursive.orly.test.state
@@ -4,7 +4,7 @@
     [],
     [
       "Synth + Symbols",
-      "36:15-36:27 [orly/expr/as.cc, 389]widening of recursive variants is not yet supported (#104)"
+      "38:15-38:27 [orly/expr/as.cc, 389]widening of recursive variants is not yet supported (#104)"
     ]
   ]
 ]

--- a/tests/lang_tests/general/.variants_widen_recursive_fold.orly.test.state
+++ b/tests/lang_tests/general/.variants_widen_recursive_fold.orly.test.state
@@ -1,0 +1,21 @@
+[
+  0,
+  [
+    [],
+    [
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++"
+    ],
+    [
+      "Running tests"
+    ],
+    [
+      "Tests done"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/variants_widen_recursive.orly
+++ b/tests/lang_tests/general/variants_widen_recursive.orly
@@ -1,20 +1,22 @@
 /* <orly/lang_tests/general/variants_widen_recursive.orly>
 
-   Deferred v1 case for variant widening (issue #104), tracked as an xfail.
+   Deferred case for variant widening (issue #104), tracked as an xfail:
+   the `as` OPERATOR does not widen recursive variants.
 
-   Widening of RECURSIVE variants is not implemented in v1. A recursive
-   variant boxes its self-edges in the native representation
-   (#103/#116/#125), so widening would have to rebuild through that boxed
-   form -- a high-cost, low-value corner left out of v1. The shared arms of
+   A recursive variant boxes its self-edges in the native representation
+   (#103/#116/#125), so `rnar as rwid` would have to AUTO-GENERATE a recursive
+   conversion through that boxed form -- still deferred. The shared arms of
    `rnar` and `rwid` are structurally identical (`Leaf(int)` and the
    self-referential `Node`), so the widening relation itself holds, but the
-   type checker rejects the cast with a clear "not yet supported (#104)"
+   type checker rejects the CAST with a clear "not yet supported (#104)"
    because a self-reference is present. This file therefore currently FAILS
    to compile and is pinned in tests/lang_tests/.xfail.
 
-   When recursive-variant widening lands, this test will compile and run
-   (xpass), prompting removal of the .xfail entry and promotion to a plain
-   positive test -- the assertion below is written to pass at that point.
+   NOTE: recursive widening can now be written by hand as a recursive FOLD --
+   see variants_widen_recursive_fold.orly, which works today. This xfail
+   tracks only the `as`-operator sugar. When that lands, this test will
+   compile and run (xpass), prompting removal of the .xfail entry and
+   promotion to a positive test -- the assertion below is written to pass.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/tests/lang_tests/general/variants_widen_recursive_fold.orly
+++ b/tests/lang_tests/general/variants_widen_recursive_fold.orly
@@ -1,0 +1,70 @@
+/* <orly/lang_tests/general/variants_widen_recursive_fold.orly>
+
+   Widening a RECURSIVE variant via a hand-written fold (issue #104).
+
+   The `as` operator does not widen recursive variants (that would need an
+   auto-generated recursive conversion through the boxed self-edge
+   representation -- still deferred, see variants_widen_recursive.orly). But
+   the widening can be written directly as a recursive fold that rebuilds
+   each arm in the wide type and recurses into the self-referential payload
+   fields:
+
+     widen = ((t) when {
+       Leaf(n):   widt.Leaf(n);
+       Branch(b): widt.Branch(<{.l: widen(.t: b.l), .r: widen(.t: b.r)}>);
+     }) where { t = given::(nart); };
+
+   This was blocked until the type checker learned to defer a recursive
+   call's (TAny) result nested ANYWHERE in a constructor payload -- here the
+   `.l` / `.r` fields of the Branch record (TVariantCtor's MatchesModuloAny,
+   plus TExpr not caching a compound that still contains TAny). It is the
+   compound generalization of the shallow #128 Option A deferral.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+/* A binary tree; `narrow` and `wide` differ only by the extra `Empty` arm. */
+nart is <| Leaf(int) | Branch(<{.l: nart, .r: nart}>) |>;
+widt is <| Empty | Leaf(int) | Branch(<{.l: widt, .r: widt}>) |>;
+
+/* Recursive widening fold: each arm rebuilt in the wide type, recursing into
+   both self-referential fields of the Branch payload. The recursive `widen`
+   results land in the `.l`/`.r` fields of the wide Branch record. */
+widen = ((t) when {
+  Leaf(n):   widt.Leaf(n);
+  Branch(b): widt.Branch(<{.l: widen(.t: b.l), .r: widen(.t: b.r)}>);
+}) where {
+  t = given::(nart);
+};
+
+/* A depth-2 narrow tree and the equivalent wide tree built directly. */
+nv = (nart.Branch(<{
+        .l: nart.Leaf(1),
+        .r: nart.Branch(<{.l: nart.Leaf(2), .r: nart.Leaf(3)}>)}>)) where {};
+wv = (widt.Branch(<{
+        .l: widt.Leaf(1),
+        .r: widt.Branch(<{.l: widt.Leaf(2), .r: widt.Leaf(3)}>)}>)) where {};
+
+with {
+} test {
+  /* Leaf base case. */
+  t_leaf: widen(.t: nart.Leaf(7)) == widt.Leaf(7);
+  /* Deep structural widening: every node remapped, structure preserved. */
+  t_deep: widen(.t: nv) == wv;
+  /* The widened tree is genuinely the wide type -- it can hold the new arm. */
+  t_wide_arm: widt.Branch(<{.l: widen(.t: nart.Leaf(1)), .r: widt.Empty()}>)
+      == widt.Branch(<{.l: widt.Leaf(1), .r: widt.Empty()}>);
+  /* A structurally different narrow tree widens to a non-equal wide tree. */
+  t_neq: widen(.t: nart.Leaf(1)) != widt.Leaf(2);
+};


### PR DESCRIPTION
## What

Next phase of **#104** (recursive-variant widening) — implemented as the leveraged unblock rather than the literal `as` operator.

The investigation overturned the issue's framing. Recursive widening was assumed to be "low-value sugar you could write by hand as a fold." In fact the hand-written fold **did not compile**:

```orly
nart is <| Leaf(int) | Branch(<{.l: nart, .r: nart}>) |>;
widt is <| Empty | Leaf(int) | Branch(<{.l: widt, .r: widt}>) |>;

widen = ((t) when {
  Leaf(n):   widt.Leaf(n);
  Branch(b): widt.Branch(<{.l: widen(.t: b.l), .r: widen(.t: b.r)}>);   /* was rejected */
}) where { t = given::(nart); };
```

A recursive call returns the `TAny` placeholder until the recursion resolves, and Option A (#129) only deferred a payload that **is** directly `TAny`. A recursive variant's self-reference almost always sits **inside a record/container** (`Branch(<{.l: self, .r: self}>)`, the #116/#125 shape), so the rebuild produced a payload `<{.l: TAny, .r: TAny}>` — a compound *containing* `TAny` — which (a) the variant-ctor check rejected and (b) `TExpr` then cached, leaking `TAny` into codegen (`Attempted to print out the TAny type`).

## How

The compound generalization of Option A's shallow `Is<TAny>`:

- **`TVariantCtor`** (`orly/expr/variant.cc`): `MatchesModuloAny` compares the payload to the declared (unrolled) arm type treating `TAny` as a wildcard **anywhere**, so a recursive result nested in a record / list / set / seq / opt / dict / variant is deferred while the non-recursive parts stay **strictly** checked.
- **`TExpr::GetType`** (`orly/expr/expr.cc`): refuse to cache a type that contains `TAny` anywhere (new `Type::HasAny`), not just one that *is* `TAny` — so a compound-with-`TAny` recomputes once the recursion resolves to a concrete type by codegen, instead of freezing the placeholder in.

This is the #128 Option A "caching note" made real, scoped narrowly to the (already-tolerated) unverified-recursive-result surface.

## Scope

The **`as` operator** on recursive variants stays deferred — it would need an auto-generated recursive conversion through the boxed self-edge representation. `variants_widen_recursive.orly` remains the xfail tracking that, its comment updated to point at the fold as the way to do recursive widening today.

## Tests

New positive `variants_widen_recursive_fold.orly`: a binary-tree recursive variant widened via a fold — deep structure, multi-field self-ref payload, equality with a directly-built wide tree. Full lang suite green — `0 unexpected, 148 passed, 3 tracked failures (xfail)`. C++ unit suite green.