### PR TITLE
Recursive-variant `as` widening via synthesized top-level fold (#104)

### DIFF
--- a/orly/code_gen/builder.cc
+++ b/orly/code_gen/builder.cc
@@ -346,6 +346,18 @@ TInline::TPtr Orly::CodeGen::Build(const L0::TPackage *package, const Expr::TExp
     }
     //TODO: Cast should be able to maintain mutability of list elements, as well as when doing the no-op cast.
     virtual void operator()(const Expr::TAs *that) const {
+      /* A RECURSIVE-variant widening (#104) cannot be a value rebuild here --
+         the self-edges are boxed, so the synth pass replaced it with a call
+         to a synthesized top-level fold (see
+         Synth::SynthesizeRecursiveVariantWidenings). Emit that call: it
+         lowers exactly like a TFunctionApp with the cast operand as the `t`
+         argument. */
+      if (const auto &widen_fn = that->GetRecursiveWidenFn()) {
+        TCall::TArgs args;
+        args.push_back(Build(Package, that->GetExpr(), false));
+        Res = Interner.GetCall(Package, TSymbolFunc::Find(widen_fn.get()), args);
+        return;
+      }
       /* A variant -> wider-variant widening (#104) is a value rebuild, not a
          reinterpret cast: the two are distinct C++ structs with different
          `Which` numbering. Detect it by source and result both unwrapping to

--- a/orly/expr/as.cc
+++ b/orly/expr/as.cc
@@ -386,8 +386,16 @@ Type::TType TAs::GetTypeImpl() const {
       return false;
     };
     if (is_recursive(src_variant) || is_recursive(dst_variant)) {
-      throw TExprError(HERE, GetPosRange(),
-          "widening of recursive variants is not yet supported (#104)");
+      /* A recursive widening the synth pass turned into a fold call
+         (Synth::SynthesizeRecursiveVariantWidenings) is now supported: the
+         cast carries the synthesized fold and codegen emits a call to it, so
+         the result is simply the (already computed) wide type. An
+         un-annotated recursive widening uses a payload shape that is not yet
+         synthesized -- keep the canonical diagnostic for it (#104). */
+      if (!RecursiveWidenFn) {
+        throw TExprError(HERE, GetPosRange(),
+            "widening of recursive variants is not yet supported (#104)");
+      }
     }
   }
   return type;

--- a/orly/expr/as.h
+++ b/orly/expr/as.h
@@ -21,10 +21,19 @@
 
 #pragma once
 
+#include <cassert>
+#include <memory>
+
 #include <base/class_traits.h>
 #include <orly/expr/unary.h>
 
 namespace Orly {
+
+  namespace Symbol {
+
+    class TFunction;
+
+  }  // Symbol
 
   namespace Expr {
 
@@ -39,6 +48,26 @@ namespace Orly {
 
       virtual void Accept(const TVisitor &visitor) const;
 
+      /* The target type of the cast (the annotation). */
+      const Type::TType &GetCastType() const {
+        return Type;
+      }
+
+      /* The synthesized top-level fold this cast widens through, when this is
+         a recursive-variant widening (#104); null otherwise. Set by the synth
+         pass Synth::SynthesizeRecursiveVariantWidenings once -- the flat
+         reinterpret cast cannot rebuild a recursive variant through its boxed
+         self-edges, so codegen emits a call to this fold instead, and
+         GetTypeImpl accepts the otherwise-deferred widening. */
+      const std::shared_ptr<Symbol::TFunction> &GetRecursiveWidenFn() const {
+        return RecursiveWidenFn;
+      }
+
+      void SetRecursiveWidenFn(const std::shared_ptr<Symbol::TFunction> &fn) {
+        assert(!RecursiveWidenFn);
+        RecursiveWidenFn = fn;
+      }
+
       virtual Type::TType GetTypeImpl() const override;
 
       private:
@@ -46,6 +75,8 @@ namespace Orly {
       TAs(const TExpr::TPtr &expr, const Type::TType &type, const TPosRange &pos_range);
 
       const Type::TType Type;
+
+      std::shared_ptr<Symbol::TFunction> RecursiveWidenFn;
 
     };  // TAs
 

--- a/orly/synth/package.cc
+++ b/orly/synth/package.cc
@@ -26,6 +26,7 @@
 #include <orly/synth/cst_utils.h>
 #include <orly/synth/get_pos_range.h>
 #include <orly/synth/new_expr.h>
+#include <orly/synth/postfix_cast.h>
 
 using namespace Orly;
 using namespace Orly::Synth;
@@ -62,6 +63,13 @@ TPackage::TPackage(const Package::TName &name, const Package::Syntax::TPackage *
     if (!GetContext().HasErrors()) {
       BuildSymbol();
       Build();
+      /* Turn recursive-variant `as` widenings into calls to synthesized
+         top-level folds (#104). Run after Build (every def's type is now
+         resolvable) and before TypeCheck (so the minted functions are not
+         added to the package's function set while it is being iterated). */
+      if (!GetContext().HasErrors()) {
+        SynthesizeRecursiveVariantWidenings(Symbol);
+      }
     }
   }
 }

--- a/orly/synth/postfix_cast.cc
+++ b/orly/synth/postfix_cast.cc
@@ -18,14 +18,367 @@
 
 #include <orly/synth/postfix_cast.h>
 
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <base/as_str.h>
 #include <base/assert_true.h>
+#include <base/hash.h>
 #include <orly/expr/as.h>
+#include <orly/expr/function_app.h>
+#include <orly/expr/obj.h>
+#include <orly/expr/obj_member.h>
+#include <orly/expr/ref.h>
+#include <orly/expr/variant.h>
+#include <orly/expr/walker.h>
+#include <orly/expr/when.h>
+#include <orly/symbol/function.h>
+#include <orly/symbol/given_param_def.h>
+#include <orly/symbol/result_def.h>
+#include <orly/symbol/test/test.h>
+#include <orly/symbol/test/test_case_block.h>
 #include <orly/synth/get_pos_range.h>
 #include <orly/synth/new_expr.h>
 #include <orly/synth/new_type.h>
+#include <orly/type/impl.h>
+#include <orly/type/obj.h>
+#include <orly/type/unroll.h>
+#include <orly/type/unwrap.h>
+#include <orly/type/variant.h>
 
 using namespace Orly;
 using namespace Orly::Synth;
+
+namespace {
+
+  /* True iff `v` is a recursive variant (some arm payload contains a free
+     self-reference or a group reference) -- mirrors the recursion test in
+     orly/expr/as.cc. */
+  bool IsRecursiveVariant(const Type::TVariant *v) {
+    for (const auto &arm : v->GetElems()) {
+      if (Type::HasFreeSelfRef(arm.second) || Type::HasGroupRef(arm.second)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /* Synthesizes the body of a recursive widening fold (#104). Given the
+     source (narrow) and target (wide) recursive variant types, it produces
+     the expression that converts a value of the narrow type into the wide
+     one, applying a recursive `widen(.t: ...)` call at each recursion point.
+
+     The fold is exactly the one a user writes by hand (which works since
+     #157):
+       widen = ((t) when {
+         Leaf(n):   wide.Leaf(n);
+         Branch(b): wide.Branch(<{.l: widen(.t: b.l), .r: widen(.t: b.r)}>);
+       }) where { t = given::(narrow); };
+     so type-check, recursion resolution, and codegen are all already proven;
+     we only assemble the Expr/Symbol tree it lowers to -- as a TOP-LEVEL
+     package function, because recursion is only supported for top-level
+     functions (an inline / where-bound recursive function is rejected). */
+  struct TWidenSynth {
+    /* The narrow and wide variant types: a subterm typed exactly as the
+       narrow variant is a recursion point (it widens to the wide variant via
+       a recursive call). */
+    Type::TType NarrowVariant;
+    Type::TType WideVariant;
+    /* The synthesized `widen` function's result def -- the callee of every
+       recursive call. Null while pre-flighting support with CanRebuild(). */
+    Symbol::TResultDef::TPtr WidenResult;
+    TPosRange PosRange;
+
+    /* True iff Rebuild() can convert a value of narrow subterm type `src`
+       into wide type `dst`. A pure structural pre-flight (no Expr built, no
+       function minted) so an unsupported payload shape is left for the plain
+       `as` cast -- whose type-checker emits the canonical "widening of
+       recursive variants is not yet supported (#104)" diagnostic. */
+    bool CanRebuild(const Type::TType &src, const Type::TType &dst) const {
+      /* Identical subterm (interned): no recursion inside -- passes through. */
+      if (src == dst) {
+        return true;
+      }
+      /* The recursion point: narrow widens to wide via a recursive call. */
+      if (src == NarrowVariant && dst == WideVariant) {
+        return true;
+      }
+      /* Record of self: rebuildable iff every field is. */
+      if (const auto *src_obj = src.TryAs<Type::TObj>()) {
+        const auto *dst_obj = dst.TryAs<Type::TObj>();
+        if (!dst_obj) {
+          return false;
+        }
+        const auto &dst_elems = dst_obj->GetElems();
+        for (const auto &field : src_obj->GetElems()) {
+          auto dst_field = dst_elems.find(field.first);
+          if (dst_field == dst_elems.end() || !CanRebuild(field.second, dst_field->second)) {
+            return false;
+          }
+        }
+        return true;
+      }
+      /* Nested variant of self (a payload that is itself a variant carrying a
+         self-reference, e.g. `Node(<| Some(self) | None |>)`). The outer
+         Unroll has already turned its self-edges into the narrow variant, so
+         it is a payload-widening: identical tag set, each arm's payload
+         rebuilt (Some's becomes the recursion point). A nested variant that is
+         itself recursive would need its own fold -- defer it. */
+      if (const auto *src_var = src.TryAs<Type::TVariant>()) {
+        const auto *dst_var = dst.TryAs<Type::TVariant>();
+        if (!dst_var || IsRecursiveVariant(src_var) || IsRecursiveVariant(dst_var)) {
+          return false;
+        }
+        const auto &dst_elems = dst_var->GetElems();
+        if (src_var->GetElems().size() != dst_elems.size()) {
+          return false;
+        }
+        for (const auto &arm : src_var->GetElems()) {
+          auto dst_arm = dst_elems.find(arm.first);
+          if (dst_arm == dst_elems.end() || !CanRebuild(arm.second, dst_arm->second)) {
+            return false;
+          }
+        }
+        return true;
+      }
+      /* Optional, container (list / set / seq) and dict of self are not yet
+         synthesized; leave them to the plain cast so the type checker reports
+         the canonical #104 diagnostic. (Optional of self needs the recursive
+         call's deferred TAny result to flow through the optional construction;
+         the #128/#157 deferral covers ctor payloads but not the cast / if-else
+         path -- the type checker hits NOT_IMPLEMENTED on `(TAny, TOpt)` in
+         orly/type/infix_visitor.h. A follow-up #104 task.) */
+      return false;
+    }
+
+    /* True iff every arm of the narrow variant has a payload Rebuild() can
+       convert to the wide variant's corresponding arm. */
+    bool CanSynthesize(const Type::TVariant *narrow_variant,
+                       const Type::TVariant *wide_variant) const {
+      const auto &wide_elems = wide_variant->GetElems();
+      for (const auto &arm : narrow_variant->GetElems()) {
+        auto wide_arm = wide_elems.find(arm.first);
+        assert(wide_arm != wide_elems.end());  // guaranteed by IsWidenableTo
+        if (!CanRebuild(Type::Unroll(arm.second, NarrowVariant),
+                        Type::Unroll(wide_arm->second, WideVariant))) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    /* Convert a value of narrow subterm type `src` to wide type `dst`. The
+       two differ only at recursion points; everything else is identical and
+       passes through unchanged.
+
+       `make` builds a FRESH accessor expression for the value each time it is
+       called -- the caller must not share Expr nodes (each node may have only
+       one parent), so a record that reads its source twice (`.l` and `.r`)
+       rebuilds the access path per field rather than reusing one node. */
+    Expr::TExpr::TPtr Rebuild(const std::function<Expr::TExpr::TPtr ()> &make,
+                              const Type::TType &src,
+                              const Type::TType &dst) const {
+      /* Identical subterm (interned): no recursion inside -- pass through.
+         Covers all non-recursive parts (scalars, sibling fields, etc.). */
+      if (src == dst) {
+        return make();
+      }
+      /* The recursion point: a narrow-variant-typed value widens to the wide
+         variant via a recursive call. After Unroll, every top-level
+         self-reference in a payload appears as the narrow variant itself. */
+      if (src == NarrowVariant && dst == WideVariant) {
+        Expr::TFunctionApp::TFunctionAppArgMap args;
+        args["t"] = Expr::TFunctionAppArg::New(make());
+        return Expr::TFunctionApp::New(Expr::TRef::New(WidenResult, PosRange), args, PosRange);
+      }
+      /* Record of self (the common `Branch(<{.l: self, .r: self}>)` shape):
+         rebuild field by field, each reading the source record afresh. */
+      if (const auto *src_obj = src.TryAs<Type::TObj>()) {
+        const auto *dst_obj = dst.As<Type::TObj>();
+        const auto &dst_elems = dst_obj->GetElems();
+        Expr::TObj::TMemberMap members;
+        for (const auto &field : src_obj->GetElems()) {
+          auto dst_field = dst_elems.find(field.first);
+          assert(dst_field != dst_elems.end());
+          const std::string name = field.first;
+          members[field.first] = Rebuild(
+              [this, &make, name]() {
+                return Expr::TObjMember::New(make(), name, PosRange);
+              },
+              field.second, dst_field->second);
+        }
+        return Expr::TObj::New(members, PosRange);
+      }
+      /* Nested variant of self: a `when` that rebuilds each arm in the wide
+         nested variant (the recursion point falls inside an arm whose payload
+         is the narrow variant). */
+      if (const auto *src_var = src.TryAs<Type::TVariant>()) {
+        const auto *dst_var = dst.As<Type::TVariant>();
+        const auto &dst_elems = dst_var->GetElems();
+        std::vector<std::string> tags;
+        Expr::TWhen::TExprVec bodies;
+        for (const auto &arm : src_var->GetElems()) {
+          auto dst_arm = dst_elems.find(arm.first);
+          assert(dst_arm != dst_elems.end());
+          const std::string tag = arm.first;
+          auto rebuilt = Rebuild(
+              [this, &make, tag]() {
+                return Expr::TObjMember::New(make(), tag, PosRange);
+              },
+              arm.second, dst_arm->second);
+          tags.push_back(tag);
+          bodies.push_back(Expr::TVariantCtor::New(tag, rebuilt, dst, PosRange));
+        }
+        return Expr::TWhen::New(make(), tags, bodies, PosRange);
+      }
+      /* CanRebuild() gates every call, so any other shape is a logic error. */
+      assert(false);
+      return make();
+    }
+
+    /* The synthesized function's body: a `when` over the narrow arms whose
+       body rebuilds each arm's payload in the wide type. The recursion points
+       inside it (via Rebuild) call back into the function via WidenResult. */
+    Expr::TExpr::TPtr BuildBody(const Symbol::TParamDef::TPtr &param,
+                                const Type::TVariant *narrow_variant,
+                                const Type::TVariant *wide_variant) const {
+      std::vector<std::string> tags;
+      Expr::TWhen::TExprVec bodies;
+      const auto &wide_elems = wide_variant->GetElems();
+      for (const auto &arm : narrow_variant->GetElems()) {
+        auto wide_arm = wide_elems.find(arm.first);
+        assert(wide_arm != wide_elems.end());  // guaranteed by IsWidenableTo
+        auto src_payload = Type::Unroll(arm.second, NarrowVariant);
+        auto dst_payload = Type::Unroll(wide_arm->second, WideVariant);
+        const std::string tag = arm.first;
+        /* The arm body reads the active payload via `t.Tag`, rebuilt fresh
+           wherever the payload value is read (no shared Expr nodes). */
+        auto rebuilt = Rebuild(
+            [this, &param, tag]() {
+              return Expr::TObjMember::New(Expr::TRef::New(param, PosRange), tag, PosRange);
+            },
+            src_payload, dst_payload);
+        tags.push_back(tag);
+        bodies.push_back(Expr::TVariantCtor::New(tag, rebuilt, WideVariant, PosRange));
+      }
+      return Expr::TWhen::New(Expr::TRef::New(param, PosRange), tags, bodies, PosRange);
+    }
+  };  // TWidenSynth
+
+  /* The (narrow, wide) -> synthesized fold cache for one package's synth
+     pass, so a narrow->wide widening appearing at several `as` sites mints a
+     single shared fold. */
+  typedef std::unordered_map<std::pair<Type::TType, Type::TType>,
+                             Symbol::TFunction::TPtr> TWidenCache;
+
+  /* Look up -- or, on a miss, mint -- the top-level `widen` fold for the
+     given narrow->wide recursive-variant pair. The function is added to the
+     package scope so it is type-checked (Symbol::TScope::TypeCheck) and
+     emitted (CodeGen::TPackage) alongside the user's own top-level functions,
+     and recursion resolves to a top-level C++ function. */
+  Symbol::TFunction::TPtr GetOrMintWiden(const Symbol::TScope::TPtr &package_scope,
+                                         TWidenCache &cache,
+                                         const Type::TVariant *narrow_variant,
+                                         const Type::TVariant *wide_variant,
+                                         const TPosRange &pos_range) {
+    auto narrow_type = narrow_variant->AsType();
+    auto wide_type = wide_variant->AsType();
+    auto key = std::make_pair(narrow_type, wide_type);
+    auto found = cache.find(key);
+    if (found != cache.end()) {
+      return found->second;
+    }
+
+    /* A fresh, alphanumeric name -- the C++ emitter prefixes it with 'F'
+       (orly/code_gen/export_func.cc), so it must be a valid identifier and
+       must not collide with a user function. */
+    auto name = Base::AsStr("widenRec", cache.size());
+    auto widen = Symbol::TFunction::New(package_scope, name, pos_range);
+    auto widen_result = Symbol::TResultDef::New(widen, name, pos_range);
+    auto param = Symbol::TGivenParamDef::New(widen, "t", narrow_type, pos_range);
+
+    /* Register before building the body so a self-recursive widening reuses
+       this same function rather than recursing here. */
+    cache[key] = widen;
+
+    TWidenSynth synth{narrow_type, wide_type, widen_result, pos_range};
+    widen->SetExpr(synth.BuildBody(param, narrow_variant, wide_variant));
+    return widen;
+  }
+
+  /* Collect every `Expr::TAs` reachable from `root` (including inside inner /
+     where-bound functions) into `casts`. */
+  void CollectCasts(const Expr::TExpr::TPtr &root, std::vector<Expr::TAs *> &casts) {
+    if (!root) {
+      return;
+    }
+    Expr::ForEachExpr(root, [&casts](const Expr::TExpr::TPtr &expr) -> bool {
+      if (auto *as = dynamic_cast<Expr::TAs *>(expr.get())) {
+        casts.push_back(as);
+      }
+      return false;  // keep recursing
+    }, /* include_inner_funcs */ true);
+  }
+
+  void CollectCastsInTestBlock(const Symbol::Test::TTestCaseBlock::TPtr &block,
+                               std::vector<Expr::TAs *> &casts) {
+    if (!block) {
+      return;
+    }
+    for (const auto &test_case : block->GetTestCases()) {
+      CollectCasts(test_case->GetExpr(), casts);
+      CollectCastsInTestBlock(test_case->GetOptTestCaseBlock(), casts);
+    }
+  }
+
+}  // namespace
+
+void Synth::SynthesizeRecursiveVariantWidenings(const Symbol::TPackage::TPtr &package) {
+  assert(package);
+
+  /* Phase 1 -- collect candidate casts. Done before any minting so the
+     package's function set is not mutated while it is being iterated. */
+  std::vector<Expr::TAs *> casts;
+  for (const auto &func : package->GetFunctions()) {
+    CollectCasts(func->GetExpr(), casts);
+  }
+  for (const auto &test : package->GetTests()) {
+    CollectCastsInTestBlock(test->GetTestCaseBlock(), casts);
+  }
+
+  /* Phase 2 -- for each recursive-variant widening with a synthesizable
+     payload shape, mint (or reuse) its fold and annotate the cast. */
+  TWidenCache cache;
+  for (auto *as : casts) {
+    /* The source type is now safe to query: every def has finished its build
+       passes. A genuinely ill-typed operand throws here rather than in
+       TypeCheck; swallow it so the diagnostic is reported in its usual place. */
+    Type::TType src_type;
+    try {
+      src_type = as->GetExpr()->GetType();
+    } catch (...) {
+      continue;
+    }
+    const Type::TVariant *src_variant = Type::Unwrap(src_type).TryAs<Type::TVariant>();
+    const Type::TVariant *dst_variant = Type::Unwrap(as->GetCastType()).TryAs<Type::TVariant>();
+    if (!src_variant || !dst_variant || src_variant == dst_variant
+        || !src_variant->IsWidenableTo(dst_variant)
+        || !(IsRecursiveVariant(src_variant) || IsRecursiveVariant(dst_variant))) {
+      continue;
+    }
+    /* Pre-flight the payload shapes; an unsupported shape is left for the
+       type checker's canonical #104 diagnostic. */
+    TWidenSynth probe{src_variant->AsType(), dst_variant->AsType(), nullptr, as->GetPosRange()};
+    if (!probe.CanSynthesize(src_variant, dst_variant)) {
+      continue;
+    }
+    as->SetRecursiveWidenFn(
+        GetOrMintWiden(package, cache, src_variant, dst_variant, as->GetPosRange()));
+  }
+}
 
 TPostfixCast::TPostfixCast(const TExprFactory *expr_factory, const Package::Syntax::TPostfixCast *postfix_cast)
     : PostfixCast(Base::AssertTrue(postfix_cast)), Lhs(nullptr), Rhs(nullptr) {
@@ -46,6 +399,11 @@ TPostfixCast::~TPostfixCast() {
 }
 
 Expr::TExpr::TPtr TPostfixCast::Build() const {
+  /* Always lower to a plain `Expr::TAs`. A recursive-variant widening is
+     turned into a call to a synthesized fold afterwards, by the package-level
+     pass Synth::SynthesizeRecursiveVariantWidenings (#104) -- it cannot be
+     done here because detecting the widening needs the source expression's
+     type, which is not resolvable until every def has finished building. */
   return Expr::TAs::New(Lhs->Build(), Rhs->GetSymbolicType(), GetPosRange(PostfixCast));
 }
 

--- a/orly/synth/postfix_cast.h
+++ b/orly/synth/postfix_cast.h
@@ -22,6 +22,7 @@
 
 #include <base/class_traits.h>
 #include <orly/orly.package.cst.h>
+#include <orly/symbol/package.h>
 #include <orly/synth/type.h>
 #include <orly/synth/expr.h>
 
@@ -65,6 +66,18 @@ namespace Orly {
       TType *Rhs;
 
     };  // TPostfixCast
+
+    /* Synthesize recursive-variant `as`-widening (#104). Run once per package
+       AFTER the multi-pass synth Build (so every def -- and therefore every
+       expression's type -- is resolvable) and BEFORE Symbol::TScope::TypeCheck
+       (so newly minted functions are not added to the package's function set
+       while it is being iterated). For each `narrow as wide` cast between
+       recursive variants, mint a deduplicated top-level widening fold into the
+       package scope and annotate the cast's `Expr::TAs` to call it; codegen
+       then emits the call instead of the (impossible) flat reinterpret cast.
+       Casts whose payloads use a shape we do not yet synthesize are left
+       un-annotated, so the type checker reports the canonical #104 message. */
+    void SynthesizeRecursiveVariantWidenings(const Symbol::TPackage::TPtr &package);
 
   }  // Synth
 

--- a/tests/lang_tests/.xfail
+++ b/tests/lang_tests/.xfail
@@ -13,9 +13,3 @@
 
 general/unsorted/multiple_sequences.orly #74
 general/unsorted/sequence_in_effecting.orly #75
-
-# Deferred case of variant widening (#104): rejected today with a clear
-# "not yet supported" diagnostic; will xpass (and should be promoted to a
-# positive test) when recursive-variant widening is implemented.
-# (Optional-target widening landed in phase 2; its test is now a positive.)
-general/variants_widen_recursive.orly #104

--- a/tests/lang_tests/general/.variants_widen_recursive.orly.test.state
+++ b/tests/lang_tests/general/.variants_widen_recursive.orly.test.state
@@ -1,10 +1,21 @@
 [
-  1,
+  0,
   [
     [],
     [
-      "Synth + Symbols",
-      "38:15-38:27 [orly/expr/as.cc, 389]widening of recursive variants is not yet supported (#104)"
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++"
+    ],
+    [
+      "Running tests"
+    ],
+    [
+      "Tests done"
     ]
   ]
 ]

--- a/tests/lang_tests/general/variants_widen_recursive.orly
+++ b/tests/lang_tests/general/variants_widen_recursive.orly
@@ -1,22 +1,28 @@
 /* <orly/lang_tests/general/variants_widen_recursive.orly>
 
-   Deferred case for variant widening (issue #104), tracked as an xfail:
-   the `as` OPERATOR does not widen recursive variants.
+   Widening a RECURSIVE variant with the `as` OPERATOR (issue #104) -- the
+   last variant-widening gap.
 
    A recursive variant boxes its self-edges in the native representation
-   (#103/#116/#125), so `rnar as rwid` would have to AUTO-GENERATE a recursive
-   conversion through that boxed form -- still deferred. The shared arms of
-   `rnar` and `rwid` are structurally identical (`Leaf(int)` and the
-   self-referential `Node`), so the widening relation itself holds, but the
-   type checker rejects the CAST with a clear "not yet supported (#104)"
-   because a self-reference is present. This file therefore currently FAILS
-   to compile and is pinned in tests/lang_tests/.xfail.
+   (#103/#116/#125), so the flat `TVariantWiden` reinterpret-rebuild cannot
+   widen one: the narrow and wide structs have different `Which` numbering and
+   the self-edge is a different boxed type. Instead the synth pass
+   Synth::SynthesizeRecursiveVariantWidenings turns each recursive
+   `narrow as wide` into a call to a synthesized TOP-LEVEL widening fold -- the
+   same fold one can write by hand (variants_widen_recursive_fold.orly, #157),
+   but generated and deduplicated automatically. It recurses into the
+   self-referential payload fields, rebuilding each arm in the wide type.
 
-   NOTE: recursive widening can now be written by hand as a recursive FOLD --
-   see variants_widen_recursive_fold.orly, which works today. This xfail
-   tracks only the `as`-operator sugar. When that lands, this test will
-   compile and run (xpass), prompting removal of the .xfail entry and
-   promotion to a positive test -- the assertion below is written to pass.
+   The shared arms of `rnar`/`rwid` are structurally identical (`Leaf(int)`
+   and the self-referential `Node`); `rwid` adds the `Extra` arm. The
+   recursion point sits inside the `Node` payload record (`.next`), the
+   #116/#125 record-of-self shape, so this exercises both the direct arm
+   (`Leaf`) and a record-of-self arm (`Node`). The `nvnar`/`nvwid` pair adds a
+   recursion point inside a NESTED variant payload (`Node(<| Some(self) |
+   None |>)`), widened by recursing through an inline `when`.
+
+   Payload shapes not yet synthesized (optional / list / set / seq / dict of
+   self) still report the canonical "not yet supported (#104)" diagnostic.
 
    Copyright 2010-2026 Atomic Kismet Company
 
@@ -35,11 +41,47 @@
 rnar is <| Leaf(int) | Node(<{.next: rnar}>) |>;
 rwid is <| Extra | Leaf(int) | Node(<{.next: rwid}>) |>;
 
+/* A second pair whose recursion point sits inside a NESTED variant payload
+   (`Node(<| Some(self) | None |>)`), to exercise widening that recurses
+   through an inline `when` over the nested variant. */
+nvnar is <| Leaf(int) | Node(<| Some(nvnar) | None |>) |>;
+nvwid is <| Extra | Leaf(int) | Node(<| Some(nvwid) | None |>) |>;
+
+/* The `as` widening through a where-bound source: the source expression
+   (`rnar.Leaf(n)`) depends on a given parameter, so its type is only known
+   after the whole function has built -- which is exactly why the widening is
+   synthesized as a post-build pass rather than at the cast site. */
 widen_rec = ((rnar.Leaf(n) as rwid)) where {
   n = given::(int);
 };
 
+/* A depth-2 narrow chain and the equivalent wide chain built directly, to
+   check the recursion descends every self-edge. */
+nv = (rnar.Node(<{.next: rnar.Node(<{.next: rnar.Leaf(5)}>)}>)) where {};
+wv = (rwid.Node(<{.next: rwid.Node(<{.next: rwid.Leaf(5)}>)}>)) where {};
+
+/* A nested-variant tree and its directly-built wide equivalent. */
+nvn = (nvnar.Node(<| Some(nvnar) | None |>.Some(nvnar.Leaf(9)))) where {};
+nvw = (nvwid.Node(<| Some(nvwid) | None |>.Some(nvwid.Leaf(9)))) where {};
+
 with {
 } test {
-  t: widen_rec(.n: 1) is Leaf;
+  /* The where-bound-source widening returns the wide type and preserves the
+     payload. */
+  t_fn_leaf: widen_rec(.n: 3) == rwid.Leaf(3);
+  t_fn_is:   widen_rec(.n: 1) is Leaf;
+  /* Direct-arm base case via the `as` operator inline. */
+  t_leaf: (rnar.Leaf(7) as rwid) == rwid.Leaf(7);
+  /* Deep structural widening: every node remapped, structure preserved. */
+  t_deep: (nv as rwid) == wv;
+  /* The widened value is genuinely the wide type -- it sits beside the new
+     `Extra` arm in a freshly built wide node. */
+  t_wide_arm: rwid.Node(<{.next: (rnar.Leaf(1) as rwid)}>)
+      == rwid.Node(<{.next: rwid.Leaf(1)}>);
+  /* A structurally different narrow value widens to a non-equal wide value. */
+  t_neq: (rnar.Leaf(1) as rwid) != rwid.Leaf(2);
+  /* Widening that recurses through a nested-variant payload (the recursion
+     point is inside the `Some` arm of the inner variant). */
+  t_nv_leaf: (nvnar.Leaf(4) as nvwid) == nvwid.Leaf(4);
+  t_nv_some: (nvn as nvwid) == nvw;
 };


### PR DESCRIPTION
## What

Implements the `as` operator for widening **recursive** variants (`narrow as wide`) — the last variant-widening gap under #104. Recursive widening already worked as a hand-written fold (#157); this generates that fold automatically so the `as` operator works on recursive variants too, for consistency.

```orlyscript
rnar is <| Leaf(int) | Node(<{.next: rnar}>) |>;
rwid is <| Extra | Leaf(int) | Node(<{.next: rwid}>) |>;

widen = ((rnar.Leaf(n) as rwid)) where { n = given::(int); };   // now works
```

## Why a synthesized top-level fold (not a flat cast)

A recursive variant boxes its self-edges in the native representation (#103/#116/#125), so the flat `TVariantWiden` reinterpret-rebuild cannot widen one: the narrow and wide structs have different `Which` numbering and the self-edge is a different boxed type. The equivalent recursive **fold** can — and must be a **top-level** package function, because recursion is only supported there (an inline / where-bound recursive function is rejected, `bad_function_call`).

## How

Detecting a recursive widening needs the source expression's type, which is not resolvable until every def has finished building (a where-bound source depends on a `given` param built *after* its enclosing function). So the synthesis is a package-level pass, `Synth::SynthesizeRecursiveVariantWidenings`, run **after** the multi-pass synth `Build()` (types resolvable) and **before** `Symbol::TScope::TypeCheck` (so a minted function is not added to the package's function set while it is being iterated):

- **Phase 1** collects every `Expr::TAs` in the package's function and test bodies (including inner / where-bound functions).
- **Phase 2** mints — or reuses, deduplicated per `narrow -> wide` pair — a top-level fold into the package scope for each recursive-variant widening with a synthesizable payload shape, and annotates the `Expr::TAs` with it.

A minted fold lands in `package->GetFunctions()`, so it is type-checked and emitted alongside the user's own top-level functions. Codegen lowers an annotated `TAs` to a call to it (`orly/code_gen/builder.cc`), and `TAs::GetTypeImpl` accepts the otherwise-deferred widening (`orly/expr/as.cc`). The fold's recursive calls return the deferred `TAny` placeholder nested in constructor payloads, which the #128/#157 substrate (`MatchesModuloAny` + `HasAny`-no-cache) already resolves to concrete by codegen — the generated fold is identical to the #157 hand-written one (clean top-level recursion, no DeepBox/DeepUnbox).

## Supported payload shapes

- direct self arm (`Leaf` / the recursion point)
- record-of-self (`Node(<{.next: self}>)`)
- nested-variant-of-self (`Node(<| Some(self) | None |>)`, via an inline `when`)

Optional / list / set / seq / dict of self are pre-flighted by `TWidenSynth::CanRebuild` and left to the plain cast, which still reports the canonical "not yet supported (#104)" diagnostic — no crash, no silent wrong behavior. Optional-of-self in particular needs the deferred `TAny` result to flow through the optional construction, which hits `NOT_IMPLEMENTED` on `(TAny, TOpt)` in `orly/type/infix_visitor.h`; that needs a type-checker extension and is tracked as a follow-up in #159.

## Tests

`tests/lang_tests/general/variants_widen_recursive.orly` is promoted from an **xfail to a positive test** (covering the where-bound source, deep record-of-self trees, and nested-variant recursion); its `.xfail` entry is removed and its `.state` baseline regenerated.

- `lang_test.py`: `0 unexpected, 149 passed, 2 tracked failures (xfail)` (the two remaining xfails are the unrelated #74 / #75)
- `make test`: green
