### PR TITLE
widen optional-of-self payloads in recursive-variant `as` (#159)

### DIFF
--- a/orly/expr/as.cc
+++ b/orly/expr/as.cc
@@ -80,6 +80,13 @@ Type::TType TAs::GetTypeImpl() const {
     virtual void operator()(const Type::TAny      *, const Type::TInt      *rhs) const { Type = rhs->AsType(); }
     virtual void operator()(const Type::TAny      *, const Type::TList     *rhs) const { Type = rhs->AsType(); }
     virtual void operator()(const Type::TAny      *, const Type::TObj      *rhs) const { Type = rhs->AsType(); }
+    /* A recursive widening fold defers each recursive call to the TAny
+       placeholder (#128/#157), so the optional lift the synth pass wraps around
+       such a call -- `widen(..) as wide?` for an optional-of-self payload --
+       runs the cast visitor over (TAny, TOpt). The base visitor reports that as
+       NOT_IMPLEMENTED; for an explicit cast the result is simply the concrete
+       target, exactly as the other (TAny, *) arms above (#104/#159). */
+    virtual void operator()(const Type::TAny      *, const Type::TOpt      *rhs) const { Type = rhs->AsType(); }
     virtual void operator()(const Type::TAny      *, const Type::TReal     *rhs) const { Type = rhs->AsType(); }
     virtual void operator()(const Type::TAny      *, const Type::TSet      *rhs) const { Type = rhs->AsType(); }
     virtual void operator()(const Type::TAny      *, const Type::TStr      *rhs) const { Type = rhs->AsType(); }

--- a/orly/synth/postfix_cast.cc
+++ b/orly/synth/postfix_cast.cc
@@ -29,9 +29,12 @@
 #include <base/hash.h>
 #include <orly/expr/as.h>
 #include <orly/expr/function_app.h>
+#include <orly/expr/if_else.h>
+#include <orly/expr/known.h>
 #include <orly/expr/obj.h>
 #include <orly/expr/obj_member.h>
 #include <orly/expr/ref.h>
+#include <orly/expr/unknown.h>
 #include <orly/expr/variant.h>
 #include <orly/expr/walker.h>
 #include <orly/expr/when.h>
@@ -45,6 +48,7 @@
 #include <orly/synth/new_type.h>
 #include <orly/type/impl.h>
 #include <orly/type/obj.h>
+#include <orly/type/opt.h>
 #include <orly/type/unroll.h>
 #include <orly/type/unwrap.h>
 #include <orly/type/variant.h>
@@ -121,6 +125,14 @@ namespace {
         }
         return true;
       }
+      /* Optional of self (`Node(self?)`, or `self?` as a record field):
+         rebuildable iff the optional's element is. The element is a recursion
+         point (the only self-placement under an optional that #116 permits),
+         reached by unwrapping the known case (see Rebuild). */
+      if (const auto *src_opt = src.TryAs<Type::TOpt>()) {
+        const auto *dst_opt = dst.TryAs<Type::TOpt>();
+        return dst_opt && CanRebuild(src_opt->GetElem(), dst_opt->GetElem());
+      }
       /* Nested variant of self (a payload that is itself a variant carrying a
          self-reference, e.g. `Node(<| Some(self) | None |>)`). The outer
          Unroll has already turned its self-edges into the narrow variant, so
@@ -144,13 +156,10 @@ namespace {
         }
         return true;
       }
-      /* Optional, container (list / set / seq) and dict of self are not yet
-         synthesized; leave them to the plain cast so the type checker reports
-         the canonical #104 diagnostic. (Optional of self needs the recursive
-         call's deferred TAny result to flow through the optional construction;
-         the #128/#157 deferral covers ctor payloads but not the cast / if-else
-         path -- the type checker hits NOT_IMPLEMENTED on `(TAny, TOpt)` in
-         orly/type/infix_visitor.h. A follow-up #104 task.) */
+      /* Container (list / set / seq) and dict of self are not yet synthesized;
+         leave them to the plain cast so the type checker reports the canonical
+         #104 diagnostic. (They need the fold to map each element through the
+         recursive call -- a separate Phase 2 increment.) */
       return false;
     }
 
@@ -211,6 +220,31 @@ namespace {
               field.second, dst_field->second);
         }
         return Expr::TObj::New(members, PosRange);
+      }
+      /* Optional of self: widen the inner value only when it is known,
+         otherwise pass the unknown through.
+
+           (make() is known) ? (widen(known make()) as wide?) : (unknown wide)
+
+         The recursive-variant shape rules (#116) only let a self-reference sit
+         under an optional as the optional's element itself (`Node(self?)`, or
+         `self?` as a record field -- a record *under* an optional is rejected),
+         so the optional's element is always a recursion point. The known branch
+         widens it -- the recursive call's result is the deferred TAny
+         placeholder -- and the `as wide?` cast both lifts the bare widened value
+         into an optional and resolves the deferred result via the (TAny, TOpt)
+         cast arm (#104). The unknown branch is `unknown wide` (TUnknown takes
+         the element type, yielding `wide?`), so both branches agree on `wide?`. */
+      if (const auto *src_opt = src.TryAs<Type::TOpt>()) {
+        const auto *dst_opt = dst.As<Type::TOpt>();
+        auto widened = Rebuild(
+            [this, &make]() { return Expr::TKnown::New(make(), PosRange); },
+            src_opt->GetElem(), dst_opt->GetElem());
+        return Expr::TIfElse::New(
+            Expr::TAs::New(widened, dst, PosRange),
+            Expr::TIsKnown::New(make(), PosRange),
+            Expr::TUnknown::New(dst_opt->GetElem(), PosRange),
+            PosRange);
       }
       /* Nested variant of self: a `when` that rebuilds each arm in the wide
          nested variant (the recursion point falls inside an arm whose payload

--- a/tests/lang_tests/general/variants_widen_recursive.orly
+++ b/tests/lang_tests/general/variants_widen_recursive.orly
@@ -19,10 +19,12 @@
    #116/#125 record-of-self shape, so this exercises both the direct arm
    (`Leaf`) and a record-of-self arm (`Node`). The `nvnar`/`nvwid` pair adds a
    recursion point inside a NESTED variant payload (`Node(<| Some(self) |
-   None |>)`), widened by recursing through an inline `when`.
+   None |>)`), widened by recursing through an inline `when`. The `optnar`/
+   `optwid` and `ornar`/`orwid` pairs add a recursion point under an OPTIONAL
+   (#159), widened by recursing into the optional's known case.
 
-   Payload shapes not yet synthesized (optional / list / set / seq / dict of
-   self) still report the canonical "not yet supported (#104)" diagnostic.
+   Payload shapes not yet synthesized (list / set / seq / dict of self) still
+   report the canonical "not yet supported (#104)" diagnostic.
 
    Copyright 2010-2026 Atomic Kismet Company
 
@@ -47,6 +49,18 @@ rwid is <| Extra | Leaf(int) | Node(<{.next: rwid}>) |>;
 nvnar is <| Leaf(int) | Node(<| Some(nvnar) | None |>) |>;
 nvwid is <| Extra | Leaf(int) | Node(<| Some(nvwid) | None |>) |>;
 
+/* Two pairs whose recursion point sits under an OPTIONAL (#159) -- the only
+   placements the recursive-variant shape rules (#116) allow for a self-edge
+   inside an optional: as the optional's element directly at the arm payload
+   (`Node(self?)`), and as the optional's element in a record field
+   (`Node(<{.next: self?}>)`). The widening fold recurses into the optional,
+   widening the element only when it is known and passing an unknown through. */
+optnar is <| Leaf(int) | Node(optnar?) |>;
+optwid is <| Extra | Leaf(int) | Node(optwid?) |>;
+
+ornar is <| Leaf(int) | Node(<{.next: ornar?}>) |>;
+orwid is <| Extra | Leaf(int) | Node(<{.next: orwid?}>) |>;
+
 /* The `as` widening through a where-bound source: the source expression
    (`rnar.Leaf(n)`) depends on a given parameter, so its type is only known
    after the whole function has built -- which is exactly why the widening is
@@ -63,6 +77,20 @@ wv = (rwid.Node(<{.next: rwid.Node(<{.next: rwid.Leaf(5)}>)}>)) where {};
 /* A nested-variant tree and its directly-built wide equivalent. */
 nvn = (nvnar.Node(<| Some(nvnar) | None |>.Some(nvnar.Leaf(9)))) where {};
 nvw = (nvwid.Node(<| Some(nvwid) | None |>.Some(nvwid.Leaf(9)))) where {};
+
+/* Optional-payload trees and their directly-built wide equivalents. `on`/`ow`
+   nest a depth-2 chain through the optional arm payload (every known edge
+   recursed into); `on_u`/`ow_u` hold an unknown (absent) edge that must pass
+   through unchanged. `orn`/`orw` repeat both via the optional record field. */
+on   = (optnar.Node(optnar.Node(optnar.Leaf(7) as optnar?) as optnar?)) where {};
+ow   = (optwid.Node(optwid.Node(optwid.Leaf(7) as optwid?) as optwid?)) where {};
+on_u = (optnar.Node(unknown optnar)) where {};
+ow_u = (optwid.Node(unknown optwid)) where {};
+
+orn   = (ornar.Node(<{.next: ornar.Leaf(2) as ornar?}>)) where {};
+orw   = (orwid.Node(<{.next: orwid.Leaf(2) as orwid?}>)) where {};
+orn_u = (ornar.Node(<{.next: unknown ornar}>)) where {};
+orw_u = (orwid.Node(<{.next: unknown orwid}>)) where {};
 
 with {
 } test {
@@ -84,4 +112,13 @@ with {
      point is inside the `Some` arm of the inner variant). */
   t_nv_leaf: (nvnar.Leaf(4) as nvwid) == nvwid.Leaf(4);
   t_nv_some: (nvn as nvwid) == nvw;
+  /* Widening through an OPTIONAL payload (#159): a known self-edge is recursed
+     into, an unknown one passes through. Both the direct optional payload and
+     the optional record field are exercised. */
+  t_opt_leaf:       (optnar.Leaf(4) as optwid) == optwid.Leaf(4);
+  t_opt_known:      (on as optwid) == ow;
+  t_opt_unknown:    (on_u as optwid) == ow_u;
+  t_opt_neq:        (on_u as optwid) != ow;
+  t_optrec_known:   (orn as orwid) == orw;
+  t_optrec_unknown: (orn_u as orwid) == orw_u;
 };


### PR DESCRIPTION
Phase 1 of #159, the follow-up to #158 (recursive-variant `as` widening synthesized as a top-level fold). Extends the synthesized fold to payloads whose self-edge sits under an **optional** — the placements the #116 shape rules permit: as the optional's element directly at an arm payload (`Node(self?)`) and as `self?` in the payload record (`Node(<{.next: self?}>)`).

## What

The fold recurses into the optional, widening the element only when it is known and passing an unknown through:

```
(t.Node is known) ? (widen(known t.Node) as wide?) : (unknown wide)
```

Two pieces:

- **`TWidenSynth` (`orly/synth/postfix_cast.cc`)** gains an opt case in `CanRebuild` / `Rebuild`. The optional's element is always a recursion point (the only self-placement #116 allows under an optional), so the known branch widens it and the `as wide?` cast lifts the bare result into the optional.
- **`TAsTypeVisitor` (`orly/expr/as.cc`)** now handles `(TAny, TOpt)`. The `as wide?` cast runs the cast visitor with a `TAny` left operand, because the recursive call's result is the deferred `TAny` placeholder (#128/#157). The base infix visitor reports `(TAny, TOpt)` as `NOT_IMPLEMENTED`; this adds it to the `(TAny, *)` family — a cast's result is its concrete target.

## Scope

Container-of-self payloads (list / set / seq / dict) remain a separate **Phase 2** increment — they need the fold to map each element through the recursive call — and still fall through to the canonical "not yet supported (#104)" diagnostic. The previously misleading deferral comment is updated accordingly.

Record-*under*-optional, optional-of-nested-variant, and opt-inside-a-nested-variant-arm are not handled here because they are rejected up front by the #116 recursive-variant shape validator (`SelfRefPlacementOk`), so they can never reach the widening pass.

## Tests

`tests/lang_tests/general/variants_widen_recursive.orly` adds the `optnar`/`optwid` and `ornar`/`orwid` pairs and tests covering the known edge (recursed into), the unknown edge (passed through), and a non-equal widening — for both the direct optional payload and the optional record field.

- `make debug` — clean
- `lang_test.py -d orly/data tests/lang_tests` — 0 unexpected, 149 passed, 2 tracked xfail (pre-existing)
- `make test` — exit 0
