### PR TITLE
widen list/set/dict-of-self payloads in recursive-variant `as` (#159)

### DIFF
--- a/orly/code_gen/variant_access.h
+++ b/orly/code_gen/variant_access.h
@@ -107,17 +107,28 @@ namespace Orly {
       void WriteExpr(TCppPrinter &out) const;
 
       virtual void AppendDependsOn(std::unordered_set<TInline::TPtr> &dependency_set) const override {
-        dependency_set.insert(Operand);
-        Operand->AppendDependsOn(dependency_set);
-        for (const auto &arm : Arms) {
-          dependency_set.insert(arm.second);
-          arm.second->AppendDependsOn(dependency_set);
+        /* Reentrancy guard, as in TIfElse: a `when` arm may (via a map over a
+           recursive call -- a recursive-variant widening fold, #104/#159)
+           reach back into this same `when`, which would otherwise walk the
+           dependency graph forever. Stop the second entry. */
+        if (!InDependsOn) {
+          InDependsOn = true;
+          dependency_set.insert(Operand);
+          Operand->AppendDependsOn(dependency_set);
+          for (const auto &arm : Arms) {
+            dependency_set.insert(arm.second);
+            arm.second->AppendDependsOn(dependency_set);
+          }
+          InDependsOn = false;
         }
       }
 
       private:
         TInline::TPtr Operand;
         TArmVec Arms;
+
+        /* True while inside AppendDependsOn, to detect reentrant recursion. */
+        mutable bool InDependsOn = false;
     }; // TVariantWhen
 
     /* `narrow_val as wide_t` -- widening a narrow variant to a superset

--- a/orly/synth/postfix_cast.cc
+++ b/orly/synth/postfix_cast.cc
@@ -27,6 +27,8 @@
 #include <base/as_str.h>
 #include <base/assert_true.h>
 #include <base/hash.h>
+#include <orly/expr/addr.h>
+#include <orly/expr/addr_member.h>
 #include <orly/expr/as.h>
 #include <orly/expr/function_app.h>
 #include <orly/expr/if_else.h>
@@ -34,6 +36,7 @@
 #include <orly/expr/obj.h>
 #include <orly/expr/obj_member.h>
 #include <orly/expr/ref.h>
+#include <orly/expr/sequence_of.h>
 #include <orly/expr/unknown.h>
 #include <orly/expr/variant.h>
 #include <orly/expr/walker.h>
@@ -46,9 +49,14 @@
 #include <orly/synth/get_pos_range.h>
 #include <orly/synth/new_expr.h>
 #include <orly/synth/new_type.h>
+#include <orly/type/addr.h>
+#include <orly/type/dict.h>
 #include <orly/type/impl.h>
+#include <orly/type/list.h>
 #include <orly/type/obj.h>
 #include <orly/type/opt.h>
+#include <orly/type/seq.h>
+#include <orly/type/set.h>
 #include <orly/type/unroll.h>
 #include <orly/type/unwrap.h>
 #include <orly/type/variant.h>
@@ -95,6 +103,13 @@ namespace {
        recursive call. Null while pre-flighting support with CanRebuild(). */
     Symbol::TResultDef::TPtr WidenResult;
     TPosRange PosRange;
+    /* For dict-of-self payloads only: the package scope that minted pair
+       helpers are added to, a per-fold cache (keyed by the dict's key type)
+       of the helper that rebuilds one key/value pair, and the base name for
+       those helpers. All null/empty while pre-flighting with CanRebuild(). */
+    Symbol::TScope::TPtr PackageScope;
+    std::unordered_map<Type::TType, Symbol::TResultDef::TPtr> *PairHelpers;
+    std::string NameStem;
 
     /* True iff Rebuild() can convert a value of narrow subterm type `src`
        into wide type `dst`. A pure structural pre-flight (no Expr built, no
@@ -156,10 +171,37 @@ namespace {
         }
         return true;
       }
-      /* Container (list / set / seq) and dict of self are not yet synthesized;
-         leave them to the plain cast so the type checker reports the canonical
-         #104 diagnostic. (They need the fold to map each element through the
-         recursive call -- a separate Phase 2 increment.) */
+      /* List / set of self (`Node([self])`, `Node({self})`): rebuildable iff
+         the element is the recursion point itself. The fold maps the narrow
+         widening fold over the elements (`widen(.t: **xs) as wide-container`,
+         the implicit element-wise map orly applies when a function is handed a
+         sequence) -- which only type-checks when the element is the narrow
+         variant the fold takes, so a nested container of self
+         (`[[self]]`, needing a per-element fold of its own) is left to the
+         plain cast's canonical #104 diagnostic. */
+      if (const auto *src_list = src.TryAs<Type::TList>()) {
+        const auto *dst_list = dst.TryAs<Type::TList>();
+        return dst_list && src_list->GetElem() == NarrowVariant
+            && dst_list->GetElem() == WideVariant;
+      }
+      if (const auto *src_set = src.TryAs<Type::TSet>()) {
+        const auto *dst_set = dst.TryAs<Type::TSet>();
+        return dst_set && src_set->GetElem() == NarrowVariant
+            && dst_set->GetElem() == WideVariant;
+      }
+      /* Dict of self (`Node({key: self})`): the key is self-free (so identical
+         narrow/wide), the value is the recursion point. Same element-only
+         restriction as list/set -- a nested container as the value is left to
+         the plain cast. */
+      if (const auto *src_dict = src.TryAs<Type::TDict>()) {
+        const auto *dst_dict = dst.TryAs<Type::TDict>();
+        return dst_dict && src_dict->GetKey() == dst_dict->GetKey()
+            && src_dict->GetVal() == NarrowVariant
+            && dst_dict->GetVal() == WideVariant;
+      }
+      /* Any other payload shape (seq, nested containers, ...) is not yet
+         synthesized; leave it to the plain cast so the type checker reports
+         the canonical #104 diagnostic. */
       return false;
     }
 
@@ -268,9 +310,85 @@ namespace {
         }
         return Expr::TWhen::New(make(), tags, bodies, PosRange);
       }
+      /* List / set of self: map the recursive widening fold over the elements
+         and collect back into the wide container.
+
+           widen(.t: **make()) as wide-container
+
+         `**make()` turns the narrow container into a sequence of its elements
+         (each the narrow variant -- the recursion point, per CanRebuild), and
+         handing that sequence to `widen` applies it element-wise (orly's
+         implicit map over a sequence argument), yielding a sequence of widened
+         elements whose deferred TAny results the `as` collect resolves to the
+         wide container. */
+      if (src.Is<Type::TList>() || src.Is<Type::TSet>()) {
+        Expr::TFunctionApp::TFunctionAppArgMap args;
+        args["t"] = Expr::TFunctionAppArg::New(Expr::TSequenceOf::New(make(), PosRange));
+        auto mapped = Expr::TFunctionApp::New(Expr::TRef::New(WidenResult, PosRange), args, PosRange);
+        return Expr::TAs::New(mapped, dst, PosRange);
+      }
+      /* Dict of self: map a per-pair helper over the key/value sequence and
+         collect back into the wide dict.
+
+           pairHelper(.p: **make()) as wide-dict
+
+         `**make()` turns the dict into a sequence of `<[key, value]>` pairs;
+         the minted pairHelper rebuilds each pair, recursing into the value
+         (the recursion point). The `as` collects the sequence of widened pairs
+         back into the wide dict, resolving the deferred element results. */
+      if (const auto *src_dict = src.TryAs<Type::TDict>()) {
+        const auto *dst_dict = dst.As<Type::TDict>();
+        auto pair_helper = GetOrMintPairHelper(src_dict->GetKey(),
+                                               src_dict->GetVal(), dst_dict->GetVal());
+        Expr::TFunctionApp::TFunctionAppArgMap args;
+        args["p"] = Expr::TFunctionAppArg::New(Expr::TSequenceOf::New(make(), PosRange));
+        auto mapped = Expr::TFunctionApp::New(Expr::TRef::New(pair_helper, PosRange), args, PosRange);
+        return Expr::TAs::New(mapped, dst, PosRange);
+      }
       /* CanRebuild() gates every call, so any other shape is a logic error. */
       assert(false);
       return make();
+    }
+
+    /* Look up -- or, on a miss, mint -- the top-level helper that rebuilds one
+       `<[key, value]>` pair of a dict-of-self payload, widening the value:
+
+         pairHelper = ((p) <[p.0, widen(.t: p.1)]>) where {
+           p = given::(<[key, narrow]>);
+         };
+
+       It is a SIBLING top-level function (not nested in the widening fold):
+       recursion is only resolved for top-level functions, and a nested helper
+       calling the enclosing fold hits the unbound-enclosing-function
+       limitation. Cached per key type within this fold (its value widening is
+       always this fold's recursion point). */
+    Symbol::TResultDef::TPtr GetOrMintPairHelper(const Type::TType &key_type,
+                                                 const Type::TType &val_src,
+                                                 const Type::TType &val_dst) const {
+      auto found = PairHelpers->find(key_type);
+      if (found != PairHelpers->end()) {
+        return found->second;
+      }
+      auto pair_type = Type::TAddr::Get({{TAddrDir::Asc, key_type}, {TAddrDir::Asc, val_src}});
+      auto name = Base::AsStr(NameStem, "Pair", PairHelpers->size());
+      auto helper = Symbol::TFunction::New(PackageScope, name, PosRange);
+      auto result = Symbol::TResultDef::New(helper, name, PosRange);
+      auto param = Symbol::TGivenParamDef::New(helper, "p", pair_type, PosRange);
+      /* Register before building the body (mirrors GetOrMintWiden). */
+      (*PairHelpers)[key_type] = result;
+      /* Body: <[p.0, <widened p.1>]> -- a fresh accessor per read (no shared
+         Expr nodes). The value rebuild is the recursion point, so Rebuild
+         emits the `widen(.t: p.1)` recursive call. */
+      auto key_member = Expr::TAddrMember::New(Expr::TRef::New(param, PosRange), 0, PosRange);
+      auto val_widened = Rebuild(
+          [this, &param]() {
+            return Expr::TAddrMember::New(Expr::TRef::New(param, PosRange), 1, PosRange);
+          },
+          val_src, val_dst);
+      Expr::TAddr::TMemberVec members{{TAddrDir::Asc, key_member},
+                                      {TAddrDir::Asc, val_widened}};
+      helper->SetExpr(Expr::TAddr::New(members, PosRange));
+      return result;
     }
 
     /* The synthesized function's body: a `when` over the narrow arms whose
@@ -338,7 +456,11 @@ namespace {
        this same function rather than recursing here. */
     cache[key] = widen;
 
-    TWidenSynth synth{narrow_type, wide_type, widen_result, pos_range};
+    /* Per-fold cache of dict pair helpers (empty unless a dict-of-self payload
+       is rebuilt); minted into the package scope alongside the fold. */
+    std::unordered_map<Type::TType, Symbol::TResultDef::TPtr> pair_helpers;
+    TWidenSynth synth{narrow_type, wide_type, widen_result, pos_range,
+                      package_scope, &pair_helpers, name};
     widen->SetExpr(synth.BuildBody(param, narrow_variant, wide_variant));
     return widen;
   }
@@ -405,7 +527,8 @@ void Synth::SynthesizeRecursiveVariantWidenings(const Symbol::TPackage::TPtr &pa
     }
     /* Pre-flight the payload shapes; an unsupported shape is left for the
        type checker's canonical #104 diagnostic. */
-    TWidenSynth probe{src_variant->AsType(), dst_variant->AsType(), nullptr, as->GetPosRange()};
+    TWidenSynth probe{src_variant->AsType(), dst_variant->AsType(), nullptr, as->GetPosRange(),
+                      nullptr, nullptr, std::string()};
     if (!probe.CanSynthesize(src_variant, dst_variant)) {
       continue;
     }

--- a/tests/lang_tests/general/variants_widen_recursive.orly
+++ b/tests/lang_tests/general/variants_widen_recursive.orly
@@ -21,10 +21,17 @@
    recursion point inside a NESTED variant payload (`Node(<| Some(self) |
    None |>)`), widened by recursing through an inline `when`. The `optnar`/
    `optwid` and `ornar`/`orwid` pairs add a recursion point under an OPTIONAL
-   (#159), widened by recursing into the optional's known case.
+   (#159), widened by recursing into the optional's known case. The `lnar`/
+   `lwid`, `snar`/`swid`, and `dnar`/`dwid` pairs add a recursion point under a
+   CONTAINER -- a list, a set, and a dict value (#159 Phase 2). The fold maps
+   itself over the container's elements (orly's implicit element-wise map over
+   a sequence, `widen(.t: **xs) as wide-container`) and collects the widened
+   elements back; the dict case maps a minted per-pair helper that widens each
+   value.
 
-   Payload shapes not yet synthesized (list / set / seq / dict of self) still
-   report the canonical "not yet supported (#104)" diagnostic.
+   Payload shapes not yet synthesized (a bare seq of self, or a nested
+   container of self such as `[[self]]`) still report the canonical "not yet
+   supported (#104)" diagnostic.
 
    Copyright 2010-2026 Atomic Kismet Company
 
@@ -61,6 +68,20 @@ optwid is <| Extra | Leaf(int) | Node(optwid?) |>;
 ornar is <| Leaf(int) | Node(<{.next: ornar?}>) |>;
 orwid is <| Extra | Leaf(int) | Node(<{.next: orwid?}>) |>;
 
+/* Three pairs whose recursion point sits under a CONTAINER (#159 Phase 2):
+   a list (`Node([self])`), a set (`Node({self})`), and a dict value
+   (`Node({str: self})`). The widening fold maps itself over the elements and
+   collects back into the wide container; the dict fold maps a minted per-pair
+   helper that widens each value while passing the (self-free) key through. */
+lnar is <| Leaf(int) | Node([lnar]) |>;
+lwid is <| Extra | Leaf(int) | Node([lwid]) |>;
+
+snar is <| Leaf(int) | Node({snar}) |>;
+swid is <| Extra | Leaf(int) | Node({swid}) |>;
+
+dnar is <| Leaf(int) | Node({str: dnar}) |>;
+dwid is <| Extra | Leaf(int) | Node({str: dwid}) |>;
+
 /* The `as` widening through a where-bound source: the source expression
    (`rnar.Leaf(n)`) depends on a given parameter, so its type is only known
    after the whole function has built -- which is exactly why the widening is
@@ -92,6 +113,17 @@ orw   = (orwid.Node(<{.next: orwid.Leaf(2) as orwid?}>)) where {};
 orn_u = (ornar.Node(<{.next: unknown ornar}>)) where {};
 orw_u = (orwid.Node(<{.next: unknown orwid}>)) where {};
 
+/* Container-payload trees and their directly-built wide equivalents: a
+   depth-2 list, set, and dict, so the fold maps over a nested level. */
+ln = (lnar.Node([lnar.Leaf(1), lnar.Node([lnar.Leaf(2), lnar.Leaf(3)])])) where {};
+lw = (lwid.Node([lwid.Leaf(1), lwid.Node([lwid.Leaf(2), lwid.Leaf(3)])])) where {};
+
+sn = (snar.Node({snar.Leaf(1), snar.Node({snar.Leaf(2)})})) where {};
+sw = (swid.Node({swid.Leaf(1), swid.Node({swid.Leaf(2)})})) where {};
+
+dn = (dnar.Node({"a": dnar.Leaf(1), "b": dnar.Node({"c": dnar.Leaf(2)})})) where {};
+dw = (dwid.Node({"a": dwid.Leaf(1), "b": dwid.Node({"c": dwid.Leaf(2)})})) where {};
+
 with {
 } test {
   /* The where-bound-source widening returns the wide type and preserves the
@@ -121,4 +153,16 @@ with {
   t_opt_neq:        (on_u as optwid) != ow;
   t_optrec_known:   (orn as orwid) == orw;
   t_optrec_unknown: (orn_u as orwid) == orw_u;
+  /* Widening through a CONTAINER payload (#159 Phase 2): the fold maps over
+     list / set / dict-value self-edges, descending every nested element. The
+     base (`Leaf`) case still widens directly; an empty container maps to an
+     empty wide container; a structurally different tree stays non-equal. */
+  t_list_leaf:  (lnar.Leaf(4) as lwid) == lwid.Leaf(4);
+  t_list_deep:  (ln as lwid) == lw;
+  t_list_empty: (lnar.Node(empty [lnar]) as lwid) == lwid.Node(empty [lwid]);
+  t_list_neq:   (ln as lwid) != lwid.Node(empty [lwid]);
+  t_set_leaf:   (snar.Leaf(4) as swid) == swid.Leaf(4);
+  t_set_deep:   (sn as swid) == sw;
+  t_dict_leaf:  (dnar.Leaf(4) as dwid) == dwid.Leaf(4);
+  t_dict_deep:  (dn as dwid) == dw;
 };


### PR DESCRIPTION
## What

Phase 2 of #159: a recursive variant's self-edge under a **container** now widens via the `as` operator, completing container-of-self widening alongside the record / nested-variant / optional payloads already handled (#157 / #158 / #160).

```
lnar is <| Leaf(int) | Node([lnar]) |>;          # list of self
lwid is <| Extra | Leaf(int) | Node([lwid]) |>;
(ln as lwid) == lw                                # deep widening, structure preserved

snar/swid   # {self}        -- set of self
dnar/dwid   # {str: self}   -- dict value of self
```

## How

The synthesized top-level fold (`Synth::SynthesizeRecursiveVariantWidenings`) reuses orly's **implicit element-wise map over a sequence argument**:

- **list / set**: `widen(.t: **xs) as wide-container`. `**xs` turns the container into a sequence of its elements (each the recursion point); handing that sequence to `widen` maps it element-wise, and the collect-cast resolves the deferred recursive-call results back into the wide container.
- **dict**: maps a **minted sibling pair-helper** `((p) <[p.0, widen(.t: p.1)]>)` over `**dict` (a sequence of `<[key, value]>` pairs), widening each value while passing the self-free key through, then collects back with `as {key: wide}`. It is a sibling (not a nested) top-level function because recursion only resolves for top-level functions.

No new `(TAny, *)` cast arms were needed: the base `(TAny, TVariant)` propagates `TAny` and the `(TSeq, TList/TSet/TDict)` arms validate-then-force the target type.

Only the case where the element is the recursion point itself is synthesized; a nested container of self (`[[self]]`) is left to the canonical `#104` diagnostic (the map function takes the narrow variant, not a container).

## Codegen fix (latent bug this surfaced)

`TVariantWhen::AppendDependsOn` had no reentrancy guard, so a `when` arm that maps a recursive call back into the same `when` — exactly the container fold — walked the dependency graph forever and **segfaulted the compiler**. Mirrored the existing `mutable bool InDependsOn` guard from `TIfElse` (which is why an `if/else`-bodied recursive map already worked but a `when`-bodied one crashed).

## Tests

- Extended `tests/lang_tests/general/variants_widen_recursive.orly` with list / set / dict pairs and 8 assertions (base arm, deep nested tree, empty container, non-equality).
- Full `lang_test` suite: **0 unexpected, 144 passed**.
- `make test`: green.
- Verified a nested container of self (`[[self]]`) still reports the canonical `#104` diagnostic cleanly (no crash).