### PR TITLE
widen nested-container-of-self payloads in recursive-variant `as` (#159)

### DIFF
--- a/orly/synth/postfix_cast.cc
+++ b/orly/synth/postfix_cast.cc
@@ -103,12 +103,16 @@ namespace {
        recursive call. Null while pre-flighting support with CanRebuild(). */
     Symbol::TResultDef::TPtr WidenResult;
     TPosRange PosRange;
-    /* For dict-of-self payloads only: the package scope that minted pair
-       helpers are added to, a per-fold cache (keyed by the dict's key type)
-       of the helper that rebuilds one key/value pair, and the base name for
-       those helpers. All null/empty while pre-flighting with CanRebuild(). */
+    /* For container-of-self payloads only: the package scope that minted
+       helpers are added to, the base name for them, and two per-fold caches:
+       PairHelpers (keyed by a dict's key type) for the helper that rebuilds
+       one key/value pair, and ElemHelpers (keyed by a list/set element type)
+       for the helper that rebuilds one element whose own shape is not the
+       bare recursion point (a NESTED container of self). All null/empty while
+       pre-flighting with CanRebuild(). */
     Symbol::TScope::TPtr PackageScope;
     std::unordered_map<Type::TType, Symbol::TResultDef::TPtr> *PairHelpers;
+    std::unordered_map<Type::TType, Symbol::TResultDef::TPtr> *ElemHelpers;
     std::string NameStem;
 
     /* True iff Rebuild() can convert a value of narrow subterm type `src`
@@ -172,36 +176,31 @@ namespace {
         return true;
       }
       /* List / set of self (`Node([self])`, `Node({self})`): rebuildable iff
-         the element is the recursion point itself. The fold maps the narrow
-         widening fold over the elements (`widen(.t: **xs) as wide-container`,
-         the implicit element-wise map orly applies when a function is handed a
-         sequence) -- which only type-checks when the element is the narrow
-         variant the fold takes, so a nested container of self
-         (`[[self]]`, needing a per-element fold of its own) is left to the
-         plain cast's canonical #104 diagnostic. */
+         the element is. The fold maps a per-element widening over the elements
+         (`f(.t: **xs) as wide-container`, the implicit element-wise map orly
+         applies when a function is handed a sequence) and collects the result.
+         When the element is the recursion point the map function is the fold
+         itself; when it is a NESTED container of self (`[[self]]`) a per-element
+         helper rebuilds it -- see Rebuild / GetOrMintElemHelper. */
       if (const auto *src_list = src.TryAs<Type::TList>()) {
         const auto *dst_list = dst.TryAs<Type::TList>();
-        return dst_list && src_list->GetElem() == NarrowVariant
-            && dst_list->GetElem() == WideVariant;
+        return dst_list && CanRebuild(src_list->GetElem(), dst_list->GetElem());
       }
       if (const auto *src_set = src.TryAs<Type::TSet>()) {
         const auto *dst_set = dst.TryAs<Type::TSet>();
-        return dst_set && src_set->GetElem() == NarrowVariant
-            && dst_set->GetElem() == WideVariant;
+        return dst_set && CanRebuild(src_set->GetElem(), dst_set->GetElem());
       }
       /* Dict of self (`Node({key: self})`): the key is self-free (so identical
-         narrow/wide), the value is the recursion point. Same element-only
-         restriction as list/set -- a nested container as the value is left to
-         the plain cast. */
+         narrow/wide), the value rebuildable -- the recursion point, or a nested
+         container of self as the value (`{key: [self]}`). */
       if (const auto *src_dict = src.TryAs<Type::TDict>()) {
         const auto *dst_dict = dst.TryAs<Type::TDict>();
         return dst_dict && src_dict->GetKey() == dst_dict->GetKey()
-            && src_dict->GetVal() == NarrowVariant
-            && dst_dict->GetVal() == WideVariant;
+            && CanRebuild(src_dict->GetVal(), dst_dict->GetVal());
       }
-      /* Any other payload shape (seq, nested containers, ...) is not yet
-         synthesized; leave it to the plain cast so the type checker reports
-         the canonical #104 diagnostic. */
+      /* Any other payload shape (a bare seq of self -- not a legal placement
+         anyway) is not yet synthesized; leave it to the plain cast so the type
+         checker reports the canonical #104 diagnostic. */
       return false;
     }
 
@@ -310,21 +309,28 @@ namespace {
         }
         return Expr::TWhen::New(make(), tags, bodies, PosRange);
       }
-      /* List / set of self: map the recursive widening fold over the elements
-         and collect back into the wide container.
+      /* List / set of self: map a per-element widening over the elements and
+         collect back into the wide container.
 
-           widen(.t: **make()) as wide-container
+           f(.t: **make()) as wide-container
 
-         `**make()` turns the narrow container into a sequence of its elements
-         (each the narrow variant -- the recursion point, per CanRebuild), and
-         handing that sequence to `widen` applies it element-wise (orly's
-         implicit map over a sequence argument), yielding a sequence of widened
-         elements whose deferred TAny results the `as` collect resolves to the
-         wide container. */
+         `**make()` turns the narrow container into a sequence of its elements;
+         handing that sequence to `f` applies it element-wise (orly's implicit
+         map over a sequence argument), and the `as` collect resolves the
+         (deferred) element results back into the wide container. The map
+         function `f` is the fold itself when the element is the recursion
+         point, or a minted per-element helper when the element is a nested
+         container of self (`[[self]]`). Both take a parameter named "t". */
       if (src.Is<Type::TList>() || src.Is<Type::TSet>()) {
+        const auto &src_elem = src.Is<Type::TList>()
+            ? src.As<Type::TList>()->GetElem() : src.As<Type::TSet>()->GetElem();
+        const auto &dst_elem = dst.Is<Type::TList>()
+            ? dst.As<Type::TList>()->GetElem() : dst.As<Type::TSet>()->GetElem();
+        auto map_fn = (src_elem == NarrowVariant && dst_elem == WideVariant)
+            ? WidenResult : GetOrMintElemHelper(src_elem, dst_elem);
         Expr::TFunctionApp::TFunctionAppArgMap args;
         args["t"] = Expr::TFunctionAppArg::New(Expr::TSequenceOf::New(make(), PosRange));
-        auto mapped = Expr::TFunctionApp::New(Expr::TRef::New(WidenResult, PosRange), args, PosRange);
+        auto mapped = Expr::TFunctionApp::New(Expr::TRef::New(map_fn, PosRange), args, PosRange);
         return Expr::TAs::New(mapped, dst, PosRange);
       }
       /* Dict of self: map a per-pair helper over the key/value sequence and
@@ -360,8 +366,8 @@ namespace {
        It is a SIBLING top-level function (not nested in the widening fold):
        recursion is only resolved for top-level functions, and a nested helper
        calling the enclosing fold hits the unbound-enclosing-function
-       limitation. Cached per key type within this fold (its value widening is
-       always this fold's recursion point). */
+       limitation. Cached per key type within this fold. The value rebuild is
+       the recursion point, or a nested container of self (`{key: [self]}`). */
     Symbol::TResultDef::TPtr GetOrMintPairHelper(const Type::TType &key_type,
                                                  const Type::TType &val_src,
                                                  const Type::TType &val_dst) const {
@@ -377,8 +383,8 @@ namespace {
       /* Register before building the body (mirrors GetOrMintWiden). */
       (*PairHelpers)[key_type] = result;
       /* Body: <[p.0, <widened p.1>]> -- a fresh accessor per read (no shared
-         Expr nodes). The value rebuild is the recursion point, so Rebuild
-         emits the `widen(.t: p.1)` recursive call. */
+         Expr nodes). Rebuild emits the value's widening (the recursion point's
+         `widen(.t: p.1)` call, or a nested-container map). */
       auto key_member = Expr::TAddrMember::New(Expr::TRef::New(param, PosRange), 0, PosRange);
       auto val_widened = Rebuild(
           [this, &param]() {
@@ -388,6 +394,38 @@ namespace {
       Expr::TAddr::TMemberVec members{{TAddrDir::Asc, key_member},
                                       {TAddrDir::Asc, val_widened}};
       helper->SetExpr(Expr::TAddr::New(members, PosRange));
+      return result;
+    }
+
+    /* Look up -- or, on a miss, mint -- the top-level helper that rebuilds one
+       element of a list/set whose element is itself a NESTED container of self
+       (`[[self]]`, `[{self}]`, `[{key: self}]`, `[self?]`, ...):
+
+         elemHelper = ((t) <widened t>) where { t = given::(elem_src); };
+
+       The body is the element's own Rebuild -- recursing through the inner
+       container (minting further helpers as needed) down to the recursion
+       point, which calls the fold. Like the pair helper it must be a sibling
+       top-level function, and takes a parameter named "t" so the same call
+       shape works whether the map function is the fold or this helper. Cached
+       per element type within this fold. */
+    Symbol::TResultDef::TPtr GetOrMintElemHelper(const Type::TType &elem_src,
+                                                 const Type::TType &elem_dst) const {
+      auto found = ElemHelpers->find(elem_src);
+      if (found != ElemHelpers->end()) {
+        return found->second;
+      }
+      auto name = Base::AsStr(NameStem, "Elem", ElemHelpers->size());
+      auto helper = Symbol::TFunction::New(PackageScope, name, PosRange);
+      auto result = Symbol::TResultDef::New(helper, name, PosRange);
+      auto param = Symbol::TGivenParamDef::New(helper, "t", elem_src, PosRange);
+      /* Register before building the body (mirrors GetOrMintWiden), so a
+         self-referential element shape reuses this helper rather than looping. */
+      (*ElemHelpers)[elem_src] = result;
+      auto body = Rebuild(
+          [this, &param]() { return Expr::TRef::New(param, PosRange); },
+          elem_src, elem_dst);
+      helper->SetExpr(body);
       return result;
     }
 
@@ -456,11 +494,13 @@ namespace {
        this same function rather than recursing here. */
     cache[key] = widen;
 
-    /* Per-fold cache of dict pair helpers (empty unless a dict-of-self payload
-       is rebuilt); minted into the package scope alongside the fold. */
+    /* Per-fold caches of minted container helpers (empty unless a dict-of-self
+       or nested-container-of-self payload is rebuilt); minted into the package
+       scope alongside the fold. */
     std::unordered_map<Type::TType, Symbol::TResultDef::TPtr> pair_helpers;
+    std::unordered_map<Type::TType, Symbol::TResultDef::TPtr> elem_helpers;
     TWidenSynth synth{narrow_type, wide_type, widen_result, pos_range,
-                      package_scope, &pair_helpers, name};
+                      package_scope, &pair_helpers, &elem_helpers, name};
     widen->SetExpr(synth.BuildBody(param, narrow_variant, wide_variant));
     return widen;
   }
@@ -528,7 +568,7 @@ void Synth::SynthesizeRecursiveVariantWidenings(const Symbol::TPackage::TPtr &pa
     /* Pre-flight the payload shapes; an unsupported shape is left for the
        type checker's canonical #104 diagnostic. */
     TWidenSynth probe{src_variant->AsType(), dst_variant->AsType(), nullptr, as->GetPosRange(),
-                      nullptr, nullptr, std::string()};
+                      nullptr, nullptr, nullptr, std::string()};
     if (!probe.CanSynthesize(src_variant, dst_variant)) {
       continue;
     }

--- a/tests/lang_tests/general/variants_widen_recursive.orly
+++ b/tests/lang_tests/general/variants_widen_recursive.orly
@@ -23,15 +23,22 @@
    `optwid` and `ornar`/`orwid` pairs add a recursion point under an OPTIONAL
    (#159), widened by recursing into the optional's known case. The `lnar`/
    `lwid`, `snar`/`swid`, and `dnar`/`dwid` pairs add a recursion point under a
-   CONTAINER -- a list, a set, and a dict value (#159 Phase 2). The fold maps
-   itself over the container's elements (orly's implicit element-wise map over
-   a sequence, `widen(.t: **xs) as wide-container`) and collects the widened
-   elements back; the dict case maps a minted per-pair helper that widens each
-   value.
+   CONTAINER -- a list, a set, and a dict value (#159 Phase 2). The fold maps a
+   per-element widening over the container's elements (orly's implicit
+   element-wise map over a sequence, `f(.t: **xs) as wide-container`) and
+   collects them back; the dict case maps a minted per-pair helper that widens
+   each value. The `llnar`/`llwid`, `dlnar`/`dlwid`, and `lonar`/`lowid` pairs
+   nest a container one level deeper -- list-of-list, dict-value-of-list, and
+   list-of-optional of self -- where the per-element map function is a minted
+   helper that recursively rebuilds the inner container down to the recursion
+   point.
 
-   Payload shapes not yet synthesized (a bare seq of self, or a nested
-   container of self such as `[[self]]`) still report the canonical "not yet
-   supported (#104)" diagnostic.
+   With containers nesting arbitrarily, every self-placement the #103/#116
+   shape rules allow (direct, record field, nested-variant arm, optional, and
+   list/set/opt/dict-value containers in any combination) is now widenable.
+   Mutually-recursive variant GROUPS remain out of scope (a per-variant
+   widening is not a superset cast -- rejected earlier by IsWidenableTo), as
+   does implicit widening at assignment/parameter/branch join (#104 Phase 5).
 
    Copyright 2010-2026 Atomic Kismet Company
 
@@ -82,6 +89,20 @@ swid is <| Extra | Leaf(int) | Node({swid}) |>;
 dnar is <| Leaf(int) | Node({str: dnar}) |>;
 dwid is <| Extra | Leaf(int) | Node({str: dwid}) |>;
 
+/* Three pairs whose recursion point sits under a NESTED container (one level
+   deeper than the Phase 2 pairs): a list of lists (`Node([[self]])`), a dict
+   value that is a list (`Node({str: [self]})`), and a list of optionals
+   (`Node([self?])`). The per-element map function is now a minted helper that
+   rebuilds the inner container, recursing down to the recursion point. */
+llnar is <| Leaf(int) | Node([[llnar]]) |>;
+llwid is <| Extra | Leaf(int) | Node([[llwid]]) |>;
+
+dlnar is <| Leaf(int) | Node({str: [dlnar]}) |>;
+dlwid is <| Extra | Leaf(int) | Node({str: [dlwid]}) |>;
+
+lonar is <| Leaf(int) | Node([lonar?]) |>;
+lowid is <| Extra | Leaf(int) | Node([lowid?]) |>;
+
 /* The `as` widening through a where-bound source: the source expression
    (`rnar.Leaf(n)`) depends on a given parameter, so its type is only known
    after the whole function has built -- which is exactly why the widening is
@@ -124,6 +145,18 @@ sw = (swid.Node({swid.Leaf(1), swid.Node({swid.Leaf(2)})})) where {};
 dn = (dnar.Node({"a": dnar.Leaf(1), "b": dnar.Node({"c": dnar.Leaf(2)})})) where {};
 dw = (dwid.Node({"a": dwid.Leaf(1), "b": dwid.Node({"c": dwid.Leaf(2)})})) where {};
 
+/* Nested-container trees: the inner level holds recursion points, so the
+   minted element helper recurses one extra step. `lon`/`low` mix a known and
+   an unknown optional element to exercise both optional branches. */
+lln = (llnar.Node([[llnar.Leaf(1), llnar.Leaf(2)], [llnar.Leaf(3)]])) where {};
+llw = (llwid.Node([[llwid.Leaf(1), llwid.Leaf(2)], [llwid.Leaf(3)]])) where {};
+
+dln = (dlnar.Node({"a": [dlnar.Leaf(1), dlnar.Leaf(2)], "b": empty [dlnar]})) where {};
+dlw = (dlwid.Node({"a": [dlwid.Leaf(1), dlwid.Leaf(2)], "b": empty [dlwid]})) where {};
+
+lon = (lonar.Node([lonar.Leaf(1) as lonar?, unknown lonar])) where {};
+low = (lowid.Node([lowid.Leaf(1) as lowid?, unknown lowid])) where {};
+
 with {
 } test {
   /* The where-bound-source widening returns the wide type and preserves the
@@ -165,4 +198,12 @@ with {
   t_set_deep:   (sn as swid) == sw;
   t_dict_leaf:  (dnar.Leaf(4) as dwid) == dwid.Leaf(4);
   t_dict_deep:  (dn as dwid) == dw;
+  /* Widening through a NESTED container: a minted element helper rebuilds the
+     inner container, recursing to the recursion point. Covers list-of-list,
+     dict-value-of-list (incl. an empty inner list), and list-of-optional
+     (both a known and an unknown optional element). */
+  t_ll_deep:   (lln as llwid) == llw;
+  t_dl_deep:   (dln as dlwid) == dlw;
+  t_lo_deep:   (lon as lowid) == low;
+  t_lo_neq:    (lon as lowid) != lowid.Node([unknown lowid, unknown lowid]);
 };


### PR DESCRIPTION
## What

Extends container-of-self widening (#161) to **nested** containers: a recursive variant whose self-edge sits under a container of a container now widens via the `as` operator.

```
llnar is <| Leaf(int) | Node([[llnar]]) |>;          # list of lists of self
dlnar is <| Leaf(int) | Node({str: [dlnar]}) |>;     # dict value is a list of self
lonar is <| Leaf(int) | Node([lonar?]) |>;           # list of optional self
(lln as llwid) == llw                                # deep widening, structure preserved
```

This closes the **last single-self-recursion payload gap** — every self-placement the #103/#116 shape rules allow (direct, record field, nested-variant arm, optional, and list/set/opt/dict-value containers **in any combination**) is now widenable.

## How

The fold already maps a per-element widening over a container's elements (#161). The generalization is to let that per-element widening be an arbitrary **rebuild** rather than only the bare recursive call:

- `CanRebuild` now recurses into a container's element / dict value (`CanRebuild(elem_src, elem_dst)`) instead of requiring it to be the recursion point.
- In `Rebuild`, when a list/set element is itself a container, it mints a **sibling per-element helper** `((t) <widened t>) where { t = given::(elem) }` that recurses through the inner container down to the recursion point (which calls the fold). The dict pair-helper's value rebuild handles a nested-container value the same way.

Mutual recursion between the fold and these helpers is fine: every cycle routes through the fold's `when`, whose dependency-walk reentrancy guard (added in #161) breaks it — so **no codegen change is needed this time**.

## Scope boundary (unchanged)

- **Mutually-recursive variant groups** remain out of scope — a per-variant widening is not a superset cast, so it is rejected earlier by `IsWidenableTo` (a different, also-correct diagnostic).
- **#104 Phase 5** (implicit widening at assignment / parameter / branch join) is still future work.

## Tests

- Extended `tests/lang_tests/general/variants_widen_recursive.orly` with list-of-list, dict-value-of-list (incl. an empty inner list), and list-of-optional (known + unknown elements) pairs and assertions.
- Full `lang_test` suite: **0 unexpected, 144 passed**.
- `make test`: green.
- Verified separately that a mutually-recursive variant group widening still errors cleanly.