### PR TITLE
widen mutually-recursive variant groups with the `as` operator (#104)

### DIFF
--- a/orly/expr/as.cc
+++ b/orly/expr/as.cc
@@ -25,6 +25,7 @@
 #include <orly/pos_range.h>
 #include <orly/type.h>
 #include <orly/type/infix_visitor.h>
+#include <orly/type/rec_group.h>
 #include <orly/type/unroll.h>
 #include <orly/type/unwrap.h>
 #include <orly/type/unwrap_visitor.h>
@@ -195,7 +196,16 @@ Type::TType TAs::GetTypeImpl() const {
        v1-scope guards (recursive variants, optional-target widening) are
        applied once, after the visitor, in GetTypeImpl. */
     virtual void operator()(const Type::TVariant  *lhs, const Type::TVariant  *rhs) const {
-      if (!lhs->IsWidenableTo(rhs)) {
+      /* Accept either a plain superset widening (IsWidenableTo: tag set widens,
+         payloads invariant -- covers the single-def recursive case, whose
+         self-edge is a shared de Bruijn TSelfRef) or a mutually-recursive GROUP
+         widening, where sibling cross-edges are TGroupRefs that differ between
+         the narrow and wide groups but co-widen (issue #104). The synth pass
+         turns a recursive widening into a fold; the v1-scope guard below
+         requires that fold to be present. */
+      std::unordered_map<Type::TType, Type::TType> corr;
+      if (!lhs->IsWidenableTo(rhs)
+          && !Type::VariantWidensTo(lhs->AsType(), rhs->AsType(), corr)) {
         throw TExprError(HERE, PosRange,
             "a variant can only be cast to its own type or widened to a superset variant type");
       }

--- a/orly/synth/postfix_cast.cc
+++ b/orly/synth/postfix_cast.cc
@@ -55,6 +55,7 @@
 #include <orly/type/list.h>
 #include <orly/type/obj.h>
 #include <orly/type/opt.h>
+#include <orly/type/rec_group.h>
 #include <orly/type/seq.h>
 #include <orly/type/set.h>
 #include <orly/type/unroll.h>
@@ -94,14 +95,16 @@ namespace {
      package function, because recursion is only supported for top-level
      functions (an inline / where-bound recursive function is rejected). */
   struct TWidenSynth {
-    /* The narrow and wide variant types: a subterm typed exactly as the
-       narrow variant is a recursion point (it widens to the wide variant via
-       a recursive call). */
-    Type::TType NarrowVariant;
-    Type::TType WideVariant;
-    /* The synthesized `widen` function's result def -- the callee of every
-       recursive call. Null while pre-flighting support with CanRebuild(). */
-    Symbol::TResultDef::TPtr WidenResult;
+    /* The widening's member correspondence: each narrow (member) variant type
+       mapped to the wide variant it widens to. A single self-recursive def has
+       one entry (`narrow -> wide`); a mutually-recursive GROUP (#104) has one
+       per member. A subterm typed as a narrow member -- after Unroll resolves
+       its self-/group-edges -- is a recursion point: it widens to the
+       corresponding wide member via a call to that member's fold. */
+    std::unordered_map<Type::TType, Type::TType> Corr;
+    /* Each narrow member's synthesized fold result def -- the callee of a
+       recursive call into that member. Empty while pre-flighting CanRebuild(). */
+    std::unordered_map<Type::TType, Symbol::TResultDef::TPtr> Folds;
     TPosRange PosRange;
     /* For container-of-self payloads only: the package scope that minted
        helpers are added to, the base name for them, and two per-fold caches:
@@ -125,8 +128,10 @@ namespace {
       if (src == dst) {
         return true;
       }
-      /* The recursion point: narrow widens to wide via a recursive call. */
-      if (src == NarrowVariant && dst == WideVariant) {
+      /* The recursion point: a narrow member widens to its wide correspondent
+         via a recursive call into that member's fold. */
+      auto corr = Corr.find(src);
+      if (corr != Corr.end() && corr->second == dst) {
         return true;
       }
       /* Record of self: rebuildable iff every field is. */
@@ -204,17 +209,28 @@ namespace {
       return false;
     }
 
-    /* True iff every arm of the narrow variant has a payload Rebuild() can
-       convert to the wide variant's corresponding arm. */
-    bool CanSynthesize(const Type::TVariant *narrow_variant,
-                       const Type::TVariant *wide_variant) const {
-      const auto &wide_elems = wide_variant->GetElems();
-      for (const auto &arm : narrow_variant->GetElems()) {
-        auto wide_arm = wide_elems.find(arm.first);
-        assert(wide_arm != wide_elems.end());  // guaranteed by IsWidenableTo
-        if (!CanRebuild(Type::Unroll(arm.second, NarrowVariant),
-                        Type::Unroll(wide_arm->second, WideVariant))) {
+    /* True iff every member's every arm has a payload Rebuild() can convert to
+       the corresponding wide member's arm. For a single def Corr has one
+       member; for a mutually-recursive group, all members must synthesize (the
+       folds call one another). Each arm payload is Unrolled with ITS member as
+       the binder, so a self-/group-edge resolves to a recursion point. */
+    bool CanSynthesize() const {
+      for (const auto &member : Corr) {
+        const auto *narrow_variant = member.first.TryAs<Type::TVariant>();
+        const auto *wide_variant = member.second.TryAs<Type::TVariant>();
+        if (!narrow_variant || !wide_variant) {
           return false;
+        }
+        const auto &wide_elems = wide_variant->GetElems();
+        for (const auto &arm : narrow_variant->GetElems()) {
+          auto wide_arm = wide_elems.find(arm.first);
+          if (wide_arm == wide_elems.end()) {  // guaranteed by VariantWidensTo
+            return false;
+          }
+          if (!CanRebuild(Type::Unroll(arm.second, member.first),
+                          Type::Unroll(wide_arm->second, member.second))) {
+            return false;
+          }
         }
       }
       return true;
@@ -236,13 +252,15 @@ namespace {
       if (src == dst) {
         return make();
       }
-      /* The recursion point: a narrow-variant-typed value widens to the wide
-         variant via a recursive call. After Unroll, every top-level
-         self-reference in a payload appears as the narrow variant itself. */
-      if (src == NarrowVariant && dst == WideVariant) {
+      /* The recursion point: a narrow-member-typed value widens to its wide
+         correspondent via a recursive call into that member's fold. After
+         Unroll, a self-/group-edge in a payload appears as the narrow member
+         type itself, which Corr maps to the wide member it widens to. */
+      auto corr = Corr.find(src);
+      if (corr != Corr.end() && corr->second == dst) {
         Expr::TFunctionApp::TFunctionAppArgMap args;
         args["t"] = Expr::TFunctionAppArg::New(make());
-        return Expr::TFunctionApp::New(Expr::TRef::New(WidenResult, PosRange), args, PosRange);
+        return Expr::TFunctionApp::New(Expr::TRef::New(Folds.at(src), PosRange), args, PosRange);
       }
       /* Record of self (the common `Branch(<{.l: self, .r: self}>)` shape):
          rebuild field by field, each reading the source record afresh. */
@@ -326,8 +344,9 @@ namespace {
             ? src.As<Type::TList>()->GetElem() : src.As<Type::TSet>()->GetElem();
         const auto &dst_elem = dst.Is<Type::TList>()
             ? dst.As<Type::TList>()->GetElem() : dst.As<Type::TSet>()->GetElem();
-        auto map_fn = (src_elem == NarrowVariant && dst_elem == WideVariant)
-            ? WidenResult : GetOrMintElemHelper(src_elem, dst_elem);
+        auto elem_corr = Corr.find(src_elem);
+        auto map_fn = (elem_corr != Corr.end() && elem_corr->second == dst_elem)
+            ? Folds.at(src_elem) : GetOrMintElemHelper(src_elem, dst_elem);
         Expr::TFunctionApp::TFunctionAppArgMap args;
         args["t"] = Expr::TFunctionAppArg::New(Expr::TSequenceOf::New(make(), PosRange));
         auto mapped = Expr::TFunctionApp::New(Expr::TRef::New(map_fn, PosRange), args, PosRange);
@@ -431,18 +450,20 @@ namespace {
 
     /* The synthesized function's body: a `when` over the narrow arms whose
        body rebuilds each arm's payload in the wide type. The recursion points
-       inside it (via Rebuild) call back into the function via WidenResult. */
+       inside it (via Rebuild) call back into the member folds via Folds. */
     Expr::TExpr::TPtr BuildBody(const Symbol::TParamDef::TPtr &param,
                                 const Type::TVariant *narrow_variant,
                                 const Type::TVariant *wide_variant) const {
+      auto narrow_type = narrow_variant->AsType();
+      auto wide_type = wide_variant->AsType();
       std::vector<std::string> tags;
       Expr::TWhen::TExprVec bodies;
       const auto &wide_elems = wide_variant->GetElems();
       for (const auto &arm : narrow_variant->GetElems()) {
         auto wide_arm = wide_elems.find(arm.first);
-        assert(wide_arm != wide_elems.end());  // guaranteed by IsWidenableTo
-        auto src_payload = Type::Unroll(arm.second, NarrowVariant);
-        auto dst_payload = Type::Unroll(wide_arm->second, WideVariant);
+        assert(wide_arm != wide_elems.end());  // guaranteed by VariantWidensTo
+        auto src_payload = Type::Unroll(arm.second, narrow_type);
+        auto dst_payload = Type::Unroll(wide_arm->second, wide_type);
         const std::string tag = arm.first;
         /* The arm body reads the active payload via `t.Tag`, rebuilt fresh
            wherever the payload value is read (no shared Expr nodes). */
@@ -452,7 +473,7 @@ namespace {
             },
             src_payload, dst_payload);
         tags.push_back(tag);
-        bodies.push_back(Expr::TVariantCtor::New(tag, rebuilt, WideVariant, PosRange));
+        bodies.push_back(Expr::TVariantCtor::New(tag, rebuilt, wide_type, PosRange));
       }
       return Expr::TWhen::New(Expr::TRef::New(param, PosRange), tags, bodies, PosRange);
     }
@@ -465,44 +486,61 @@ namespace {
                              Symbol::TFunction::TPtr> TWidenCache;
 
   /* Look up -- or, on a miss, mint -- the top-level `widen` fold for the
-     given narrow->wide recursive-variant pair. The function is added to the
-     package scope so it is type-checked (Symbol::TScope::TypeCheck) and
-     emitted (CodeGen::TPackage) alongside the user's own top-level functions,
-     and recursion resolves to a top-level C++ function. */
+     given narrow->wide widening, returning the fold for the narrow member
+     being cast. For a single self-recursive def this is one fold; for a
+     mutually-recursive GROUP (#104) it mints one fold per member, wired to
+     call one another, and returns the cast member's. Each fold is added to the
+     package scope so it is type-checked (Symbol::TScope::TypeCheck) and emitted
+     (CodeGen::TPackage) alongside the user's own top-level functions, and
+     recursion resolves to a top-level C++ function.
+
+     `corr` is the member correspondence VariantWidensTo computed for the cast
+     (one entry for a single def, all members for a group). */
   Symbol::TFunction::TPtr GetOrMintWiden(const Symbol::TScope::TPtr &package_scope,
                                          TWidenCache &cache,
-                                         const Type::TVariant *narrow_variant,
-                                         const Type::TVariant *wide_variant,
+                                         const Type::TType &narrow_type,
+                                         const Type::TType &wide_type,
+                                         const std::unordered_map<Type::TType, Type::TType> &corr,
                                          const TPosRange &pos_range) {
-    auto narrow_type = narrow_variant->AsType();
-    auto wide_type = wide_variant->AsType();
     auto key = std::make_pair(narrow_type, wide_type);
     auto found = cache.find(key);
     if (found != cache.end()) {
-      return found->second;
+      return found->second;  // whole group already minted
     }
 
-    /* A fresh, alphanumeric name -- the C++ emitter prefixes it with 'F'
-       (orly/code_gen/export_func.cc), so it must be a valid identifier and
-       must not collide with a user function. */
-    auto name = Base::AsStr("widenRec", cache.size());
-    auto widen = Symbol::TFunction::New(package_scope, name, pos_range);
-    auto widen_result = Symbol::TResultDef::New(widen, name, pos_range);
-    auto param = Symbol::TGivenParamDef::New(widen, "t", narrow_type, pos_range);
+    /* Mint a fold (function + result def + param) for every member up front,
+       so a member's body can call any sibling -- including itself -- through a
+       resolved result def. Names are fresh alphanumeric identifiers; the C++
+       emitter prefixes them with 'F' (orly/code_gen/export_func.cc), so they
+       must be valid identifiers that cannot collide with a user function. */
+    std::unordered_map<Type::TType, Symbol::TResultDef::TPtr> folds;
+    std::unordered_map<Type::TType,
+                       std::pair<Symbol::TFunction::TPtr, Symbol::TParamDef::TPtr>> minted;
+    for (const auto &member : corr) {
+      auto name = Base::AsStr("widenRec", cache.size());
+      auto widen = Symbol::TFunction::New(package_scope, name, pos_range);
+      auto widen_result = Symbol::TResultDef::New(widen, name, pos_range);
+      auto param = Symbol::TGivenParamDef::New(widen, "t", member.first, pos_range);
+      cache[std::make_pair(member.first, member.second)] = widen;
+      folds[member.first] = widen_result;
+      minted[member.first] = {widen, param};
+    }
 
-    /* Register before building the body so a self-recursive widening reuses
-       this same function rather than recursing here. */
-    cache[key] = widen;
-
-    /* Per-fold caches of minted container helpers (empty unless a dict-of-self
-       or nested-container-of-self payload is rebuilt); minted into the package
-       scope alongside the fold. */
+    /* Build each member's body with the shared correspondence + fold maps. The
+       container helper caches are shared across the group so a payload shape
+       appearing in several members mints a single helper. The helper names are
+       stemmed off the cast member's fold name. */
     std::unordered_map<Type::TType, Symbol::TResultDef::TPtr> pair_helpers;
     std::unordered_map<Type::TType, Symbol::TResultDef::TPtr> elem_helpers;
-    TWidenSynth synth{narrow_type, wide_type, widen_result, pos_range,
-                      package_scope, &pair_helpers, &elem_helpers, name};
-    widen->SetExpr(synth.BuildBody(param, narrow_variant, wide_variant));
-    return widen;
+    TWidenSynth synth{corr, folds, pos_range, package_scope,
+                      &pair_helpers, &elem_helpers, minted.at(narrow_type).first->GetName()};
+    for (const auto &member : corr) {
+      const auto &fn = minted.at(member.first).first;
+      const auto &param = minted.at(member.first).second;
+      fn->SetExpr(synth.BuildBody(param, member.first.As<Type::TVariant>(),
+                                  member.second.As<Type::TVariant>()));
+    }
+    return cache.at(key);
   }
 
   /* Collect every `Expr::TAs` reachable from `root` (including inside inner /
@@ -561,19 +599,27 @@ void Synth::SynthesizeRecursiveVariantWidenings(const Symbol::TPackage::TPtr &pa
     const Type::TVariant *src_variant = Type::Unwrap(src_type).TryAs<Type::TVariant>();
     const Type::TVariant *dst_variant = Type::Unwrap(as->GetCastType()).TryAs<Type::TVariant>();
     if (!src_variant || !dst_variant || src_variant == dst_variant
-        || !src_variant->IsWidenableTo(dst_variant)
         || !(IsRecursiveVariant(src_variant) || IsRecursiveVariant(dst_variant))) {
+      continue;
+    }
+    /* The member correspondence for this widening: one entry for a single
+       self-recursive def, all members for a mutually-recursive group. Also the
+       widenability gate -- a non-widenable cast yields an empty/false result
+       and is left for the type checker's diagnostic. */
+    auto narrow_type = src_variant->AsType();
+    auto wide_type = dst_variant->AsType();
+    std::unordered_map<Type::TType, Type::TType> corr;
+    if (!Type::VariantWidensTo(narrow_type, wide_type, corr)) {
       continue;
     }
     /* Pre-flight the payload shapes; an unsupported shape is left for the
        type checker's canonical #104 diagnostic. */
-    TWidenSynth probe{src_variant->AsType(), dst_variant->AsType(), nullptr, as->GetPosRange(),
-                      nullptr, nullptr, nullptr, std::string()};
-    if (!probe.CanSynthesize(src_variant, dst_variant)) {
+    TWidenSynth probe{corr, {}, as->GetPosRange(), nullptr, nullptr, nullptr, std::string()};
+    if (!probe.CanSynthesize()) {
       continue;
     }
     as->SetRecursiveWidenFn(
-        GetOrMintWiden(package, cache, src_variant, dst_variant, as->GetPosRange()));
+        GetOrMintWiden(package, cache, narrow_type, wide_type, corr, as->GetPosRange()));
   }
 }
 

--- a/orly/type/rec_group.cc
+++ b/orly/type/rec_group.cc
@@ -158,7 +158,126 @@ namespace {
     return t;
   }
 
+  /* --- Group-aware variant widening relation (issue #104). --- */
+
+  struct TWidenChecker {
+    unordered_map<TType, TType> &Corr;          // narrow member -> wide member
+    vector<pair<TType, TType>> Work;            // member pairs still to verify
+
+    /* Record a narrow->wide member correspondence; enqueue a new pair for
+       verification; reject an inconsistent remapping (each narrow member must
+       map to a single wide member -- the synth mints one fold per member). */
+    bool Link(const TType &n, const TType &w) {
+      auto it = Corr.find(n);
+      if (it != Corr.end()) {
+        return it->second == w;
+      }
+      Corr[n] = w;
+      Work.emplace_back(n, w);
+      return true;
+    }
+
+    /* Two arm-payload positions: structurally identical except that a
+       TGroupRef on each side may denote a corresponding (co-widening) member
+       pair. Compound payloads recurse; everything else must be equal. */
+    bool PayloadOk(const TType &n, const TType &w) {
+      if (n == w) {
+        return true;
+      }
+      if (const TGroupRef *ng = n.TryAs<TGroupRef>()) {
+        const TGroupRef *wg = w.TryAs<TGroupRef>();
+        return wg && Link(ResolveGroupRef(ng), ResolveGroupRef(wg));
+      }
+      if (const TObj *no = n.TryAs<TObj>()) {
+        const TObj *wo = w.TryAs<TObj>();
+        if (!wo || no->GetElems().size() != wo->GetElems().size()) {
+          return false;
+        }
+        const auto &we = wo->GetElems();
+        for (const auto &f : no->GetElems()) {
+          auto wf = we.find(f.first);
+          if (wf == we.end() || !PayloadOk(f.second, wf->second)) {
+            return false;
+          }
+        }
+        return true;
+      }
+      /* A nested non-member variant in a payload (e.g. `Some(b) | None`): its
+         tag set must be identical (only group members may tag-widen), but its
+         payloads may reach corresponding group refs. */
+      if (const TVariant *nv = n.TryAs<TVariant>()) {
+        const TVariant *wv = w.TryAs<TVariant>();
+        if (!wv || nv->GetElems().size() != wv->GetElems().size()) {
+          return false;
+        }
+        const auto &we = wv->GetElems();
+        for (const auto &arm : nv->GetElems()) {
+          auto wa = we.find(arm.first);
+          if (wa == we.end() || !PayloadOk(arm.second, wa->second)) {
+            return false;
+          }
+        }
+        return true;
+      }
+      if (const TList *nl = n.TryAs<TList>()) {
+        const TList *wl = w.TryAs<TList>();
+        return wl && PayloadOk(nl->GetElem(), wl->GetElem());
+      }
+      if (const TSet *ns = n.TryAs<TSet>()) {
+        const TSet *ws = w.TryAs<TSet>();
+        return ws && PayloadOk(ns->GetElem(), ws->GetElem());
+      }
+      if (const TOpt *no = n.TryAs<TOpt>()) {
+        const TOpt *wo = w.TryAs<TOpt>();
+        return wo && PayloadOk(no->GetElem(), wo->GetElem());
+      }
+      if (const TDict *nd = n.TryAs<TDict>()) {
+        const TDict *wd = w.TryAs<TDict>();
+        return wd && nd->GetKey() == wd->GetKey() && PayloadOk(nd->GetVal(), wd->GetVal());
+      }
+      return false;  // differing scalar / self-ref / shape: not group-widenable
+    }
+
+    /* A member variant widens: its tags are a subset and each shared arm's
+       payload is PayloadOk. */
+    bool MemberOk(const TType &n, const TType &w) {
+      const TVariant *nv = n.TryAs<TVariant>();
+      const TVariant *wv = w.TryAs<TVariant>();
+      if (!nv || !wv) {
+        return false;
+      }
+      const auto &we = wv->GetElems();
+      for (const auto &arm : nv->GetElems()) {
+        auto wa = we.find(arm.first);
+        if (wa == we.end() || !PayloadOk(arm.second, wa->second)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    bool Run(const TType &narrow, const TType &wide) {
+      if (!Link(narrow, wide)) {
+        return false;
+      }
+      while (!Work.empty()) {
+        auto pair = Work.back();
+        Work.pop_back();
+        if (!MemberOk(pair.first, pair.second)) {
+          return false;
+        }
+      }
+      return true;
+    }
+  };  // TWidenChecker
+
 }  // namespace
+
+bool Orly::Type::VariantWidensTo(const TType &narrow, const TType &wide,
+                                 unordered_map<TType, TType> &corr) {
+  TWidenChecker checker{corr, {}};
+  return checker.Run(narrow, wide);
+}
 
 vector<TType> Orly::Type::MakeRecGroup(const vector<TVariantElems> &members) {
   const size_t n = members.size();

--- a/orly/type/rec_group.h
+++ b/orly/type/rec_group.h
@@ -33,6 +33,7 @@
 
 #pragma once
 
+#include <unordered_map>
 #include <vector>
 
 #include <orly/type/group_ref.h>
@@ -69,6 +70,25 @@ namespace Orly {
        leaf and the rest of the single-recursion machinery carry it. `member`
        must be a type built by MakeRecGroup. */
     TType InlinedMemberType(const TType &member);
+
+    /* The group-aware variant widening (subtype) relation `narrow ⊑ wide`
+       (issue #104): the coinductive generalization of TVariant::IsWidenableTo
+       across a mutually-recursive group. A `<| X(b) |> as <| Extra | X(b') |>`
+       widening, where `b`/`b'` are sibling group members, is legal iff walking
+       the two variants in lockstep -- each member's tag set may widen (subset),
+       but its arm payloads must be structurally IDENTICAL except where a
+       TGroupRef on each side denotes a corresponding member pair (which must
+       itself widen) -- succeeds. This is exactly IsWidenableTo for a single
+       def (whose self-edge is a shared de Bruijn TSelfRef, so the payloads are
+       literally identical); the relaxation is only at cross-member TGroupRef
+       leaves. NOT general payload subtyping (a differing scalar or nested
+       non-member variant fails), which keeps it sound for the rebuild codegen.
+
+       On success `corr` is filled with each reachable narrow member variant
+       mapped to its wide correspondent -- a well-defined 1:1 mapping the synth
+       uses to mint one fold per member (an inconsistent mapping fails). */
+    bool VariantWidensTo(const TType &narrow, const TType &wide,
+                         std::unordered_map<TType, TType> &corr);
 
   }  // Type
 

--- a/tests/lang_tests/general/variants_widen_mutual.orly
+++ b/tests/lang_tests/general/variants_widen_mutual.orly
@@ -1,0 +1,84 @@
+/* <orly/lang_tests/general/variants_widen_mutual.orly>
+
+   Widening a member of a MUTUALLY-RECURSIVE variant group with the `as`
+   operator (issue #104). This is the group generalization of the single-def
+   recursive widening (variants_widen_recursive.orly): there the self-edge is a
+   shared de Bruijn TSelfRef, so the narrow and wide arm payloads are literally
+   identical and TVariant::IsWidenableTo passes. In a group the cross-edges are
+   TGroupRefs keyed by group identity, so `a`'s `ToB(b)` and `a'`'s `ToB(b')`
+   differ -- the plain widenability check rejects them.
+
+   Two things make it work (Type::VariantWidensTo + the synth group pass):
+     - Widenability is checked coinductively: walk the narrow and wide groups
+       in lockstep, building a member correspondence (a <-> a', b <-> b', ...);
+       each member's tag set may widen (subset) but its arm payloads must be
+       identical EXCEPT where a TGroupRef on each side denotes a corresponding
+       member pair. This is sound -- it is NOT general payload subtyping; a
+       differing scalar or a dropped tag still rejects (see the .xfail-free
+       negative reasoning: `Leaf(int)` vs `Leaf(str)`, or a narrow-only tag,
+       are rejected by the same check).
+     - The synth mints one fold PER narrow member, wired to call one another
+       (a mutually-recursive top-level fold group, exactly what one would write
+       by hand), and annotates the cast with the cast member's fold.
+
+   `anar`/`bnar` is a 2-member group (`a` carries `b`, `b` carries `a`); the
+   wide pair adds arms to both members. `cx`/`cy`/`cz` is a 3-cycle, to drive
+   the correspondence walk and the fold group through more than two members.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+/* A 2-member group and a wide pair that adds an arm to EACH member (`Extra`
+   to a, `Other` to b), so both members genuinely tag-widen. */
+anar is <| Leaf(int) | ToB(bnar) |>;
+bnar is <| Node(anar) | Nil |>;
+awid is <| Extra | Leaf(int) | ToB(bwid) |>;
+bwid is <| Other | Node(awid) | Nil |>;
+
+/* A depth-2 alternating chain through both members, and its wide twin. */
+na = (anar.ToB(bnar.Node(anar.ToB(bnar.Nil())))) where {};
+wa = (awid.ToB(bwid.Node(awid.ToB(bwid.Nil())))) where {};
+
+/* A 3-cycle group: cx -> cy -> cz -> cx. */
+cx is <| C(cy) |>;
+cy is <| Y(cz) |>;
+cz is <| Z(cx) | Stop |>;
+dx is <| Extra | C(dy) |>;
+dy is <| Y(dz) |>;
+dz is <| Z(dx) | Stop |>;
+
+nc = (cx.C(cy.Y(cz.Z(cx.C(cy.Y(cz.Stop())))))) where {};
+wc = (dx.C(dy.Y(dz.Z(dx.C(dy.Y(dz.Stop())))))) where {};
+
+/* The widening through a where-bound source, so its type is only known after
+   the whole function builds (the reason the widening is a post-build pass). */
+widen_a = ((anar.Leaf(n) as awid)) where {
+  n = given::(int);
+};
+
+test {
+  /* Base arm, and the deep alternating chain: every member node remapped,
+     structure preserved. */
+  t_leaf:  (anar.Leaf(7) as awid) == awid.Leaf(7);
+  t_deep:  (na as awid) == wa;
+  t_fn:    widen_a(.n: 3) == awid.Leaf(3);
+  /* Widen starting from the OTHER member of the group -- the fold group is
+     entered at `b`, which calls `a`'s fold for its `Node` payload. */
+  t_b_nil:  (bnar.Nil() as bwid) == bwid.Nil();
+  t_b_node: (bnar.Node(anar.Leaf(3)) as bwid) == bwid.Node(awid.Leaf(3));
+  /* A 3-cycle group widens through all three members. */
+  t_cycle:  (nc as dx) == wc;
+  /* A structurally different narrow value widens to a non-equal wide value. */
+  t_neq:    (na as awid) != awid.Leaf(0);
+};


### PR DESCRIPTION
## What

A member of a **mutually-recursive variant group** now widens via the `as` operator:

```
anar is <| Leaf(int) | ToB(bnar) |>;
bnar is <| Node(anar) | Nil |>;
awid is <| Extra | Leaf(int) | ToB(bwid) |>;
bwid is <| Other | Node(awid) | Nil |>;

(someAnar as awid)   # now legal; previously rejected as "not a superset"
```

This was the last variant-widening gap apart from #104 Phase 5. The single-def recursive case (already shipped) works because the self-edge is a shared de Bruijn `TSelfRef`, so narrow and wide arm payloads are literally identical and `TVariant::IsWidenableTo` passes. In a group the cross-edges are `TGroupRef`s keyed by group identity, so a member's sibling payload differs between the narrow and wide groups and the plain check rejected it.

## How (type + synth; no codegen change)

**`Type::VariantWidensTo`** (`orly/type/rec_group.{h,cc}`) — the coinductive group generalization of `IsWidenableTo`. It walks the narrow/wide groups in lockstep, building a member correspondence (seeded by the cast, extended through shared arms via `ResolveGroupRef`). Each member's tag set may widen (subset), but its arm payloads must be structurally **identical except where a `TGroupRef` on each side denotes a corresponding, co-widening member pair**. This is *not* general payload subtyping — a differing scalar, a dropped tag, or an inconsistent correspondence still rejects — so it stays sound for the rebuild codegen. `as.cc`'s `(variant, variant)` cast arm accepts it when `IsWidenableTo` does not.

**The synth fold pass** (`orly/synth/postfix_cast.cc`) is generalized from a single `narrow→wide` pair to the member correspondence: it mints one top-level fold **per narrow member**, wired to call one another, and the recursion-point check in `CanRebuild`/`Rebuild` is now a correspondence lookup rather than equality with a single narrow variant. All the existing payload handling (records, optionals, list/set/dict, nested containers) carries over unchanged.

Codegen needs nothing new — a mutually-recursive top-level fold group is exactly what one writes by hand (verified before implementing).

## Scope

Covers 2-member and N-cycle groups, widening entered at any member. Mutual groups whose members differ by more than tag-widening + co-widening cross-edges are left to the canonical `#104` diagnostic; **#104 Phase 5** (implicit widening at assignment / parameter / branch join) remains the only widening axis left.

## Tests

- New `tests/lang_tests/general/variants_widen_mutual.orly`: 2-member group, 3-cycle group, widening entered at either member, where-bound source, non-equality.
- Verified separately that unsound casts still reject: a scalar arm payload change (`Leaf(int)` → `Leaf(str)`) and a narrow-only tag.
- Full `lang_test` suite: **0 unexpected, 145 passed**.
- `make test`: green.