### PR TITLE
insert implicit variant widenings (#104 Phase 5)

### DIFF
--- a/orly/expr/if_else.h
+++ b/orly/expr/if_else.h
@@ -59,6 +59,16 @@ namespace Orly {
 
       const TExpr::TPtr &GetFalse() const;
 
+      /* Wrap the true / false branch with `wrap(branch)` -- used by the
+         implicit-widening pass (#104 Phase 5) to widen the narrower branch so
+         both branches share the join type. */
+      void WrapTrue(const std::function<TExpr::TPtr (const TExpr::TPtr &)> &wrap) {
+        WrapChild(GetContainer()[0], wrap);
+      }
+      void WrapFalse(const std::function<TExpr::TPtr (const TExpr::TPtr &)> &wrap) {
+        WrapChild(GetContainer()[2], wrap);
+      }
+
       virtual Type::TType GetTypeImpl() const override;
 
       private:

--- a/orly/expr/n_ary.h
+++ b/orly/expr/n_ary.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <array>
+#include <functional>
 #include <map>
 #include <unordered_map>
 #include <vector>
@@ -104,6 +105,25 @@ namespace Orly {
       }
 
       protected:
+
+      TContainer &GetContainer() {
+        return Container;
+      }
+
+      /* Replace child `slot` (a reference into Container) with `wrap(slot)`,
+         re-parenting safely: the old child is detached from this node first so
+         the wrapper's constructor may adopt it (SetExprParent asserts the
+         child is parentless), then the wrapper is parented here. Used by the
+         implicit-widening pass (#104 Phase 5) to slip an `as wide` cast around
+         a branch / arm value. */
+      void WrapChild(TExpr::TPtr &slot,
+                     const std::function<TExpr::TPtr (const TExpr::TPtr &)> &wrap) {
+        assert(slot);
+        slot->UnsetExprParent(this);
+        slot = wrap(slot);
+        assert(slot);
+        slot->SetExprParent(this);
+      }
 
       /* Empty constructor */
       TNAry(const TPosRange &pos_range)

--- a/orly/expr/when.h
+++ b/orly/expr/when.h
@@ -78,6 +78,14 @@ namespace Orly {
         return GetContainer()[arm_idx + 1];
       }
 
+      /* Wrap arm `arm_idx`'s body with `wrap(body)` -- used by the implicit-
+         widening pass (#104 Phase 5) to widen a narrower arm so all arms share
+         the join type. */
+      void WrapArmBody(size_t arm_idx,
+                       const std::function<TExpr::TPtr (const TExpr::TPtr &)> &wrap) {
+        WrapChild(GetContainer()[arm_idx + 1], wrap);
+      }
+
       /* The asciibetical index (the value the generated native struct's
          GetWhich() returns) of arm `arm_idx`'s tag in the operand variant
          type. Valid once the operand has type-checked as a variant. */

--- a/orly/symbol/root.cc
+++ b/orly/symbol/root.cc
@@ -46,3 +46,12 @@ void TRoot::SetExpr(const Expr::TExpr::TPtr &expr) {
   Expr = expr;
   Expr->SetExprParent(this);
 }
+
+void TRoot::WrapExpr(const std::function<Expr::TExpr::TPtr (const Expr::TExpr::TPtr &)> &wrap) {
+  assert(Expr);
+  /* Detach the current expression so the wrapper's constructor can adopt it
+     (SetExprParent asserts the child is parentless), then re-root the wrapper. */
+  Expr->UnsetExprParent(this);
+  Expr = Base::AssertTrue(wrap(Expr));
+  Expr->SetExprParent(this);
+}

--- a/orly/symbol/root.h
+++ b/orly/symbol/root.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <functional>
+
 #include <base/assert_true.h>
 #include <base/class_traits.h>
 #include <orly/expr/expr.h>
@@ -40,6 +42,14 @@ namespace Orly {
       const Expr::TExpr::TPtr &GetExpr() const;
 
       void SetExpr(const Expr::TExpr::TPtr &expr);
+
+      /* Replace the held expression with one that wraps it -- `wrap(old)` must
+         return a new expression whose construction re-parents `old` to itself
+         (e.g. `Expr::TAs::New(old, ...)`). Used by the implicit-widening pass
+         (#104 Phase 5) to slip an `as wide` cast around an argument value. The
+         old expression is detached from this root before `wrap` runs, so the
+         wrapper's constructor sees it parentless and may adopt it. */
+      void WrapExpr(const std::function<Expr::TExpr::TPtr (const Expr::TExpr::TPtr &)> &wrap);
 
       protected:
 

--- a/orly/synth/package.cc
+++ b/orly/synth/package.cc
@@ -63,11 +63,16 @@ TPackage::TPackage(const Package::TName &name, const Package::Syntax::TPackage *
     if (!GetContext().HasErrors()) {
       BuildSymbol();
       Build();
-      /* Turn recursive-variant `as` widenings into calls to synthesized
-         top-level folds (#104). Run after Build (every def's type is now
-         resolvable) and before TypeCheck (so the minted functions are not
-         added to the package's function set while it is being iterated). */
+      /* Insert implicit variant widenings (#104 Phase 5) -- slip `as wide`
+         casts around values flowing into a wider variant context -- then turn
+         every recursive-variant `as` widening (explicit or just-inserted) into
+         a call to a synthesized top-level fold (#104). Both run after Build
+         (every def's type is now resolvable) and before TypeCheck (so the
+         minted functions are not added to the package's function set while it
+         is being iterated, and the inserted casts are in place when the fold
+         pass collects them). */
       if (!GetContext().HasErrors()) {
+        InsertImplicitVariantWidenings(Symbol);
         SynthesizeRecursiveVariantWidenings(Symbol);
       }
     }

--- a/orly/synth/postfix_cast.cc
+++ b/orly/synth/postfix_cast.cc
@@ -568,7 +568,179 @@ namespace {
     }
   }
 
+  /* True iff a value of variant type `src` flows into a `dst` variant context
+     by WIDENING (#104 Phase 5): both unwrap to DISTINCT variants and src
+     widens to dst -- a plain superset (IsWidenableTo) or a mutually-recursive
+     group (VariantWidensTo). When false the value is left alone (an identity,
+     an optional auto-wrap, or a genuine type error the checker will report). */
+  bool VariantWidens(const Type::TType &src, const Type::TType &dst) {
+    if (src == dst) {
+      return false;
+    }
+    const auto *src_variant = Type::Unwrap(src).TryAs<Type::TVariant>();
+    const auto *dst_variant = Type::Unwrap(dst).TryAs<Type::TVariant>();
+    if (!src_variant || !dst_variant || src_variant == dst_variant) {
+      return false;
+    }
+    if (src_variant->IsWidenableTo(dst_variant)) {
+      return true;
+    }
+    std::unordered_map<Type::TType, Type::TType> corr;
+    return Type::VariantWidensTo(src_variant->AsType(), dst_variant->AsType(), corr);
+  }
+
+  /* Wrap every argument of `app` whose value's variant type widens to the
+     parameter's variant type in an implicit `as param` cast (#104 Phase 5). */
+  void WidenAppArgs(Expr::TFunctionApp *app) {
+    Symbol::TAnyFunction::TPtr function;
+    try {
+      function = app->GetFunction();
+    } catch (...) {
+      return;  // unresolved callee -- leave it for the type checker
+    }
+    if (!function) {
+      return;
+    }
+    auto params = function->GetParams();
+    for (const auto &arg : app->GetFunctionAppArgs()) {
+      auto param = params.find(arg.first);
+      if (param == params.end()) {
+        continue;  // unexpected argument -- the type checker reports it
+      }
+      Type::TType arg_type;
+      try {
+        arg_type = arg.second->GetExpr()->GetType();
+      } catch (...) {
+        continue;
+      }
+      const Type::TType &param_type = param->second;
+      if (VariantWidens(arg_type, param_type)) {
+        arg.second->WrapExpr([&param_type](const Expr::TExpr::TPtr &e) {
+          return Expr::TAs::New(e, param_type, e->GetPosRange());
+        });
+      }
+    }
+  }
+
+  /* Widen the narrower branch of an if/else so both branches share a join
+     type (#104 Phase 5). If one branch's variant type widens to the other's,
+     wrap it in an `as <other>` cast; otherwise leave it (the type checker
+     handles equal branches and reports a genuine mismatch). */
+  void WidenIfElse(Expr::TIfElse *if_else) {
+    Type::TType t_true, t_false;
+    try {
+      t_true = if_else->GetTrue()->GetType();
+      t_false = if_else->GetFalse()->GetType();
+    } catch (...) {
+      return;
+    }
+    if (VariantWidens(t_true, t_false)) {
+      if_else->WrapTrue([&t_false](const Expr::TExpr::TPtr &e) {
+        return Expr::TAs::New(e, t_false, e->GetPosRange());
+      });
+    } else if (VariantWidens(t_false, t_true)) {
+      if_else->WrapFalse([&t_true](const Expr::TExpr::TPtr &e) {
+        return Expr::TAs::New(e, t_true, e->GetPosRange());
+      });
+    }
+  }
+
+  /* Widen the narrower arms of a `when` so all arms share a join type (#104
+     Phase 5). The join is an arm type that every other arm equals or widens to
+     (a unique maximum); when one exists, every strictly-narrower arm is wrapped
+     in an `as <join>` cast. If no arm dominates (incomparable arm types, or an
+     unresolved TAny arm inside a fold), nothing is changed. */
+  void WidenWhen(Expr::TWhen *when) {
+    const size_t arm_count = when->GetArmCount();
+    if (arm_count < 2) {
+      return;
+    }
+    std::vector<Type::TType> types(arm_count);
+    for (size_t i = 0; i < arm_count; ++i) {
+      try {
+        types[i] = when->GetArmBody(i)->GetType();
+      } catch (...) {
+        return;
+      }
+    }
+    for (size_t j = 0; j < arm_count; ++j) {
+      const Type::TType &join = types[j];
+      bool dominates = true;
+      for (size_t i = 0; i < arm_count && dominates; ++i) {
+        dominates = (types[i] == join) || VariantWidens(types[i], join);
+      }
+      if (!dominates) {
+        continue;
+      }
+      for (size_t i = 0; i < arm_count; ++i) {
+        if (types[i] != join && VariantWidens(types[i], join)) {
+          when->WrapArmBody(i, [&join](const Expr::TExpr::TPtr &e) {
+            return Expr::TAs::New(e, join, e->GetPosRange());
+          });
+        }
+      }
+      return;
+    }
+  }
+
+  /* Every flow point the implicit-widening pass rewrites, gathered from one
+     expression tree (including inner / where-bound functions). */
+  struct TWidenSites {
+    std::vector<Expr::TFunctionApp *> Apps;
+    std::vector<Expr::TIfElse *> IfElses;
+    std::vector<Expr::TWhen *> Whens;
+  };
+
+  void CollectWidenSites(const Expr::TExpr::TPtr &root, TWidenSites &sites) {
+    if (!root) {
+      return;
+    }
+    Expr::ForEachExpr(root, [&sites](const Expr::TExpr::TPtr &expr) -> bool {
+      if (auto *app = dynamic_cast<Expr::TFunctionApp *>(expr.get())) {
+        sites.Apps.push_back(app);
+      } else if (auto *if_else = dynamic_cast<Expr::TIfElse *>(expr.get())) {
+        sites.IfElses.push_back(if_else);
+      } else if (auto *when = dynamic_cast<Expr::TWhen *>(expr.get())) {
+        sites.Whens.push_back(when);
+      }
+      return false;  // keep recursing
+    }, /* include_inner_funcs */ true);
+  }
+
+  void CollectWidenSitesInTestBlock(const Symbol::Test::TTestCaseBlock::TPtr &block,
+                                    TWidenSites &sites) {
+    if (!block) {
+      return;
+    }
+    for (const auto &test_case : block->GetTestCases()) {
+      CollectWidenSites(test_case->GetExpr(), sites);
+      CollectWidenSitesInTestBlock(test_case->GetOptTestCaseBlock(), sites);
+    }
+  }
+
 }  // namespace
+
+void Synth::InsertImplicitVariantWidenings(const Symbol::TPackage::TPtr &package) {
+  assert(package);
+  /* Collect every flow point first (mutating one must not disturb an
+     in-progress traversal), then widen. */
+  TWidenSites sites;
+  for (const auto &func : package->GetFunctions()) {
+    CollectWidenSites(func->GetExpr(), sites);
+  }
+  for (const auto &test : package->GetTests()) {
+    CollectWidenSitesInTestBlock(test->GetTestCaseBlock(), sites);
+  }
+  for (auto *app : sites.Apps) {
+    WidenAppArgs(app);
+  }
+  for (auto *if_else : sites.IfElses) {
+    WidenIfElse(if_else);
+  }
+  for (auto *when : sites.Whens) {
+    WidenWhen(when);
+  }
+}
 
 void Synth::SynthesizeRecursiveVariantWidenings(const Symbol::TPackage::TPtr &package) {
   assert(package);

--- a/orly/synth/postfix_cast.h
+++ b/orly/synth/postfix_cast.h
@@ -79,6 +79,16 @@ namespace Orly {
        un-annotated, so the type checker reports the canonical #104 message. */
     void SynthesizeRecursiveVariantWidenings(const Symbol::TPackage::TPtr &package);
 
+    /* Insert IMPLICIT variant widenings (#104 Phase 5). Run once per package
+       after Build and BEFORE SynthesizeRecursiveVariantWidenings: it slips an
+       `as wide` cast around any value that flows into a wider variant context
+       without an explicit cast -- a function argument whose parameter is a
+       wider variant -- so the value is widened to the expected type. The
+       inserted casts are ordinary `Expr::TAs` nodes, so the widening-synth pass
+       that runs next lowers them exactly like an explicit cast (a fold for a
+       recursive widening, a flat rebuild otherwise). */
+    void InsertImplicitVariantWidenings(const Symbol::TPackage::TPtr &package);
+
   }  // Synth
 
 }  // Orly

--- a/tests/lang_tests/general/variants_widen_implicit.orly
+++ b/tests/lang_tests/general/variants_widen_implicit.orly
@@ -1,0 +1,90 @@
+/* <orly/lang_tests/general/variants_widen_implicit.orly>
+
+   IMPLICIT variant widening (issue #104 Phase 5): a narrow variant value
+   flows into a wider variant context WITHOUT an explicit `as` cast, and is
+   widened automatically. The explicit `as` operator (the rest of #104) is the
+   substrate -- the synth pass InsertImplicitVariantWidenings simply slips an
+   `as wide` cast in wherever a value reaches a wider variant context, so the
+   existing widening machinery (a synthesized fold for a recursive widening, a
+   flat reinterpret-rebuild otherwise) lowers it. The flow points:
+
+     - a FUNCTION ARGUMENT whose parameter is a wider variant; and
+     - a BRANCH JOIN -- the arms of an `if/else` or a `when` -- where the
+       result type is the widest arm and every narrower arm widens to it.
+
+   All three widening kinds reach here: single-def recursive (`rnar`/`rwid`),
+   non-recursive (`flat_n`/`flat_w`), and a mutually-recursive group
+   (`anar`/`bnar` -> `awid`/`bwid`). A widening only happens when the source is
+   a strict-narrower variant; an exact-type argument or same-type branches are
+   untouched, and a genuinely incompatible type is still a clean error.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+rnar is <| Leaf(int) | Node(<{.next: rnar}>) |>;
+rwid is <| Extra | Leaf(int) | Node(<{.next: rwid}>) |>;
+
+flat_n is <| A | B(int) |>;
+flat_w is <| A | B(int) | C |>;
+
+anar is <| Leaf(int) | ToB(bnar) |>;
+bnar is <| Node(anar) | Nil |>;
+awid is <| Extra | Leaf(int) | ToB(bwid) |>;
+bwid is <| Other | Node(awid) | Nil |>;
+
+/* Functions whose parameters are the WIDE types; calls below pass narrow
+   values, widened implicitly at the boundary. */
+is_leaf   = ((t is Leaf)) where { t = given::(rwid); };
+echo_w    = ((v)) where { v = given::(flat_w); };
+a_is_leaf = ((t is Leaf)) where { t = given::(awid); };
+
+nn = (rnar.Node(<{.next: rnar.Leaf(5)}>)) where {};
+
+/* if/else branch join: a wide branch and a narrow branch -> the narrow branch
+   widens to the wide result type. */
+pick = ((rwid.Extra() if b else rnar.Leaf(n))) where {
+  b = given::(bool);
+  n = given::(int);
+};
+
+/* when arm join: arms of mixed narrow (flat_n) and wide (flat_w) result type
+   all widen to the common wide type. */
+classify = (((v) when {
+  A:    flat_n.B(0);
+  B(k): flat_w.B(k);
+  C:    flat_n.A();
+})) where {
+  v = given::(flat_w);
+};
+
+test {
+  /* Parameter binding -- recursive widening at the boundary. */
+  t_param_rec_leaf: is_leaf(.t: rnar.Leaf(5));
+  t_param_rec_node: not is_leaf(.t: nn);
+  /* Parameter binding -- non-recursive (flat) widening. */
+  t_param_flat_b: echo_w(.v: flat_n.B(3)) == flat_w.B(3);
+  t_param_flat_a: echo_w(.v: flat_n.A()) == flat_w.A();
+  /* Parameter binding -- mutually-recursive group widening. */
+  t_param_grp_leaf: a_is_leaf(.t: anar.Leaf(9));
+  t_param_grp_tob:  not a_is_leaf(.t: anar.ToB(bnar.Nil()));
+  /* An explicit `as` to the same wide type still works at the boundary. */
+  t_param_explicit: is_leaf(.t: (rnar.Leaf(1) as rwid));
+  /* if/else branch join widens the narrow branch to the wide result. */
+  t_if_wide:   pick(.b: true, .n: 9) == rwid.Extra();
+  t_if_narrow: pick(.b: false, .n: 9) == rwid.Leaf(9);
+  /* when arm join widens narrow arms to the common wide type. */
+  t_when_a: classify(.v: flat_w.A()) == flat_w.B(0);
+  t_when_b: classify(.v: flat_w.B(7)) == flat_w.B(7);
+  t_when_c: classify(.v: flat_w.C()) == flat_w.A();
+};


### PR DESCRIPTION
## What

A narrow variant value flowing into a wider variant context is now widened **automatically**, with no explicit `as` — the last axis of #104.

```
f = ((t is Leaf)) where { t = given::(rwid); };
f(.t: rnar.Leaf(5))                        # argument widened rnar -> rwid

(rwid.Extra() if b else rnar.Leaf(n))      # narrow branch widened to the join
```

Flow points handled:
- **function arguments** whose parameter is a wider variant;
- **branch joins** — `if/else` branches and `when` arms — where the result type is the widest arm and every narrower arm widens to it.

All three widening kinds reach this: single-def recursive, non-recursive, and mutually-recursive groups.

## How (no codegen or type-checker change)

The explicit `as` operator (the rest of #104) is the substrate. A new post-`Build` pass `InsertImplicitVariantWidenings` slips an `as wide` cast in wherever a value reaches a wider variant context; it runs right before the existing widening synth, which then lowers those inserted casts exactly like explicit ones (a synthesized fold for a recursive/group widening, a flat reinterpret-rebuild otherwise).

By widening the value to the **expected** type, the function-app argument check and the `if/else` / `when` type joins all see matching types and pass unchanged — no type-checker rewrite needed.

For branch joins this is the "one arm dominates" case (the widest arm is a declared type all others widen to); it deliberately does **not** construct anonymous least-upper-bound types — if no arm dominates, it's left to the existing same-type join (a clean error as before).

A widening fires only for a **strict-narrower variant** source, so exact-type arguments and same-type branches are untouched, and a genuinely incompatible type is still a clean error.

Mechanics: `TRoot::WrapExpr` and `TNAry::WrapChild` re-wrap a held child safely (detach, build the wrapper around the now-parentless child, re-parent); `TIfElse`/`TWhen` expose branch/arm wrappers over them.

## Tests

- New `tests/lang_tests/general/variants_widen_implicit.orly`: parameter binding (recursive / non-recursive / group), `if/else` join, `when` join, plus an explicit-`as`-at-the-boundary control.
- Full `lang_test` suite: **0 unexpected, 146 passed** — and crucially **no existing program changed behavior** (implicit widening only fires on a strict-narrower source).
- `make test`: green.

## #104 status

With this, **every variant-widening axis of #104 is complete** — explicit `as` (single-def recursion, all payload shapes, nested containers, mutual groups) and now implicit widening at parameter binding and branch joins.