### PR TITLE
lang: verify recursive-call results in propagating positions (#128 Option B)

### DIFF
--- a/orly/expr/expr.cc
+++ b/orly/expr/expr.cc
@@ -54,6 +54,10 @@ Type::TType TExpr::GetType() const {
   return type;
 }
 
+void TExpr::ClearCachedType() const {
+  CachedType.reset();
+}
+
 void TExpr::SetExprParent(const TExprParent *expr_parent) {
   assert(expr_parent);
   assert(!ExprParent);

--- a/orly/expr/expr.h
+++ b/orly/expr/expr.h
@@ -59,6 +59,14 @@ namespace Orly {
 
       Type::TType GetType() const;
 
+      /* Drop the memoized type so the next GetType() recomputes from
+         GetTypeImpl(). Used by the recursive-return verification fixpoint
+         (TFunction::VerifyRecursiveReturns, #128 Option B) to re-evaluate a
+         function body after substituting a concrete estimate for the
+         recursive-call placeholder -- a node that cached a concrete type from
+         a TAny operand (e.g. a variant ctor) would otherwise never re-check. */
+      void ClearCachedType() const;
+
       template <typename TFinal>
       bool Is() const;
 

--- a/orly/symbol/function.cc
+++ b/orly/symbol/function.cc
@@ -20,6 +20,7 @@
 
 #include <base/assert_true.h>
 #include <orly/error.h>
+#include <orly/expr/walker.h>
 #include <orly/symbol/scope.h>
 #include <orly/type/any.h>
 
@@ -37,7 +38,8 @@ TFunction::TPtr TFunction::New(const TScope::TPtr &scope, const std::string &nam
 }
 
 TFunction::TFunction(const TScope::TPtr &scope, const std::string &name, const TPosRange &pos_range)
-    : TAnyFunction(name), IsRecursive(false), Scope(Base::AssertTrue(scope)), PosRange(pos_range) {}
+    : TAnyFunction(name), IsRecursive(false), Verifying(false),
+      Scope(Base::AssertTrue(scope)), PosRange(pos_range) {}
 
 TFunction::~TFunction() {
   auto scope = TryGetScope();
@@ -78,10 +80,18 @@ const TPosRange &TFunction::GetPosRange() const {
 Type::TType TFunction::GetReturnType() const {
   Type::TType type;
   if (IsRecursive) {
-    /* Re-entered through a recursive call: the return type is not yet known.
-       TAny is the placeholder; a `when`/if-else with a concrete arm anchors
-       it, and an all-recursive node now defers rather than throwing (#126). */
-    type = Type::TAny::Get();
+    /* Re-entered through a recursive call: the return type is not yet known. */
+    if (Verifying) {
+      /* Verification pass (#128 Option B): hand back the concrete return-type
+         estimate so the strict payload/argument/operator checks see a real
+         type and can catch a genuine error in the recursive result. */
+      type = RecursiveEstimate;
+    } else {
+      /* Inference: TAny is the placeholder; a `when`/if-else with a concrete
+         arm anchors it, and an all-recursive node defers rather than throwing
+         (#126). */
+      type = Type::TAny::Get();
+    }
   } else {
     IsRecursive = true;
     type = GetExpr()->GetType();
@@ -96,6 +106,61 @@ Type::TType TFunction::GetReturnType() const {
     }
   }
   return type;
+}
+
+void TFunction::ClearBodyCachedTypes() const {
+  /* include_inner_funcs = false: stop at inner/where-bound function roots --
+     each has its own return-type fixpoint and clearing across them would be
+     both wrong (different recursion guard) and wasteful. */
+  Expr::ForEachExpr(GetExpr(),
+      [](const Expr::TExpr::TPtr &expr) {
+        expr->ClearCachedType();
+        return false;  // keep recursing
+      },
+      /* include_inner_funcs */ false);
+}
+
+void TFunction::VerifyRecursiveReturns() const {
+  /* Pass 1: infer the return type with today's behavior -- recursive calls
+     deferred to TAny, the #126 no-base-case diagnostic fires here. */
+  Type::TType estimate = GetReturnType();
+  /* Passes 2..N: re-evaluate the body with the recursive call resolved to the
+     current estimate. Now no operand is TAny, so the payload/argument/operator
+     checks that Option A skipped on a TAny operand run normally and reject a
+     genuine error. Iterate to a fixpoint (self-recursion converges in one
+     extra pass); cap the iteration so a pathological non-converging program
+     falls back to the inferred type rather than looping. Caching is cleared
+     before each pass so a node that memoized a concrete type from a TAny
+     operand (e.g. a variant ctor) is actually rechecked. */
+  static const int max_iters = 16;
+  for (int iter = 0; iter < max_iters; ++iter) {
+    RecursiveEstimate = estimate;
+    Verifying = true;
+    /* IsRecursive so a recursive self-call re-enters and takes the
+       Verifying branch above (returning the estimate) rather than recomputing
+       the whole body. */
+    IsRecursive = true;
+    ClearBodyCachedTypes();
+    Type::TType recomputed;
+    try {
+      recomputed = GetExpr()->GetType();
+    } catch (...) {
+      Verifying = false;
+      IsRecursive = false;
+      ClearBodyCachedTypes();
+      throw;
+    }
+    Verifying = false;
+    IsRecursive = false;
+    if (recomputed == estimate) {
+      break;
+    }
+    estimate = recomputed;
+  }
+  /* Leave no trace: drop the estimate-substituted caches so later consumers
+     (codegen) recompute through the normal inference path. The resolved types
+     are identical, but this keeps verification side-effect-free. */
+  ClearBodyCachedTypes();
 }
 
 TScope::TPtr TFunction::GetScope() const {

--- a/orly/symbol/function.h
+++ b/orly/symbol/function.h
@@ -79,6 +79,21 @@ namespace Orly {
 
       TScopePtr GetScope() const;
 
+      /* Verify recursive-call results in propagating positions (#128 Option B).
+         GetReturnType() defers a recursive call to a TAny placeholder while the
+         return type is being inferred, so a payload/argument/operator check on
+         that result is skipped (Option A). This re-evaluates the body with the
+         inferred return type substituted for the placeholder so those checks
+         fire against a concrete type and catch genuine errors -- e.g. a
+         recursive result fed to `+` against a `str`, or into a ctor arm that
+         wants a scalar. A two-pass fixpoint (re-evaluation cleared between
+         passes); self-recursion converges in one extra pass. Harmless for a
+         non-recursive function -- the re-evaluation just reproduces the
+         inferred type and raises nothing. Run once per function during
+         TypeCheck, after the post-build widening passes have settled the
+         body. */
+      void VerifyRecursiveReturns() const;
+
       void Remove(const TParamDef::TPtr &param_def);
 
       TScopePtr TryGetScope() const;
@@ -87,7 +102,27 @@ namespace Orly {
 
       TFunction(const TScopePtr &scope, const std::string &name, const TPosRange &pos_range);
 
+      /* Drop the memoized type of every node in the body expr tree (but NOT of
+         inner/where-bound function bodies -- they are their own roots and
+         fixpoint independently). Used by VerifyRecursiveReturns between passes
+         so the re-evaluation actually recomputes nodes that cached a concrete
+         type from a TAny operand. */
+      void ClearBodyCachedTypes() const;
+
+      /* Re-entrancy guard for return-type inference: set while computing the
+         body type so a recursive call returns the placeholder rather than
+         recursing forever. */
       mutable bool IsRecursive;
+
+      /* Set while VerifyRecursiveReturns re-evaluates the body: a recursive
+         call then returns RecursiveEstimate (the current concrete return-type
+         estimate) instead of the TAny placeholder, so the strict checks fire.
+         (#128 Option B.) */
+      mutable bool Verifying;
+
+      /* The concrete return-type estimate handed back to a recursive call
+         during verification. Only meaningful while Verifying is true. */
+      mutable Type::TType RecursiveEstimate;
 
       TParamDefSet ParamDefs;
 

--- a/orly/symbol/scope.cc
+++ b/orly/symbol/scope.cc
@@ -65,6 +65,10 @@ void TScope::Remove(const Test::TTest::TPtr &test) {
 void TScope::TypeCheck() const {
   for (const auto &function : Functions) {
     function->GetType();
+    /* Verify recursive-call results that return-type inference left deferred
+       (#128 Option B). Runs here -- after the post-build widening passes have
+       settled every body -- so the re-evaluation sees the final tree. */
+    function->VerifyRecursiveReturns();
   }
   for (const auto &test : Tests) {
     test->TypeCheck();

--- a/tests/lang_tests/general/.recursive_verify.orly.test.state
+++ b/tests/lang_tests/general/.recursive_verify.orly.test.state
@@ -1,0 +1,21 @@
+[
+  0,
+  [
+    [],
+    [
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++"
+    ],
+    [
+      "Running tests"
+    ],
+    [
+      "Tests done"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/recursive_verify.orly
+++ b/tests/lang_tests/general/recursive_verify.orly
@@ -1,0 +1,101 @@
+/* <orly/lang_tests/general/recursive_verify.orly>
+
+   Tests #128 Option B: the recursive-return verification fixpoint. A
+   recursive call returns the `TAny` placeholder while a function's return
+   type is being inferred, so the payload / argument / operator checks that
+   would normally fire are skipped on it (Option A, #129/#157). Option B
+   re-evaluates each function body once the return type is inferred, with
+   the recursive call resolved to that concrete type, so those checks run
+   and a genuine error in a recursive result is caught.
+
+   This file is the POSITIVE side: three recursive functions that use their
+   own recursive result in each of the deferred positions with the CORRECT
+   type, so verification must accept them (and they evaluate correctly):
+
+     - operator:     `sum(.t: b.l) + sum(.t: b.r)`     (recursive result in `+`)
+     - ctor payload: `tree.Branch(<{.l: dbl(...), ...}>)` (recursive result in a
+                     variant ctor payload field)
+     - argument:     `max2(.a: maxleaf(...), .b: ...)`  (recursive result as a
+                     function-call argument)
+
+   Each converges in one extra pass: the base-case arm fixes the return type
+   (`int` / `tree`), and feeding that back into the recursive arm reproduces
+   it.
+
+   The NEGATIVE side -- the same three positions with a WRONG type, which
+   verification now rejects with a clean compile error -- cannot be a green
+   entry in this harness (a rejected program has a non-zero exit). They are
+   hand-verified; for the record, each is rejected at its strict-check site:
+
+     - `tree.Leaf(rec)` where `rec` is a `tree` (Leaf wants int):
+         "variant constructor payload type does not match the declared type
+          of arm \"Leaf\"" (orly/expr/variant.cc)
+     - `rec + 1` where `rec` is a `str`:
+         "This expression is invalid." (orly/type/add_visitor.h)
+     - `needs_str(.s: rec)` where `rec` is an `int`:
+         "Function call with parameter type mismatch" (orly/expr/function_app.cc)
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+tree is <| Leaf(int) | Branch(<{.l: tree, .r: tree}>) |>;
+
+/* (operator) Sum the leaves: the recursive results feed `+`. */
+sum = ((t) when {
+  Leaf(n):   n;
+  Branch(b): sum(.t: b.l) + sum(.t: b.r);
+}) where {
+  t = given::(tree);
+};
+
+/* (ctor payload) Double every leaf, rebuilding the tree from the recursive
+   results in the Branch payload's `.l` / `.r` fields. */
+dbl = ((t) when {
+  Leaf(n):   tree.Leaf(n + n);
+  Branch(b): tree.Branch(<{.l: dbl(.t: b.l), .r: dbl(.t: b.r)}>);
+}) where {
+  t = given::(tree);
+};
+
+/* (argument) Largest leaf: the recursive results are passed as arguments. */
+max2 = ((a if a > b else b)) where {
+  a = given::(int);
+  b = given::(int);
+};
+
+maxleaf = ((t) when {
+  Leaf(n):   n;
+  Branch(b): max2(.a: maxleaf(.t: b.l), .b: maxleaf(.t: b.r));
+}) where {
+  t = given::(tree);
+};
+
+sample = (tree.Branch(<{
+            .l: tree.Leaf(3),
+            .r: tree.Branch(<{.l: tree.Leaf(5), .r: tree.Leaf(2)}>)}>)) where {};
+
+test {
+  /* operator: recursive results summed. */
+  t_sum_leaf: sum(.t: tree.Leaf(7)) == 7;
+  t_sum_deep: sum(.t: sample) == 10;
+
+  /* ctor payload: recursive results rebuild the tree. */
+  t_dbl_leaf: dbl(.t: tree.Leaf(4)) == tree.Leaf(8);
+  t_dbl_deep: dbl(.t: tree.Branch(<{.l: tree.Leaf(1), .r: tree.Leaf(2)}>)) ==
+              tree.Branch(<{.l: tree.Leaf(2), .r: tree.Leaf(4)}>);
+
+  /* argument: recursive results passed to a helper. */
+  t_max_leaf: maxleaf(.t: tree.Leaf(9)) == 9;
+  t_max_deep: maxleaf(.t: sample) == 5;
+};


### PR DESCRIPTION
## What

Closes the per-function self-recursion half of #128 **Option B**: actually
*verify* a recursive call's result in the positions where Option A only
*deferred* it.

Option A (#129/#157) lets a recursive call's result -- the `TAny` placeholder
the return type carries while it is being inferred -- flow through a variant
ctor payload, a function-call argument, and operators, by skipping the strict
check whenever an operand is `TAny`. That deferral is never re-examined, so a
genuine type error in a recursive result slips through and compiles cleanly:

- `g(x) + 1` where `g` returns `str`
- `tree.Leaf(rec)` where `rec` is a `tree` and `Leaf` wants an `int`
- a recursive result passed as an argument of the wrong type

## How

A per-function verification fixpoint (`TFunction::VerifyRecursiveReturns`), run
once per function during `TypeCheck` -- after the #104 post-build widening
passes have settled every body:

1. Infer the return type `R` with today's behavior (recursive calls deferred to
   `TAny`; the #126 no-base-case diagnostic still fires here).
2. Re-evaluate the body with the recursive call resolved to `R`. With no `TAny`
   operand left, the payload/argument/operator checks run normally and reject a
   genuine error. The expr-tree type cache is **cleared before the pass** so a
   node that memoized a concrete type from a `TAny` operand (a variant ctor
   returns its concrete variant type even with a `TAny` payload) is actually
   re-checked -- this is the crux; a naive scheme would cache the concrete type
   in pass 1 and never re-verify. Iterate to a fixpoint (self-recursion
   converges in one extra pass), capped, falling back to `R` if it does not
   converge. The estimate-substituted caches are dropped afterward so codegen
   recomputes through the normal path -- verification leaves no trace.

This follows the issue's recommended Approach 2: ctor/argument/operator
propagation is **untouched**, so the #104 widening folds are unaffected. Their
synthesized arm bodies are concretely `wide` precisely *because* a ctor absorbed
a deferred `TAny` payload; feeding the concrete `wide` type back in re-checks
and passes.

The verification is realized as a dedicated `TypeCheck`-time pass rather than
folded into the per-call `GetReturnType` (the issue's literal sketch), because
the body-rewriting #104 passes run *after* `Build`: a `GetReturnType` that
memoized during `Build` would be stale, and a per-call fixpoint would clear and
recompute caches on every codegen call. A once-per-function pass after all
rewrites is the same two-phase mechanism without those hazards.

## Scope

Per-function self-recursion. The mutual-recursion SCC tier (a fixpoint over a
def group -- the synth/type half of #116) remains a follow-up.

## Tests

`tests/lang_tests/general/recursive_verify.orly` exercises the verification
**accepting** valid recursive results in all three positions (operator, ctor
payload, argument) and evaluating correctly.

The **negative** side -- the same three positions with a wrong type, now
rejected with a clean compile error during `TypeCheck` -- is documented in that
file's header and hand-verified. A rejected program has a non-zero exit and so
cannot be a green entry in this harness (matching how #126's no-base-case
diagnostic is handled). Each is a clean diagnostic (no crash/assert), pointing
at the offending expression:

| recursive result used as | rejected with |
| --- | --- |
| `tree.Leaf(rec)`, `rec: tree` | `variant constructor payload type does not match the declared type of arm "Leaf"` (`orly/expr/variant.cc`) |
| `rec + 1`, `rec: str` | `This expression is invalid.` (`orly/type/add_visitor.h`; identical to the non-recursive `"x" + 1` error) |
| `needs_str(.s: rec)`, `rec: int` | `Function call with parameter type mismatch` (`orly/expr/function_app.cc`) |

## Gate

- `python3 tools/lang_test.py -d orly/data tests/lang_tests`: **0 unexpected, 152 passed, 2 tracked xfails** (#74/#75).
- `make test`: passes.

Regression set confirmed green: `variants_widen_recursive`,
`variants_widen_recursive_fold`, `variants_widen_mutual`,
`variants_widen_implicit` (+ container/nested cases), `factorial`,
`recursive_fold`, `recursive_transform`.
