### PR TITLE
lang: `when` over optionals -- share the variant match surface with `T?` (#105 Stage 1)

### DIFF
--- a/orly/code_gen/builder.cc
+++ b/orly/code_gen/builder.cc
@@ -614,10 +614,16 @@ TInline::TPtr Orly::CodeGen::Build(const L0::TPackage *package, const Expr::TExp
     virtual void operator()(const Expr::TObjMember *that) const {
       /* `e.<Tag>` overloads on operand type (matching Expr::TObjMember::
          GetTypeImpl): a variant operand is the #95 guarded payload
-         accessor (-> GetV<Tag>()); a record operand is field access. */
-      if (Type::Unwrap(that->GetExpr()->GetType()).Is<Type::TVariant>()) {
+         accessor (-> GetV<Tag>()); an optional operand's `.Known` is the
+         optional's payload accessor, the same unwrap as `known e` (#105);
+         a record operand is field access. */
+      const Type::TType operand_type = Type::Unwrap(that->GetExpr()->GetType());
+      if (operand_type.Is<Type::TVariant>()) {
         Res = TVariantMember::TPtr(new TVariantMember(Package, ReturnType,
             Build(Package, that->GetExpr(), false), that->GetName()));
+      } else if (operand_type.Is<Type::TOpt>()) {
+        Res = Interner.GetUnary(Package, ReturnType, TUnary::Known,
+            Build(Package, that->GetExpr(), false));
       } else {
         Res = Interner.GetObjMember(Package, ReturnType, Build(Package, that->GetExpr(), true), that->GetName());
       }
@@ -765,11 +771,26 @@ TInline::TPtr Orly::CodeGen::Build(const L0::TPackage *package, const Expr::TExp
           Build(Package, that->GetExpr(), false), that->GetWhich()));
     }
     virtual void operator()(const Expr::TWhen *that) const {
+      TInline::TPtr operand = Build(Package, that->GetOperand(), false);
+      /* An optional operand is the built-in sum `<| Known(T) | Unknown |>`
+         (#105): select on the presence flag rather than a `GetWhich()`. */
+      if (Type::Unwrap(that->GetOperand()->GetType()).Is<Type::TOpt>()) {
+        TInline::TPtr known_body, unknown_body;
+        for (size_t arm_idx = 0; arm_idx < that->GetArmCount(); ++arm_idx) {
+          TInline::TPtr body = Build(Package, that->GetArmBody(arm_idx), false);
+          if (that->GetArmTag(arm_idx) == "Known") {
+            known_body = body;
+          } else {
+            unknown_body = body;
+          }
+        }
+        Res = TInline::TPtr(new TOptWhen(Package, ReturnType, operand, known_body, unknown_body));
+        return;
+      }
       /* Lower to a nested ternary on the operand's active arm (#95 Phase 4),
          reusing the M4 GetWhich() primitive. The operand inline is shared
          across arms; exhaustiveness was checked at type time, so the last
          arm is the unconditional fall-through. */
-      TInline::TPtr operand = Build(Package, that->GetOperand(), false);
       TVariantWhen::TArmVec arms;
       for (size_t arm_idx = 0; arm_idx < that->GetArmCount(); ++arm_idx) {
         arms.emplace_back(that->GetArmWhich(arm_idx),

--- a/orly/code_gen/variant_access.cc
+++ b/orly/code_gen/variant_access.cc
@@ -82,6 +82,19 @@ void TVariantWhen::WriteExpr(TCppPrinter &out) const {
   out << '(' << Arms.back().second << "))";
 }
 
+TOptWhen::TOptWhen(const L0::TPackage *package,
+                   const Type::TType &type,
+                   const TInline::TPtr &operand,
+                   const TInline::TPtr &known_body,
+                   const TInline::TPtr &unknown_body)
+    : TInline(package, type), Operand(operand), KnownBody(known_body), UnknownBody(unknown_body) {}
+
+void TOptWhen::WriteExpr(TCppPrinter &out) const {
+  /* Presence selects the arm; the `Known(v)` binder reads `(op).GetVal()`
+     inside the known body (an `optional.Known` accessor). */
+  out << "((" << Operand << ").IsKnown() ? (" << KnownBody << ") : (" << UnknownBody << "))";
+}
+
 TVariantWiden::TVariantWiden(const L0::TPackage *package,
                              const Type::TType &type,
                              const TInline::TPtr &operand,

--- a/orly/code_gen/variant_access.h
+++ b/orly/code_gen/variant_access.h
@@ -131,6 +131,47 @@ namespace Orly {
         mutable bool InDependsOn = false;
     }; // TVariantWhen
 
+    /* `(e) when { Known(v): ...; Unknown: ...; }` over an OPTIONAL operand
+       (#105) -- the built-in sum `<| Known(T) | Unknown |>`. Lowers to a
+       ternary on the optional's presence flag rather than a `GetWhich()`:
+         ((op).IsKnown() ? (known_body) : (unknown_body))
+       The `Known(v)` payload binder reaches the value via `(op).GetVal()`
+       (an `optional.Known` accessor lowered to TUnary::Known), so this node
+       just selects the branch. */
+    class TOptWhen : public TInline {
+      NO_COPY(TOptWhen);
+      public:
+
+      TOptWhen(const L0::TPackage *package,
+               const Type::TType &type,
+               const TInline::TPtr &operand,
+               const TInline::TPtr &known_body,
+               const TInline::TPtr &unknown_body);
+
+      void WriteExpr(TCppPrinter &out) const;
+
+      virtual void AppendDependsOn(std::unordered_set<TInline::TPtr> &dependency_set) const override {
+        /* Reentrancy guard mirroring TVariantWhen: an arm may map over a
+           recursive call that reaches back into this same `when`. */
+        if (!InDependsOn) {
+          InDependsOn = true;
+          for (const auto &dep : {Operand, KnownBody, UnknownBody}) {
+            dependency_set.insert(dep);
+            dep->AppendDependsOn(dependency_set);
+          }
+          InDependsOn = false;
+        }
+      }
+
+      private:
+        TInline::TPtr Operand;
+        TInline::TPtr KnownBody;
+        TInline::TPtr UnknownBody;
+
+        /* True while inside AppendDependsOn, to detect reentrant recursion. */
+        mutable bool InDependsOn = false;
+    }; // TOptWhen
+
     /* `narrow_val as wide_t` -- widening a narrow variant to a superset
        variant (#104). The narrow and wide native structs have different
        `Which` numbering (the asciibetical arm index shifts when arms are

--- a/orly/expr/obj_member.cc
+++ b/orly/expr/obj_member.cc
@@ -64,6 +64,20 @@ Type::TType TObjMember::GetTypeImpl() const {
        (every self-reference becomes the variant type itself, #103). */
     return Type::Unroll(iter->second, variant->AsType());
   }
+  /* An optional is the built-in sum `<| Known(T) | Unknown |>`; `.Known` is
+     its payload accessor, yielding the wrapped element type `T` (#105). This
+     is what lets the `when` payload binder `Known(v): ...` reach the value,
+     and mirrors a variant's `.Tag`. The value is valid only when the optional
+     is known (gated by the `when` arm / a prior `is known`), exactly like a
+     variant arm. `Unknown` is the payload-less arm, so no other accessor name
+     is valid on an optional. */
+  if (const Type::TOpt *opt = Type::Unwrap(GetExpr()->GetType()).TryAs<Type::TOpt>()) {
+    if (Name != "Known") {
+      std::string msg = Base::AsStr("optional payload accessor \".", Name, "\" is not valid; only `.Known` accesses an optional's payload");
+      throw TExprError(HERE, GetPosRange(), msg.c_str());
+    }
+    return opt->GetElem();
+  }
   class TObjMemberTypeVisitor
       : public Type::TUnwrapVisitor {
     NO_COPY(TObjMemberTypeVisitor);

--- a/orly/expr/when.cc
+++ b/orly/expr/when.cc
@@ -81,31 +81,55 @@ size_t TWhen::GetArmWhich(size_t arm_idx) const {
 }
 
 Type::TType TWhen::GetTypeImpl() const {
-  /* Operand must be a variant. */
-  const Type::TVariant *variant = Type::Unwrap(GetOperand()->GetType()).TryAs<Type::TVariant>();
-  if (!variant) {
-    throw TExprError(HERE, GetPosRange(), "`when` operand must be a variant type");
-  }
-  const Type::TVariantElems &elems = variant->GetElems();
+  /* The operand is a variant -- or, as the built-in 2-arm sum, an optional
+     (#105). Either way, exhaustiveness is "every declared tag has exactly one
+     arm". */
+  const Type::TType operand_type = Type::Unwrap(GetOperand()->GetType());
+  if (const Type::TVariant *variant = operand_type.TryAs<Type::TVariant>()) {
+    const Type::TVariantElems &elems = variant->GetElems();
 
-  /* Exhaustiveness: every arm names a real tag, with no duplicates, and
-     every tag of the variant has an arm. */
-  std::unordered_set<std::string> seen;
-  for (const auto &tag : Tags) {
-    if (elems.find(tag) == elems.end()) {
-      std::string msg = Base::AsStr("`when` arm `", tag, "` is not a tag of the operand variant type");
-      throw TExprError(HERE, GetPosRange(), msg.c_str());
+    /* Exhaustiveness: every arm names a real tag, with no duplicates, and
+       every tag of the variant has an arm. */
+    std::unordered_set<std::string> seen;
+    for (const auto &tag : Tags) {
+      if (elems.find(tag) == elems.end()) {
+        std::string msg = Base::AsStr("`when` arm `", tag, "` is not a tag of the operand variant type");
+        throw TExprError(HERE, GetPosRange(), msg.c_str());
+      }
+      if (!seen.insert(tag).second) {
+        std::string msg = Base::AsStr("`when` has a duplicate arm for tag `", tag, "`");
+        throw TExprError(HERE, GetPosRange(), msg.c_str());
+      }
     }
-    if (!seen.insert(tag).second) {
-      std::string msg = Base::AsStr("`when` has a duplicate arm for tag `", tag, "`");
-      throw TExprError(HERE, GetPosRange(), msg.c_str());
+    for (const auto &elem : elems) {
+      if (seen.find(elem.first) == seen.end()) {
+        std::string msg = Base::AsStr("`when` is not exhaustive: missing arm for tag `", elem.first, "`");
+        throw TExprError(HERE, GetPosRange(), msg.c_str());
+      }
     }
-  }
-  for (const auto &elem : elems) {
-    if (seen.find(elem.first) == seen.end()) {
-      std::string msg = Base::AsStr("`when` is not exhaustive: missing arm for tag `", elem.first, "`");
-      throw TExprError(HERE, GetPosRange(), msg.c_str());
+  } else if (operand_type.Is<Type::TOpt>()) {
+    /* An optional is the built-in sum `<| Known(T) | Unknown |>`, so a `when`
+       may match it with exactly the arms `Known` (payload-bearing, bindable
+       as `Known(v)`) and `Unknown` (payload-less) (#105). */
+    std::unordered_set<std::string> seen;
+    for (const auto &tag : Tags) {
+      if (tag != "Known" && tag != "Unknown") {
+        std::string msg = Base::AsStr("`when` arm `", tag, "` is not an arm of the operand optional type (expected `Known` or `Unknown`)");
+        throw TExprError(HERE, GetPosRange(), msg.c_str());
+      }
+      if (!seen.insert(tag).second) {
+        std::string msg = Base::AsStr("`when` has a duplicate arm for tag `", tag, "`");
+        throw TExprError(HERE, GetPosRange(), msg.c_str());
+      }
     }
+    if (seen.find("Known") == seen.end()) {
+      throw TExprError(HERE, GetPosRange(), "`when` on an optional is not exhaustive: missing arm for `Known`");
+    }
+    if (seen.find("Unknown") == seen.end()) {
+      throw TExprError(HERE, GetPosRange(), "`when` on an optional is not exhaustive: missing arm for `Unknown`");
+    }
+  } else {
+    throw TExprError(HERE, GetPosRange(), "`when` operand must be a variant or optional type");
   }
   if (Tags.empty()) {
     throw TExprError(HERE, GetPosRange(), "`when` must have at least one arm");

--- a/tests/lang_tests/general/.when_optional.orly.test.state
+++ b/tests/lang_tests/general/.when_optional.orly.test.state
@@ -1,0 +1,21 @@
+[
+  0,
+  [
+    [],
+    [
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++"
+    ],
+    [
+      "Running tests"
+    ],
+    [
+      "Tests done"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/when_optional.orly
+++ b/tests/lang_tests/general/when_optional.orly
@@ -1,0 +1,100 @@
+/* <orly/lang_tests/general/when_optional.orly>
+
+   Tests #105 Stage 1: `when` over an OPTIONAL, treating the built-in optional
+   `T?` as the sum `<| Known(T) | Unknown |>`. This shares the variant
+   destructuring surface (`when`, the `Tag(binder)` payload bind) with
+   optionals, so the `is known ... else ...` idiom can be written as an
+   exhaustive match:
+
+     (o) when {
+       Known(v): <use v, the unwrapped value>;
+       Unknown:  <the absent case>;
+     }
+
+   The `Known(v)` binder reaches the payload through an `optional.Known`
+   accessor (the same unwrap as prefix `known`); `Unknown` is the payload-less
+   arm. Exhaustiveness requires exactly the two arms `Known` and `Unknown`.
+
+   This is a surface unification only -- the optional's representation,
+   auto-unwrap-through-operators, storage, and codegen are unchanged. The
+   deeper type-level reduction of `TOpt` to a `TVariant` is out of scope
+   (blocked by variant on-disk storage being defined in terms of `TOpt`).
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+/* Scalar optional: bind the value in the Known arm, fall back in Unknown. */
+plus1 = ((o) when {
+  Known(v): v + 1;
+  Unknown:  0;
+}) where {
+  o = given::(int?);
+};
+
+/* The binder value is an ordinary expression -- usable anywhere. */
+doubled = ((o) when {
+  Known(v): v * 2;
+  Unknown:  -1;
+}) where {
+  o = given::(int?);
+};
+
+/* Unknown arm without binding the (absent) value; Known with binder. */
+or_zero = ((o) when {
+  Unknown:  0;
+  Known(v): v;
+}) where {
+  o = given::(int?);
+};
+
+/* Optional of a VARIANT: the Known arm binds the variant, which a nested
+   `when` then matches -- optional and variant destructuring compose. */
+col is <| Red | Green | Blue |>;
+col_name = ((o) when {
+  Known(c): ((c) when { Red: "red"; Green: "green"; Blue: "blue"; });
+  Unknown:  "none";
+}) where {
+  o = given::(col?);
+};
+
+/* Optional of a RECORD: the bound value is the record; read a field. */
+first_or = ((o) when {
+  Known(r): r.x;
+  Unknown:  -1;
+}) where {
+  o = given::(<{.x: int, .y: int}>?);
+};
+
+rec = (<{.x: 7, .y: 9}>) where {};
+
+test {
+  /* scalar optional */
+  t_plus1_known:   plus1(.o: 41 as int?) == 42;
+  t_plus1_unknown: plus1(.o: unknown int) == 0;
+  t_doubled_known: doubled(.o: 5 as int?) == 10;
+  t_doubled_unk:   doubled(.o: unknown int) == -1;
+
+  /* arm order does not matter */
+  t_orzero_known:  or_zero(.o: 8 as int?) == 8;
+  t_orzero_unk:    or_zero(.o: unknown int) == 0;
+
+  /* optional of a variant, matched by a nested `when` */
+  t_col_red:   col_name(.o: col.Red() as col?) == "red";
+  t_col_blue:  col_name(.o: col.Blue() as col?) == "blue";
+  t_col_none:  col_name(.o: unknown col) == "none";
+
+  /* optional of a record, reading a field off the bound value */
+  t_rec_known: first_or(.o: rec as <{.x: int, .y: int}>?) == 7;
+  t_rec_unk:   first_or(.o: unknown <{.x: int, .y: int}>) == -1;
+};


### PR DESCRIPTION
## What

**Stage 1 of #105**: share the variant destructuring surface with the built-in
optional. A `when` may now match a `T?` as the sum `<| Known(T) | Unknown |>`,
so the `is known ... else ...` idiom becomes an exhaustive match:

```orly
(o) when {
  Known(v): <use v, the unwrapped value>;
  Unknown:  <the absent case>;
}
```

Optional and variant destructuring compose — a `when` over an optional variant
binds the variant in the `Known` arm, which a nested `when` then matches.

## Scope (and what's deliberately left out)

This is the **surface** half of #105. The optional's representation,
auto-unwrap-through-operators, storage, and codegen are **unchanged**.

The deeper **type-level reduction** of `TOpt` to a `TVariant` is out of scope —
the planning pass surfaced that it's blocked by a circularity: variant on-disk
storage is itself defined in terms of `TOpt` (a variant serializes to a
`$which` record whose per-arm payloads are `TOpt<payload>`), so reducing `TOpt`
to a variant would make its own storage recurse through the mechanism that
depends on it. Plus the auto-unwrap semantics (`int? + int? → int?`, composing
through every operator and nesting with `TMutable`/`TSeq`) have no variant
analogue. That stays tracked on #105.

## How (all additive, dispatching on operand type)

- **`orly/expr/obj_member.cc`** — `optional.Known` is the optional's payload
  accessor (yields the wrapped element type; the same unwrap as prefix
  `known`). The `Known(v)` binder is synthesized as `v = operand.Known`,
  reusing the existing variant payload-binder machinery unchanged. `Unknown` is
  payload-less, so any other accessor name on an optional errors.
- **`orly/expr/when.cc`** — `TWhen::GetTypeImpl` accepts a `TOpt` operand,
  requiring exactly the arms `Known` and `Unknown` (exhaustive, no dups); the
  arm-body type join is shared with the variant path.
- **`orly/code_gen/{builder,variant_access}.{cc,h}`** — an optional `when`
  lowers to a new `TOptWhen` inline emitting
  `((op).IsKnown() ? (known) : (unknown))`; the `.Known` accessor lowers to the
  existing `TUnary::Known` (`(op).GetVal()`). No new native runtime — reuses
  `Rt::TOpt`'s `IsKnown()`/`GetVal()`.

## Tests

`tests/lang_tests/general/when_optional.orly` — scalar / variant / record
optionals, arm-order independence, both arms exercised. Non-exhaustive (missing
`Known`/`Unknown`) and unknown-tag cases are rejected with clean diagnostics
(hand-verified; a rejected program can't be a green harness entry).

## Gate

- `python3 tools/lang_test.py -d orly/data tests/lang_tests`: **0 unexpected, 154 passed, 2 tracked xfails** (#74/#75).
- `make test`: passes.

Part of #105 (Stage 1 of 2); leaves the type-level reduction tracked there.
