### PR TITLE
lang_test: normalize compiler source line numbers out of baselines

### DIFF
--- a/tests/lang_tests/general/unsorted/.multiple_sequences.orly.test.state
+++ b/tests/lang_tests/general/unsorted/.multiple_sequences.orly.test.state
@@ -35,7 +35,7 @@
       "210:3-210:4 syntax error, unexpected CloseBrace, expecting end of file",
       "220:1-220:2 syntax error, unexpected CloseBrace, expecting end of file",
       "225:1-225:2 syntax error, unexpected CloseBrace, expecting end of file",
-      "compile failure: compile failure[orly/compiler.cc, 202]; Compiling Orly language"
+      "compile failure: compile failure[orly/compiler.cc]; Compiling Orly language"
     ]
   ]
 ]

--- a/tests/lang_tests/general/unsorted/.sequence_in_effecting.orly.test.state
+++ b/tests/lang_tests/general/unsorted/.sequence_in_effecting.orly.test.state
@@ -7,7 +7,7 @@
     ],
     [
       "Code Gen",
-      "error: Not implemented@[\"orly/code_gen/builder.cc\":259]: Sequences in effecting blocks"
+      "error: Not implemented@[\"orly/code_gen/builder.cc\"]: Sequences in effecting blocks"
     ]
   ]
 ]

--- a/tools/lang_test.py
+++ b/tools/lang_test.py
@@ -19,6 +19,7 @@ import multiprocessing
 import json
 import os
 import os.path
+import re
 import subprocess
 
 # Process object. wraps subprocess.Popen object to augment it with a filename.
@@ -91,10 +92,27 @@ def GetArgParser():
       help='Specify the number of workers for the script. (default: ' + str(default_worker_count) + ')')
   return parser
 
+# Compiler diagnostics embed the THROW site's source location via the HERE
+# macro -- e.g. `@["orly/code_gen/builder.cc":259]` (errors) or
+# `[orly/compiler.cc, 202]` (compile failures). Baselines captured that line
+# number verbatim, so any edit shifting lines in a file named in a diagnostic
+# silently invalidated the checked-in `.state` (it bit #73; #75's baseline had
+# drifted 259 -> 282). Strip just the line number, keeping the filename (which
+# still says which check fired). Test-file positions like `19:4-19:5` have no
+# bracketed path and are left intact.
+_SRC_LOC_QUOTED = re.compile(r'(\["[^"]+"):\d+\]')                       # ["path":NNN] -> ["path"]
+_SRC_LOC_BARE = re.compile(r'(\[[^][,]+\.(?:cc|h|hh|hpp|cpp|cxx)), \d+\]')  # [path.cc, NNN] -> [path.cc]
+
+def NormalizeSourceLocations(text):
+  text = _SRC_LOC_QUOTED.sub(r'\1]', text)
+  text = _SRC_LOC_BARE.sub(r'\1]', text)
+  return text
+
 def GetResult(proc):
   output = proc.stdout.read()
   if isinstance(output, bytes):
     output = output.decode('utf-8', errors='replace')
+  output = NormalizeSourceLocations(output)
   sections = [x.splitlines() for x in output.split('MM_NOTICE: ')]
   return proc.returncode(), sections
 


### PR DESCRIPTION
## What

Fixes the standout fragility in the test harness: lang-test `.state` baselines baked in compiler **source line numbers**, so unrelated refactors silently invalidated them.

Compiler diagnostics embed the throw site via the `HERE` macro:

```
error: Not implemented@["orly/code_gen/builder.cc":259]: Sequences in effecting blocks   (errors)
compile failure[orly/compiler.cc, 202]; Compiling Orly language                          (compile failures)
```

Baselines captured `:259` / `, 202` verbatim. Any edit that shifted lines in a file named in a diagnostic broke the checked-in baseline even though behavior was identical.

This isn't hypothetical:
- It **bit #73** — fixed reactively by regenerating the baseline in #108.
- **#75's baseline had drifted** `259 → 282` and was sitting stale in the repo (masked only because it's an `xfail` "Differs").

## Fix

Root-cause it in `tools/lang_test.py`: `GetResult` now strips just the **line number** from bracketed source-location tokens, keeping the **filename** (which still tells you which check fired). Test-file positions like `19:4-19:5` (no bracketed path) are untouched.

```python
_SRC_LOC_QUOTED = re.compile(r'(\["[^"]+"):\d+\]')                          # ["path":NNN] -> ["path"]
_SRC_LOC_BARE   = re.compile(r'(\[[^][,]+\.(?:cc|h|hh|hpp|cpp|cxx)), \d+\]')  # [path.cc, NNN] -> [path.cc]
```

Regenerated the **only two** baselines that reference a compiler source file (the two xfails). Now an unrelated source edit can't red the suite, and the existing #75 drift is gone.

## Gate

`python3 tools/lang_test.py -d orly/data tests/lang_tests`: **0 unexpected, 155 passed, 2 tracked xfails** (#74/#75), and **no baseline-drift reports** (previously `sequence_in_effecting` reported "Differs: Code Gen"). Harness + baselines only — no engine change.
