### PR TITLE
build: fix make clean/install output path (../out -> ../out_orly)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,12 @@
 # can find both binaries by name -- matches how bootstrap.sh invokes them.
 export PATH := $(CURDIR)/tools:$(PATH)
 
-PREFIX=/usr/local
+PREFIX ?= /usr/local
 BINDIR=$(PREFIX)/bin
 PACKAGE_DIR=$(PREFIX)/packages
 DATA_DIR=$(PREFIX)/data
-RELEASE_OUT=../out/release/
+# jhm emits to ../out_orly/<config>/ (see README / docs/walkthrough.md), not ../out/.
+RELEASE_OUT=../out_orly/release/
 #Apps get installed on 'make install'
 ORLY_APPS=orly/orlyc orly/server/orlyi orly/spa/spa orly/client/orly_client orly/indy/disk/util/orly_dm orly/core_import
 ORLY_DATASET_GEN=beer complete_graph game_of_thrones money_laundering belgian_beer friends_of_friends matrix shakespeare social_graph twitter twitter_ego twitter_live
@@ -37,7 +38,7 @@ test_lang: debug
 	python3 tools/lang_test.py -d orly/data tests/lang_tests
 
 clean:
-	rm -rf ../out/
+	rm -rf ../out_orly/
 	rm -rf ../.jhm
 	rm -f tools/jhm
 	rm -f tools/make_dep_file

--- a/docs/memcached.md
+++ b/docs/memcached.md
@@ -1,6 +1,8 @@
 Memcached on Orly
 =================
 
+> **⚠️ Experimental / incomplete.** This document describes a Memcached-protocol frontend that is not a finished, supported surface. Several sections below are placeholders (`TODO` / `TBD`), and some behaviors are unspecified or not yet implemented. Treat it as a design sketch, not a description of guaranteed current behavior.
+
 In addition to it's own custom protocol, Orly speaks Memcached to be more easily accessible from arbitrary languages/hosts/etc. Memcached is literally available everywhere at this point.
 
 # Overview


### PR DESCRIPTION
## What

Fixes a real `Makefile` bug (the "clearest win" from a build/docs audit) plus two small follow-ons.

### 1. `make clean` / `make install` pointed at the wrong output path

jhm emits to **`../out_orly/<config>/`** (confirmed by CI, `docs/walkthrough.md`, every example script, and the README), but the Makefile used `../out/`:

- **`clean`** ran `rm -rf ../out/` — a directory that never exists — so the real build tree (**~5 GB** locally) was silently left on disk.
- **`install`** copied from `RELEASE_OUT=../out/release/`, which never exists → `make install` was **broken** (nothing to copy).

Both now point at `../out_orly/`. Verified by dry-run:

```
$ make -n install   ->  install -m755 -t /usr/local/bin ../out_orly/release/orly/orlyc ...
$ make -n clean     ->  rm -rf ../out_orly/
```

### 2. `PREFIX ?= /usr/local`

So an environment `PREFIX` is honored. (Command-line `make install PREFIX=~/.local` already overrode the plain `=`; this adds the `export PREFIX=…` case.)

### 3. `docs/memcached.md` — experimental banner

The doc is full of `TODO`/`TBD` placeholders but reads as a description of finished, supported behavior. Added a top banner marking it experimental/incomplete.

## Note on what I did *not* change

The same audit suggested removing `.NOTPARALLEL:` as "redundant." I left it deliberately: with no prerequisites it forces serial execution across the whole makefile, which guards the multi-goal `-j` case (`make -j debug release` would otherwise fire two concurrent `jhm` invocations against the same `../out_orly` tree). It's harmless and has a purpose.

Build/docs only — no engine or test change.
