### PR TITLE
fix: reclaim leaked TLocal objects on TSync teardown (#174)

### DIFF
--- a/orly/spa/flux_capacitor/sync.cc
+++ b/orly/spa/flux_capacitor/sync.cc
@@ -75,7 +75,13 @@ void TSync::TLocal::IncrLockCount(bool is_exclusive) {
 }
 
 void TSync::TLocal::DeleteLocal(void *arg) {
-  delete static_cast<TLocal *>(arg);
+  auto *local = static_cast<TLocal *>(arg);
+  /* Stop tracking before we free, so a concurrent Cleanup() can't also reclaim this one. */
+  {
+    std::lock_guard<std::mutex> lock(local->Sync.LocalsLock);
+    local->Sync.Locals.erase(local);
+  }
+  delete local;
 }
 
 TSync::TLocal *TSync::TLocal::GetLocal(const TSync &sync) {
@@ -88,6 +94,10 @@ TSync::TLocal *TSync::TLocal::GetLocal(const TSync &sync) {
       delete local;
       throw;
     }
+    /* Track the new local so Cleanup() can reclaim it if its thread never runs DeleteLocal
+       (e.g. the thread outlives the target, or the process tears down after pthread_key_delete). */
+    std::lock_guard<std::mutex> lock(sync.LocalsLock);
+    sync.Locals.insert(local);
   }
   return local;
 }
@@ -101,11 +111,15 @@ void TSync::Cleanup() {
     pthread_rwlock_destroy(&RwLock);
   }
   if (KeyInitialized) {
+    /* Delete the key first: pthread_key_delete() does not run the key's destructor, but it does guarantee no further
+       TLocal can be registered against this target while we mow down the survivors below.  Any TLocal still tracked here
+       belongs to a thread that locked the target earlier and has not yet terminated (its DeleteLocal never ran); without
+       this sweep those objects would leak. */
     pthread_key_delete(Key);
-    /* TODO: Deleting the TLS key doesn't invoke the destructor associated with the key.  This means that we'll leak TLocal objects.
-       This isn't a huge deal because the locking threads should have already shut down by the time we're destroying the rw-lock target
-       and the threads will release their TLocal objects when they go.  Nevertheless, we should keep a list of all the TLocal instances
-       and destroy them that remain after they key is destroyed.  Destroying the key first prevents new TLocal instances from cropping
-       up while we're mowing them down. */
+    std::lock_guard<std::mutex> lock(LocalsLock);
+    for (TLocal *local : Locals) {
+      delete local;
+    }
+    Locals.clear();
   }
 }

--- a/orly/spa/flux_capacitor/sync.h
+++ b/orly/spa/flux_capacitor/sync.h
@@ -20,6 +20,8 @@
 
 #include <cassert>
 #include <exception>
+#include <mutex>
+#include <unordered_set>
 #include <pthread.h>
 
 #include <base/class_traits.h>
@@ -130,6 +132,11 @@ namespace Orly {
         /* Each thread has a local instance of this class.  It tracks the kind and number of locks the thread currently holds on this target. */
         class TLocal {
           NO_COPY(TLocal);
+
+          /* TSync owns the lifetime of every TLocal (it tracks them in Locals and reclaims the survivors in Cleanup()),
+             so it needs access to the private destructor. */
+          friend class TSync;
+
           public:
 
           /* When the count reaches zero, the lock is released. */
@@ -183,6 +190,14 @@ namespace Orly {
 
         /* The rw-lock for which threads will contend.  It's mutable so we can lock and unlock a constant target. */
         mutable pthread_rwlock_t RwLock;
+
+        /* Every TLocal currently alive for this target.  pthread_key_delete() does not run the key's destructor, so a
+           TLocal whose owning thread outlives the target (or simply hasn't terminated yet) would leak.  GetLocal() registers
+           each new TLocal here and DeleteLocal() removes it; Cleanup() reclaims whatever remains.  Mutable for the same
+           reason RwLock is: locks are taken through a const target.  Guarded by LocalsLock because TLocals are created and
+           destroyed from many threads concurrently. */
+        mutable std::mutex LocalsLock;
+        mutable std::unordered_set<TLocal *> Locals;
 
       };  // TSync
 

--- a/orly/spa/flux_capacitor/sync.test.cc
+++ b/orly/spa/flux_capacitor/sync.test.cc
@@ -268,3 +268,23 @@ FIXTURE(Typical) {
   TAppender appender;
   TGetter getter;
 }
+
+/* Regression for #174.  A thread that locks a target registers a thread-local TLocal that lives until
+   the thread terminates.  When a target is destroyed while such a thread is still alive, Cleanup() must
+   reclaim those TLocal objects itself: pthread_key_delete() does not run the key's destructor, so before
+   the fix they leaked.  Here the calling (test) thread takes and releases a lock -- registering its
+   TLocal -- and is still very much alive when each local TSync goes out of scope, so the destructor hits
+   exactly that path.  The loop also exercises pthread-key-slot reuse across create/destroy cycles.
+
+   Functionally this just has to not crash (a double-free or use-after-free in the sweep would abort here);
+   its leak-detection teeth come out under valgrind/ASan -- see #177. */
+FIXTURE(ReclaimsLocalOnDestroy) {
+  for (int i = 0; i < 3; ++i) {
+    TSync sync;
+    {
+      TSync::TSharedLock lock(sync);
+    }
+    /* sync is destroyed here while this thread's TLocal is still registered; Cleanup() must reclaim it. */
+  }
+  EXPECT_TRUE(true);
+}


### PR DESCRIPTION
Closes #174.

## Problem

`TSync::Cleanup()` deletes the pthread TLS key with `pthread_key_delete()`, which **does not** run the key's per-thread destructor. Any `TLocal` whose owning thread outlived the target — or simply hadn't terminated yet — was therefore leaked. The existing code even documented this in a TODO and left the proposed "track them and sweep" fix unimplemented:

> Nevertheless, we should keep a list of all the TLocal instances and destroy them that remain after the key is destroyed. Destroying the key first prevents new TLocal instances from cropping up while we're mowing them down.

## Fix

`TSync` now tracks every live `TLocal` in a mutex-guarded `std::unordered_set` (both `mutable`, since locks are taken through a `const TSync &`, same as `RwLock`):

- `GetLocal()` registers each newly created `TLocal`.
- `DeleteLocal()` (the normal per-thread teardown path) removes it.
- `Cleanup()` deletes the TLS key **first** — guaranteeing no new `TLocal` can be registered — then reclaims whatever survivors remain.

`TSync` is granted `friend` access to `TLocal` so `Cleanup()` can invoke its private destructor (all `TLocal` lifetime was already owned by `TSync`).

## Testing

Added a deterministic, single-threaded regression fixture `ReclaimsLocalOnDestroy` that destroys a `TSync` while the calling thread's `TLocal` is still registered — the exact leak path, which the existing static-target test never exercises.

Verified with valgrind:

| | `definitely lost` | `in use at exit` | errors |
|---|---|---|---|
| before fix | 32 bytes / 2 blocks | 64 bytes | 1 |
| after fix | 0 | **0 bytes** | **0** |

`make test`-style run: `passed 2, failed 0`. Its leak-detection teeth fully come out under a sanitizer/valgrind CI job — see #177.