### PR TITLE
indy: remove dead UB stack-deletes after popper TODO throws (partial #172)

### DIFF
--- a/orly/indy/transaction_base.cc
+++ b/orly/indy/transaction_base.cc
@@ -90,7 +90,6 @@ bool TTransaction::Pop(const L0::TManager::TPtr<TRepo> &repo, const std::optiona
               return true;
             } else {
               throw std::runtime_error("TODO: check behavior");
-              delete &popper;
             }
             break;
           }
@@ -101,7 +100,6 @@ bool TTransaction::Pop(const L0::TManager::TPtr<TRepo> &repo, const std::optiona
               return true;
             } else {
               throw std::runtime_error("TODO: check behavior");
-              delete &popper;
             }
             break;
           }
@@ -146,7 +144,6 @@ bool TTransaction::Fail(const L0::TManager::TPtr<TRepo> &repo, const std::option
               return true;
             } else {
               throw std::runtime_error("TODO: check behavior");
-              delete &popper;
             }
             break;
           }
@@ -157,7 +154,6 @@ bool TTransaction::Fail(const L0::TManager::TPtr<TRepo> &repo, const std::option
               return true;
             } else {
               throw std::runtime_error("TODO: check behavior");
-              delete &popper;
             }
             break;
           }


### PR DESCRIPTION
## What

Removes the four dead `delete &popper;` statements in the popper state machine (`orly/indy/transaction_base.cc`). Each sits immediately after `throw std::runtime_error("TODO: check behavior");`, so it is:

- **dead** — unreachable after the throw, and
- **undefined behavior if reached** — `popper` is a reference parameter, so `delete &popper` deletes the address of a reference.

This is the **safe half of #172**. The throws themselves stay: they fire on a popper discard whose sequence number doesn't match, a case whose correct semantics were never decided (hence `"check behavior"`). Deciding and implementing that behavior is the rest of #172 and is intentionally left for a dedicated change — so this does **not** close the issue.

## Gate

`make debug` + `make test` pass, including `orly/indy/transaction_base.test`. (Pure dead-code removal — provably inert.)

Partial #172.
