### PR TITLE
ci: add non-gating ThreadSanitizer job to validate the lock-free claim (#177)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
-          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex ccache
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind ccache
           version: 1.2
 
       - name: Set up ccache
@@ -109,7 +109,7 @@ jobs:
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
-          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex ccache
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind ccache
           version: 1.2
 
       - name: Set up ccache
@@ -175,7 +175,7 @@ jobs:
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
-          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex ccache
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind ccache
           version: 1.2
 
       - name: Set up ccache
@@ -223,7 +223,7 @@ jobs:
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
-          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex ccache
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind ccache
           version: 1.2
 
       - name: Set up ccache
@@ -402,7 +402,7 @@ jobs:
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
-          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex ccache
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind ccache
           version: 1.2
 
       - name: Set up ccache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@
 #   4. examples           -- run each examples/* end-to-end with both
 #                            its Python and Go drivers (orlyc + orlyi + WS)
 #
+# A fifth job, `tsan`, builds the concurrency tests under ThreadSanitizer to
+# validate the lock-free / commutative-merge claim at the memory level (data-
+# race freedom). It is NON-GATING (continue-on-error) and skips pull_request
+# events -- sanitizer builds are slow, and an engine revived from 2014 still
+# surfaces races we have not triaged yet. It runs on push-to-master, the
+# nightly schedule, and manual dispatch. See issue #177.
+#
 # Caching: apt packages and the ccache store are cached across runs. The
 # ~4.5 GB build-output tree is too large to persist in the 10 GB Actions
 # cache, so we cache ccache instead: jhm and orlyc both invoke g++/gcc by
@@ -26,6 +33,7 @@ on:
   schedule:
     # Daily at 05:17 UTC -- off-peak, avoids the top-of-hour scheduler rush.
     - cron: '17 5 * * *'
+  workflow_dispatch:
 
 jobs:
   debug-and-test:
@@ -38,7 +46,7 @@ jobs:
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
-          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind ccache
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex ccache
           version: 1.2
 
       - name: Set up ccache
@@ -101,7 +109,7 @@ jobs:
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
-          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind ccache
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex ccache
           version: 1.2
 
       - name: Set up ccache
@@ -167,7 +175,7 @@ jobs:
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
-          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind ccache
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex ccache
           version: 1.2
 
       - name: Set up ccache
@@ -215,7 +223,7 @@ jobs:
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
-          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind ccache
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex ccache
           version: 1.2
 
       - name: Set up ccache
@@ -376,3 +384,115 @@ jobs:
         run: ./run-go.sh
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         working-directory: examples/recursive-variants
+
+  tsan:
+    name: ThreadSanitizer (non-gating)
+    # Sanitizer builds are slow, so skip pull_request events to keep PR latency
+    # low; runs on push-to-master, the nightly schedule, and manual dispatch.
+    # continue-on-error makes it informational: the engine still surfaces races
+    # we have not triaged, and a known-incomplete surface should inform, not
+    # block. Triage findings and ratchet toward gating. See issue #177.
+    if: github.event_name != 'pull_request'
+    continue-on-error: true
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install system dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        with:
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex ccache
+          version: 1.2
+
+      - name: Set up ccache
+        # Same masquerade as the other jobs: jhm/orlyc invoke g++/gcc by bare
+        # name via execvp, so symlink them ahead of /usr/bin to route compiles
+        # through ccache. TSan objects are large, hence the bigger ceiling.
+        run: |
+          for c in gcc g++ cc c++; do
+            sudo ln -sf "$(command -v ccache)" "/usr/local/bin/$c"
+          done
+          {
+            echo "CCACHE_DIR=$HOME/.ccache"
+            echo "CCACHE_MAXSIZE=3G"
+            echo "CCACHE_COMPRESS=1"
+          } >> "$GITHUB_ENV"
+
+      - name: Cache ccache
+        # Cache on every trigger (including schedule): unlike the stale-cache
+        # canary the other jobs run nightly, this job's value is the race
+        # report, not cache-correctness, and a cold TSan build is expensive.
+        uses: actions/cache@v5
+        with:
+          path: ~/.ccache
+          key: orly-ccache-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
+          restore-keys: |
+            orly-ccache-${{ runner.os }}-${{ github.job }}-
+            orly-ccache-${{ runner.os }}-
+
+      # ThreadSanitizer's shadow memory needs lower ASLR entropy than modern
+      # kernels default to; otherwise libtsan aborts at startup with
+      # "FATAL: ThreadSanitizer: unexpected memory mapping". Lower it for the
+      # job, and additionally run each binary under `setarch -R` (no per-process
+      # randomization) as belt-and-suspenders.
+      - name: Lower ASLR entropy for TSan
+        run: sudo sysctl -w vm.mmap_rnd_bits=28
+
+      - name: Bootstrap jhm
+        run: make bootstrap
+
+      - name: Build & run concurrency tests under TSan
+        run: |
+          set -u
+          # Concurrency-focused targets: the synchronization primitive, the
+          # fiber scheduler and lock pools, the Tetris promotion logic, and the
+          # cross-repo / fold merge tests the lock-free claim rests on.
+          TESTS="
+          base/scheduler.test
+          base/event_semaphore.test
+          base/pump.test
+          base/thread_local_global_pool.test
+          base/thread_local_registered_pool.test
+          orly/indy/fiber/fiber.test
+          orly/indy/fiber/fiber_lock.test
+          orly/indy/fiber/algorithm.test
+          orly/spa/flux_capacitor/sync.test
+          orly/spa/flux_capacitor/tetris_piece.test
+          orly/indy/context_fold.test
+          orly/indy/context_xrepo.test
+          "
+          PATH="$PWD/tools:$PATH" tools/jhm -c tsan $TESTS
+
+          mkdir -p tsan-logs
+          total=0
+          line="----------------------------------------------------------------"
+          fmt='%-48s %s\n'
+          printf "$fmt" "TEST" "TSAN WARNINGS"
+          echo "$line"
+          for t in $TESTS; do
+            bin="../out_orly/tsan/$t"
+            log="tsan-logs/$(echo "$t" | tr / _).log"
+            # Per-test wall-clock guard: a real deadlock under TSan would
+            # otherwise hang the job to its timeout. exitcode=0 so a race does
+            # not itself fail the run -- we count warnings from the logs.
+            timeout 600 setarch "$(uname -m)" -R \
+              env TSAN_OPTIONS="halt_on_error=0 exitcode=0 history_size=4" \
+              "$bin" >"$log" 2>&1 || true
+            n=$(grep -c "WARNING: ThreadSanitizer" "$log" || true)
+            total=$((total + n))
+            printf "$fmt" "$t" "$n"
+          done
+          echo "$line"
+          echo "Total ThreadSanitizer warnings: $total"
+          echo
+          echo "Full reports are uploaded as the 'tsan-logs' artifact. This job"
+          echo "is non-gating; triage findings and ratchet toward gating (#177)."
+
+      - name: Upload TSan reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tsan-logs
+          path: tsan-logs/
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -68,6 +68,23 @@ Exercise the Orlyscript test suite against compiled `.orly` programs:
 python3 tools/lang_test.py -d orly/data tests/lang_tests
 ```
 
+### ThreadSanitizer build
+
+A `tsan` config builds with ThreadSanitizer (`-fsanitize=thread`) to check the
+lock-free / commutative-merge machinery for data races. Build a target and run
+it under TSan:
+
+```sh
+tools/jhm -c tsan orly/indy/context_fold.test          # output: ../out_orly/tsan/...
+setarch "$(uname -m)" -R ../out_orly/tsan/orly/indy/context_fold.test
+```
+
+The `setarch -R` (disable ASLR) is required on modern kernels — without it
+libtsan aborts at startup with *"unexpected memory mapping"*. CI runs a curated
+set of concurrency tests this way in a **non-gating** job (it still surfaces
+untriaged races); see [`.github/workflows/ci.yml`](.github/workflows/ci.yml) and
+[#177](https://github.com/orlyatomics/orly/issues/177).
+
 ## Examples
 
 ### [`examples/bitcoin-time-travel/`](examples/bitcoin-time-travel/) — time travel + multiverse via key-encoded version

--- a/tsan.jhm
+++ b/tsan.jhm
@@ -1,0 +1,44 @@
+{
+  "test": {
+    "build_with_default_targets": true,
+    "excluded": [
+      "third_party",
+      ".git"
+    ]
+  },
+  "cmd": {
+    "+g++": [
+      "-DDEBUG",
+      "-g",
+      "-O1",
+      "-fsanitize=thread",
+      "-fno-omit-frame-pointer"
+    ],
+    "+gcc": [
+      "-DDEBUG",
+      "-g",
+      "-O1",
+      "-fsanitize=thread",
+      "-fno-omit-frame-pointer"
+    ],
+    "flex": {
+      "+g++": [
+        "-g",
+        "-DDEBUG",
+        "-fsanitize=thread"
+      ]
+    },
+    "bison": {
+      "+g++": [
+        "-g",
+        "-DDEBUG",
+        "-fsanitize=thread"
+      ]
+    },
+    "ld": {
+      "+flags": [
+        "-fsanitize=thread"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Closes #177.

The README sells **lock-free, commutative-merge** concurrency, but CI ran **no sanitizers** — and `valgrind` was apt-installed in all four jobs yet never invoked (cargo-cult). ThreadSanitizer is exactly the tool that validates the core claim: memory-level data-race freedom. This adds that, scoped per the issue (functional merge semantics are already unit-tested; the gap was *data-race freedom*).

## What's here

- **`tsan.jhm`** — a `debug`-shaped build config (asserts on, `-g`) that instruments every compile **and** link with `-fsanitize=thread` (gcc included, since third-party C links into the same binaries). Build/run locally:
  ```sh
  tools/jhm -c tsan orly/indy/context_fold.test
  setarch "$(uname -m)" -R ../out_orly/tsan/orly/indy/context_fold.test
  ```
- **`tsan` CI job** — builds a curated set of concurrency tests (synchronization primitive, fiber scheduler + lock pools, Tetris promotion, and the `context_fold` / `context_xrepo` merge tests) under TSan, runs each under `setarch -R` with a per-test timeout, prints a per-test warning count, and uploads full reports as the `tsan-logs` artifact. It is:
  - **non-gating** (`continue-on-error`) — a revived 2014 engine still surfaces untriaged races; findings should inform, not block;
  - **PR-skipping** (`if: github.event_name != 'pull_request'`) — sanitizer builds are slow; runs on push-to-master, the nightly schedule, and `workflow_dispatch`.
- **Dropped `valgrind`** from the four existing apt lists (never invoked).
- **README** — documents the `tsan` config and the non-obvious `setarch -R` / ASLR caveat (`vm.mmap_rnd_bits`).

## ASLR caveat

Modern kernels' ASLR entropy breaks TSan's shadow mapping (`FATAL: ThreadSanitizer: unexpected memory mapping`). The job lowers it (`sudo sysctl -w vm.mmap_rnd_bits=28`) **and** wraps each binary in `setarch -R` as belt-and-suspenders.

## Verification (local)

- Config builds with libtsan linked: `sync.test` (15 `__tsan` symbols) and the heavy `context_fold.test` (377 jobs, ~100 MB binary) both build clean under `-c tsan`.
- The run/summary loop was exercised against both binaries and is robust to a binary aborting mid-run:
  | test | TSan warnings |
  |---|---|
  | `orly/spa/flux_capacitor/sync.test` | 3 |
  | `orly/indy/context_fold.test` | 11 |
- **It already finds real races** in core concurrency code:
  - fiber scheduler — `orly/indy/fiber/fiber.h:1040` `TRunner::ScheduleFrameSlow`
  - vptr ctor/dtor-vs-virtual-call — `orly/indy/disk/util/volume_manager.cc:841` `~TStrategy`
  - `Base::TFd::~TFd` — `base/fd.h:79`

  These are intentionally **left for triage** — this PR adds the detection infrastructure; fixing the findings and ratcheting toward gating is the follow-up the issue describes.

## Recommended follow-ups (out of scope here)
- A multi-threaded stress test (N threads `+= 1` the same key → promote → assert the sum) run under TSan, per the issue.
- Extend the job to example workloads once the unit-test races are triaged.
- ASan/UBSan configs (cheap to add alongside `tsan.jhm`).