### PR TITLE
indy: discard stale popper Pop/Fail instead of throwing "TODO: check behavior" (#172)

### DIFF
--- a/orly/indy/transaction_base.cc
+++ b/orly/indy/transaction_base.cc
@@ -88,9 +88,11 @@ bool TTransaction::Pop(const L0::TManager::TPtr<TRepo> &repo, const std::optiona
             assert (!ensure_or_discard || (!repo->GetSequenceNumberStart() || *(repo->GetSequenceNumberStart()) >= *ensure_or_discard));
             if (!ensure_or_discard || (repo->GetSequenceNumberStart() && *(repo->GetSequenceNumberStart()) == *ensure_or_discard)) {
               return true;
-            } else {
-              throw std::runtime_error("TODO: check behavior");
             }
+            /* ensure_or_discard is set but the repo's sequence start does not match it. The assert
+               above guarantees start >= ensure, so the repo has advanced past the requested point
+               (or has no start yet): this Pop is stale. Discard it -- leave the existing popper as it
+               is and fall through to return false, exactly as the no-mutation discard path above does. */
             break;
           }
           case TPopper::Fail : {
@@ -98,9 +100,9 @@ bool TTransaction::Pop(const L0::TManager::TPtr<TRepo> &repo, const std::optiona
             if (!ensure_or_discard || (repo->GetSequenceNumberStart() && *(repo->GetSequenceNumberStart()) == *ensure_or_discard)) {
               popper.SetState(TPopper::Pop);
               return true;
-            } else {
-              throw std::runtime_error("TODO: check behavior");
             }
+            /* Stale Pop (sequence start past ensure_or_discard): discard it and leave the popper in
+               Fail rather than promoting it to Pop. Fall through to return false. */
             break;
           }
         }
@@ -142,9 +144,9 @@ bool TTransaction::Fail(const L0::TManager::TPtr<TRepo> &repo, const std::option
             if (!follow_or_discard || (*(repo->GetSequenceNumberStart()) == *follow_or_discard)) {
               popper.SetState(TPopper::Fail);
               return true;
-            } else {
-              throw std::runtime_error("TODO: check behavior");
             }
+            /* Stale Fail (sequence start past follow_or_discard): discard it and leave the popper in
+               Peek rather than transitioning to Fail. Fall through to return false. */
             break;
           }
           case TPopper::Pop : {
@@ -152,9 +154,9 @@ bool TTransaction::Fail(const L0::TManager::TPtr<TRepo> &repo, const std::option
             if ((!follow_or_discard || (*(repo->GetSequenceNumberStart()) == *follow_or_discard))) {
               popper.SetState(TPopper::Fail);
               return true;
-            } else {
-              throw std::runtime_error("TODO: check behavior");
             }
+            /* Stale Fail (sequence start past follow_or_discard): discard it and leave the popper in
+               Pop rather than transitioning to Fail. Fall through to return false. */
             break;
           }
           case TPopper::Fail : {

--- a/orly/indy/transaction_base.test.cc
+++ b/orly/indy/transaction_base.test.cc
@@ -436,6 +436,74 @@ FIXTURE(Issue143PromotionWindow) {
   });
 }
 
+/* Issue #172: a Pop/Fail that lands on an already-attached popper with a stale
+   ensure_or_discard -- the repo's sequence start has advanced past the requested
+   point -- must be *discarded* (return false, leave the popper's state untouched),
+   not crash with runtime_error("TODO: check behavior"). We attach a popper in each
+   reachable state (Pop / Fail / Peek) and then issue the mismatching call. The repo
+   holds one committed update (sequence start 1), so passing ensure/follow = 0 never
+   matches and exercises the discard branch with the start-aware assert satisfied
+   (start 1 >= 0). Before the fix each of these threw; here they must return false. */
+FIXTURE(Issue172StaleDiscard) {
+  Fiber::TFiberTestRunner runner([](std::mutex &mut, std::condition_variable &cond, bool &fin, Fiber::TRunner::TRunnerCons &) {
+    TSuprena arena;
+    void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
+    const TScheduler::TPolicy scheduler_policy(10, 10, 10ms);
+    TScheduler scheduler;
+    scheduler.SetPolicy(scheduler_policy);
+    Orly::Indy::Disk::Sim::TMemEngine mem_engine(&scheduler, 256, 64, 128, 1, 64, 1);
+    auto manager = make_unique<TMyManager>(mem_engine.GetEngine(), &scheduler, MemMergeCoreVec, DiskMergeCoreVec);
+    Base::TUuid repo_id(TUuid::Twister);
+    Base::TUuid idx_id(TUuid::Twister);
+    auto repo = manager->GetRepo(repo_id, TTtl::max(), std::nullopt, false, true);
+
+    /* commit one update so the repo has a sequence start of 1 */ {
+      auto transaction = manager->NewTransaction();
+      auto update = TUpdate::NewUpdate(TUpdate::TOpByKey{ { TIndexKey(idx_id, TKey(make_tuple(1L), &arena, state_alloc)), TKey(10L, &arena, state_alloc)} }, TKey(&arena), TKey(Base::TUuid(TUuid::Best), &arena, state_alloc));
+      transaction->Push(repo, update);
+      transaction->Prepare();
+      transaction->CommitAction();
+    }
+
+    const std::optional<TSequenceNumber> stale(0);  // start is 1, so 0 never matches -> discard
+
+    /* Pop reaching an existing Pop-state popper (was: throw at transaction_base.cc Pop/Pop) */ {
+      auto transaction = manager->NewTransaction();
+      EXPECT_TRUE(transaction->Pop(repo));          // attach popper in Pop
+      EXPECT_FALSE(transaction->Pop(repo, stale));   // stale -> discard, must not throw
+    }
+    /* Pop reaching an existing Fail-state popper (was: throw at Pop/Fail) */ {
+      auto transaction = manager->NewTransaction();
+      EXPECT_TRUE(transaction->Fail(repo));         // attach popper in Fail
+      EXPECT_FALSE(transaction->Pop(repo, stale));
+    }
+    /* Fail reaching an existing Peek-state popper (was: throw at Fail/Peek) */ {
+      auto transaction = manager->NewTransaction();
+      transaction->Peek(repo);                      // attach popper in Peek
+      EXPECT_FALSE(transaction->Fail(repo, stale));
+    }
+    /* Fail reaching an existing Pop-state popper (was: throw at Fail/Pop) */ {
+      auto transaction = manager->NewTransaction();
+      EXPECT_TRUE(transaction->Pop(repo));          // attach popper in Pop
+      EXPECT_FALSE(transaction->Fail(repo, stale));
+    }
+
+    /* None of the discarded ops were committed, so the repo is untouched: still
+       Normal, with the original update still present. */
+    EXPECT_EQ(repo->GetStatus(), Normal);
+    {
+      auto view = make_unique<TRepo::TView>(repo);
+      auto walker_ptr = repo->NewPresentWalker(view, TIndexKey(idx_id, TKey(make_tuple(1L), &arena, state_alloc)), TIndexKey(idx_id, TKey(make_tuple(10L), &arena, state_alloc)));
+      auto &walker = *walker_ptr;
+      EXPECT_TRUE(static_cast<bool>(walker));
+    }
+
+    std::lock_guard<std::mutex> lock(mut);
+    fin = true;
+    cond.notify_one();
+  });
+}
+
 FIXTURE(DiskPromoter) {
   Fiber::TFiberTestRunner runner([](std::mutex &mut, std::condition_variable &cond, bool &fin, Fiber::TRunner::TRunnerCons &) {
     TSuprena arena;


### PR DESCRIPTION
Closes #172.

## Problem

In the popper state machine (`orly/indy/transaction_base.cc`), four branches threw `runtime_error("TODO: check behavior")` when a `Pop`/`Fail` reached an **already-attached popper** with an `ensure_or_discard` sequence number that didn't match the repo's sequence start — `Pop`@`Pop`, `Pop`@`Fail`, `Fail`@`Peek`, `Fail`@`Pop`. These are **conditionally reachable**: a transaction that hits a discard with a sequence mismatch crashed with a placeholder instead of defined behavior.

## The decision

The `assert` directly above each branch guarantees `start >= ensure`, so the only way to reach the `else` is a repo that has **advanced past** the requested sequence point (or has no start yet) — i.e. the request is **stale**. The whole point of `ensure_or_discard` is *"apply at exactly this sequence, otherwise discard,"* and the engine already implements discard as **"do nothing, return false"** in two sibling paths:

- the no-mutation `Pop` path (`transaction_base.cc:65-67`)
- `Push` (`transaction_base.cc:50-53`)

So the four branches now do the same: leave the existing popper's state untouched and fall through to `return false`. Since the throw currently crashes, there is **no regression risk** to any passing path.

The dead `delete &popper;` lines (the issue's part 2) were already removed in `fa591ef7` (the "partial #172" commit), so this PR is the behavioral half.

## Testing

Added `Issue172StaleDiscard`, which commits one update (sequence start 1), then attaches a popper in each reachable state and issues a mismatching call with `ensure/follow = 0` (stale: `1 > 0`, assert satisfied):

| popper state | call | branch (was a throw) |
|---|---|---|
| Pop | `Pop(repo, 0)` | Pop@Pop |
| Fail | `Pop(repo, 0)` | Pop@Fail |
| Peek | `Fail(repo, 0)` | Fail@Peek |
| Pop | `Fail(repo, 0)` | Fail@Pop |

Each must return `false` without throwing, and the repo must be untouched afterwards (still `Normal`, update still present).

Built and run locally: `transaction_base.test` → **passed 5, failed 0**. Confirmed the pre-existing pool-diagnostic footprint is unchanged in kind (one extra committed update vs. the prior 4 fixtures; no popper/mutation leak from the discard path).