### PR TITLE
fix: make checkpoint load atomic across DB update and package install (#175)

### DIFF
--- a/orly/package/manager.cc
+++ b/orly/package/manager.cc
@@ -124,6 +124,18 @@ void TManager::Uninstall(const TVersionedNames &packages) {
   std::swap(Installed, installed);
 }
 
+TManager::TInstalledSnapshot TManager::SnapshotInstalled() const {
+  shared_lock<shared_timed_mutex> lock(InstallLock);
+  // Cheap shared_ptr copy; also pins the loaded packages alive for the lifetime of the snapshot.
+  return Installed;
+}
+
+void TManager::RestoreInstalled(TInstalledSnapshot snapshot) {
+  unique_lock<shared_timed_mutex> lock(InstallLock);
+  // No-throw swap; safe to call from a rollback path.
+  std::swap(Installed, snapshot);
+}
+
 void TManager::YieldInstalled(std::function<bool (const TVersionedName &name)> cb) const {
   shared_lock<shared_timed_mutex> lock(InstallLock);
 

--- a/orly/package/manager.h
+++ b/orly/package/manager.h
@@ -77,6 +77,21 @@ namespace Orly {
          the moment. */
       void Uninstall(const TVersionedNames &packages);
 
+      /* An opaque snapshot of the installed package set, taken by SnapshotInstalled() and given back to
+         RestoreInstalled() to exactly undo any intervening Install/Uninstall. Used to compensate (roll back) a
+         package install when a later step in a multi-step operation fails -- see TService::LoadCheckpoint. */
+      typedef TInstalled TInstalledSnapshot;
+
+      /* Capture the current installed package set so it can later be restored exactly. The map holds shared_ptrs,
+         so this is a cheap refcount-bumping copy, and it pins the loaded packages alive until the snapshot is
+         dropped (so a rollback can put back a package that the failed step would otherwise have unloaded). */
+      TInstalledSnapshot SnapshotInstalled() const;
+
+      /* Restore the installed package set to a previously captured snapshot, exactly undoing any Install/Uninstall
+         done since. No-throw swap, so it is safe to call from a rollback/compensation path. This restores upgraded
+         packages back to their prior version (which a plain Uninstall of the newly-installed set could not do). */
+      void RestoreInstalled(TInstalledSnapshot snapshot);
+
       /* Yield each installed package */
       void YieldInstalled(std::function<bool (const TVersionedName &name)> cb) const;
 

--- a/orly/spa/service.cc
+++ b/orly/spa/service.cc
@@ -277,9 +277,28 @@ void TService::LoadCheckpoint(const string &name) {
   Atom::TSuprena arena;
   ReadCheckpoint(name.c_str(), stmts, packages, &arena);
 
-  //TODO: the database changes and package install should be one atomic operation.
-  NewUpdateAndWait(&GlobalPov, pov_obj->GetPrivatePov(), std::move(stmts));
+  // We can't do a true two-phase commit across the Flux DB and the package manager, so we apply the two
+  // checkpoint steps as a saga: do the reversible step first, the irreversible step last, and compensate the
+  // reversible step if the irreversible one fails. That leaves no partial-failure state where the DB holds the
+  // checkpoint's data but its packages aren't installed (or vice versa).
+  //
+  //   1. Install the packages first. Install is atomic w.r.t. the package set (copy-and-swap), so if it throws
+  //      nothing was committed -- the DB is never touched and we just let it propagate. Consistent.
+  //   2. Commit the DB data. If this throws (realistically only the 2s promotion timeout in NewUpdateAndWait),
+  //      roll the install back to the exact pre-install package set so we don't leave the just-installed (or
+  //      just-upgraded) packages behind, then rethrow.
+  //
+  // We use a full snapshot/restore rather than uninstalling `packages`: a plain Uninstall would over-reach,
+  // erasing packages that were already installed before this load (Install no-ops same-version packages) and
+  // failing to put an upgraded package back at its prior version.
+  Package::TManager::TInstalledSnapshot pre_install = PackageManager.SnapshotInstalled();
   PackageManager.Install(packages);
+  try {
+    NewUpdateAndWait(&GlobalPov, pov_obj->GetPrivatePov(), std::move(stmts));
+  } catch (...) {
+    PackageManager.RestoreInstalled(std::move(pre_install));
+    throw;
+  }
 }
 
 void TService::OnPovFail(FluxCapacitor::TPov *pov) {


### PR DESCRIPTION
## What

Fixes #175. `TService::LoadCheckpoint` applied a checkpoint in two non-atomic steps — it committed the checkpoint's DB data first (`NewUpdateAndWait`) and then installed the packages (`PackageManager.Install`). If the install threw (dlopen failure, missing `.so`, downgrade), the database was left holding the checkpoint's data while its packages were never installed — an inconsistent partial-failure state. This is the only DB-update-then-install site in the service.

## Approach

A true two-phase commit across the Flux DB and the package manager is a much larger design change (the "or" alternative in the issue). Instead this applies the two steps as a **saga**: reversible step first, irreversible step last, compensate the reversible step if the irreversible one fails.

1. **Install the packages first.** `TManager::Install` is already atomic w.r.t. the package set (it builds a copy of the installed map, loads every package, then commits with a no-throw `std::swap`). So if loading any package throws, nothing was committed — the DB is never touched and the exception just propagates. Consistent.
2. **Commit the DB data.** Realistically `NewUpdateAndWait` only throws on its 2s promotion timeout (the update is uncontested and per the code's own NOTE "must" promote), so this is a rare safety net. On failure, roll the install back to the exact pre-install package set, then rethrow.

The rollback uses a new `TManager` snapshot/restore pair rather than `Uninstall(packages)`. A plain `Uninstall(packages)` would **over-reach**: `Install` no-ops a package already installed at the same version and upgrades one at a lower version, so uninstalling the requested set would erase packages that existed before this load and would fail to version-restore an upgraded package. The snapshot is a cheap `shared_ptr` copy of the installed map (and pins the loaded packages alive), and restore is a no-throw `std::swap` — the same copy-and-swap the manager already relies on for `Install`/`Uninstall`.

## Changes

- `orly/package/manager.h` / `orly/package/manager.cc`: add `TManager::TInstalledSnapshot`, `SnapshotInstalled()`, and `RestoreInstalled()`.
- `orly/spa/service.cc`: reorder `LoadCheckpoint` to install-then-commit, wrap the DB commit in a try/catch that restores the snapshot and rethrows, and replace the old `//TODO: ... atomic operation.` comment with the ordering + compensation rationale.

## Verification

- `make debug` clean; full `make test` green (all C++ unit tests incl. `orly/spa`).
- `python3 tools/lang_test.py -d orly/data tests/lang_tests`: `0 unexpected, 155 passed, 2 tracked failures (xfail)` (#74, #75) — no regressions.
- **End-to-end failure path (the #175 scenario):** hand-authored a checkpoint with a data statement plus `imports <nonexistent_pkg> #1;` (no such `.so`), ran the `spa` binary against it via `--checkpoint`. `LoadCheckpoint` threw at the install step (`libdl error: nonexistent_pkg.1.so: cannot open shared object file`), the server exited (code 1) without ever serving, and **no output checkpoint was written** — confirming the DB commit was never reached because the install failed first.
- **End-to-end happy path:** authored a checkpoint with a real compiled package (`friends #1`) plus data statements; the server came up (`LoadCheckpoint` succeeded), and the package round-tripped through `SaveCheckpoint` on shutdown.
- The compensation/rollback branch (install succeeds, DB commit then throws) is not reachable from a checkpoint file alone — `NewUpdateAndWait` only throws on its internal 2s timeout, which can't be induced externally. Its correctness rests on the snapshot/restore being the same no-throw copy-and-swap the manager already uses for `Install`/`Uninstall`.
