### PR TITLE
indy: replace bare "TODO: implement" disk stubs with explicit unsupported errors (#173)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -285,6 +285,32 @@ retries/fails — the classic lost-update serialization that field calls avoid.
 - The merge/Tetris core has **quarantined tests** (`*.test.broken.cc` for
   `orly/indy/context`, `orly/server/tetris_manager`, `orly/server/repo_tetris_manager`)
   — issue #178.
-- Several persistence/load paths are unimplemented stubs (issue #173); the
-  transaction popper has an undecided-semantics branch (issue #172); cross-package
-  imports were never re-ported (issue #171).
+- Several persistence/load paths are unimplemented stubs (issue #173 — see the
+  persistence boundary below); cross-package imports were never re-ported (issue #171).
+
+### Persistence boundary (issue #173)
+
+Orly **does** persist and restart — two mechanisms exist:
+
+- **`spa` checkpoints (logical replay).** The single-process app server saves the global
+  state as a set of key→change statements plus installed packages (`SaveCheckpoint`), and on
+  startup replays them into a fresh global POV (`LoadCheckpoint` → `NewUpdateAndWait(&GlobalPov, …)`,
+  `orly/spa/service.cc`), driven by the `--checkpoint` flag (`orly/spa/spa.cc`). This is a
+  working restart-from-disk path (modulo the non-atomic load called out in issue #175).
+- **`orlyi` on a real disk engine.** The indy server runs on `TDiskEngine` (`orly/server/server.cc`)
+  with fsync, an append log, and named instances; memory layers flush to disk and the merge /
+  compaction passes run, so a live repo's reads union its in-memory and on-disk layers.
+
+What issue #173's stubs gate is narrower: the indy **L0 manager's path that turns a saved
+on-disk repo/durable-object image back into a live in-memory object** — used for in-process
+repo reopen / raw-image reload. That path was never ported, and now fails with an explicit
+"not implemented" error (rather than a bare `TODO`) if ever reached:
+
+- **Repo reconstruct** — `ReconstructRepo` → `TManager::ConstructRepo` (`orly/indy/manager.cc`)
+  never resolves a reconstructed repo's parent or TTL.
+- **Durable-object load** — `L0::TManager::Open`'s load-from-disk arm (`orly/indy/manager_base.h`)
+  and the `Delete`/`Save`/`TryLoad` overrides (`orly/indy/manager.h`), gated off because
+  `TObj::OnDisk` is never set and the loader is `#if 0`'d.
+
+So: durability/restart at the **server** layer works via the spa checkpoint; what is missing is
+the indy-layer raw repo/object reload-from-image. Wiring that up is a separate effort.

--- a/orly/indy/disk/data_file.cc
+++ b/orly/indy/disk/data_file.cc
@@ -343,14 +343,15 @@ class TIndexFile
     */
   }
 
-  /* TODO */
+  /* TIndexFile is a write-only sink: it flushes a memory layer to disk and is never read back
+     through this interface, so the TInFile read accessors are unreachable here. Fail clearly if
+     that ever changes -- the indy L0 reload-from-disk path was never ported (see issue #173). */
   virtual size_t GetStartingBlock() const override {
-    throw std::logic_error("TODO: implement TIndexFile::GetStartingBlock");
+    throw std::logic_error("TIndexFile::GetStartingBlock not implemented: TIndexFile is write-only and never read back (the indy L0 reload-from-disk path was never ported, #173).");
   }
 
-  /* TODO */
   virtual void ReadMeta(size_t /*offset*/, size_t &/*out*/) const override {
-    throw std::logic_error("TODO: implement TIndexFile::ReadMeta");
+    throw std::logic_error("TIndexFile::ReadMeta not implemented: TIndexFile is write-only and never read back (the indy L0 reload-from-disk path was never ported, #173).");
   }
 
   /* TODO */

--- a/orly/indy/manager.cc
+++ b/orly/indy/manager.cc
@@ -1188,7 +1188,11 @@ L0::TManager::TRepo *TManager::ConstructRepo(const TUuid &repo_id,
         }
       }
       Indy::TRepo::TParentRepo parent_repo;
-      throw std::runtime_error("TODO : set parent repo");
+      /* This is the repo-reload boundary (ReconstructRepo -> ConstructRepo with a saved image).
+         It is not implemented: the parent repo and ttl below were never resolved, so durable
+         on-disk repo reload does not work (it was never ported, see issue #173). The construction
+         sketch below is kept, unreached, as a starting point for whoever implements reload. */
+      throw std::runtime_error("TManager::ConstructRepo: reconstructing a repo from a saved on-disk image is not implemented (the indy L0 reload-from-disk path was never ported, #173).");
       assert(ttl); /* TODO fill in */
       return saved_repo.IsSafe ?
           static_cast<TRepo *>(new TSafeRepo(this, repo_id, *ttl /* todo fill in with correct val */, parent_repo, saved_repo.LowestSequenceNumber, saved_repo.HighestSequenceNumber, saved_repo.NextUpdate, status)) :

--- a/orly/indy/manager.h
+++ b/orly/indy/manager.h
@@ -500,19 +500,22 @@ namespace Orly {
       /* TODO */
       virtual bool CanLoad(const L0::TId &id) override;
 
-      /* TODO */
+      /* The L0 manager's load/save/delete of durable objects by id. Not wired up: the call sites
+         are gated off (TObj::OnDisk is never set true; the loader is #if 0'd), so these are
+         unreachable today. This is distinct from the server's working persistence (the spa
+         checkpoint replays statements; orlyi runs on a real disk engine) -- it is specifically the
+         in-process reload-from-on-disk-image path that was never ported. Fail clearly rather than
+         with a bare TODO if a path ever reaches them. See issue #173. */
       virtual void Delete(const L0::TId &/*id*/, L0::TSem */*sem*/) override {
-        throw std::logic_error("TODO: TManager::Delete()");
+        throw std::logic_error("TManager::Delete not implemented: durable on-disk object deletion was never ported (#173).");
       }
 
-      /* TODO */
       virtual void Save(const L0::TId &/*id*/, const L0::TDeadline &/*deadline*/, const std::string &/*blob*/, L0::TSem */*sem*/) override {
-        throw std::logic_error("TODO: TManager::Save()");
+        throw std::logic_error("TManager::Save not implemented: durable on-disk object save was never ported (#173).");
       }
 
-      /* TODO */
       virtual bool TryLoad(const L0::TId &/*id*/, std::string &/*blob*/) override {
-        throw std::logic_error("TODO: TManager::TryLoad()");
+        throw std::logic_error("TManager::TryLoad not implemented: durable on-disk object load was never ported (#173).");
       }
 
       /* TODO */

--- a/orly/indy/manager_base.cc
+++ b/orly/indy/manager_base.cc
@@ -438,7 +438,10 @@ void TManager::GetFileGenSet(const Base::TUuid &repo_id, std::vector<Disk::TFile
 void TManager::OnClose(TRepo *repo) {
   assert(repo);
   assert(repo->Manager == this);
-  throw std::logic_error("TODO: implement TManager::OnClose()");
+  /* OnCloseCb is bound to this but never invoked: repos are not closed-to-disk in supported
+     workflows. Fail clearly if a path ever reaches it -- durable on-disk persistence/reload
+     was never ported (see issue #173). */
+  throw std::logic_error("TManager::OnClose not implemented: repo close-to-disk is never wired up (the indy L0 reload-from-disk path was never ported, #173).");
 }
 
 void TManager::EnqueueMergeMem(TRepo *repo) {
@@ -686,7 +689,9 @@ TManager::TPtr<TManager::TRepo> TManager::Open(const TId &id) {
     }
   }
   try {
-    /* Load the object from disk and keep it in the openable set. */
+    /* Reopen the repo from disk. The actual reload boundary is ReconstructRepo ->
+       ConstructRepo, which is not implemented (durable on-disk persistence/reload was never
+       ported, see issue #173); it fails there with a descriptive error if ever reached. */
     TRepo *repo = ReconstructRepo(id);
     std::lock_guard<std::mutex> lock(DurableMutex);
     TObj *&openable_obj = ret.first->second;
@@ -694,7 +699,6 @@ TManager::TPtr<TManager::TRepo> TManager::Open(const TId &id) {
     openable_obj = repo;
     DurableCond.notify_all();
     return TPtr<TManager::TRepo>(repo, Orly::Indy::L0::New);
-    throw std::logic_error("TODO: implement L0::TManager Load from disk");
   } catch (...) {
     /* We could not find the object on disk or the object's constructor failed.
        Either way, we need to dispose of the slot we made before continuing to handle the error. */

--- a/orly/indy/manager_base.h
+++ b/orly/indy/manager_base.h
@@ -1042,7 +1042,9 @@ namespace Orly {
       }
 
       inline void TManager::TRepo::RemoveFromClosedBuffer() {
-        throw std::logic_error("TODO: implement TRepo::RemoveFromClosedBuffer");
+        /* Never called: the on-disk closed-object buffer is not wired up. Fail clearly if a
+           path ever reaches it -- the indy L0 reload-from-disk path was never ported (#173). */
+        throw std::logic_error("TManager::TRepo::RemoveFromClosedBuffer not implemented: the on-disk closed-object buffer is never wired up (the indy L0 reload-from-disk path was never ported, #173).");
       }
 
       inline const std::chrono::steady_clock::time_point &TManager::TRepo::GetTimeOfNextMergeMem() const {
@@ -1249,7 +1251,7 @@ namespace Orly {
           openable_obj = some_obj;
           return TPtr<TSomeObj>(some_obj, Orly::Indy::L0::New);
           #endif
-          throw std::logic_error("TODO: implement L0::TManager Load from disk");
+          throw std::logic_error("TManager::Open: loading a durable object from disk is not implemented (the indy L0 reload-from-disk path was never ported, #173).");
         } catch (...) {
           /* We could not find the object on disk or the object's constructor failed.
              Either way, we need to dispose of the slot we made before continuing to handle the error. */


### PR DESCRIPTION
Closes #173.

Several disk/manager methods were bare `throw std::logic_error("TODO: implement …")` placeholders — latent crashes that also map the boundary of what persistence supports.

## Triage

I checked reachability of every cited site. **None are hit on a supported workflow** — CI (188 unit tests + all examples + lang_tests) is green, which it couldn't be if any were reached. They all sit on the indy **L0 manager's reload-from-on-disk-image path**: turning a saved repo/durable-object image back into a live in-memory object (repos run in memory; the loader arms are `#if 0`'d and `TObj::OnDisk` is never set). That path was never ported from the pre-2019 tree.

**Important scoping** (thanks to a review question): this is *not* "Orly has no persistence." The server layer does persist and restart:
- **`spa`** checkpoints the global state and replays it on startup — `SaveCheckpoint`/`LoadCheckpoint` (`orly/spa/service.cc`), `--checkpoint` flag (`orly/spa/spa.cc`). Logical-replay durability (modulo the non-atomic load in #175).
- **`orlyi`** runs on a real `TDiskEngine` (fsync, append log, named instances).

What's missing is specifically the indy-layer **raw repo/object reload-from-image**.

## Change

Rather than implement that reload (a separate effort), this maps the boundary and makes each stub fail clearly:

| Site | Disposition |
|---|---|
| `data_file.cc` `TIndexFile::GetStartingBlock` / `ReadMeta` | write-only sink, never read back → descriptive error + comment |
| `manager_base.cc` `TManager::OnClose` | never-invoked callback → descriptive error |
| `manager_base.cc:697` | **removed** a dead `throw` after an unconditional `return` (real boundary is `ReconstructRepo`→`ConstructRepo`) |
| `manager_base.h` `RemoveFromClosedBuffer` + generic `Open` load arm | descriptive errors |
| `manager.h` `Delete` / `Save` / `TryLoad` | descriptive errors |
| `manager.cc:1191` `ConstructRepo` reconstruct | descriptive error (kept the unreached construction sketch for whoever implements reload) |

Every message names the method and carries a `#173` breadcrumb so the boundary is greppable. `docs/architecture.md` gains a **Persistence boundary** subsection describing the two working mechanisms and the narrow gap these stubs guard.

## Verification

- No bare `TODO: implement` throws remain at the cited sites.
- Compiles and links clean (the changed headers force a wide recompile).
- No behavior change on any supported path: `transaction_base.test` → **passed 4, failed 0**.

## Follow-up (out of scope)
Actually implementing indy repo/durable-object reload-from-disk-image (so `orlyi` can reconstitute repos on restart) is a separate effort — worth its own issue if that capability is wanted.