### PR TITLE
docs: catch CHANGELOG up with the 2026-06-22 merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The project does not currently cut numbered releases. Entries reference the orig
 ## [Unreleased]
 
 ### Added
+- **Architecture doc for the concurrency model** (`docs/architecture.md`). POV / Flux Capacitor / Tetris / merge-semantics overview that previously lived only in headers and this changelog. (#180, closes #179, 2026-06-22)
+- **Non-gating ThreadSanitizer CI job.** Validates the lock-free claim — data-race freedom is the one property the existing suite (unit + integration) didn't cover. Non-gating so the known pre-existing flakes don't red the build while the TSan signal accumulates. (#183, closes #177, 2026-06-22)
 - **`when` over optionals.** A `T?` may be matched as the built-in sum `<| Known(T) | Unknown |>` — payload binder `Known(v)`, exhaustive `Known`/`Unknown` — so the `is known … else …` idiom becomes an exhaustive match. Plus a conformance spec pinning where an optional and the equivalent variant agree (`when`, `is`) and intentionally diverge (`==`, via auto-unwrap). Surface unification only; the type-level reduction of `TOpt` to a variant was evaluated and declined. (#167, #168, #105, 2026-06-22)
 - **Recursive-return type verification** (#128 Option B). The type checker now verifies a recursive call's result in propagating positions — e.g. `g(x) + 1` where `g` returns `str`, or a recursive value fed to a constructor/argument of the wrong type — via a per-function `TypeCheck`-time fixpoint that also covers mutual recursion. (#165, #166, closes #128, 2026-06-22)
 - **Variant widening with `as`** (#104). Widen a variant to a superset variant: direct, optional target, recursive (through a synthesized fold), optional / list / set / dict / nested-container payloads, mutually-recursive groups, and implicit widening at parameter binding and `if`/`when` branch joins. (#155–#164, closes #104, 2026-06-20 → 2026-06-22)
@@ -24,6 +26,9 @@ The project does not currently cut numbered releases. Entries reference the orig
 - **`compile_commands.json`** auto-emitted on every `make debug` for clangd / clang-tidy / IWYU. (#45, 2026-06-01)
 
 ### Fixed
+- **Atomic checkpoint load.** `TService::LoadCheckpoint` committed the checkpoint's DB data and then installed its packages as two separate steps; if the install threw (missing / bad `.so`, downgrade) the database was left holding data whose packages were never installed. It now installs packages first (already atomic) and commits the DB last, rolling the install back to the exact prior package set if the commit fails — so a partial failure can't leave data and packages out of sync. (#186, closes #175, 2026-06-22)
+- **Transaction popper no longer crashes on a stale discard.** A `Pop`/`Fail` reaching a repo that has an attached popper and a non-matching `ensure_or_discard` sequence number threw `runtime_error("TODO: check behavior")` in four conditionally-reachable branches. Such a request is simply stale (the repo advanced past the requested point), so those branches now discard — leave the popper's state untouched and return `false`, matching the other `ensure_or_discard` paths. Also removed four dead `delete &popper;` lines after the throws (UB if ever reached: `popper` is a reference). (#182, #185, closes #172, 2026-06-22)
+- **TLocal leak on `TSync` teardown.** `pthread_key_delete()` doesn't run the TLS key's destructor, so any `TLocal` whose owning thread outlived the target leaked. `TSync` now tracks every live `TLocal` and reclaims the survivors at cleanup (after deleting the key, so none can be registered mid-sweep). Verified clean under valgrind. (#181, closes #174, 2026-06-22)
 - **Lost-update / create-race hardening** (the #143 arc). Closed several windows where commutative writes could be lost or miscounted under contention: an engine create-race on commutative upsert of an absent key, a compaction fold undercount, a Tetris promotion-window guard, a cross-repo snapshot guard, and an agent-swarm read-back barrier; commutative upsert (`+=` / `|=`) of bare ops in the demos. (#145–#153, closes #143/#151, 2026-06-16 → 2026-06-20)
 - **Scheduler teardown race.** (#154, closes #147, 2026-06-20)
 - **Variant arm-name macro collision** — an arm named like a C++ macro (e.g. a single capital letter) no longer breaks generated code. (#122, closes #119, 2026-06-14)
@@ -34,6 +39,8 @@ The project does not currently cut numbered releases. Entries reference the orig
 - **Skip the `TFoldDataFile` pass when the source has no non-Assign entries.** Perf win for Assign-heavy workloads where the fold pass has nothing to do. (closes #64, #67, 2026-06-03)
 
 ### Changed
+- **Build output path.** `make clean` and the install target now point at `../out_orly/` (the real build directory) instead of the vestigial `../out/`. (#176, 2026-06-22)
+- **lang-test baselines normalize compiler source line numbers**, so an unrelated line shift in `orly/compiler.cc` no longer drifts every checked-in `.state` baseline. (#170, 2026-06-22)
 - **#128 Option A — `TAny` deferral at constructor / argument sites.** A recursive call's (as-yet-unresolved) result may flow through a variant-constructor payload or a function argument, the substrate for recursive transforms and variant widening; strictly verified later by Option B (above). (#129, 2026-06-15)
 - **`base::TOpt` → `std::optional`** across the codebase. (#111, 2026-06-09)
 - **Readable JSON lang-test baselines** so a changed baseline shows up in review (#112); CI ccache and an incremental-build mtime fix (#113, #114). (2026-06-09)


### PR DESCRIPTION
## What

Catches `CHANGELOG.md` `[Unreleased]` up with the eight PRs merged on 2026-06-22 that landed without changelog entries — the same drift the June arc accumulated and that #169 last reconciled.

### Added
- Architecture/concurrency doc `docs/architecture.md` (#180, closes #179)
- Non-gating ThreadSanitizer CI job (#183, closes #177)

### Fixed
- Atomic checkpoint load — `LoadCheckpoint` installs packages first then commits the DB, with rollback on failure (#186, closes #175)
- Transaction popper stale-discard semantics + removal of the dead `delete &popper;` UB lines (#182, #185, closes #172)
- `TLocal` leak on `TSync` teardown (#181, closes #174)

### Changed
- Build output path `../out` → `../out_orly` (#176)
- lang-test baselines normalize compiler source line numbers (#170)

## Notes
- Entries follow the existing style (bold lead, one-line description, `(#PR, closes #issue, date)`).
- `README.md` already reflects the architecture doc and the ThreadSanitizer job — those were updated in #180 / #183 — so no README change is included here.
- Docs only; no code changes.
