### PR TITLE
test: make the test runner's pass/fail flag atomic (#184 finding 5)

### DIFF
--- a/base/test/runner.cc
+++ b/base/test/runner.cc
@@ -44,18 +44,20 @@ TRunner::TRunner(TApp *app, const TFixture *fixture)
 TRunner::~TRunner() {
   assert(Runner == this);
   PreDtor();
-  TApp::TLogger(!Pass)
+  const bool pass = Pass.load(std::memory_order_relaxed);
+  TApp::TLogger(!pass)
       << "end " << Fixture->GetName()
-      << "; " << (Pass ? "pass" : "fail");
+      << "; " << (pass ? "pass" : "fail");
   Runner = 0;
 }
 
 TRunner::operator bool() const {
-  return Pass;
+  return Pass.load(std::memory_order_relaxed);
 }
 
 void TRunner::Run() {
-  Pass = true;
+  /* Single-threaded: this runs before the fixture spawns any worker threads. */
+  Pass.store(true, std::memory_order_relaxed);
   try {
     (*Fixture->GetFunc())();
   } catch (const exception &ex) {
@@ -71,7 +73,13 @@ void TRunner::Run() {
 
 void TRunner::OnExpectDtor(const TExpect *expect) {
   assert(expect);
-  Pass = Pass && *expect;
+  /* Fold this expectation's result in. The flag only ever moves true -> false,
+     so a failed expectation stores false and a passing one leaves it alone --
+     an idempotent, order-independent update that is safe to run concurrently
+     from the worker threads of a multi-threaded fixture (issue #184). */
+  if (!bool(*expect)) {
+    Pass.store(false, std::memory_order_relaxed);
+  }
 }
 
 TRunner *TRunner::Runner = 0;

--- a/base/test/runner.h
+++ b/base/test/runner.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include <base/assert_true.h>
 #include <base/class_traits.h>
 #include <base/test/app.h>
@@ -77,8 +79,14 @@ namespace Test {
     /* TODO */
     const TFixture *Fixture;
 
-    /* TODO */
-    bool Pass;
+    /* The fixture's running pass/fail state. A multi-threaded fixture fires
+       `EXPECT_*` from worker threads, so every `TExpect` destructor folds its
+       result into this flag (see OnExpectDtor) from whatever thread it runs
+       on. The flag only ever moves true -> false, but the concurrent
+       read-modify-writes are still a data race on a plain bool (flagged by
+       ThreadSanitizer, issue #184). Making it atomic turns the fold into an
+       idempotent relaxed store and de-noises every multi-threaded test. */
+    std::atomic<bool> Pass;
 
     /* TODO */
     static TRunner *Runner;


### PR DESCRIPTION
## What

Fixes finding 5 of the ThreadSanitizer triage (#184): the unit-test harness itself has a data race that pollutes every multi-threaded test under TSan.

A multi-threaded fixture fires `EXPECT_*` from worker threads. Each `TExpect` destructor folds its result into the shared `TRunner` singleton's `Pass` flag via `OnExpectDtor` (`Pass = Pass && *expect`, `base/test/runner.cc:74`) — a read-modify-write on a plain `bool` from multiple threads with no synchronization. TSan reports it as a data race (two writes + a read on the same stack address) in the harness, not the engine.

## Fix

`Pass` becomes `std::atomic<bool>`. The flag only ever moves `true → false`, so the fold is now an idempotent, order-independent relaxed store (`if (!*expect) Pass.store(false)`); reads use a relaxed load. No lock, no behavior change — `Run()` still sets it `true` before the fixture spawns threads, and the final read happens after the threads join.

## Verification

Reproduced on `orly/spa/flux_capacitor/sync.test` under the `tsan` config (`setarch -R … TSAN_OPTIONS=halt_on_error=0`):

- **Before:** 2 `data race` warnings, both on the `TRunner::Pass` address via `OnExpectDtor` ← `EXPECT_*` in `TAppender::Go` / `TGetter::Go` on different threads.
- **After:** 0 harness data races (`OnExpectDtor` no longer appears in any report). The one remaining warning is the unrelated `TSync` lock-order-inversion (finding 6), left for its own triage.
- Test still passes (`passed 2, failed 0`).

`base/test/runner.{h,cc}` is included by every unit-test binary, so the change was gated on a full `make debug && make test` (green) — not just the TSan target.

## Scope

This is finding 5 only — the test-harness race, which the issue calls out as worth fixing on its own because it de-noises every multi-threaded test. The remaining #184 findings (fiber-scheduler annotations, the `TFd` / `TVolume::TStrategy` teardown races, and confirming/suppressing the recursive-lock LOI) are separate follow-ups.

Part of #184.
