### PR TITLE
fix: stop/join TVolume strategy workers before teardown (#184 findings 2-4)

### DIFF
--- a/orly/indy/disk/util/volume_manager.cc
+++ b/orly/indy/disk/util/volume_manager.cc
@@ -908,7 +908,10 @@ namespace Orly {
                 NumBlocks(((volume->GetDesc().NumLogicalExtent / volume->GetDesc().ReplicationFactor) * volume->GetDesc().DeviceDesc.Capacity) / PhysicalBlockSize),
                 NumBlocksPerExtent(NumBlocks / Volume->GetDesc().NumLogicalExtent),
                 BlockMapByteSize(ceil(static_cast<double>(NumBlocks) / 8)),
-                BlockMapBufByteSize(ceil(static_cast<double>(NumBlocks) / (getpagesize() * 64)) * getpagesize()) {
+                BlockMapBufByteSize(ceil(static_cast<double>(NumBlocks) / (getpagesize() * 64)) * getpagesize()),
+                DiscardRunnerScheduled(false),
+                DiscardShuttingDown(false),
+                DiscardRunnerExited(false) {
             assert(NumBlocks % Volume->GetDesc().NumLogicalExtent == 0UL);
             std::lock_guard<std::mutex> lock(BlockMapLock);
             BlockMapBuf = Base::MemAlignedAllocZeroInitialized<size_t>(getpagesize(), BlockMapByteSize);
@@ -918,7 +921,15 @@ namespace Orly {
           }
 
           void PostCtor() {
-            Scheduler->Schedule(bind(&TVolume::TStrategy::DiscardRunner, this));
+            const bool scheduled = Scheduler->Schedule(bind(&TVolume::TStrategy::DiscardRunner, this));
+            std::lock_guard<std::mutex> lock(DiscardMapLock);
+            DiscardRunnerScheduled = scheduled;
+            if (!scheduled) {
+              /* The scheduler refused the job (e.g. already shutting down), so
+                 no runner will ever execute. Mark it exited so a later
+                 StopDiscardRunner() doesn't wait forever. */
+              DiscardRunnerExited = true;
+            }
           }
 
           /* TODO */
@@ -1006,6 +1017,13 @@ namespace Orly {
           /* TODO */
           void DiscardRunner();
 
+          /* Signal the background DiscardRunner job to exit and block until it
+             has actually left its loop. Idempotent. Must be called by the
+             most-derived strategy dtor (before that dtor's members / the
+             vtable / DiscardEpollFd are destroyed) so the runner never races
+             the teardown. */
+          void StopDiscardRunner();
+
           Base::TScheduler *Scheduler;
 
           /* TODO */
@@ -1027,6 +1045,22 @@ namespace Orly {
           epoll_event DiscardEvent;
           bool DiscardRan;
           std::condition_variable DiscardCond;
+
+          /* Teardown coordination for the background DiscardRunner job.
+             DiscardRunner is a fire-and-forget scheduler job (Schedule()
+             returns no join handle and the scheduler outlives any single
+             volume), so we cannot rely on scheduler shutdown to stop it at
+             volume-teardown time. Instead the most-derived strategy dtor
+             calls StopDiscardRunner(), which signals DiscardShuttingDown,
+             wakes the runner via DiscardSem, and blocks until the runner
+             confirms it has left its loop (DiscardRunnerExited). This is the
+             join-equivalent that must complete before any state the runner
+             touches -- the vtable, the block/discard maps, DiscardEpollFd --
+             is torn down. Guarded by DiscardMapLock. */
+          bool DiscardRunnerScheduled;
+          bool DiscardShuttingDown;
+          bool DiscardRunnerExited;
+          std::condition_variable DiscardRunnerDoneCond;
 
           /* TODO */
           const size_t SuperBytes;
@@ -1548,8 +1582,11 @@ class TVolume::TStripedStrategy
     PostCtor();
   }
 
-  /* TODO */
-  virtual ~TStripedStrategy() {}
+  /* Stop and join the background DiscardRunner before any derived state, the
+     vtable, or the base's maps/fds are torn down. */
+  virtual ~TStripedStrategy() {
+    StopDiscardRunner();
+  }
 
   /* TODO */
   virtual void DelegateWrite(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
@@ -1613,8 +1650,11 @@ class TVolume::TChainedStrategy
     PostCtor();
   }
 
-  /* TODO */
-  virtual ~TChainedStrategy() {}
+  /* Stop and join the background DiscardRunner before any derived state, the
+     vtable, or the base's maps/fds are torn down. */
+  virtual ~TChainedStrategy() {
+    StopDiscardRunner();
+  }
 
   /* TODO */
   virtual void DelegateWrite(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
@@ -1790,11 +1830,20 @@ void TVolume::TStrategy::DiscardRunner() {
   IfLt0(epoll_ctl(DiscardEpollFd, EPOLL_CTL_ADD, DiscardSem.GetFd(), &DiscardEvent));
   epoll_event event;
   int timeout = 30000;
+  /* Mark the runner as having left its loop and wake any teardown thread
+     waiting in StopDiscardRunner(). Must be done before returning/throwing so
+     the dtor can proceed to destroy the maps / fds this runner touches. */
+  auto signal_exit = [this]() {
+    std::lock_guard<std::mutex> lock(DiscardMapLock);
+    DiscardRunnerExited = true;
+    DiscardRunnerDoneCond.notify_all();
+  };
   for (;;) {
     for (;;) {
       int ret = epoll_wait(DiscardEpollFd, &event, 1, timeout);
       if (ret < 0 && errno == EINTR) {
         if (Base::IsShuttingDown()) {
+          signal_exit();
           throw TScheduler::TJobExit("Discard() runner shutting down.");
         } else {
           continue;
@@ -1808,6 +1857,18 @@ void TVolume::TStrategy::DiscardRunner() {
         break;
       }
     }
+    /* A teardown may have woken us via StopDiscardRunner(). Bail out cleanly
+       before touching any virtual methods (DoDiscard /
+       GetBlockMapBytesPerDiscardRange), the block/discard maps, or any other
+       state the most-derived dtor is about to destroy. */
+    /* acquire shutdown check lock */ {
+      std::lock_guard<std::mutex> lock(DiscardMapLock);
+      if (DiscardShuttingDown) {
+        DiscardRunnerExited = true;
+        DiscardRunnerDoneCond.notify_all();
+        return;
+      }
+    }  // release shutdown check lock
     assert(blocks_from_vec.size() == 0);
     /* acquire Discard lock */ {
       std::lock_guard<std::mutex> lock(DiscardMapLock);
@@ -1854,6 +1915,32 @@ void TVolume::TStrategy::DiscardRunner() {
       DiscardRan = true;
     }  // release DiscardRan lock
     DiscardCond.notify_one();
+  }
+}
+
+void TVolume::TStrategy::StopDiscardRunner() {
+  std::unique_lock<std::mutex> lock(DiscardMapLock);
+  if (DiscardShuttingDown) {
+    /* Already stopping/stopped (idempotent); still wait for the runner to
+       confirm exit so we never return while it is mid-loop. */
+    while (!DiscardRunnerExited) {
+      DiscardRunnerDoneCond.wait(lock);
+    }
+    return;
+  }
+  DiscardShuttingDown = true;
+  if (!DiscardRunnerScheduled) {
+    /* No runner was ever scheduled (PostCtor's Schedule() was refused), so
+       there is nothing to join. */
+    assert(DiscardRunnerExited);
+    return;
+  }
+  /* Wake the runner so it observes DiscardShuttingDown and exits, then block
+     until it has actually left its loop. This is the join-equivalent for a
+     job that the scheduler gives us no handle to. */
+  DiscardSem.Push();
+  while (!DiscardRunnerExited) {
+    DiscardRunnerDoneCond.wait(lock);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes the ThreadSanitizer-confirmed teardown data race in `Orly::Indy::Disk::Util::TVolume`'s strategy reported in issue #184 (findings 2, 3, and 4 — one root cause).

`TVolume`'s strategy (`TStripedStrategy` / `TChainedStrategy`) schedules a background `DiscardRunner` job on the shared `Base::TScheduler` from `PostCtor()`. That job is an infinite loop that only exits on a *global* forced scheduler shutdown (`Base::IsShuttingDown()` + an `EINTR`). The scheduler, however, outlives any individual volume, so at volume teardown the runner is still executing while:

- `~TStrategy` frees the block/discard maps and lets `DiscardEpollFd` (a `TFd`) close, and
- the most-derived strategy dtor flips the vtable.

A concurrent `DoDiscard()` / `GetBlockMapBytesPerDiscardRange()` virtual dispatch in the runner then races the destruction. TSan reports this as a vptr race (x2) in `TStrategy::~TStrategy` (ctor/dtor vs virtual call), a `close()` race (x4), and an `operator delete` race (x4), and the vptr race crashes the test.

## The fix

`Base::TScheduler::Schedule()` hands out no per-job join handle, and the scheduler is shared/long-lived, so we can't rely on scheduler shutdown to stop a single volume's runner. Instead this adds a per-strategy shutdown handshake:

- a `DiscardShuttingDown` flag the runner checks immediately after each wake — *before* any virtual call, map access, or fd access;
- `DiscardSem` (the existing event semaphore the runner already waits on) to wake it;
- a `DiscardRunnerExited` flag + `DiscardRunnerDoneCond` the destroyer blocks on (the join-equivalent).

`StopDiscardRunner()` is called as the **first action of the most-derived strategy dtor** (`~TStripedStrategy`, `~TChainedStrategy`), so the runner is fully joined before the vtable, the block/discard maps, or `DiscardEpollFd` are torn down. `PostCtor()` records whether the job was actually accepted by the scheduler, so a refused schedule never makes `StopDiscardRunner()` wait forever. The handshake is idempotent and all flags are guarded by the existing `DiscardMapLock`; no new lock-ordering edge is introduced.

## Verification

Built under the `tsan` jhm config and run with `setarch -R` + `TSAN_OPTIONS="halt_on_error=0 exitcode=0 history_size=4"`:

| test | before | after |
| --- | --- | --- |
| `orly/indy/context_fold.test` | 11 warnings (9 data races + 2 vptr), aborts | 1 warning, no strategy race |
| `orly/indy/context_xrepo.test` | 11 warnings (9 data races + 2 vptr), aborts | 1 warning, no strategy race |

All ten `~TStrategy` vptr / `close` / `operator delete` races are gone. The single remaining warning in each is the pre-existing fiber-scheduler `ScheduleFrameSlow` race (finding 1 in the issue — unrelated to this change and out of scope here). That fiber race also accounts for the residual `longjmp causes uninitialized stack frame` abort, which is present in the baseline too (the strategy-dtor-induced crash is gone).

Build gates:

- `make debug` — clean.
- `make test` — green (exit 0).
