### PR TITLE
test: failing two-package import lang test — Stage 0 of #171

### DIFF
--- a/tests/lang_tests/.xfail
+++ b/tests/lang_tests/.xfail
@@ -13,3 +13,8 @@
 
 general/unsorted/multiple_sequences.orly #74
 general/unsorted/sequence_in_effecting.orly #75
+
+# Stage 0 of cross-package imports: a two-package import (main.orly imports a
+# symbol from imports/lib) currently fails at synth (import not implemented).
+# This is the end-to-end target the staged implementation will turn green.
+general/imports/main.orly #171

--- a/tests/lang_tests/general/imports/.lib.orly.test.state
+++ b/tests/lang_tests/general/imports/.lib.orly.test.state
@@ -1,0 +1,21 @@
+[
+  0,
+  [
+    [],
+    [
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++"
+    ],
+    [
+      "Running tests"
+    ],
+    [
+      "Tests done"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/imports/.main.orly.test.state
+++ b/tests/lang_tests/general/imports/.main.orly.test.state
@@ -1,0 +1,10 @@
+[
+  1,
+  [
+    [],
+    [
+      "Synth + Symbols",
+      "26:1-26:55 [orly/synth/def_factory.cc]This feature is not yet implemented"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/imports/lib.orly
+++ b/tests/lang_tests/general/imports/lib.orly
@@ -1,0 +1,23 @@
+/* <orly/lang_tests/general/imports/lib.orly>
+
+   Stage 0 (issue #171): the exporting half of a two-package cross-import test.
+   A normal, standalone-compilable package that defines one top-level symbol the
+   companion `main.orly` imports. This file compiles cleanly today.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package #1;
+
+get_answer = (42);

--- a/tests/lang_tests/general/imports/main.orly
+++ b/tests/lang_tests/general/imports/main.orly
@@ -1,0 +1,30 @@
+/* <orly/lang_tests/general/imports/main.orly>
+
+   Stage 0 (issue #171): the importing half of a two-package cross-import test.
+   It imports `get_answer` from the `imports/lib` package as a local `int` named
+   `answer` and asserts the value. Cross-package imports are not implemented yet
+   (synth throws TNotImplementedError on the import def), so this is an EXPECTED
+   FAILURE tracked in .xfail until the staged implementation lands. It is the
+   end-to-end target that Stages 1-4 will turn green.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+package #1;
+
+answer is int get_answer from package <imports/lib>#1;
+
+test {
+  t1: answer == 42;
+};


### PR DESCRIPTION
**Stage 0** of the cross-package imports plan (#171, design in #192). Adds the end-to-end target test, tracked as an `xfail` until the feature lands — no source changes.

## What's here

Two packages under `tests/lang_tests/general/` (already an `__orly__` package-tree root):

- **`imports/lib.orly`** — exporter: `package #1; get_answer = (42);`. Compiles + passes standalone today.
- **`imports/main.orly`** — importer: `answer is int get_answer from package <imports/lib>#1;` then `test { t1: answer == 42; };`.

Compiling `main.orly` fails today at synthesis with the import-not-implemented throw (`orly/synth/def_factory.cc:83`, `"This feature is not yet implemented"`). That's captured in its `.state` baseline and marked `xfail (#171)` so the suite stays green while documenting the gap.

This is the target Stages 1–4 will turn green. When it passes, the harness reports it as an **xpass** (xfail_strict semantics), which forces removal of the `.xfail` entry — so the test can't silently rot.

## Verification

Full `lang_test` suite (as CI runs it):

```
Overall: 0 unexpected, 156 passed, 3 tracked failures (xfail)
  xfail: tests/lang_tests/general/imports/main.orly (#171)
harness_rc=0
```

- `lib.orly` → **Pass**
- `main.orly` → **tracked xfail**, failing with exactly the `def_factory` `TNotImplementedError` (not a parse error — the import statement parses and reaches the synth handler).
- No existing test affected (only two new files + one `.xfail` line).