### PR TITLE
tsan: suppress provably-benign TSync lock-order report (#184 finding 6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,7 +477,7 @@ jobs:
             # otherwise hang the job to its timeout. exitcode=0 so a race does
             # not itself fail the run -- we count warnings from the logs.
             timeout 600 setarch "$(uname -m)" -R \
-              env TSAN_OPTIONS="halt_on_error=0 exitcode=0 history_size=4" \
+              env TSAN_OPTIONS="halt_on_error=0 exitcode=0 history_size=4 suppressions=$PWD/orly/tsan.supp" \
               "$bin" >"$log" 2>&1 || true
             n=$(grep -c "WARNING: ThreadSanitizer" "$log" || true)
             total=$((total + n))

--- a/orly/tsan.supp
+++ b/orly/tsan.supp
@@ -1,0 +1,51 @@
+# ThreadSanitizer suppressions for the Orly TSan CI job (#177).
+#
+# Format: one rule per line, "<type>:<match>".  "deadlock:" suppresses
+# lock-order-inversion (potential deadlock) reports whose stack contains the
+# named frame.  Keep this file minimal: every entry must be justified below as
+# a proven false positive, never used to paper over a real race or deadlock.
+
+# ---------------------------------------------------------------------------
+# orly/spa/flux_capacitor/sync.test -- lock-order-inversion in the TEST HARNESS
+# ---------------------------------------------------------------------------
+# WARNING: ThreadSanitizer: lock-order-inversion (potential deadlock)
+#   Cycle in lock order graph: M0 => M1 => M0
+#   ... pthread_rwlock_wrlock
+#       Orly::Spa::FluxCapacitor::TSync::TLocal::IncrLockCount (sync.cc:69)
+#
+# This is NOT a defect in the TSync primitive, and it is NOT related to the
+# LocalsLock/Locals tracking added by the #174 leak fix.  The two mutexes in
+# the cycle are:
+#   M0 = the test harness's own `static std::mutex Mutex` (sync.test.cc:33)
+#   M1 = the `RwLock` (pthread_rwlock_t) inside the single shared `VecSync`
+#        target (sync.test.cc:31), locked via TSync::TLocal::IncrLockCount.
+# (Confirmed: the reported runtime addresses match the relative layout of the
+#  `Mutex` and `VecSync` statics, ~112 bytes apart; IncrLockCount is merely
+#  where pthread_rwlock_wrlock is *called* -- the other end of the cycle is the
+#  harness Mutex, nothing in sync.cc.)  The Locals/LocalsLock mutex is never
+#  held while RwLock is acquired (GetLocal releases LocalsLock before the lock
+#  ctor calls IncrLockCount; recursive locks return the existing TLocal without
+#  touching LocalsLock), so #174 plays no part in this report.
+#
+# The TSAppender/TGetter threads in the `Typical` fixture walk a hand-rolled
+# lock-step protocol (Step1..Step6 + condition variables).  That protocol
+# forces the harness Mutex and the TSync RwLock to nest in BOTH orders across
+# the test's phases:
+#   * Mutex -> RwLock   (e.g. hold Mutex, then take an exclusive/shared lock)
+#   * RwLock -> Mutex   (hold a shared lock across a Cond.wait that reacquires
+#                        Mutex -- the deliberate "two threads hold shared locks
+#                        simultaneously" check).
+# TSan's lock-order graph is purely topological: it records both edges and
+# reports the M0=>M1=>M0 cycle without modelling the Step* handshake that
+# serialises the two threads so the opposing orders never execute concurrently
+# in different threads.  No real deadlock is reachable.
+#
+# This interleaving is irreducible: flattening it was attempted and provably
+# DEADLOCKS the test.  The getter must hold Mutex and wait for Step4 *before*
+# taking its shared lock (taking it earlier blocks the appender's exclusive
+# push that gates Step4), yet it must also hold that shared lock across the
+# Step5/Step6 cond_waits -- an unavoidable Mutex->RwLock->Mutex nesting that is
+# the whole point of the simultaneous-shared-lock test.  Rewriting the harness
+# to a single global order would change the synchronisation semantics under
+# test, so the report is suppressed rather than "fixed".
+deadlock:Orly::Spa::FluxCapacitor::TSync::TLocal::IncrLockCount


### PR DESCRIPTION
## Summary

Resolves issue #184 finding 6: the `tsan` CI job reports a lock-order-inversion (potential deadlock) at `Orly::Spa::FluxCapacitor::TSync::TLocal::IncrLockCount` (`orly/spa/flux_capacitor/sync.cc:69`) when running `orly/spa/flux_capacitor/sync.test`.

After tracing every lock path, the report is a **benign false positive in the test harness**, not a defect in the TSync primitive. This PR adds a documented TSan suppression and wires it into the tsan job (#177). No functional code changes.

## Analysis: the two acquisition orders

The reported cycle is `M0 => M1 => M0`. From the symbolized stacks (and confirmed against the static-symbol layout -- the two mutex addresses are ~112 bytes apart, matching the relative offsets of the `Mutex` and `VecSync` statics), the two mutexes are:

- **M0** = the test harness's own `static std::mutex Mutex` (`sync.test.cc:33`)
- **M1** = the `RwLock` (`pthread_rwlock_t`) inside the single shared `VecSync` target (`sync.test.cc:31`), locked via `IncrLockCount`

`IncrLockCount` appears in the summary only because it is where `pthread_rwlock_wrlock` is *called*; the other end of the cycle is the harness `Mutex`, nothing in `sync.cc`.

The `TAppender`/`TGetter` threads walk a hand-rolled lock-step protocol (`Step1..Step6` + condition variables) that forces `Mutex` and `RwLock` to nest in **both** orders across the test's phases:

- `Mutex -> RwLock`: e.g. `sync.test.cc:87` (`Mutex`) then `:90` (`TExclusiveLock` -> `IncrLockCount` -> `pthread_rwlock_wrlock`).
- `RwLock -> Mutex`: e.g. `sync.test.cc:114` (`TSharedLock`, `RwLock` held) then `:122` (`Cond5.wait` re-acquires `Mutex` while the shared lock is still held) -- the deliberate "two threads hold shared locks simultaneously" check.

TSan's lock-order graph is purely topological: it records both edges and reports the cycle without modelling the `Step*` handshake that serialises the two threads so the opposing orders never execute concurrently in different threads. No real deadlock is reachable.

## Why not "fix the ordering"?

Flattening the harness to a single global order was attempted and **deterministically deadlocks** the test. The getter must hold `Mutex` and wait for `Step4` *before* taking its shared lock -- taking it earlier blocks the appender's exclusive push that gates `Step4` -- yet it must also hold that shared lock across the `Step5`/`Step6` `cond_wait`s, which is the entire point of the simultaneous-shared-lock test. That is an irreducible `Mutex -> RwLock -> Mutex` nesting; rewriting it to one consistent order would change the synchronisation semantics under test. So the report is suppressed, not "fixed".

## Not related to #174

The `LocalsLock`/`Locals` tracking added by the #174 leak fix plays no part in this report. `GetLocal` releases `LocalsLock` before the lock ctor calls `IncrLockCount`, and recursive locks return the existing `TLocal` without touching `LocalsLock`, so `LocalsLock` is never held while `RwLock` is acquired. This LOI lives in the pre-existing `Typical` fixture, which #174 did not modify; it surfaced now only because the harness data races from finding 5 (which previously masked it) are fixed on master.

## Changes

- **`orly/tsan.supp`** (new): a `deadlock:Orly::Spa::FluxCapacitor::TSync::TLocal::IncrLockCount` suppression with the full justification above inline.
- **`.github/workflows/ci.yml`**: append `suppressions=$PWD/orly/tsan.supp` to `TSAN_OPTIONS` in the `tsan` job (#177).

## Verification

- `sync.test` under tsan -- **before:** 1 lock-order-inversion warning; **after:** 0 warnings (`ThreadSanitizer: Matched 1 suppressions`), `passed 2, failed 0`.
- `make debug` + `make test`: green (exit 0).
- Reverted (master) `sync.test` run 5x under the debug build: no hang, `passed 2, failed 0` each time.
