### PR TITLE
lang: synth layer for cross-package imports — bind + typecheck the alias (#171 Stage 1)

### DIFF
--- a/orly/symbol/function.h
+++ b/orly/symbol/function.h
@@ -92,15 +92,19 @@ namespace Orly {
          inferred type and raises nothing. Run once per function during
          TypeCheck, after the post-build widening passes have settled the
          body. */
-      void VerifyRecursiveReturns() const;
+      /* Virtual so an import function (#171), whose result type is declared and
+         which has only a placeholder body, can skip the body re-evaluation. */
+      virtual void VerifyRecursiveReturns() const;
 
       void Remove(const TParamDef::TPtr &param_def);
 
       TScopePtr TryGetScope() const;
 
-      private:
+      protected:
 
       TFunction(const TScopePtr &scope, const std::string &name, const TPosRange &pos_range);
+
+      private:
 
       /* Drop the memoized type of every node in the body expr tree (but NOT of
          inner/where-bound function bodies -- they are their own roots and

--- a/orly/symbol/import_function.cc
+++ b/orly/symbol/import_function.cc
@@ -1,0 +1,53 @@
+/* <orly/symbol/import_function.cc>
+
+   Implements <orly/symbol/import_function.h>.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <orly/symbol/import_function.h>
+
+#include <base/assert_true.h>
+#include <orly/symbol/scope.h>
+
+using namespace Orly;
+using namespace Orly::Symbol;
+
+TFunction::TPtr TImportFunction::New(const TScopePtr &scope,
+                                     const std::string &name,
+                                     const TPosRange &pos_range,
+                                     const Type::TType &declared_return_type,
+                                     const std::string &remote_name) {
+  assert(scope);
+  auto function = TPtr(new TImportFunction(scope, name, pos_range, declared_return_type, remote_name));
+  scope->Add(function);
+  return function;
+}
+
+TImportFunction::TImportFunction(const TScopePtr &scope,
+                                 const std::string &name,
+                                 const TPosRange &pos_range,
+                                 const Type::TType &declared_return_type,
+                                 const std::string &remote_name)
+    : TFunction(scope, name, pos_range),
+      DeclaredReturnType(declared_return_type),
+      RemoteName(remote_name) {}
+
+TImportFunction::~TImportFunction() {}
+
+Type::TType TImportFunction::GetReturnType() const {
+  return DeclaredReturnType;
+}
+
+void TImportFunction::VerifyRecursiveReturns() const {}

--- a/orly/symbol/import_function.h
+++ b/orly/symbol/import_function.h
@@ -1,0 +1,83 @@
+/* <orly/symbol/import_function.h>
+
+   A top-level function symbol that stands for a value imported from another
+   package (issue #171). `answer is int get_answer from package <imports/lib>#1;`
+   binds `answer` to the symbol `get_answer` in another package. Its result type
+   is *declared* at the import site rather than inferred from a body, so the
+   importing package type-checks against that type without the other package's
+   symbols: it overrides GetReturnType() to return the declared type and
+   VerifyRecursiveReturns() to a no-op (there is no body to re-evaluate). It
+   carries no body; the codegen stage finds these (via RemoteName) and emits the
+   real cross-package call.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <orly/pos_range.h>
+#include <orly/symbol/function.h>
+#include <orly/type.h>
+
+namespace Orly {
+
+  namespace Symbol {
+
+    class TImportFunction
+        : public TFunction {
+      NO_COPY(TImportFunction);
+      public:
+
+      typedef std::shared_ptr<TImportFunction> TPtr;
+
+      /* Construct and register the import function in the given scope (mirrors
+         TFunction::New). Returned as a TFunction::TPtr so it slots into the
+         ordinary function-reference path. It has no body. */
+      static TFunction::TPtr New(const TScopePtr &scope,
+                                 const std::string &name,
+                                 const TPosRange &pos_range,
+                                 const Type::TType &declared_return_type,
+                                 const std::string &remote_name);
+
+      virtual ~TImportFunction();
+
+      /* The declared type, not an inference over a (nonexistent) body. */
+      virtual Type::TType GetReturnType() const override;
+
+      /* No body to verify; the declared type is authoritative. */
+      virtual void VerifyRecursiveReturns() const override;
+
+      /* The symbol's name in the source package (for the codegen stage). */
+      const std::string &GetRemoteName() const { return RemoteName; }
+
+      private:
+
+      TImportFunction(const TScopePtr &scope,
+                      const std::string &name,
+                      const TPosRange &pos_range,
+                      const Type::TType &declared_return_type,
+                      const std::string &remote_name);
+
+      Type::TType DeclaredReturnType;
+
+      std::string RemoteName;
+
+    };  // TImportFunction
+
+  }  // Symbol
+
+}  // Orly

--- a/orly/synth/def_factory.cc
+++ b/orly/synth/def_factory.cc
@@ -26,6 +26,7 @@
 #include <orly/synth/context.h>
 #include <orly/synth/cst_utils.h>
 #include <orly/synth/given_collector.h>
+#include <orly/synth/import_def.h>
 #include <orly/synth/new_expr.h>
 #include <orly/synth/test_def.h>
 #include <orly/synth/type_def.h>
@@ -80,9 +81,7 @@ void TDefFactory::operator()(const Package::Syntax::TTypeDef *that) const {
 }
 
 void TDefFactory::operator()(const Package::Syntax::TImportDef *that) const {
-  throw TNotImplementedError(HERE, TPosRange(
-      that->GetName()->GetLexeme().GetPosRange(),
-      that->GetSemi()->GetLexeme().GetPosRange()));
+  new TImportDef(ExprFactory->OuterScope, that);
 }
 
 void TDefFactory::operator()(const Package::Syntax::TGeneratorDef *that) const {

--- a/orly/synth/func_def.cc
+++ b/orly/synth/func_def.cc
@@ -108,6 +108,12 @@ void TFuncDef::SetExpr(TExpr *expr) {
   Expr = expr;
 }
 
+void TFuncDef::SetSymbol(const Symbol::TFunction::TPtr &symbol) {
+  assert(symbol);
+  assert(!Symbol);
+  Symbol = symbol;
+}
+
 const char *TDef::TInfo<TFuncDef>::Name = "a function defintion";
 
 TParamFuncDef::TParamFuncDef(

--- a/orly/synth/func_def.h
+++ b/orly/synth/func_def.h
@@ -78,6 +78,13 @@ namespace Orly {
       /* TODO */
       void SetExpr(TExpr *expr);
 
+      /* Install the lowered function symbol directly. Used by a subclass whose
+         symbol is not a plain TFunction built in the default pass-2 path -- e.g.
+         an import def, which lowers to a TImportFunction with a declared result
+         type and no body (#171). GetSymbol() then returns it for the ordinary
+         function-reference path. */
+      void SetSymbol(const Symbol::TFunction::TPtr &symbol);
+
       /* The backing CST node, or null for a synthetic def (see the
          CST-less constructor above). */
       const Package::Syntax::TFuncDef *FuncDef;

--- a/orly/synth/import_def.cc
+++ b/orly/synth/import_def.cc
@@ -1,0 +1,90 @@
+/* <orly/synth/import_def.cc>
+
+   Implements <orly/synth/import_def.h>.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <orly/synth/import_def.h>
+
+#include <base/assert_true.h>
+#include <base/no_default_case.h>
+#include <orly/expr/unknown.h>
+#include <orly/symbol/import_function.h>
+#include <orly/symbol/result_def.h>
+#include <orly/synth/new_type.h>
+
+using namespace Orly;
+using namespace Orly::Synth;
+
+static TPosRange ImportPosRange(const Package::Syntax::TImportDef *import_def) {
+  return TPosRange(
+      import_def->GetName()->GetLexeme().GetPosRange(),
+      import_def->GetSemi()->GetLexeme().GetPosRange());
+}
+
+TImportDef::TImportDef(TScope *scope, const Package::Syntax::TImportDef *import_def)
+    : TFuncDef(scope, TName(Base::AssertTrue(import_def)->GetName()), ImportPosRange(import_def)),
+      DeclaredType(NewType(import_def->GetType())),
+      /* Stage 1 binds against the declared type; the source symbol name (opt_name)
+         and package ref are resolved in the codegen/driver stages. Default the
+         remote name to the local name until then. */
+      RemoteName(TName(import_def->GetName()).GetText()) {}
+
+TImportDef::~TImportDef() {}
+
+TAction TImportDef::Build(int pass) {
+  TAction action;
+  switch (pass) {
+    case 1: {
+      action = Continue;
+      break;
+    }
+    case 2: {
+      auto symbol = Symbol::TImportFunction::New(
+                      GetOuterScope()->GetScopeSymbol(),   /* scope */
+                      GetName().GetText(),                 /* name */
+                      PosRange,                            /* pos_range */
+                      DeclaredType->GetSymbolicType(),     /* declared result type */
+                      RemoteName);                         /* source symbol name */
+      Symbol::TResultDef::New(symbol, GetName().GetText(), PosRange);
+      SetSymbol(symbol);
+      action = Continue;
+      break;
+    }
+    case 3: {
+      action = Continue;
+      break;
+    }
+    case 4: {
+      /* Placeholder body so the many body-walking passes (typecheck, #104
+         widening, codegen) have a real leaf to traverse: a typed-unknown of the
+         declared type. The function's *result* type still comes from
+         TImportFunction::GetReturnType() (the declared type, non-optional), not
+         from this body -- so `answer` types as the declared type. The codegen
+         stage (#171) replaces this with the real cross-package call to RemoteName. */
+      GetSymbol()->SetExpr(Expr::TUnknown::New(DeclaredType->GetSymbolicType(), PosRange));
+      action = Finish;
+      break;
+    }
+    NO_DEFAULT_CASE;
+  }
+  return action;
+}
+
+void TImportDef::ForEachInnerScope(const std::function<void (TScope *)> &) {}
+
+void TImportDef::ForEachRef(const std::function<void (TAnyRef &)> &) {}
+
+const char *TDef::TInfo<TImportDef>::Name = "an import definition";

--- a/orly/synth/import_def.h
+++ b/orly/synth/import_def.h
@@ -1,0 +1,79 @@
+/* <orly/synth/import_def.h>
+
+   Synth-layer node for a cross-package import definition
+   (`answer is int get_answer from package <imports/lib>#1;`, issue #171).
+   It binds a local value name of a *declared* type to a symbol in another
+   package. Modeled as a TFuncDef so the ordinary value-reference path
+   (`TryGetDef<TFuncDef>` -> GetSymbol() -> result def) resolves it, but it
+   lowers to a Symbol::TImportFunction with the declared result type and no
+   body rather than the default pass-2 function.
+
+   Stage 1 (#171) implements binding + type-checking against the declared type;
+   resolving/building/linking the source package is a later stage.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#pragma once
+
+#include <functional>
+#include <string>
+
+#include <orly/orly.package.cst.h>
+#include <orly/synth/func_def.h>
+#include <orly/synth/scope_and_def.h>
+#include <orly/synth/type.h>
+
+namespace Orly {
+
+  namespace Synth {
+
+    /* TODO */
+    class TImportDef
+        : public TFuncDef {
+      NO_COPY(TImportDef);
+      public:
+
+      /* TODO */
+      TImportDef(TScope *scope, const Package::Syntax::TImportDef *import_def);
+
+      /* TODO */
+      virtual ~TImportDef();
+
+      private:
+
+      /* Lower to a Symbol::TImportFunction with the declared result type. */
+      virtual TAction Build(int pass);
+
+      /* No body, hence no inner scopes and no references to bind. */
+      virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
+      virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
+
+      /* The declared type the local name is bound at. */
+      TType *DeclaredType;
+
+      /* The symbol's name in the source package (opt_name, or the local name). */
+      std::string RemoteName;
+
+    };  // TImportDef
+
+    /* TODO */
+    template <>
+    struct TDef::TInfo<TImportDef> {
+      static const char *Name;
+    };
+
+  }  // Synth
+
+}  // Orly

--- a/tests/lang_tests/general/imports/.main.orly.test.state
+++ b/tests/lang_tests/general/imports/.main.orly.test.state
@@ -3,8 +3,21 @@
   [
     [],
     [
-      "Synth + Symbols",
-      "26:1-26:55 [orly/synth/def_factory.cc]This feature is not yet implemented"
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++",
+      "/tmp/orly_compiler/main.cc: In function \u2018int64_t NSmain::Fanswer(Orly::Package::TContext&)\u2019:",
+      "/tmp/orly_compiler/main.cc:74:22: error: cannot convert \u2018Orly::Rt::TOpt<long int>\u2019 to \u2018int64_t\u2019 {aka \u2018long int\u2019} in return",
+      "   74 |     return Orly::Rt::TOpt<int64_t>();",
+      "      |                      ^~~~~~~~~~~~~~~",
+      "      |                      |",
+      "      |                      Orly::Rt::TOpt<long int>",
+      "Error while compiling an Intermediate Representation. See a Orly team member with your Orly code for support",
+      "compile failure: compile failure[orly/compiler.cc]; Compiling C++ and linking"
     ]
   ]
 ]


### PR DESCRIPTION
**Stage 1** of cross-package imports (#171; design #192, target test #193 now merged).

Implements the **synth half**: `answer is int get_answer from package <imports/lib>#1;` now binds a local value of the declared type instead of throwing `TNotImplementedError`.

## Change
- **`Symbol::TImportFunction`** (new) — a top-level function symbol whose result type is *declared* at the import site (`GetReturnType` override), not inferred; `VerifyRecursiveReturns` is a no-op (no real body). Carries `RemoteName` for the codegen stage. To allow it, `TFunction`'s ctor is `protected` and `VerifyRecursiveReturns` is `virtual`.
- **`Synth::TImportDef`** (new) — a `TFuncDef` that lowers an `import_def` to a `TImportFunction` + result def, so the ordinary value-reference path (`TryGetDef<TFuncDef>` → result def) resolves the alias. Placeholder body = a typed-unknown of the declared type, so the body-walking passes (typecheck, #104 widening, codegen) have a real leaf; the alias's type comes from the *declared* return type, so it's non-optional.
- **`TFuncDef::SetSymbol`** (new, protected) — lets the subclass install its symbol.
- **`def_factory`** — route to `TImportDef` instead of throwing.

## Gate (verified)
- `orlyc --semantic-only` on the two-package importer now **succeeds**; `answer` type-checks as the declared `int`.
- A declared/use **type mismatch** (`answer is str`, compared to an int) is still **rejected** at type-check.
- Full `lang_test` suite: **0 unexpected, 156 passed, 3 tracked xfail** — no regressions.

## Still xfail (expected)
The *full* compile of `main.orly` still fails: the placeholder body lowers to an optional that doesn't match the declared non-optional return, so it errors cleanly at C++ codegen. `general/imports/main.orly` stays `xfail (#171)`, baseline updated to that point. **Stage 2 (codegen)** replaces the placeholder with the real cross-package call, which flips it green.

> The updated xfail baseline captures the placeholder's generated-C++ error; it's regenerated when Stage 2 lands the real codegen.