### PR TITLE
base/inv_con: fix AtomicUnorderedList Insert/Remove data races (#184)

### DIFF
--- a/base/inv_con/atomic_unordered_list.h
+++ b/base/inv_con/atomic_unordered_list.h
@@ -22,8 +22,6 @@
 #include <cassert>
 #include <functional>
 
-#include <xmmintrin.h>
-
 #include <base/class_traits.h>
 #include <base/no_default_case.h>
 
@@ -231,7 +229,10 @@ namespace InvCon {
       void Insert(TTypedCollection *collection) {
         assert(!Collection);
         assert(collection);
-        _mm_prefetch(collection->LastMembership, _MM_HINT_T0);
+        /* NB: we deliberately do not prefetch collection->LastMembership here.
+           It is a shared linkage field, mutated under LastLock by FixupLinkage,
+           and reading it before we hold any lock is a data race (the value would
+           only be a speculative hint and is re-read under lock below anyway). */
         for (;;) {
           while (collection->LastLock.test_and_set(std::memory_order_acquire)) {/* acquire last lock */}
           if (collection->LastMembership) {
@@ -268,10 +269,11 @@ namespace InvCon {
         assert(Collection);
         /* Fixup the pointers on either side of us to point around us,
            then go back to the unlinked state. */
-        _mm_prefetch(&NextMembership->PrevLock, _MM_HINT_T0);
-        _mm_prefetch(reinterpret_cast<uint8_t *>(&NextMembership->Collection), _MM_HINT_T0);
-        _mm_prefetch(&PrevMembership->PrevLock, _MM_HINT_T0);
-        _mm_prefetch(reinterpret_cast<uint8_t *>(&PrevMembership->Collection), _MM_HINT_T0);
+        /* NB: we deliberately do not prefetch our neighbors here.
+           Computing &NextMembership->... / &PrevMembership->... reads our own
+           NextMembership/PrevMembership fields, which a neighbor's FixupLinkage
+           may concurrently write under lock; reading them before we hold any
+           lock is a data race.  The values are re-read under lock below. */
         for (;;) {
           while (PrevLock.test_and_set(std::memory_order_acquire)) {/* acquire prev lock */}
           if (PrevMembership) {

--- a/orly/indy/disk/util/cache.h
+++ b/orly/indy/disk/util/cache.h
@@ -26,6 +26,7 @@
 
 #include <sched.h>
 #include <unistd.h>
+#include <xmmintrin.h>
 
 #include <atomic>
 #include <stdexcept>


### PR DESCRIPTION
## Summary

Part of the #184 TSan-hardening effort (Plan B: get the curated TSan set clean).

`base/inv_con/atomic_unordered_list.h` is a doubly-linked list with fine-grained per-node spinlocks (`PrevLock`/`NextLock` per `TMembership`, `FirstLock`/`LastLock` on the collection). The spinlock protocol correctly guards every read and write of the plain-pointer linkage fields (`FirstMembership`/`LastMembership`/`PrevMembership`/`NextMembership`/`Collection`) — **except** for the speculative `_mm_prefetch` cache hints at the top of `Insert()` and `Remove()`, which execute *before any lock is acquired*.

## The races (TSan-confirmed)

Reproduced under the `tsan` jhm config via `base/thread_local_global_pool.test` and `base/thread_local_registered_pool.test` (2 warnings each on master). Both warnings are rooted in the unlocked prefetches:

- **`Insert()` line 234** does `_mm_prefetch(collection->LastMembership, ...)`, reading the shared `LastMembership` field lock-free. This races a concurrent `FixupLinkage()` (line 322) write to `LastMembership` performed under `LastLock` by another thread's insert/remove.
- **`Remove()` line 271** does `_mm_prefetch(&NextMembership->PrevLock, ...)`; forming that address reads *this node's* `NextMembership` pointer lock-free. This races a neighbor's `FixupLinkage()` (line 321) write to that same field under lock.

The remaining prefetch sites (Remove lines 272–274) have the same shape. In all cases no lock is held at prefetch time, while another thread legitimately mutates those fields under the appropriate lock.

## Why the spinlock discipline didn't cover it

The prefetches are pure performance hints that run ahead of the locking loop. Every linkage field they touch is re-read under the correct lock immediately afterward — but the prefetch itself performs an unsynchronized read of a plain pointer that is concurrently written under lock. There is no way to do that unlocked plain-pointer read without a data race, and the prefetched pointer can be stale or dangling by the time the lock is taken anyway, so its value is never load-bearing.

## Fix

Drop the racy `_mm_prefetch` hints from `Insert()` and `Remove()`. The locking algorithm and the hot locked path are entirely unchanged; only the speculative pre-lock reads are removed. This is a proportionate gap-close — atomicizing five pointer fields across every access site purely to feed a cache hint would be over-engineering, and the hint is the only unsynchronized access in the file.

Removing the prefetches leaves `<xmmintrin.h>` unused in `atomic_unordered_list.h`. `orly/indy/disk/util/cache.h` had been relying on that header to *transitively* supply `_mm_prefetch`; it now includes `<xmmintrin.h>` directly (a latent leaky-include that this change surfaced).

## Verification

TSan (`setarch -R`, `TSAN_OPTIONS=halt_on_error=0 exitcode=0`):

| test | before | after |
|---|---|---|
| `base/thread_local_global_pool.test` | 2 warnings (exit 0) | **0 warnings** (exit 0, passed 4/4) |
| `base/thread_local_registered_pool.test` | 2 warnings (exit 0) | **0 warnings** (exit 0, passed 4/4) |

Build gates (real `../out_orly/` dir): `make debug` GREEN (exit 0), `make test` GREEN (exit 0). This header is included widely, so the full suite is the gate.
