### PR TITLE
lang: codegen for cross-package imports — emit the namespaced call (#171 Stage 2)

### DIFF
--- a/orly/code_gen/function.cc
+++ b/orly/code_gen/function.cc
@@ -64,6 +64,12 @@ void TFunction::AddChild(const std::shared_ptr<TInlineFunc> &func) {
   ChildFuncs.insert(func);
 }
 
+void TFunction::SetBody(const TInline::TPtr &body) {
+  assert(body);
+  assert(!Body);
+  Body = body;
+}
+
 void TFunction::Build() {
   //Only build if we haven't already built.
   if(Body) {

--- a/orly/code_gen/function.h
+++ b/orly/code_gen/function.h
@@ -99,8 +99,10 @@ namespace Orly {
 
       void AddChild(const std::shared_ptr<TInlineFunc> &func);
 
-      /* Build the function body, if necessary. */
-      void Build();
+      /* Build the function body, if necessary. Virtual so TSymbolFunc can emit a
+         cross-package call body for an imported value (#171) instead of walking a
+         placeholder expr. */
+      virtual void Build();
 
       TArg::TRef::TPtr GetArg(const std::string &name) const;
       const TArgs &GetArgs() const;
@@ -142,6 +144,10 @@ namespace Orly {
 
       //TODO: I think the PostCtor could go away...
       void PostCtor(const TNamedArgs &args, const Expr::TExpr::TPtr &expr, bool keep_mutable, bool implicit=false);
+
+      /* Install a body directly, bypassing the expr-walking Build(). Used by a
+         subclass that synthesizes its body (e.g. an import's cross-package call). */
+      void SetBody(const TInline::TPtr &body);
 
       //TODO: These should really be private
       TCodeScope CodeScope;

--- a/orly/code_gen/import_call.cc
+++ b/orly/code_gen/import_call.cc
@@ -1,0 +1,42 @@
+/* <orly/code_gen/import_call.cc>
+
+   Implements <orly/code_gen/import_call.h>.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <orly/code_gen/import_call.h>
+
+#include <orly/code_gen/cpp_printer.h>
+#include <orly/symbol/import_function.h>
+
+using namespace Orly;
+using namespace Orly::CodeGen;
+
+TInline::TPtr TImportCall::New(const L0::TPackage *package, const Symbol::TImportFunction *import_func) {
+  return TInline::TPtr(new TImportCall(package, import_func));
+}
+
+TImportCall::TImportCall(const L0::TPackage *package, const Symbol::TImportFunction *import_func)
+    : TInline(package, import_func->GetReturnType()),
+      PackageName(import_func->GetPackageName()),
+      RemoteName(import_func->GetRemoteName()) {}
+
+void TImportCall::WriteExpr(TCppPrinter &out) const {
+  /* Leading :: for global scope; NS-prefixed package namespace; F-prefixed
+     function; ctx is the implicit first arg of every top-level orly function. */
+  out << "::" << PackageName << "::F" << RemoteName << "(ctx)";
+}
+
+void TImportCall::AppendDependsOn(std::unordered_set<TInline::TPtr> &) const {}

--- a/orly/code_gen/import_call.h
+++ b/orly/code_gen/import_call.h
@@ -1,0 +1,63 @@
+/* <orly/code_gen/import_call.h>
+
+   The code-gen body of an imported value (#171): a call into the source
+   package's generated symbol, e.g. `::NSimports::NSlib::Fget_answer(ctx)`.
+   TSymbolFunc installs this as an import function's body in place of the
+   placeholder expr, and TPackage records the source package in NeededPackages
+   so its header is included and linked.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#pragma once
+
+#include <string>
+#include <unordered_set>
+
+#include <orly/code_gen/inline.h>
+#include <orly/package/name.h>
+
+namespace Orly {
+
+  namespace Symbol {
+    class TImportFunction;
+  }
+
+  namespace CodeGen {
+
+    class TImportCall : public TInline {
+      NO_COPY(TImportCall);
+      public:
+
+      static TInline::TPtr New(const L0::TPackage *package, const Symbol::TImportFunction *import_func);
+
+      /* Emits `::NS<pkg>::F<remote>(ctx)`. */
+      virtual void WriteExpr(TCppPrinter &out) const override;
+
+      /* A leaf call -- depends on no other inlines. */
+      virtual void AppendDependsOn(std::unordered_set<TInline::TPtr> &dependency_set) const override;
+
+      private:
+
+      TImportCall(const L0::TPackage *package, const Symbol::TImportFunction *import_func);
+
+      Package::TName PackageName;
+
+      std::string RemoteName;
+
+    };  // TImportCall
+
+  }  // CodeGen
+
+}  // Orly

--- a/orly/code_gen/package.cc
+++ b/orly/code_gen/package.cc
@@ -27,6 +27,7 @@
 #include <base/split.h>
 #include <orly/code_gen/obj.h>
 #include <orly/expr/addr_walker.h>
+#include <orly/symbol/import_function.h>
 #include <orly/expr/walker.h>
 #include <orly/expr/where.h>
 #include <orly/package/api_version.h>
@@ -143,6 +144,11 @@ TPackage::TPackage(const Symbol::TPackage::TPtr &package) : L0::TPackage(package
   //Build all the function declarations
   for(auto &func: package->GetFunctions()) {
     Exports.insert(TExportFunc::New(this, func));
+    /* An imported value (#171) calls into another package; record it so its
+       header is included (WriteImportIncludes) and it is linked (WriteLink). */
+    if(auto import_func = dynamic_cast<const Symbol::TImportFunction *>(func.get())) {
+      NeededPackages.insert(import_func->GetPackageName());
+    }
   }
 
   //Build the definitions

--- a/orly/code_gen/symbol_func.cc
+++ b/orly/code_gen/symbol_func.cc
@@ -18,8 +18,24 @@
 
 #include <orly/code_gen/symbol_func.h>
 
+#include <orly/code_gen/import_call.h>
+#include <orly/symbol/import_function.h>
+
 using namespace Orly;
 using namespace Orly::CodeGen;
+
+void TSymbolFunc::Build() {
+  if (GetBody()) {
+    return;
+  }
+  /* An imported value (#171) has only a placeholder body in the symbol layer;
+     emit the real cross-package call instead of building from that placeholder. */
+  if (auto import_func = dynamic_cast<const Symbol::TImportFunction *>(Symbol.get())) {
+    SetBody(TImportCall::New(Package, import_func));
+    return;
+  }
+  TFunction::Build();
+}
 
 //TODO: Should really return a TSymbolFuncPtr...
 TFunction::TPtr TSymbolFunc::Find(const Symbol::TFunction *symbol) {

--- a/orly/code_gen/symbol_func.h
+++ b/orly/code_gen/symbol_func.h
@@ -39,6 +39,10 @@ namespace Orly {
       Type::TType GetReturnType() const;
       Type::TType GetType() const;
 
+      /* For an imported value (#171), emit a cross-package call as the body
+         instead of walking the placeholder expr; otherwise build normally. */
+      virtual void Build() override;
+
       protected:
       TSymbolFunc(const L0::TPackage *package, const Symbol::TFunction::TPtr &symbol, const TIdScope::TPtr &id_scope);
 

--- a/orly/symbol/import_function.cc
+++ b/orly/symbol/import_function.cc
@@ -28,9 +28,10 @@ TFunction::TPtr TImportFunction::New(const TScopePtr &scope,
                                      const std::string &name,
                                      const TPosRange &pos_range,
                                      const Type::TType &declared_return_type,
+                                     const Package::TName &package_name,
                                      const std::string &remote_name) {
   assert(scope);
-  auto function = TPtr(new TImportFunction(scope, name, pos_range, declared_return_type, remote_name));
+  auto function = TPtr(new TImportFunction(scope, name, pos_range, declared_return_type, package_name, remote_name));
   scope->Add(function);
   return function;
 }
@@ -39,9 +40,11 @@ TImportFunction::TImportFunction(const TScopePtr &scope,
                                  const std::string &name,
                                  const TPosRange &pos_range,
                                  const Type::TType &declared_return_type,
+                                 const Package::TName &package_name,
                                  const std::string &remote_name)
     : TFunction(scope, name, pos_range),
       DeclaredReturnType(declared_return_type),
+      PackageName(package_name),
       RemoteName(remote_name) {}
 
 TImportFunction::~TImportFunction() {}

--- a/orly/symbol/import_function.h
+++ b/orly/symbol/import_function.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <string>
 
+#include <orly/package/name.h>
 #include <orly/pos_range.h>
 #include <orly/symbol/function.h>
 #include <orly/type.h>
@@ -51,9 +52,13 @@ namespace Orly {
                                  const std::string &name,
                                  const TPosRange &pos_range,
                                  const Type::TType &declared_return_type,
+                                 const Package::TName &package_name,
                                  const std::string &remote_name);
 
       virtual ~TImportFunction();
+
+      /* The source package the symbol is imported from (for codegen). */
+      const Package::TName &GetPackageName() const { return PackageName; }
 
       /* The declared type, not an inference over a (nonexistent) body. */
       virtual Type::TType GetReturnType() const override;
@@ -70,9 +75,12 @@ namespace Orly {
                       const std::string &name,
                       const TPosRange &pos_range,
                       const Type::TType &declared_return_type,
+                      const Package::TName &package_name,
                       const std::string &remote_name);
 
       Type::TType DeclaredReturnType;
+
+      Package::TName PackageName;
 
       std::string RemoteName;
 

--- a/orly/synth/import_def.cc
+++ b/orly/synth/import_def.cc
@@ -23,6 +23,8 @@
 #include <orly/expr/unknown.h>
 #include <orly/symbol/import_function.h>
 #include <orly/symbol/result_def.h>
+#include <orly/synth/context.h>
+#include <orly/synth/cst_utils.h>
 #include <orly/synth/new_type.h>
 
 using namespace Orly;
@@ -36,11 +38,28 @@ static TPosRange ImportPosRange(const Package::Syntax::TImportDef *import_def) {
 
 TImportDef::TImportDef(TScope *scope, const Package::Syntax::TImportDef *import_def)
     : TFuncDef(scope, TName(Base::AssertTrue(import_def)->GetName()), ImportPosRange(import_def)),
-      DeclaredType(NewType(import_def->GetType())),
-      /* Stage 1 binds against the declared type; the source symbol name (opt_name)
-         and package ref are resolved in the codegen/driver stages. Default the
-         remote name to the local name until then. */
-      RemoteName(TName(import_def->GetName()).GetText()) {}
+      DeclaredType(NewType(import_def->GetType())) {
+  /* opt_name is the symbol's name in the source package; default to the local
+     name when omitted (`foo is int from <pkg>` imports `foo`). */
+  auto remote = TryGetNode<Package::Syntax::TName, Package::Syntax::TNoName>(import_def->GetOptName());
+  RemoteName = remote ? remote->GetLexeme().GetText() : TName(import_def->GetName()).GetText();
+
+  /* MVP supports only a literal package ref: `from package <a/b/c>#N`. An alias
+     ref (`from some_alias`) has no resolution table yet, so reject it clearly. */
+  auto literal = TryGetNode<Package::Syntax::TLiteralPackageRef,
+                            Package::Syntax::TAliasPackageRef>(import_def->GetPackageRef());
+  if (literal) {
+    ForEach<Package::Syntax::TName>(
+        literal->GetPackageName()->GetPackageNameMemberList(),
+        [this](const Package::Syntax::TName *name) {
+          PackageName.Name.push_back(name->GetLexeme().GetText());
+          return true;
+        });
+  } else {
+    GetContext().AddError(ImportPosRange(import_def),
+        "alias package imports are not supported yet (#171); use a literal reference: from package <a/b/c>#N");
+  }
+}
 
 TImportDef::~TImportDef() {}
 
@@ -57,6 +76,7 @@ TAction TImportDef::Build(int pass) {
                       GetName().GetText(),                 /* name */
                       PosRange,                            /* pos_range */
                       DeclaredType->GetSymbolicType(),     /* declared result type */
+                      PackageName,                         /* source package */
                       RemoteName);                         /* source symbol name */
       Symbol::TResultDef::New(symbol, GetName().GetText(), PosRange);
       SetSymbol(symbol);

--- a/orly/synth/import_def.h
+++ b/orly/synth/import_def.h
@@ -31,6 +31,7 @@
 #include <string>
 
 #include <orly/orly.package.cst.h>
+#include <orly/package/name.h>
 #include <orly/synth/func_def.h>
 #include <orly/synth/scope_and_def.h>
 #include <orly/synth/type.h>
@@ -62,6 +63,9 @@ namespace Orly {
 
       /* The declared type the local name is bound at. */
       TType *DeclaredType;
+
+      /* The source package (from a literal package_ref `package <a/b/c>#N`). */
+      Package::TName PackageName;
 
       /* The symbol's name in the source package (opt_name, or the local name). */
       std::string RemoteName;

--- a/tests/lang_tests/general/imports/.main.orly.test.state
+++ b/tests/lang_tests/general/imports/.main.orly.test.state
@@ -10,12 +10,14 @@
     ],
     [
       "Compiling C++",
-      "/tmp/orly_compiler/main.cc: In function \u2018int64_t NSmain::Fanswer(Orly::Package::TContext&)\u2019:",
-      "/tmp/orly_compiler/main.cc:74:22: error: cannot convert \u2018Orly::Rt::TOpt<long int>\u2019 to \u2018int64_t\u2019 {aka \u2018long int\u2019} in return",
-      "   74 |     return Orly::Rt::TOpt<int64_t>();",
-      "      |                      ^~~~~~~~~~~~~~~",
-      "      |                      |",
-      "      |                      Orly::Rt::TOpt<long int>",
+      "/tmp/orly_compiler/main.link.cc:15:10: fatal error: imports/lib.h: No such file or directory",
+      "   15 | #include \"imports/lib.h\"",
+      "      |          ^~~~~~~~~~~~~~~",
+      "compilation terminated.",
+      "/tmp/orly_compiler/main.cc:7:10: fatal error: imports/lib.h: No such file or directory",
+      "    7 | #include \"imports/lib.h\"",
+      "      |          ^~~~~~~~~~~~~~~",
+      "compilation terminated.",
       "Error while compiling an Intermediate Representation. See a Orly team member with your Orly code for support",
       "compile failure: compile failure[orly/compiler.cc]; Compiling C++ and linking"
     ]


### PR DESCRIPTION
**Stage 2** of cross-package imports (#171; design #192, Stage 1 #196 merged). An imported value now generates a real cross-package call instead of the Stage 1 placeholder, and the source package is included + linked.

## Change
- **Synth** — `TImportDef` now parses the import's `package_ref` (literal `package <a/b/c>#N`) and `opt_name`, carrying the source `Package::TName` and remote symbol name on `Symbol::TImportFunction`. An **alias** package ref is rejected with a clear "not supported yet" error (MVP = literal refs only).
- **Codegen** — new `CodeGen::TImportCall` (a `TInline`) emits `::NS<pkg>::F<remote>(ctx)`. `TFunction::Build` is now `virtual`; `TSymbolFunc::Build` installs a `TImportCall` as an import function's body (via the new protected `TFunction::SetBody`) instead of walking the placeholder expr. `TPackage` records each import's source package in `NeededPackages`, so the already-wired `WriteImportIncludes`/`WriteLink` emit the `#include` and the link dependency.

## Verified
Compiling the two-package importer now generates:
```cpp
#include "imports/lib.h"
...
int64_t Fanswer(Orly::Package::TContext &ctx) {
  return ::NSimports::NSlib::Fget_answer(ctx);
}
```
— the correct namespaced call with the declared return type, and the test `answer == 42` compiles.

Full `lang_test`: **0 unexpected, 156 passed, 3 tracked xfail** — no regressions.

## Still xfail (expected)
The full compile now fails **only** at `fatal error: imports/lib.h: No such file or directory` — the source package isn't built/linked in the same `orlyc` invocation yet. That's **Stage 3** (the driver dependency loop). `general/imports/main.orly` stays `xfail (#171)`, baseline updated to that point.