### PR TITLE
indy/fiber: atomicize lock-free work-queue heads + runner publication (#184)

### DIFF
--- a/orly/indy/fiber/fiber.cc
+++ b/orly/indy/fiber/fiber.cc
@@ -109,9 +109,12 @@ void TRunner::Run() {
     for (; likely(KeepRunning.load());) {
       assert(!ReadyToRunQueue);
       /* check for inbound frames */ {
-        if (InboundFrameQueue) {
+        if (InboundFrameQueue.load(std::memory_order_acquire)) {
           assert(rt_queue == nullptr);
-          TFrame *cur_tail = __sync_lock_test_and_set(&InboundFrameQueue, nullptr);
+          /* Drain the whole Treiber stack in one shot. Acquire pairs with the
+             pushers' release CAS so the frames' InboundQueueNextFrame links we
+             walk below are visible. */
+          TFrame *cur_tail = InboundFrameQueue.exchange(nullptr, std::memory_order_acquire);
           for (TFrame *frame = cur_tail; frame; frame = next_frame) {
             assert(frame->InboundQueueNextFrame != frame);
             next_frame = frame->InboundQueueNextFrame;
@@ -136,12 +139,14 @@ void TRunner::Run() {
           rt_queue = nullptr;
         } else {
           for (size_t i = 0; i < TotalNumRunners; ++i) {
-            TRunner *cur_runner = RunnerArray[i];
+            TRunner *cur_runner = RunnerArray[i].load(std::memory_order_acquire);
             if (cur_runner) {
-              TFrame *&cur_inbound_queue = cur_runner->QueueArray[RunnerId].Ptr;
-              if (cur_inbound_queue) {
+              std::atomic<TFrame *> &cur_inbound_queue = cur_runner->QueueArray[RunnerId].Ptr;
+              if (cur_inbound_queue.load(std::memory_order_acquire)) {
                 assert(rt_queue == nullptr);
-                TFrame *cur_tail = __sync_lock_test_and_set(&cur_inbound_queue, nullptr);
+                /* Drain the whole Treiber stack; acquire pairs with the
+                   pushers' release CAS (see InboundFrameQueue above). */
+                TFrame *cur_tail = cur_inbound_queue.exchange(nullptr, std::memory_order_acquire);
                 for (TFrame *frame = cur_tail; frame; frame = next_frame) {
                   assert(frame->InboundQueueNextFrame != frame);
                   next_frame = frame->InboundQueueNextFrame;

--- a/orly/indy/fiber/fiber.h
+++ b/orly/indy/fiber/fiber.h
@@ -376,10 +376,10 @@ namespace Orly {
           TRunnerCons(size_t num_runners)
               : NumRunners(num_runners), NextId(0UL) {
             syslog(LOG_INFO, "TRunnerCons [%ld]", num_runners);
-            RunnerArray = new TRunner *[num_runners];
+            RunnerArray = new std::atomic<TRunner *>[num_runners];
             syslog(LOG_INFO, "TRunnerCons [%ld] A", num_runners);
             for (size_t i = 0; i < num_runners; ++i) {
-              RunnerArray[i] = nullptr;
+              RunnerArray[i].store(nullptr, std::memory_order_relaxed);
             }
             syslog(LOG_INFO, "TRunnerCons [%ld] B", num_runners);
           }
@@ -409,26 +409,32 @@ namespace Orly {
           /* TODO */
           size_t NextId;
 
-          /* TODO */
-          TRunner **RunnerArray;
+          /* Per-runner publication slots. A TRunner publishes itself into its
+             own slot in its ctor (store/release) and other runner threads read
+             the slots in TRunner::Run (load/acquire), so the element type must
+             be atomic. */
+          std::atomic<TRunner *> *RunnerArray;
 
           friend class TRunner;
 
         };  // TRunnerCons
 
         TRunner(TRunnerCons &runner_cons) : TRunner(runner_cons.NumRunners, runner_cons.GetNewId(), runner_cons.RunnerArray) {
-          runner_cons.RunnerArray[RunnerId] = this;
+          /* Publish ourselves into the shared runner array. Release so that a
+             peer runner that reads this slot (acquire) in TRunner::Run sees a
+             fully constructed TRunner -- in particular our QueueArray. */
+          runner_cons.RunnerArray[RunnerId].store(this, std::memory_order_release);
         }
 
         /* TODO */
-        TRunner(size_t total_num_runners, size_t runner_id, TRunner **runner_array)
+        TRunner(size_t total_num_runners, size_t runner_id, std::atomic<TRunner *> *runner_array)
             : FreeFrame(nullptr),
               FreeFramePool(nullptr),
               //MyFrameQueue(this),
               ReadyToRunQueue(nullptr),
               NewReadyToRunQueue(nullptr),
               KeepRunning(true),
-              InboundFrameQueue(nullptr),
+              InboundFrameQueue{nullptr},
               ForeignRunnerToMoveFrameTo(nullptr),
               FrameToMoveToForeignRunner(nullptr),
               TotalNumRunners(total_num_runners),
@@ -442,13 +448,13 @@ namespace Orly {
           #endif
           QueueArray = new TOutboundQueue[total_num_runners];
           for (size_t i = 0; i < total_num_runners; ++i) {
-            QueueArray[i].Ptr = nullptr;
+            QueueArray[i].Ptr.store(nullptr, std::memory_order_relaxed);
           }
         }
 
         /* TODO */
         ~TRunner() {
-          RunnerArray[RunnerId] = nullptr;
+          RunnerArray[RunnerId].store(nullptr, std::memory_order_release);
           delete[] QueueArray;
         }
 
@@ -494,6 +500,9 @@ namespace Orly {
 
         inline void ScheduleFrameSlow(TRunner *other_runner, TFrame *frame);
 
+        /* Push 'frame' onto a Treiber-stack queue head (see definition). */
+        static inline void PushFrameOntoQueue(std::atomic<TFrame *> &head, TFrame *frame);
+
         /* TODO */
         //mutable TFrameQueue::TImpl MyFrameQueue;
         TFrame *ReadyToRunQueue;
@@ -502,10 +511,15 @@ namespace Orly {
         /* TODO */
         std::atomic<bool> KeepRunning;
 
-        /* TODO */
-        TFrame *InboundFrameQueue;
+        /* Treiber-stack head for frames scheduled onto this runner from a
+           thread that has no LocalRunner. Pushers CAS (release) onto it; the
+           owning runner drains it with exchange (acquire) in TRunner::Run. */
+        std::atomic<TFrame *> InboundFrameQueue;
         struct alignas(64) TOutboundQueue {
-          TFrame *Ptr;
+          /* Treiber-stack head: frames this runner wants to hand to runner i
+             live in this->QueueArray[i]. Pusher CAS (release); the consuming
+             runner drains with exchange (acquire). */
+          std::atomic<TFrame *> Ptr;
         };
         TOutboundQueue *QueueArray;
 
@@ -518,7 +532,7 @@ namespace Orly {
         size_t RunnerId alignas(64);
         size_t blank_buf[7];
 
-        TRunner **RunnerArray;
+        std::atomic<TRunner *> *RunnerArray;
 
         /* Access to ComeBackSoon */
         friend class TFrame;
@@ -679,7 +693,7 @@ namespace Orly {
             //printf("TFrame [%p] calling func\n", this);
 
             #ifndef NDEBUG
-            DebugIsRunning = true;
+            DebugIsRunning.store(true, std::memory_order_relaxed);
             #endif
             TRunnable::TFunc runnable_func = RunnableFunc;
             TRunnable *const runnable = Runnable;
@@ -692,7 +706,7 @@ namespace Orly {
               //abort();
             }
             #ifndef NDEBUG
-            DebugIsRunning = false;
+            DebugIsRunning.store(false, std::memory_order_relaxed);
             #endif
             //printf("TFrame [%p] FINISH calling func\n", this);
 
@@ -703,10 +717,10 @@ namespace Orly {
 
         #ifndef NDEBUG
         void AssertCanFree() {
-          if (DebugIsRunning) {
+          if (DebugIsRunning.load(std::memory_order_relaxed)) {
             throw std::logic_error("Cannot Free Frame that is still running");
           }
-          assert(!DebugIsRunning);
+          assert(!DebugIsRunning.load(std::memory_order_relaxed));
         }
         #endif
 
@@ -735,7 +749,7 @@ namespace Orly {
         }
 
         #ifndef NDEBUG
-        bool DebugIsRunning;
+        std::atomic<bool> DebugIsRunning;
         #endif
 
         /* TODO */
@@ -1175,17 +1189,25 @@ namespace Orly {
 
       };  // TSwitchToRunner
 
+      /* Push 'frame' onto a Treiber-stack queue head. The next-link field is a
+         plain TFrame member written here and read by the draining runner; the
+         head's release CAS / acquire exchange publishes it across threads, so
+         it needs no atomic of its own. We relaxed-load the current head to seed
+         the link and let compare_exchange_weak refresh 'expected' on failure. */
+      inline void TRunner::PushFrameOntoQueue(std::atomic<TFrame *> &head, TFrame *frame) {
+        TFrame *expected = head.load(std::memory_order_relaxed);
+        do {
+          frame->InboundQueueNextFrame = expected;
+        } while (!head.compare_exchange_weak(
+            expected, frame, std::memory_order_release, std::memory_order_relaxed));
+      }
+
       inline void TRunner::ScheduleFrameSlow(TFrame *frame) {
         assert(frame);
         if (LocalRunner) {
-          TFrame *&outbound_queue = LocalRunner->QueueArray[RunnerId].Ptr;
-          do {
-            frame->InboundQueueNextFrame = outbound_queue;
-          } while (!__sync_bool_compare_and_swap(&outbound_queue, frame->InboundQueueNextFrame, frame));
+          PushFrameOntoQueue(LocalRunner->QueueArray[RunnerId].Ptr, frame);
         } else {
-          do {
-            frame->InboundQueueNextFrame = InboundFrameQueue;
-          } while (!__sync_bool_compare_and_swap(&InboundFrameQueue, frame->InboundQueueNextFrame, frame));
+          PushFrameOntoQueue(InboundFrameQueue, frame);
         }
       }
 
@@ -1193,10 +1215,7 @@ namespace Orly {
         assert(LocalRunner);
         assert(other_runner);
         assert(frame);
-        TFrame *&outbound_queue = QueueArray[other_runner->RunnerId].Ptr;
-        do {
-          frame->InboundQueueNextFrame = outbound_queue;
-        } while (!__sync_bool_compare_and_swap(&outbound_queue, frame->InboundQueueNextFrame, frame));
+        PushFrameOntoQueue(QueueArray[other_runner->RunnerId].Ptr, frame);
       }
 
       inline void TRunner::ScheduleFrame(TFrame *frame) {

--- a/orly/indy/fiber/fiber_lock.test.cc
+++ b/orly/indy/fiber/fiber_lock.test.cc
@@ -100,7 +100,7 @@ FIXTURE(Typical) {
   const size_t num_runnable_per_thread = 256UL;
   size_t num_threads = 1UL;
   std::vector<TRunner *> runner_vec;
-  TRunner *runner_array[num_threads];
+  std::atomic<TRunner *> runner_array[num_threads];
   for (size_t i = 0; i < num_threads; ++i) {
     runner_array[i] = nullptr;
   }


### PR DESCRIPTION
## What

Part of the #184 TSan-hardening effort (Plan B): eliminate the ThreadSanitizer-confirmed data races in the Indy fiber scheduler's lock-free per-runner work queue.

The work queue is a Treiber stack: a producer pushes a `TFrame*` onto a per-runner head, and the owning runner atomically swaps the whole list off. It was implemented with the GCC `__sync_*` builtins over **plain (non-atomic)** `TFrame*` head fields, so the speculative head reads in the push loop and the non-empty checks in the drain loop were plain loads racing concurrent pushers and the consumer. That is real C++ memory-model UB (benign on x86, but TSan-flagged).

## Per-race analysis

1. **Queue head, producer** (`TRunner::ScheduleFrameSlow`, both overloads) — `frame->InboundQueueNextFrame = head;` plain-read the head inside the CAS loop. Now: relaxed `load` to seed the next-link, then `compare_exchange_weak(expected, frame, release, relaxed)`, with `expected` refreshed by the CAS on failure. Release publishes the node and its next-link.
2. **Queue head, consumer** (`TRunner::Run`) — `if (head)` plain-read before `__sync_lock_test_and_set(&head, nullptr)`. Now: `head.load(acquire)` for the non-empty check, `head.exchange(nullptr, acquire)` to drain. Acquire pairs with the pushers' release so the `InboundQueueNextFrame` links walked afterward are visible.
3. **RunnerArray publication** — a runner published itself with a plain store in its ctor; peers plain-read the slot in `Run()`. Now `std::atomic<TRunner*>` slots: `store(release)` on publish, `load(acquire)` on read, so a peer sees a fully constructed `TRunner` (including its `QueueArray`).
4. **DebugIsRunning** (`#ifndef NDEBUG` only) — set/cleared by the running frame, read by `AssertCanFree` from another thread. Now `std::atomic<bool>`, relaxed (debug-only flag).

The `TFrame::InboundQueueNextFrame` next-links stay **plain**: they are written by the producer before the release-CAS publishes the node and read by the consumer after the acquire-exchange, so the head atomic's release/acquire already orders them. Verified under TSan — no residual link-field races.

The fields are the only genuinely cross-thread-shared ones; the algorithm and the production hot path are unchanged. The conversion applies to both the production `setjmp`/`longjmp` switch path and the TSan `swapcontext` path.

## Memory-order rationale

- Heads: producer `release` / consumer `acquire` is the standard Treiber-stack handoff — it is exactly the edge that makes the plain next-link writes visible to the draining runner, so nothing weaker works and nothing stronger is needed.
- RunnerArray: `release`/`acquire` because the consumer dereferences the published `TRunner` and must observe its construction.
- DebugIsRunning: `relaxed` — a debug-only tripwire with no ordering obligations.

## TSan before/after (`tsan` jhm config, `setarch -R`, `TSAN_OPTIONS=halt_on_error=0 exitcode=0`)

| test | before | after |
|---|---|---|
| `orly/indy/fiber/fiber.test` | 6 | **0** |
| `orly/indy/fiber/algorithm.test` | 20 | **1** |
| `orly/indy/context_fold.test` | 1 | **0** |
| `orly/indy/context_xrepo.test` | 1 | **0** |

All four exit 0.

### The one remaining `algorithm.test` warning is a separate finding

It is **not** a work-queue race. It is a teardown ordering artifact between the frame pool and the fiber runtime: the main thread `free`s the `TFrame` backing storage in `~TThreadLocalGlobalPoolManager` while TSan still holds the fiber (`T17`)'s final `DebugIsRunning.store(false)` from `TFrame::Run`. The OS worker thread is joined (`t1.join()`), but TSan models each fiber as its own logical thread and does not transitively order that fiber's last write into the join edge at frame-pool teardown. It is debug-only (the access is the `#ifndef NDEBUG` flag) and surfaces only because that flag is now the lone TSan-tracked atomic in `TFrame` — the same access raced on master as a plain bool and was one of the original 20. Fixing it cleanly is a fiber-destroy/pool-teardown happens-before change, deeper than an atomic conversion, so it is left for a follow-up rather than forced here.

## Build gates

- `make debug` — green (also fixed `fiber_lock.test.cc`, the only other direct `TRunner(.., runner_array)` caller, to use a `std::atomic<TRunner*>` array).
- `make test` — green (exit 0).
- `fiber.test` / `algorithm.test` / `fiber_lock.test` / `context_fold.test` / `context_xrepo.test` all pass in the production debug build.
