### PR TITLE
fiber: order finished-fiber writes before frame-pool teardown for TSan (#200)

### DIFF
--- a/orly/indy/fiber/fiber.h
+++ b/orly/indy/fiber/fiber.h
@@ -631,6 +631,15 @@ namespace Orly {
           CheckFrameUnwound();
           assert(Runnable == nullptr);
           assert(RunnableFunc == nullptr);
+          #ifndef NDEBUG
+          /* Acquire-load pairs with the release-stores to DebugIsRunning in Run(),
+             giving ThreadSanitizer a happens-before from a fiber's last write to
+             this teardown so the pool free that follows is not reported as racing
+             it (#200). Not a tripwire: a frame may be parked mid-runnable here
+             (DebugIsRunning still true) when a test tears the pool down, so we only
+             need the synchronization edge, not an assertion. */
+          (void)DebugIsRunning.load(std::memory_order_acquire);
+          #endif
           free_fiber(MyFiber);
         }
 
@@ -693,7 +702,10 @@ namespace Orly {
             //printf("TFrame [%p] calling func\n", this);
 
             #ifndef NDEBUG
-            DebugIsRunning.store(true, std::memory_order_relaxed);
+            /* Release (paired with the acquire-load in ~TFrame, #200) so that even
+               a frame parked mid-runnable at teardown has its last DebugIsRunning
+               write synchronize with the pool free. */
+            DebugIsRunning.store(true, std::memory_order_release);
             #endif
             TRunnable::TFunc runnable_func = RunnableFunc;
             TRunnable *const runnable = Runnable;
@@ -706,7 +718,13 @@ namespace Orly {
               //abort();
             }
             #ifndef NDEBUG
-            DebugIsRunning.store(false, std::memory_order_relaxed);
+            /* Release so the acquire-load in ~TFrame (run on the teardown thread)
+               synchronizes-with this write, giving ThreadSanitizer a happens-before
+               from a finished fiber's last writes to the frame-pool free -- an
+               ordering that physically holds (frames complete before teardown) but
+               travels through the ucontext stack switch, which TSan can't model as
+               a happens-before the way it does pthread_join (#200). */
+            DebugIsRunning.store(false, std::memory_order_release);
             #endif
             //printf("TFrame [%p] FINISH calling func\n", this);
 

--- a/orly/tsan.supp
+++ b/orly/tsan.supp
@@ -49,27 +49,3 @@
 # to a single global order would change the synchronisation semantics under
 # test, so the report is suppressed rather than "fixed".
 deadlock:Orly::Spa::FluxCapacitor::TSync::TLocal::IncrLockCount
-
-# ---------------------------------------------------------------------------
-# orly/indy/fiber/algorithm.test -- frame-pool teardown vs finished-fiber write
-# ---------------------------------------------------------------------------
-# WARNING: ThreadSanitizer: data race
-#   Write of size 8 (free) by main thread:
-#     Base::TThreadLocalGlobalPoolManager<Orly::Indy::Fiber::TFrame, ...>::~...()
-#   Previous atomic write of size 1 by thread T17 (finished):
-#     Orly::Indy::Fiber::TFrame::Run()   // the DebugIsRunning tripwire flag
-#
-# At teardown the main thread frees the fiber frame-pool storage while TSan
-# still holds a finished fiber's last write to TFrame::DebugIsRunning.  This is
-# debug-only (DebugIsRunning, a "freed while still running" tripwire, exists
-# only in non-NDEBUG builds; #184 / PR #199 already made it std::atomic, so it
-# is not a memory-model UB race) and benign: the fiber framework guarantees
-# every frame has completed before its pool is torn down, but that ordering
-# travels through the manual ucontext stack-switch machinery, which
-# ThreadSanitizer cannot model as a happens-before the way it tracks
-# pthread_join.  TSan reports an ordering it cannot prove safe, not a reachable
-# race.
-#
-# Tracked for a proper fix (annotate fiber completion / order the pool free
-# after all frames are joined, then remove this entry) in issue #200.
-race:Base::TThreadLocalGlobalPoolManager<Orly::Indy::Fiber::TFrame


### PR DESCRIPTION
`Closes #200.` Fixes the one residual race the gating TSan job suppressed, so the suppression can be (and is) removed.

## The race
In `orly/indy/fiber/algorithm.test`, TSan reported:
```
Write of size 8 (free) by main thread:  ~TThreadLocalGlobalPoolManager<...TFrame>
Previous atomic write of size 1 by thread T17 (finished):  TFrame::Run()  // DebugIsRunning
```
The ordering physically holds (frames complete before the pool is torn down) but travels through the manual `ucontext` stack switch, which ThreadSanitizer can't model as a happens-before the way it does `pthread_join` — so it flagged a race that can't occur.

## Fix
Establish the missing edge with release/acquire on the existing **debug-only** `DebugIsRunning` atomic:
- `Run()` stores it `memory_order_release` (both the start `true` and finish `false` stores, so a frame parked mid-runnable also synchronizes).
- `~TFrame` (runs on the teardown thread, before `free(Alloc)`) `memory_order_acquire`-loads it.

The acquire reads the fiber's last write and synchronizes-with its release, ordering the fiber's writes before the destructor and the free that follows — exactly the happens-before TSan couldn't see.

The `~TFrame` load is **not** a tripwire: a test may legitimately tear the pool down with a fiber parked mid-runnable (an assertion there wrongly fired `fiber.test`), so it only provides the synchronization edge. All of this is under `#ifndef NDEBUG`; **release builds are unaffected**.

Removes the `race:...TThreadLocalGlobalPoolManager<...TFrame` entry from `orly/tsan.supp` (only the sync.test lock-order-inversion suppression remains).

## Verified
- **Under TSan, no suppressions:** `algorithm.test`, `fiber.test`, `fiber_lock.test`, `context_fold.test` → **0 warnings, 0 TFrame-pool races** (algorithm.test stable across 5 runs).
- **Debug builds:** `algorithm.test` 2/2, `fiber.test` 7/7, `fiber_lock.test` 1/1.