### PR TITLE
fix(prediction-market): commit web/package.json + ignore orlyc artifacts

### DIFF
--- a/examples/prediction-market/.gitignore
+++ b/examples/prediction-market/.gitignore
@@ -1,3 +1,10 @@
+# TypeScript driver build artifacts.
 node_modules/
 package-lock.json
 demo.js
+
+# orlyc build artifacts (e.g. `orlyc -d market.orly` emits these alongside).
+*.cc
+*.h
+*.so
+*.orly.sig

--- a/examples/prediction-market/web/package.json
+++ b/examples/prediction-market/web/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "orly-prediction-market-web",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Browser UI for the Orly prediction-market demo (on the orly TypeScript client)",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "esbuild": "^0.21.0",
+    "typescript": "^5.4.0"
+  }
+}


### PR DESCRIPTION
Follow-up to #208.

**1. `web/package.json` was never committed.** The browser UI's manifest (its `esbuild` / `typescript` / `@types/node` devDependencies) was left untracked, so from a fresh clone `web/build.sh` and `web/serve.sh` would `npm install` nothing and then fail to find `tsc`/`esbuild`. Adds a clean manifest (private, Apache-2.0, `devDependencies`). **Verified:** wiped `node_modules`, fresh `npm install` + `build.sh` → `app.js` builds clean.

**2. Ignore orlyc build artifacts.** `orlyc -d market.orly` (the inline-test run shown in the README) emits `market.cc` / `.h` / `.so` / `.link.cc` / `.orly.sig` next to the source; add those patterns (`*.cc`/`*.h`/`*.so`/`*.orly.sig`) to the example's `.gitignore` so the tree stays clean and they can't be committed by accident. Confirmed `market.orly` itself stays tracked.

Docs/build only — no engine or client-library code changed.
