### PR TITLE
examples: headless-browser Playwright test for the prediction-market UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,12 @@
 #   3. lang-tests         -- make debug + python3 tools/lang_test.py
 #   4. examples           -- run each examples/* end-to-end with both
 #                            its Python and Go drivers (orlyc + orlyi + WS)
+#   5. prediction-market-e2e -- the TS-only prediction-market example: its
+#                            terminal driver (run-ts.sh) plus a headless-browser
+#                            Playwright test driving two tabs trading on one
+#                            market (run-e2e.sh)
 #
-# A fifth job, `tsan`, builds the concurrency tests under ThreadSanitizer to
+# A sixth job, `tsan`, builds the concurrency tests under ThreadSanitizer to
 # validate the lock-free / commutative-merge claim at the memory level (data-
 # race freedom). It is GATING (issue #184): the curated set is clean, so the
 # job FAILS on any un-suppressed race. Provably-benign reports are documented
@@ -385,6 +389,74 @@ jobs:
         run: ./run-go.sh
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         working-directory: examples/recursive-variants
+
+  prediction-market-e2e:
+    name: prediction-market headless browser (Playwright)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install system dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        with:
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind ccache
+          version: 1.2
+
+      - name: Set up ccache
+        # Same masquerade-symlink trick as the examples job: route every compile
+        # through ccache so the build (and orlyc codegen) hit the cache.
+        run: |
+          for c in gcc g++ cc c++; do
+            sudo ln -sf "$(command -v ccache)" "/usr/local/bin/$c"
+          done
+          {
+            echo "CCACHE_DIR=$HOME/.ccache"
+            echo "CCACHE_MAXSIZE=2G"
+            echo "CCACHE_COMPRESS=1"
+          } >> "$GITHUB_ENV"
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Cache ccache
+        if: github.event_name != 'schedule'
+        uses: actions/cache@v5
+        with:
+          path: ~/.ccache
+          key: orly-ccache-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
+          restore-keys: |
+            orly-ccache-${{ runner.os }}-${{ github.job }}-
+            orly-ccache-${{ runner.os }}-
+
+      - name: make debug
+        run: make debug
+        id: build
+
+      # Terminal driver (orly TS client): concurrent traders on shared per-round
+      # keys via Promise.all, time-travel price history, resolution + payout, all
+      # self-checked against an independently computed ground truth.
+      - name: run-ts.sh (terminal driver, self-check)
+        run: ./run-ts.sh
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        working-directory: examples/prediction-market
+
+      # The browser's @playwright/test + a headless Chromium with its system
+      # libs (libnss3/libnspr4/libasound2, ...). --with-deps installs those.
+      - name: Install Playwright Chromium
+        run: npm install && npx playwright install --with-deps chromium
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        working-directory: examples/prediction-market/web
+
+      # Headless browser gate: two browser contexts on the same #pov= link both
+      # bet (one YES, one NO) concurrently; the test asserts the pool reaches $20
+      # and the price moves to 50/50 live in both -- the two-tab story, automated.
+      - name: run-e2e.sh (headless browser, two-tab concurrency)
+        run: ./run-e2e.sh
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        working-directory: examples/prediction-market/web
 
   tsan:
     name: ThreadSanitizer

--- a/examples/prediction-market/README.md
+++ b/examples/prediction-market/README.md
@@ -67,8 +67,9 @@ inline tests: `orlyc -d market.orly`.
 
 There's also a **browser UI** in [`web/`](web/) — `cd web && ./serve.sh`, then
 open the printed URL in two tabs to trade against yourself and watch the price
-move live (build-verified in CI-style checks; in-browser runtime confirmed by
-hand, not yet headless-tested — see its README).
+move live. It has a headless-browser test (`web/run-e2e.sh`, Playwright) that
+drives two tabs trading concurrently on one market — gated in CI; see its
+README.
 
 ## Files
 

--- a/examples/prediction-market/web/.gitignore
+++ b/examples/prediction-market/web/.gitignore
@@ -1,3 +1,7 @@
 node_modules/
 package-lock.json
 app.js
+
+# Playwright
+test-results/
+playwright-report/

--- a/examples/prediction-market/web/README.md
+++ b/examples/prediction-market/web/README.md
@@ -27,13 +27,21 @@ never runs in the browser.)
 
 ## Verification
 
-The build is verified in CI-style checks (type-checks under `tsc --strict` +
-DOM, bundles clean), and the **in-browser runtime has been confirmed by hand** —
-two tabs trading live on one market, prices moving with zero coordination. It is
-not yet exercised by an automated/headless-browser test, so treat the *build* as
-the gated check and the runtime as manually verified. The terminal driver
-([`../demo.ts`](../demo.ts), via `../run-ts.sh`) remains the fully end-to-end
-verified proof of the engine behavior.
+The runtime is exercised by an **automated headless-browser test**
+([`e2e/market.spec.ts`](e2e/market.spec.ts), Playwright): it opens the page in
+**two browser contexts on the same `#pov=` link**, has one buy YES and the other
+buy NO concurrently, and asserts both tabs see the pool reach `$20` and the
+price move to `50.0% / 50.0%` live — the two-tab story, automated. Run it with:
+
+```sh
+./run-e2e.sh         # serve.sh's setup + `npx playwright test` against it
+```
+
+It needs a headless Chromium (`npx playwright install --with-deps chromium`).
+The same flow runs as a gating job in CI. The build itself is also checked
+independently (type-checks under `tsc --strict` + DOM, bundles clean). The
+terminal driver ([`../demo.ts`](../demo.ts), via `../run-ts.sh`) remains the
+fully end-to-end verified proof of the engine behavior.
 
 ## Files
 

--- a/examples/prediction-market/web/app.ts
+++ b/examples/prediction-market/web/app.ts
@@ -7,8 +7,8 @@
 // coordination between tabs -- because every bet is a commutative `+=` in the
 // engine and the price is a read-time fold of the trade log.
 //
-// Built with esbuild (see build.sh). NOTE: written but not verified in a real
-// browser in this repo's sandbox -- run it and confirm.
+// Built with esbuild (see build.sh); exercised in a real headless browser by
+// the Playwright test in e2e/ (two tabs trading concurrently on one market).
 
 import { connect, Client } from "orly";
 

--- a/examples/prediction-market/web/e2e/market.spec.ts
+++ b/examples/prediction-market/web/e2e/market.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/test";
+
+// The smoke test for the browser UI: two "tabs" (pages) on the SAME market,
+// betting concurrently, and the price moving live in both with no coordination.
+// This is the headless-browser gate for the UI the demo's pitch rests on.
+test("two tabs trade concurrently on one market; prices move live", async ({ browser }) => {
+  // Tab A loads the app and creates the market POV (it lands in the URL hash).
+  const a = await browser.newPage();
+  await a.goto("/");
+  await expect(a.locator("#question")).toContainText("Will Orly ship");
+  await a.waitForFunction(() => location.hash.includes("pov="), null, { timeout: 15000 });
+  await expect(a.locator("#status")).toHaveText("live", { timeout: 15000 });
+  await expect(a.locator("#pool")).toHaveText("$0");
+
+  // Tab B opens the SAME shared link (#pov=...) -> same market.
+  const b = await browser.newPage();
+  await b.goto(a.url());
+  await expect(b.locator("#status")).toHaveText("live", { timeout: 15000 });
+
+  // Concurrent bets: A buys YES $10, B buys NO $10.
+  await a.getByRole("button", { name: /Buy YES/ }).click();
+  await b.getByRole("button", { name: /Buy NO/ }).click();
+
+  // Both bets land (no lost write): pool = $20 in BOTH tabs.
+  await expect(a.locator("#pool")).toHaveText("$20", { timeout: 8000 });
+  await expect(b.locator("#pool")).toHaveText("$20", { timeout: 8000 });
+
+  // Tab A sees Tab B's NO bet reflected in the live price (50/50), via the poll
+  // -- i.e. concurrent writes from another session show up with no coordination.
+  await expect(a.locator("#market")).toContainText(/YES.*50\.0%/, { timeout: 8000 });
+  await expect(a.locator("#market")).toContainText(/NO.*50\.0%/, { timeout: 8000 });
+});

--- a/examples/prediction-market/web/package.json
+++ b/examples/prediction-market/web/package.json
@@ -5,6 +5,7 @@
   "description": "Browser UI for the Orly prediction-market demo (on the orly TypeScript client)",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@playwright/test": "^1.44.0",
     "@types/node": "^20.0.0",
     "esbuild": "^0.21.0",
     "typescript": "^5.4.0"

--- a/examples/prediction-market/web/playwright.config.ts
+++ b/examples/prediction-market/web/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "@playwright/test";
+
+// The market UI + orlyi are started by run-e2e.sh; this just points the test
+// at the served page. Chromium runs with --no-sandbox for CI/container envs.
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 45_000,
+  fullyParallel: false,
+  retries: 0,
+  reporter: [["list"]],
+  use: {
+    baseURL: process.env.E2E_BASE_URL || "http://localhost:8000",
+    headless: true,
+    launchOptions: { args: ["--no-sandbox", "--disable-setuid-sandbox"] },
+  },
+});

--- a/examples/prediction-market/web/run-e2e.sh
+++ b/examples/prediction-market/web/run-e2e.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Headless browser smoke test (Playwright): two tabs trade concurrently on one
+# market and the price moves live. Starts orlyi + the static server, runs the
+# Playwright spec, tears everything down.
+#
+# The Playwright browser must be installed first (CI does this):
+#   npx playwright install --with-deps chromium
+set -e
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../../.. && pwd)"
+ORLY_OUT="${ORLY_OUT:-$REPO_ROOT/../out_orly/debug}"
+ORLYI="$ORLY_OUT/orly/server/orlyi"; ORLYC="$ORLY_OUT/orly/orlyc"
+for bin in "$ORLYI" "$ORLYC"; do
+  [ -x "$bin" ] || { echo "missing: $bin (run 'make debug')"; exit 1; }
+done
+command -v node >/dev/null && command -v npm >/dev/null || { echo "missing node/npm"; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'kill -9 $ORLYI_PID $HTTP_PID 2>/dev/null || true; rm -rf "$WORK"' EXIT
+
+echo "[1/4] build orly TS client + install web deps"
+(cd "$REPO_ROOT/clients/ts" && npm install --silent && npx tsc)
+npm install --silent
+
+echo "[2/4] compile market.orly + start orlyi"
+"$ORLYC" -o "$WORK" ../market.orly
+mkdir "$WORK/packages"; touch "$WORK/packages/__orly__"; cp "$WORK/market.0.so" "$WORK/packages/"
+pkill -9 -f 'instance_name=prediction_market_e2e' 2>/dev/null || true; sleep 1
+"$ORLYI" --mem_sim --create=true --port_number=19600 --slave_port_number=19601 \
+  --connection_backlog=10 --instance_name=prediction_market_e2e --starting_state=SOLO \
+  --package_dir="$WORK/packages" > "$WORK/orlyi.log" 2>&1 &
+ORLYI_PID=$!
+for _ in $(seq 1 60); do ss -tln 2>/dev/null | grep -q ':8082' && break; sleep 1; done
+ss -tln 2>/dev/null | grep -q ':8082' || { echo "orlyi failed:"; tail -20 "$WORK/orlyi.log"; exit 1; }
+
+echo "[3/4] build bundle + serve on :8000"
+./build.sh
+python3 -m http.server 8000 >/dev/null 2>&1 &
+HTTP_PID=$!
+for _ in $(seq 1 40); do ss -tln 2>/dev/null | grep -q ':8000' && break; sleep 0.5; done
+
+echo "[4/4] run Playwright"
+npx playwright test


### PR DESCRIPTION
Adds an automated **headless-browser test** for the prediction-market browser UI, which until now was verified by hand only.

## What it tests
The actual two-tab story the demo's pitch rests on. [`web/e2e/market.spec.ts`](../blob/test/prediction-market-e2e/examples/prediction-market/web/e2e/market.spec.ts) opens the page in **two browser contexts on the same `#pov=` link**, then:

- one context buys **YES**, the other buys **NO**, concurrently;
- asserts the pool reaches **$20** in *both* tabs (no lost write);
- asserts the price moves to **50.0% / 50.0%** live in tab A — i.e. a write from another session shows up via the poll with zero coordination.

That's the commutative-`+=`, fold-on-read, no-locks claim, exercised through a real DOM + WebSocket round-trip instead of by hand.

## Pieces
- `web/e2e/market.spec.ts` — the two-tab concurrency spec.
- `web/playwright.config.ts` — `testDir`, headless, `--no-sandbox` for container/CI envs.
- `web/run-e2e.sh` — `serve.sh`'s setup (compile `market.orly`, start `orlyi`, build the esbuild bundle, static-serve) and then `npx playwright test`, with a teardown trap.
- `web/package.json` — adds the `@playwright/test` devDependency.
- `web/.gitignore` — ignores `test-results/` and `playwright-report/`.

## CI
A new **`prediction-market-e2e`** job runs the example's terminal driver (`run-ts.sh`, which self-checks the full trajectory) and then the headless test (`run-e2e.sh`, after `playwright install --with-deps chromium`). This is the **first CI coverage of the prediction-market example** — the existing `examples` job only runs the Python and Go drivers, which this TS-only demo doesn't have.

## Docs
Both READMEs and the `app.ts` header now describe the runtime as an automated, gated check rather than "manually verified, not yet headless-tested."

## Verification
Ran locally against a real `orlyi` + headless Chromium: **`1 passed`**.
