### PR TITLE
Add min/max merge ops + intersection upsert via an identity/seed refactor (#213)

### DIFF
--- a/orly/code_gen/builder.cc
+++ b/orly/code_gen/builder.cc
@@ -207,16 +207,17 @@ TInline::TPtr BuildOptInline(const L0::TPackage *package, const Expr::TExpr::TPt
   return TInline::TPtr();
 }
 
-/* Commutative-upsert (#151): build the LHS of a `*<[k]>::(T) OP= v`
-   mutation. For an identity-default commutative mutator (Add, Or, Xor,
-   Union, SymmetricDiff) whose LHS is a typed read `expr::(T)`, emit the
-   non-throwing ReadOrIdentity read so a first-write to an absent key
-   auto-initialises from the monoid identity instead of throwing
-   "Cannot de-reference Key ... which does not exist". Every other shape
-   (other mutators, non-read LHS such as `x.field`, partial mutables)
-   keeps the existing throw-on-absent Read via BuildInline. */
+/* Commutative-upsert (#151/#152, extended #213): build the LHS of a
+   `*<[k]>::(T) OP= v` mutation. For an absent-key-seedable commutative
+   mutator (Add, Or, Xor, Union, SymmetricDiff, Min, Max, Intersection)
+   whose LHS is a typed read `expr::(T)`, emit the non-throwing
+   ReadOrIdentity read so a first-write to an absent key auto-initialises
+   (seeding from the RHS at fold time) instead of throwing "Cannot
+   de-reference Key ... which does not exist". Every other shape (other
+   mutators, non-read LHS such as `x.field`, partial mutables) keeps the
+   existing throw-on-absent Read via BuildInline. */
 TInline::TPtr BuildMutateLhs(const L0::TPackage *package, const Expr::TExpr::TPtr &lhs, TMutator mutator) {
-  if (Var::IsIdentityDefaultCommutative(mutator)) {
+  if (Var::IsAbsentKeySeedRhs(mutator)) {
     if (auto *read = dynamic_cast<const Expr::TRead *>(lhs.get())) {
       Type::TType ret_type = Type::UnwrapSequence(read->GetType());
       /* keep_mutable: the inner keys expr feeds a mutable read, exactly

--- a/orly/code_gen/effect.cc
+++ b/orly/code_gen/effect.cc
@@ -49,6 +49,10 @@ void TMutation::Write(TCppPrinter &out) const {
       break;
     case TMutator::Intersection: out << "Intersection";
       break;
+    case TMutator::Max: out << "Max";
+      break;
+    case TMutator::Min: out << "Min";
+      break;
     case TMutator::Mod: out << "Mod";
       break;
     case TMutator::Mult: out << "Mult";

--- a/orly/indy/context_fold.test.cc
+++ b/orly/indy/context_fold.test.cc
@@ -376,3 +376,69 @@ FIXTURE(Issue143CreateRaceSemantics) {
     cond.notify_one();
   });
 }
+
+/* Issue #213: the min (`<?=`) / max (`>?=`) merge mutators fold through the
+   exact same deferred-commutative read path as `+=` (ApplyDeferredFold).
+   min/max are commutative, associative AND idempotent, so a run of same-key
+   entries collapses to a single value regardless of order, and a first
+   entry on an absent key seeds from its own RHS (the singleton fold ==
+   the element). This mirrors Issue143CreateRaceSemantics but pins the
+   min/max results, exercising the real indy memory/disk fold rather than
+   just the var-layer TMutation::Apply unit. */
+FIXTURE(MinMaxDeferredFold) {
+  Fiber::TFiberTestRunner runner([](std::mutex &mut, std::condition_variable &cond, bool &fin, Fiber::TRunner::TRunnerCons &) {
+    TSuprena arena;
+    void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
+    const TScheduler::TPolicy scheduler_policy(10, 10, 10ms);
+    TScheduler scheduler;
+    scheduler.SetPolicy(scheduler_policy);
+
+    Base::TUuid idx_id(TUuid::Twister);
+    const TIndexKey gauge_key(idx_id, TKey(make_tuple(1L), &arena, state_alloc));
+
+    auto run_scenario = [&](const char *name,
+                            const std::vector<std::pair<TMutator, int64_t>> &entries,
+                            int64_t want) {
+      Orly::Indy::Disk::Sim::TMemEngine mem_engine(&scheduler, 256, 64, 128, 1, 64, 1);
+      auto manager = make_unique<TMyManager>(mem_engine.GetEngine(), &scheduler, MemMergeCoreVec, DiskMergeCoreVec);
+      Base::TUuid repo_id(TUuid::Twister);
+      auto repo = manager->GetRepo(repo_id, TTtl::max(), std::nullopt, true, true);
+      for (const auto &e : entries) {
+        auto transaction = manager->NewTransaction();
+        auto update = TUpdate::NewUpdate(TUpdate::TOpByKey{}, TKey(&arena),
+                                         TKey(Base::TUuid(TUuid::Twister), &arena, state_alloc));
+        update->AddEntry(gauge_key, TKey(e.second, &arena, state_alloc), e.first);
+        transaction->Push(repo, update);
+        transaction->Prepare();
+        transaction->CommitAction();
+      }
+      TSuprena ctx_arena;
+      TContext context(repo, &ctx_arena);
+      EXPECT_EQ(context[gauge_key], TKey(want, &arena, state_alloc));
+    };
+
+    /* Single min/max on a totally absent key seeds from the RHS. */
+    run_scenario("Min7_only_absentkey",   {{TMutator::Min,7}},                          7);
+    run_scenario("Max3_only_absentkey",   {{TMutator::Max,3}},                          3);
+    /* Two deferred mins/maxes fold; idempotent + commutative => the bound
+       wins regardless of commit order. */
+    run_scenario("Min7_then_Min3",        {{TMutator::Min,7},{TMutator::Min,3}},        3);
+    run_scenario("Min3_then_Min7",        {{TMutator::Min,3},{TMutator::Min,7}},        3);
+    run_scenario("Max3_then_Max7",        {{TMutator::Max,3},{TMutator::Max,7}},        7);
+    run_scenario("Max7_then_Max3",        {{TMutator::Max,7},{TMutator::Max,3}},        7);
+    /* Three-deep folds. */
+    run_scenario("Min_5_2_9",             {{TMutator::Min,5},{TMutator::Min,2},{TMutator::Min,9}}, 2);
+    run_scenario("Max_5_9_2",             {{TMutator::Max,5},{TMutator::Max,9},{TMutator::Max,2}}, 9);
+    /* Assign base then a min/max above it folds against the base. */
+    run_scenario("Assign10_then_Min3",    {{TMutator::Assign,10},{TMutator::Min,3}},    3);
+    run_scenario("Assign10_then_Min30",   {{TMutator::Assign,10},{TMutator::Min,30}},   10);
+    run_scenario("Assign2_then_Max9",     {{TMutator::Assign,2},{TMutator::Max,9}},     9);
+    /* A newer destructive Assign masks older min/max history (same
+       destructive semantics pinned in Issue143CreateRaceSemantics). */
+    run_scenario("Min3_then_Assign10",    {{TMutator::Min,3},{TMutator::Assign,10}},    10);
+
+    std::lock_guard<std::mutex> lock(mut);
+    fin = true;
+    cond.notify_one();
+  });
+}

--- a/orly/key_generator.h
+++ b/orly/key_generator.h
@@ -308,11 +308,12 @@ namespace Orly {
        have the addr the caller asked about), so the downstream effect
        still registers against the right key.
 
-       This is only ever emitted for the LHS of a defer-safe commutative
-       mutation whose identity equals the default value (Add, Or, Xor,
-       Union, SymmetricDiff -- see code_gen/builder.cc). For those, a
-       first-write `*<[k]>::(T) OP= v` on an absent key auto-initialises
-       from the identity and applies OP, instead of throwing -- and
+       This is only ever emitted for the LHS of an absent-key-seedable
+       commutative mutation (Add, Or, Xor, Union, SymmetricDiff, Min, Max,
+       Intersection -- IsAbsentKeySeedRhs, see code_gen/builder.cc). For
+       those, a first-write `*<[k]>::(T) OP= v` on an absent key
+       auto-initialises by seeding from the RHS at fold time, instead of
+       throwing -- and
        because session.cc routes the resulting TMutation through the
        deferred-commutative path (mutator preserved, RHS emitted as-is),
        two concurrent first-writers both emit {OP, v} entries that the

--- a/orly/orly.nycr
+++ b/orly/orly.nycr
@@ -102,6 +102,8 @@ log_10_kwd        = '"log10"';
 lt                = '"<"' inequality_prec left;
 lt_eq             = '"<="' inequality_prec left;
 match_kwd         = '"match"' lowest_prec left;
+max_assign        = '">?="';                          /* max-assign mutation operator: x >?= v  ==>  x = max(x, v) */
+min_assign        = '"<?="';                          /* min-assign mutation operator: x <?= v  ==>  x = min(x, v) */
 minus             = '"-"' add_and_sub_prec left;
 mutable_kwd       = '"mutable"' lowest_prec right;
 neq               = '"!="' equality_prec left;
@@ -644,6 +646,8 @@ mutate_stmt : stmt -> lhs:expr mutation rhs:expr semi;
   mutation_bitwise_and : mutation -> ampersand eq;
   mutation_bitwise_or  : mutation -> bar eq;
   mutation_bitwise_xor : mutation -> hat eq;
+  mutation_min         : mutation -> min_assign;
+  mutation_max         : mutation -> max_assign;
 
 /* ------------------------------------------------------------------------------------------------------------------------------------------------
     TODO

--- a/orly/rt/mutate.cc
+++ b/orly/rt/mutate.cc
@@ -50,6 +50,14 @@ Var::TVar Orly::Rt::Mutate(const Var::TVar &lhs, TMutator mutator, const Var::TV
       result.Intersection(rhs);
       break;
     }
+    case TMutator::Max: {
+      result.Max(rhs);
+      break;
+    }
+    case TMutator::Min: {
+      result.Min(rhs);
+      break;
+    }
     case TMutator::Mod: {
       result.Mod(rhs);
       break;

--- a/orly/shared_enum.h
+++ b/orly/shared_enum.h
@@ -38,7 +38,7 @@ namespace Orly {
   std::ostream &Write(std::ostream &strm, TAddrDir dir);
   std::ostream &WriteCppType(std::ostream &strm, TAddrDir dir);
 
-  enum class TMutator { Add, And, Assign, Div, Exp, Intersection, Mod, Mult, Or, SymmetricDiff, Sub, Union, Xor };
+  enum class TMutator { Add, And, Assign, Div, Exp, Intersection, Max, Min, Mod, Mult, Or, SymmetricDiff, Sub, Union, Xor };
 
   std::ostream &operator<<(std::ostream &strm, TAddrDir dir);
 

--- a/orly/symbol/stmt/mutate.cc
+++ b/orly/symbol/stmt/mutate.cc
@@ -25,6 +25,7 @@
 #include <orly/type/exp_visitor.h>
 #include <orly/type/infix_visitor.h>
 #include <orly/type/logical_ops_visitor.h>
+#include <orly/type/min_max_visitor.h>
 #include <orly/type/mod_visitor.h>
 #include <orly/type/mult_visitor.h>
 #include <orly/type/set_ops_visitor.h>
@@ -161,6 +162,14 @@ void TMutate::TypeCheck() const {
           GetLhs()->GetExpr()->GetType(),
           GetRhs()->GetExpr()->GetType(),
           TMutateTypeVisitor<Type::TSetOpsVisitor>(dummy, GetPosRange()));
+      break;
+    }
+    case TMutator::Max:
+    case TMutator::Min: {
+      Type::TType::Accept(
+          GetLhs()->GetExpr()->GetType(),
+          GetRhs()->GetExpr()->GetType(),
+          TMutateTypeVisitor<Type::TMinMaxVisitor>(dummy, GetPosRange()));
       break;
     }
     case TMutator::Mod: {

--- a/orly/synth/mutate_stmt.cc
+++ b/orly/synth/mutate_stmt.cc
@@ -63,6 +63,8 @@ Symbol::Stmt::TStmt::TPtr TMutateStmt::Build() const {
     virtual void operator()(const Package::Syntax::TMutationLogicalAnd *) const { Mutator = TMutator::And;           }
     virtual void operator()(const Package::Syntax::TMutationLogicalOr  *) const { Mutator = TMutator::Or;            }
     virtual void operator()(const Package::Syntax::TMutationLogicalXor *) const { Mutator = TMutator::Xor;           }
+    virtual void operator()(const Package::Syntax::TMutationMin        *) const { Mutator = TMutator::Min;           }
+    virtual void operator()(const Package::Syntax::TMutationMax        *) const { Mutator = TMutator::Max;           }
     virtual void operator()(const Package::Syntax::TMutationMinus      *) const { Mutator = TMutator::Sub;           }
     virtual void operator()(const Package::Syntax::TMutationMod        *) const { Mutator = TMutator::Mod;           }
     virtual void operator()(const Package::Syntax::TMutationMul        *) const { Mutator = TMutator::Mult;          }

--- a/orly/type/min_max_visitor.h
+++ b/orly/type/min_max_visitor.h
@@ -1,0 +1,135 @@
+/* <orly/type/min_max_visitor.h>
+
+   Type-check rules for the `<?=` (min) and `>?=` (max) merge-mutation
+   operators (issue #213). `TCommutativeInfixVisitor`. Only same-typed
+   orderable numeric pairs are accepted -- `TInt <?/>? TInt` -> `TInt`
+   and `TReal <?/>? TReal` -> `TReal`. The result type is the operand
+   type (unlike the comparison visitors, which yield `TBool`), because
+   min/max return one of their operands. Everything else throws, which
+   matches the runtime: `Var::TVar::Min` / `Max` are only implemented on
+   `TInt` / `TReal` (every other TVar type throws). Mixed numeric pairs
+   (`int <?= real`) are deliberately rejected -- the runtime folds same
+   typed values, so we keep the surface honest rather than silently
+   widening.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#pragma once
+
+#include <orly/error.h>
+#include <orly/pos_range.h>
+#include <orly/type/commutative_infix_visitor.h>
+
+namespace Orly {
+
+  namespace Type {
+
+    class TMinMaxVisitor
+        : public Type::TCommutativeInfixVisitor {
+      protected:
+
+      TMinMaxVisitor(Type::TType &type, const TPosRange &pos_range)
+          : Type::TCommutativeInfixVisitor(type, pos_range) {}
+
+      private:
+
+      virtual void operator()(const Type::TAddr *, const Type::TAddr     *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TAddr *, const Type::TBool     *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TAddr *, const Type::TDict     *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TAddr *, const Type::TId       *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TAddr *, const Type::TInt      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TAddr *, const Type::TList     *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TAddr *, const Type::TObj      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TAddr *, const Type::TReal     *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TAddr *, const Type::TSet      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TAddr *, const Type::TStr      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TAddr *, const Type::TTimeDiff *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TAddr *, const Type::TTimePnt  *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TBool *, const Type::TBool     *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TBool *, const Type::TDict     *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TBool *, const Type::TId       *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TBool *, const Type::TInt      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TBool *, const Type::TList     *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TBool *, const Type::TObj      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TBool *, const Type::TReal     *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TBool *, const Type::TSet      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TBool *, const Type::TStr      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TBool *, const Type::TTimeDiff *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TBool *, const Type::TTimePnt  *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TDict *, const Type::TDict     *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TDict *, const Type::TId       *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TDict *, const Type::TInt      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TDict *, const Type::TList     *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TDict *, const Type::TObj      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TDict *, const Type::TReal     *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TDict *, const Type::TSet      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TDict *, const Type::TStr      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TDict *, const Type::TTimeDiff *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TDict *, const Type::TTimePnt  *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TId   *, const Type::TId       *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TId   *, const Type::TInt      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TId   *, const Type::TList     *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TId   *, const Type::TObj      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TId   *, const Type::TReal     *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TId   *, const Type::TSet      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TId   *, const Type::TStr      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TId   *, const Type::TTimeDiff *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TId   *, const Type::TTimePnt  *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TInt  *, const Type::TInt      *) const {
+        Type = Type::TInt::Get();
+      }
+      virtual void operator()(const Type::TInt  *, const Type::TList     *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TInt  *, const Type::TObj      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TInt  *, const Type::TReal     *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TInt  *, const Type::TSet      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TInt  *, const Type::TStr      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TInt  *, const Type::TTimeDiff *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TInt  *, const Type::TTimePnt  *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TList *, const Type::TList     *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TList *, const Type::TObj      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TList *, const Type::TReal     *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TList *, const Type::TSet      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TList *, const Type::TStr      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TList *, const Type::TTimeDiff *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TList *, const Type::TTimePnt  *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TObj  *, const Type::TObj      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TObj  *, const Type::TReal     *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TObj  *, const Type::TSet      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TObj  *, const Type::TStr      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TObj  *, const Type::TTimeDiff *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TObj  *, const Type::TTimePnt  *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TReal *, const Type::TReal     *) const {
+        Type = Type::TReal::Get();
+      }
+      virtual void operator()(const Type::TReal *, const Type::TSet      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TReal *, const Type::TStr      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TReal *, const Type::TTimeDiff *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TReal *, const Type::TTimePnt  *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TSet  *, const Type::TSet      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TSet  *, const Type::TStr      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TSet  *, const Type::TTimeDiff *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TSet  *, const Type::TTimePnt  *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TStr  *, const Type::TStr      *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TStr  *, const Type::TTimeDiff *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TStr  *, const Type::TTimePnt  *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TTimeDiff *, const Type::TTimeDiff *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TTimeDiff *, const Type::TTimePnt  *) const { throw TExprError(HERE, PosRange); }
+      virtual void operator()(const Type::TTimePnt  *, const Type::TTimePnt  *) const { throw TExprError(HERE, PosRange); }
+
+    };  // TMinMaxVisitor
+
+  }  // Type
+
+}  // Orly

--- a/orly/var/impl.cc
+++ b/orly/var/impl.cc
@@ -24,6 +24,7 @@
 
 #include <base/not_implemented.h>
 #include <orly/pos_range.h>
+#include <orly/rt/runtime_error.h>
 #include <orly/type/get_prec.h>
 
 namespace Orly {
@@ -990,6 +991,18 @@ TVar::TVisitor::~TVisitor() {}
 TVar::TDoubleVisitor::~TDoubleVisitor() {}
 
 TVar::TImpl::~TImpl() {}
+
+/* Base min / max (#213): only TInt / TReal override these; every other
+   TVar type inherits these throwing defaults, so `<?=` / `>?=` against a
+   non-numeric value fails the same way the per-type throw-stubs do for
+   the other set/bitwise mutators. */
+TVar::TImpl &TVar::TImpl::Max(const TVar &) {
+  throw Rt::TSystemError(HERE, "Max (>?=) is only supported on int and real values.");
+}
+
+TVar::TImpl &TVar::TImpl::Min(const TVar &) {
+  throw Rt::TSystemError(HERE, "Min (<?=) is only supported on int and real values.");
+}
 
 void TVar::TImpl::Delete(TImpl *impl) {
   delete impl;

--- a/orly/var/impl.h
+++ b/orly/var/impl.h
@@ -110,6 +110,13 @@ namespace Orly {
         /* TODO */
         virtual TImpl &Mod(const TVar &) = 0;
 
+        /* The min / max merge-mutation operators (#213). Unlike the
+           operators above these are NOT pure: only TInt / TReal override
+           them; the base throws (see impl.cc), so every other TVar type
+           rejects `<?=` / `>?=` without a per-type stub. */
+        virtual TImpl &Max(const TVar &);
+        virtual TImpl &Min(const TVar &);
+
         /* TODO */
         virtual TImpl &Mult(const TVar &) = 0;
 
@@ -399,6 +406,20 @@ namespace Orly {
       Var::TVar &Mod(const TVar &rhs) {
         assert(*this);
         Impl->Mod(rhs);
+        return *this;
+      }
+
+      /* TODO */
+      Var::TVar &Max(const TVar &rhs) {
+        assert(*this);
+        Impl->Max(rhs);
+        return *this;
+      }
+
+      /* TODO */
+      Var::TVar &Min(const TVar &rhs) {
+        assert(*this);
+        Impl->Min(rhs);
         return *this;
       }
 

--- a/orly/var/int.cc
+++ b/orly/var/int.cc
@@ -69,6 +69,22 @@ TInt &TInt::Intersection(const TVar &) {
   throw Rt::TSystemError(HERE, "Intersection not supported on Int.");
 }
 
+TInt &TInt::Max(const TVar &rhs) {
+  int64_t r = Var::TVar::TDt<int64_t>::As(rhs);
+  if (r > Val) {
+    Val = r;
+  }
+  return *this;
+}
+
+TInt &TInt::Min(const TVar &rhs) {
+  int64_t r = Var::TVar::TDt<int64_t>::As(rhs);
+  if (r < Val) {
+    Val = r;
+  }
+  return *this;
+}
+
 TInt &TInt::Mod(const TVar &rhs) {
   Val %= Var::TVar::TDt<int64_t>::As(rhs);
   return *this;

--- a/orly/var/int.h
+++ b/orly/var/int.h
@@ -50,6 +50,10 @@ namespace Orly {
       /* TODO */
       virtual TInt &Intersection(const TVar &);
 
+      /* The max / min merge-mutation operators (#213). */
+      virtual TInt &Max(const TVar &);
+      virtual TInt &Min(const TVar &);
+
       /* TODO */
       virtual TInt &Mod(const TVar &);
 

--- a/orly/var/mutation.cc
+++ b/orly/var/mutation.cc
@@ -115,20 +115,19 @@ TPtr<TMutation> TMutation::New(TMutator mutator, const Var::TVar &rhs) {
 
 void TMutation::Apply(Var::TVar &var) const {
 
-  /* Commutative-upsert (#151): a first-write `*<[k]>::(T) OP= v` on a key
-     that was never created reaches the fold with an EMPTY base `var`
-     (default TVar). For an identity-default commutative mutator the
-     monoid identity equals the default value, and `identity OP rhs ==
-     rhs`, so we materialise the base by taking the RHS directly instead
-     of folding the RHS into an empty TVar -- which would trip the
-     `assert(*this)` in TVar::Add / TVar::Or / TVar::Union etc.
-     (var/impl.h). This is exactly type-correct for each gated op
-     (0 + r = r, false | r = r, false ^ r = r, {} U r = r, {} symdiff r
-     = r), and it keeps the seeded value's type pinned to the RHS rather
-     than to a guessed identity. Every other mutator (Assign, Mult, And,
-     Intersection, Sub, ...) keeps the existing fold, which still requires
-     a non-empty base. */
-  if (!var && IsIdentityDefaultCommutative(Mutator)) {
+  /* Commutative-upsert (#151/#152, extended #213): a first-write
+     `*<[k]>::(T) OP= v` on a key that was never created reaches the fold
+     with an EMPTY base `var` (default TVar). For an absent-key-seedable
+     commutative mutator, folding the op over the single RHS element yields
+     the RHS itself, so we materialise the base by taking the RHS directly
+     instead of folding it into an empty TVar -- which would trip the
+     `assert(*this)` in TVar::Add / Min / Intersection etc. (var/impl.h).
+     This is exactly correct for each gated op (0 + r = r, false | r = r,
+     {} U r = r, min(r) = r, max(r) = r, intersection(r) = r) and pins the
+     seeded value's type to the RHS rather than to a guessed identity.
+     Every other mutator (Assign, Mult, And, Sub, ...) keeps the existing
+     fold, which still requires a non-empty base. */
+  if (!var && IsAbsentKeySeedRhs(Mutator)) {
     var = Rhs;
     return;
   }
@@ -167,9 +166,12 @@ void TMutation::Augment(const TPtr<const TChange> &change) {
     case TMutator::Xor:
     case TMutator::Union:
     case TMutator::Intersection:
-    case TMutator::SymmetricDiff: {
+    case TMutator::SymmetricDiff:
+    case TMutator::Min:
+    case TMutator::Max: {
       // For these: `x OP a; x OP b` is equivalent to `x OP (a OP b)`,
       // so the combined Rhs is `Rt::Mutate(Rhs, Mutator, other->Rhs)`.
+      // (min/max also: max(x,a,b) == max(x, max(a,b)).)
       Rhs = Orly::Rt::Mutate(Rhs, Mutator, other->Rhs);
       return;
     }

--- a/orly/var/mutation.h
+++ b/orly/var/mutation.h
@@ -58,6 +58,10 @@ namespace Orly {
           case TMutator::Union:
           case TMutator::Intersection:
           case TMutator::SymmetricDiff:
+          /* min / max are commutative, associative AND idempotent (a
+             semilattice) -- the cleanest possible merge ops (#213). */
+          case TMutator::Min:
+          case TMutator::Max:
             return true;
           case TMutator::Assign:
           case TMutator::Sub:
@@ -69,40 +73,54 @@ namespace Orly {
         return false;
       }
 
-      /* True iff this mutator is defer-safe commutative AND its monoid
-         IDENTITY equals the default-constructed value of the operand
-         type (0 for ints, false for bools, the empty set for sets).
+      /* True iff a first-write `*<[k]>::(T) OP= v` to an ABSENT key should
+         auto-initialise (upsert) by seeding the value DIRECTLY from the
+         RHS, rather than throwing "Cannot de-reference Key ... which does
+         not exist".
 
-         This is a STRICT SUBSET of IsDeferSafeCommutative: it powers the
-         commutative-upsert (#151) statement-layer auto-initialise, where
-         a first-write `*<[k]>::(T) OP= v` on an absent key must seed the
-         LHS from the identity. The auto-seed is produced by default-
-         constructing the operand (key_generator.h ReadOrIdentity), so it
-         is only sound when default == identity.
+         This is the absent-key half of the commutative-upsert work
+         (#151/#152, extended in #213). It is a subset of
+         IsDeferSafeCommutative. Seeding from the RHS is correct precisely
+         because folding any commutative merge op over a SINGLE element
+         yields that element:
 
-           Add  -> 0        (default int)           OK
-           Or   -> 0/false  (default)               OK
-           Xor  -> 0/false  (default)               OK
-           Union-> {}       (default set)           OK
-           SymmetricDiff -> {} (A symdiff {} == A)   OK
+           Add          : 0 + r            == r
+           Or           : false | r        == r
+           Xor           : false ^ r        == r
+           Union         : {} U r           == r
+           SymmetricDiff : {} symdiff r     == r
+           Min           : min(r)           == r      (#213)
+           Max           : max(r)           == r      (#213)
+           Intersection  : intersection(r)  == r      (#213 -- identity is
+                            the universal set, NOT representable as a value,
+                            but the singleton fold is still just r)
 
-         Excluded -- default value is NOT the identity, so seeding from
-         the default would silently corrupt a real first-write:
-           Mult         -> identity 1   (default 0)
-           And          -> identity all-ones (default 0)
-           Intersection -> identity universal-set (default {})
-         These keep the existing throw-on-absent behaviour. */
-      inline bool IsIdentityDefaultCommutative(TMutator mutator) {
+         So the seed is taken as `var = Rhs` in TMutation::Apply
+         (mutation.cc) -- NOT by default-constructing the operand -- and the
+         matching LHS read is emitted as the non-throwing ReadOrIdentity
+         (code_gen/builder.cc). The read's own value is discarded: the
+         deferred-commutative path (server/session.cc) emits {mutator, RHS}
+         and the read/disk fold seeds from the RHS, so two concurrent
+         first-writers compose without a lost update.
+
+         Excluded for now -- their singleton fold is ALSO r, so they could
+         ride this path, but they are deferred to a follow-up (no current
+         demand): Mult (identity 1; PR2 of #213) and And (identity
+         all-ones). A plain read of an absent key (outside a commutative
+         mutation) still throws for every mutator. */
+      inline bool IsAbsentKeySeedRhs(TMutator mutator) {
         switch (mutator) {
           case TMutator::Add:
           case TMutator::Or:
           case TMutator::Xor:
           case TMutator::Union:
           case TMutator::SymmetricDiff:
+          case TMutator::Min:
+          case TMutator::Max:
+          case TMutator::Intersection:
             return true;
           case TMutator::Mult:
           case TMutator::And:
-          case TMutator::Intersection:
           case TMutator::Assign:
           case TMutator::Sub:
           case TMutator::Div:

--- a/orly/var/mutation.test.cc
+++ b/orly/var/mutation.test.cc
@@ -211,14 +211,74 @@ FIXTURE(UpsertEmptyBase_SymmetricDiff_Set) {
   EXPECT_EQ(val, TVar(Rt::TSet<int64_t>{1, 2}));
 }
 
-FIXTURE(UpsertEmptyBase_Mult_StillThrows) {
-  /* Mult is NOT identity-default (identity 1 != default 0), so applying
-     it onto an empty base must NOT silently seed -- it keeps the old
-     fold, which trips on the empty base. We assert it still refuses
-     (throws/aborts is acceptable; here it must not quietly succeed with
-     a wrong value). The guard is IsIdentityDefaultCommutative, so the
-     Mult branch never takes the seed path. */
-  EXPECT_FALSE(IsIdentityDefaultCommutative(TMutator::Mult));
-  EXPECT_FALSE(IsIdentityDefaultCommutative(TMutator::And));
-  EXPECT_FALSE(IsIdentityDefaultCommutative(TMutator::Intersection));
+FIXTURE(UpsertEmptyBase_Min_Int) {
+  /* min(7) == 7 on a never-created int key: a first `<?= 7` seeds the
+     value directly from the RHS (#213). */
+  TVar val;
+  EXPECT_FALSE(static_cast<bool>(val));
+  TMutation::New(TMutator::Min, TVar(int64_t(7)))->Apply(val);
+  EXPECT_TRUE(static_cast<bool>(val));
+  EXPECT_EQ(val, TVar(int64_t(7)));
+}
+
+FIXTURE(UpsertEmptyBase_Min_ThenMin) {
+  /* empty <?= 7 seeds (->7), then <?= 3 folds to min(7,3) == 3. */
+  TVar val;
+  TMutation::New(TMutator::Min, TVar(int64_t(7)))->Apply(val);
+  TMutation::New(TMutator::Min, TVar(int64_t(3)))->Apply(val);
+  EXPECT_EQ(val, TVar(int64_t(3)));
+}
+
+FIXTURE(UpsertEmptyBase_Max_ThenMax) {
+  /* empty >?= 3 seeds (->3), then >?= 7 folds to max(3,7) == 7. */
+  TVar val;
+  TMutation::New(TMutator::Max, TVar(int64_t(3)))->Apply(val);
+  TMutation::New(TMutator::Max, TVar(int64_t(7)))->Apply(val);
+  EXPECT_EQ(val, TVar(int64_t(7)));
+}
+
+FIXTURE(UpsertEmptyBase_Intersection_Set) {
+  /* intersection over the singleton {1,2,3} == {1,2,3} on a never-created
+     set key. The identity (universal set) is not representable, but the
+     singleton fold is still the RHS, so seeding from the RHS is correct
+     (#213). */
+  TVar val;
+  TMutation::New(TMutator::Intersection, TVar(Rt::TSet<int64_t>{1, 2, 3}))->Apply(val);
+  EXPECT_EQ(val, TVar(Rt::TSet<int64_t>{1, 2, 3}));
+}
+
+FIXTURE(MinMax_Augment_Fold) {
+  /* min/max are commutative + associative, so two same-key mutations
+     compose: Min(7).Augment(Min(3)) -> Min(3); Max(3).Augment(Max(7))
+     -> Max(7). */
+  auto lo = TMutation::New(TMutator::Min, TVar(int64_t(7)));
+  lo->Augment(TMutation::New(TMutator::Min, TVar(int64_t(3))));
+  TVar a(int64_t(5));
+  lo->Apply(a);
+  EXPECT_EQ(a, TVar(int64_t(3)));  // min(5, min(7,3)) == 3
+
+  auto hi = TMutation::New(TMutator::Max, TVar(int64_t(3)));
+  hi->Augment(TMutation::New(TMutator::Max, TVar(int64_t(7))));
+  TVar b(int64_t(5));
+  hi->Apply(b);
+  EXPECT_EQ(b, TVar(int64_t(7)));  // max(5, max(3,7)) == 7
+}
+
+FIXTURE(AbsentKeySeed_Membership) {
+  /* The seed-from-RHS set (#151/#152/#213): the commutative ops whose
+     singleton fold is the RHS and which therefore upsert an absent key. */
+  EXPECT_TRUE(IsAbsentKeySeedRhs(TMutator::Add));
+  EXPECT_TRUE(IsAbsentKeySeedRhs(TMutator::Or));
+  EXPECT_TRUE(IsAbsentKeySeedRhs(TMutator::Xor));
+  EXPECT_TRUE(IsAbsentKeySeedRhs(TMutator::Union));
+  EXPECT_TRUE(IsAbsentKeySeedRhs(TMutator::SymmetricDiff));
+  EXPECT_TRUE(IsAbsentKeySeedRhs(TMutator::Min));
+  EXPECT_TRUE(IsAbsentKeySeedRhs(TMutator::Max));
+  EXPECT_TRUE(IsAbsentKeySeedRhs(TMutator::Intersection));
+  /* Deferred to a follow-up (no current demand): Mult (PR2) and And. */
+  EXPECT_FALSE(IsAbsentKeySeedRhs(TMutator::Mult));
+  EXPECT_FALSE(IsAbsentKeySeedRhs(TMutator::And));
+  /* Never seedable. */
+  EXPECT_FALSE(IsAbsentKeySeedRhs(TMutator::Assign));
+  EXPECT_FALSE(IsAbsentKeySeedRhs(TMutator::Sub));
 }

--- a/orly/var/real.cc
+++ b/orly/var/real.cc
@@ -69,6 +69,22 @@ TReal &TReal::Intersection(const TVar &) {
   throw Rt::TSystemError(HERE, "Intersection not supported on Real.");
 }
 
+TReal &TReal::Max(const TVar &rhs) {
+  double r = Var::TVar::TDt<double>::As(rhs);
+  if (r > Val) {
+    Val = r;
+  }
+  return *this;
+}
+
+TReal &TReal::Min(const TVar &rhs) {
+  double r = Var::TVar::TDt<double>::As(rhs);
+  if (r < Val) {
+    Val = r;
+  }
+  return *this;
+}
+
 TReal &TReal::Mod(const TVar &) {
   throw Rt::TSystemError(HERE, "Mod not supported on Real.");
 }

--- a/orly/var/real.h
+++ b/orly/var/real.h
@@ -49,6 +49,10 @@ namespace Orly {
       /* TODO */
       virtual TReal &Intersection(const TVar &);
 
+      /* The max / min merge-mutation operators (#213). */
+      virtual TReal &Max(const TVar &);
+      virtual TReal &Min(const TVar &);
+
       /* TODO */
       virtual TReal &Mod(const TVar &);
 

--- a/tests/lang_tests/general/.min_max_merge.orly.test.state
+++ b/tests/lang_tests/general/.min_max_merge.orly.test.state
@@ -1,0 +1,21 @@
+[
+  0,
+  [
+    [],
+    [
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++"
+    ],
+    [
+      "Running tests"
+    ],
+    [
+      "Tests done"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/min_max_merge.orly
+++ b/tests/lang_tests/general/min_max_merge.orly
@@ -1,0 +1,130 @@
+/* <orly/lang_tests/general/min_max_merge.orly>
+
+   Issue #213: the `<?=` (min) and `>?=` (max) commutative merge-mutation
+   operators, plus the intersection (`&=`) absent-key upsert that rides the
+   same identity/seed refactor.
+
+   min / max are commutative, associative AND idempotent (a semilattice) --
+   the cleanest possible coordination-free merge ops. A run of same-key
+   writes folds to a single value regardless of order, so concurrent
+   writers compose without a lost update, exactly like `+=` / `|=`.
+
+   Absent-key semantics (D2 of #213): a first `<?= v` / `>?= v` / `&= {v}`
+   on a key that was NEVER created seeds the value directly from the RHS --
+   because folding the op over a single element yields that element
+   (min(v) == v, max(v) == v, intersection({v}) == {v}). So the bare op
+   "just works" on a fresh key, no `is known` guard / `new <-` create-arm.
+
+   NB: a PLAIN read of an absent key still throws -- only the LHS of a
+   commutative mutate auto-seeds. Every read below happens AFTER a first
+   write to its key.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+read_int = (*<[n]>::(int)) where {
+  n = given::(int);
+};
+
+/* Bare `<?= x` (min-assign). On an absent key seeds from x, else folds
+   to min(current, x). */
+min_int = ((true) effecting {
+  *<[n]>::(int) <?= x;
+}) where {
+  n = given::(int);
+  x = given::(int);
+};
+
+/* Bare `>?= x` (max-assign). On an absent key seeds from x, else folds
+   to max(current, x). */
+max_int = ((true) effecting {
+  *<[n]>::(int) >?= x;
+}) where {
+  n = given::(int);
+  x = given::(int);
+};
+
+read_real = (*<[n]>::(real)) where {
+  n = given::(int);
+};
+
+max_real = ((true) effecting {
+  *<[n]>::(real) >?= x;
+}) where {
+  n = given::(int);
+  x = given::(real);
+};
+
+read_set = (*<[n]>::({int})) where {
+  n = given::(int);
+};
+
+/* Bare `&= {x}` (intersection). On an absent key seeds from {x}, else
+   folds to current INTERSECT {x}. */
+intersect_set = ((true) effecting {
+  *<[n]>::({int}) &= s;
+}) where {
+  n = given::(int);
+  s = given::({int});
+};
+
+/* min on a totally fresh key: seed 7, then min(7,3)=3, then min(3,9)=3. */
+test {
+  t1: min_int(.n: 300, .x: 7) {
+    t2: read_int(.n: 300) == 7;
+    t3: min_int(.n: 300, .x: 3) {
+      t4: read_int(.n: 300) == 3;
+      t5: min_int(.n: 300, .x: 9) {
+        t6: read_int(.n: 300) == 3;
+      };
+    };
+  };
+};
+
+/* max on a fresh key: seed 3, then max(3,7)=7, then max(7,1)=7. */
+test {
+  t10: max_int(.n: 310, .x: 3) {
+    t11: read_int(.n: 310) == 3;
+    t12: max_int(.n: 310, .x: 7) {
+      t13: read_int(.n: 310) == 7;
+      t14: max_int(.n: 310, .x: 1) {
+        t15: read_int(.n: 310) == 7;
+      };
+    };
+  };
+};
+
+/* max on reals (high-water mark): seed 1.5, then max(1.5, 4.25) = 4.25. */
+test {
+  t20: max_real(.n: 320, .x: 1.5) {
+    t21: read_real(.n: 320) == 1.5;
+    t22: max_real(.n: 320, .x: 4.25) {
+      t23: read_real(.n: 320) == 4.25;
+    };
+  };
+};
+
+/* intersection on a fresh set key: seed {1,2,3}, then INTERSECT {2,3,4}
+   = {2,3}, then INTERSECT {3,9} = {3}. */
+test {
+  t30: intersect_set(.n: 330, .s: {1, 2, 3}) {
+    t31: read_set(.n: 330) == {1, 2, 3};
+    t32: intersect_set(.n: 330, .s: {2, 3, 4}) {
+      t33: read_set(.n: 330) == {2, 3};
+      t34: intersect_set(.n: 330, .s: {3, 9}) {
+        t35: read_set(.n: 330) == {3};
+      };
+    };
+  };
+};


### PR DESCRIPTION
Closes the first part of #213.

## What

Extends Orly's coordination-free merge palette with two new commutative mutation operators and closes one absent-key upsert gap:

- **`<?=` (min)** and **`>?=` (max)** — commutative, associative *and* idempotent (a semilattice), the cleanest possible CRDT merge. A run of same-key writes folds to a single value regardless of order, so concurrent writers compose without a lost update, exactly like `+=` / `|=`.
- **`&=` (intersection) absent-key upsert** — intersection already worked for existing keys; now a first `&= {…}` on an absent key seeds instead of throwing.

## Surface syntax

`<?=` / `>?=` are new symbolic tokens (GNU C++ min/max-assign precedent), **not** `min`/`max` keywords. Reserving `min`/`max` would shadow the `.min`/`.max` field labels — including the `random_int` builtin's own parameters — so a keyword was a non-starter.

```
*<[k]>::(int)  <?= 5;   // x = min(x, 5)
*<[k]>::(int)  >?= 5;   // x = max(x, 5)
*<[k]>::({int}) &= s;   // x = x ∩ s   (seeds on absent key)
```

## The identity/seed refactor (D3)

The old `IsIdentityDefaultCommutative` predicate ("monoid identity == the operand type's default value") is renamed to **`IsAbsentKeySeedRhs`** and broadened. The actual first-write seed in `TMutation::Apply` is `var = Rhs` — not default-construct-then-op — and that is correct for *every* commutative merge op, because folding the op over a single element yields that element (`min(r)=r`, `max(r)=r`, `intersection({r})={r}`, `0+r=r`, …). So min/max/intersection now upsert an absent key by riding the existing deferred-commutative read/disk fold; two concurrent first-writers compose with no lost update.

`min`/`max` are added to the `TVar::TImpl` interface as **non-pure** methods with a throwing base default (overridden only by `TInt`/`TReal`), so the other ~15 var types reject them without a per-type stub.

Mult / and still throw on an absent key — mult is the PR2 follow-up.

## Tests

- `var/mutation.test.cc` — min/max/intersection empty-base seed, min/max `Augment` fold, `IsAbsentKeySeedRhs` membership.
- `indy/context_fold.test.cc` — `MinMaxDeferredFold` drives the **real indy memory/disk fold** (seed, order-independent fold, assign-masking), not just the var-layer unit.
- `tests/lang_tests/general/min_max_merge.orly` — end-to-end orlyc: absent-key seed, multi-level fold, real high-water marks, intersection upsert (with regenerated `.state` baseline).

Full `make test` and `make test_lang` are green (158 lang tests pass, 2 tracked xfail unchanged).