### PR TITLE
Close the absent-key upsert gap for mult (#213 PR2)

### DIFF
--- a/orly/code_gen/builder.cc
+++ b/orly/code_gen/builder.cc
@@ -209,8 +209,8 @@ TInline::TPtr BuildOptInline(const L0::TPackage *package, const Expr::TExpr::TPt
 
 /* Commutative-upsert (#151/#152, extended #213): build the LHS of a
    `*<[k]>::(T) OP= v` mutation. For an absent-key-seedable commutative
-   mutator (Add, Or, Xor, Union, SymmetricDiff, Min, Max, Intersection)
-   whose LHS is a typed read `expr::(T)`, emit the non-throwing
+   mutator (Add, Or, Xor, Union, SymmetricDiff, Min, Max, Intersection,
+   Mult) whose LHS is a typed read `expr::(T)`, emit the non-throwing
    ReadOrIdentity read so a first-write to an absent key auto-initialises
    (seeding from the RHS at fold time) instead of throwing "Cannot
    de-reference Key ... which does not exist". Every other shape (other

--- a/orly/indy/context_fold.test.cc
+++ b/orly/indy/context_fold.test.cc
@@ -442,3 +442,57 @@ FIXTURE(MinMaxDeferredFold) {
     cond.notify_one();
   });
 }
+
+/* Issue #213 PR2: mult (`*=`) absent-key upsert through the real indy
+   fold. Mult was already defer-safe for existing keys; the only change is
+   that a first entry on an absent key now seeds from its RHS (1 * r == r)
+   instead of throwing. Identical fold mechanism to Add, exercised here for
+   the mult op specifically. */
+FIXTURE(MultDeferredFold) {
+  Fiber::TFiberTestRunner runner([](std::mutex &mut, std::condition_variable &cond, bool &fin, Fiber::TRunner::TRunnerCons &) {
+    TSuprena arena;
+    void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
+    const TScheduler::TPolicy scheduler_policy(10, 10, 10ms);
+    TScheduler scheduler;
+    scheduler.SetPolicy(scheduler_policy);
+
+    Base::TUuid idx_id(TUuid::Twister);
+    const TIndexKey prod_key(idx_id, TKey(make_tuple(1L), &arena, state_alloc));
+
+    auto run_scenario = [&](const char *name,
+                            const std::vector<std::pair<TMutator, int64_t>> &entries,
+                            int64_t want) {
+      Orly::Indy::Disk::Sim::TMemEngine mem_engine(&scheduler, 256, 64, 128, 1, 64, 1);
+      auto manager = make_unique<TMyManager>(mem_engine.GetEngine(), &scheduler, MemMergeCoreVec, DiskMergeCoreVec);
+      Base::TUuid repo_id(TUuid::Twister);
+      auto repo = manager->GetRepo(repo_id, TTtl::max(), std::nullopt, true, true);
+      for (const auto &e : entries) {
+        auto transaction = manager->NewTransaction();
+        auto update = TUpdate::NewUpdate(TUpdate::TOpByKey{}, TKey(&arena),
+                                         TKey(Base::TUuid(TUuid::Twister), &arena, state_alloc));
+        update->AddEntry(prod_key, TKey(e.second, &arena, state_alloc), e.first);
+        transaction->Push(repo, update);
+        transaction->Prepare();
+        transaction->CommitAction();
+      }
+      TSuprena ctx_arena;
+      TContext context(repo, &ctx_arena);
+      EXPECT_EQ(context[prod_key], TKey(want, &arena, state_alloc));
+    };
+
+    /* Single `*= 6` on a totally absent key seeds from the RHS (== 1*6). */
+    run_scenario("Mult6_only_absentkey",   {{TMutator::Mult,6}},                          6);
+    /* Two deferred mults fold: 6 * 3 = 18. */
+    run_scenario("Mult6_then_Mult3",       {{TMutator::Mult,6},{TMutator::Mult,3}},        18);
+    /* Three-deep: 2 * 3 * 5 = 30 regardless of commit order. */
+    run_scenario("Mult_2_3_5",             {{TMutator::Mult,2},{TMutator::Mult,3},{TMutator::Mult,5}}, 30);
+    /* Assign base then a mult folds against the base: 4 * 5 = 20. */
+    run_scenario("Assign4_then_Mult5",     {{TMutator::Assign,4},{TMutator::Mult,5}},       20);
+    /* A newer destructive Assign masks older mult history. */
+    run_scenario("Mult6_then_Assign10",    {{TMutator::Mult,6},{TMutator::Assign,10}},      10);
+
+    std::lock_guard<std::mutex> lock(mut);
+    fin = true;
+    cond.notify_one();
+  });
+}

--- a/orly/key_generator.h
+++ b/orly/key_generator.h
@@ -310,7 +310,8 @@ namespace Orly {
 
        This is only ever emitted for the LHS of an absent-key-seedable
        commutative mutation (Add, Or, Xor, Union, SymmetricDiff, Min, Max,
-       Intersection -- IsAbsentKeySeedRhs, see code_gen/builder.cc). For
+       Intersection, Mult -- IsAbsentKeySeedRhs, see code_gen/builder.cc).
+       For
        those, a first-write `*<[k]>::(T) OP= v` on an absent key
        auto-initialises by seeding from the RHS at fold time, instead of
        throwing -- and

--- a/orly/var/mutation.cc
+++ b/orly/var/mutation.cc
@@ -123,10 +123,10 @@ void TMutation::Apply(Var::TVar &var) const {
      instead of folding it into an empty TVar -- which would trip the
      `assert(*this)` in TVar::Add / Min / Intersection etc. (var/impl.h).
      This is exactly correct for each gated op (0 + r = r, false | r = r,
-     {} U r = r, min(r) = r, max(r) = r, intersection(r) = r) and pins the
-     seeded value's type to the RHS rather than to a guessed identity.
-     Every other mutator (Assign, Mult, And, Sub, ...) keeps the existing
-     fold, which still requires a non-empty base. */
+     {} U r = r, min(r) = r, max(r) = r, intersection(r) = r, 1 * r = r)
+     and pins the seeded value's type to the RHS rather than to a guessed
+     identity. Every other mutator (Assign, And, Sub, ...) keeps the
+     existing fold, which still requires a non-empty base. */
   if (!var && IsAbsentKeySeedRhs(Mutator)) {
     var = Rhs;
     return;

--- a/orly/var/mutation.h
+++ b/orly/var/mutation.h
@@ -94,6 +94,9 @@ namespace Orly {
            Intersection  : intersection(r)  == r      (#213 -- identity is
                             the universal set, NOT representable as a value,
                             but the singleton fold is still just r)
+           Mult          : 1 * r            == r      (#213 PR2 -- identity
+                            1, also not the default 0, but again the
+                            singleton fold is just r)
 
          So the seed is taken as `var = Rhs` in TMutation::Apply
          (mutation.cc) -- NOT by default-constructing the operand -- and the
@@ -103,9 +106,8 @@ namespace Orly {
          and the read/disk fold seeds from the RHS, so two concurrent
          first-writers compose without a lost update.
 
-         Excluded for now -- their singleton fold is ALSO r, so they could
-         ride this path, but they are deferred to a follow-up (no current
-         demand): Mult (identity 1; PR2 of #213) and And (identity
+         Excluded for now -- And's singleton fold is ALSO r, so it could
+         ride this path, but it is deferred (no current demand; identity
          all-ones). A plain read of an absent key (outside a commutative
          mutation) still throws for every mutator. */
       inline bool IsAbsentKeySeedRhs(TMutator mutator) {
@@ -118,8 +120,8 @@ namespace Orly {
           case TMutator::Min:
           case TMutator::Max:
           case TMutator::Intersection:
-            return true;
           case TMutator::Mult:
+            return true;
           case TMutator::And:
           case TMutator::Assign:
           case TMutator::Sub:

--- a/orly/var/mutation.test.cc
+++ b/orly/var/mutation.test.cc
@@ -247,6 +247,27 @@ FIXTURE(UpsertEmptyBase_Intersection_Set) {
   EXPECT_EQ(val, TVar(Rt::TSet<int64_t>{1, 2, 3}));
 }
 
+FIXTURE(UpsertEmptyBase_Mult_Int) {
+  /* 1 (identity) * 6 == 6 on a never-created int key: a first `*= 6`
+     seeds the value directly from the RHS (#213 PR2). Mult's identity is
+     1, not the default 0, but the singleton fold is still the RHS, so the
+     seed is correct -- a default-construct-then-multiply (0 * 6 = 0) would
+     have been wrong, which is why Mult used to throw on an absent key. */
+  TVar val;
+  EXPECT_FALSE(static_cast<bool>(val));
+  TMutation::New(TMutator::Mult, TVar(int64_t(6)))->Apply(val);
+  EXPECT_TRUE(static_cast<bool>(val));
+  EXPECT_EQ(val, TVar(int64_t(6)));
+}
+
+FIXTURE(UpsertEmptyBase_Mult_ThenMult) {
+  /* empty *= 6 seeds (->6), then *= 3 folds to 18. */
+  TVar val;
+  TMutation::New(TMutator::Mult, TVar(int64_t(6)))->Apply(val);
+  TMutation::New(TMutator::Mult, TVar(int64_t(3)))->Apply(val);
+  EXPECT_EQ(val, TVar(int64_t(18)));
+}
+
 FIXTURE(MinMax_Augment_Fold) {
   /* min/max are commutative + associative, so two same-key mutations
      compose: Min(7).Augment(Min(3)) -> Min(3); Max(3).Augment(Max(7))
@@ -275,8 +296,8 @@ FIXTURE(AbsentKeySeed_Membership) {
   EXPECT_TRUE(IsAbsentKeySeedRhs(TMutator::Min));
   EXPECT_TRUE(IsAbsentKeySeedRhs(TMutator::Max));
   EXPECT_TRUE(IsAbsentKeySeedRhs(TMutator::Intersection));
-  /* Deferred to a follow-up (no current demand): Mult (PR2) and And. */
-  EXPECT_FALSE(IsAbsentKeySeedRhs(TMutator::Mult));
+  EXPECT_TRUE(IsAbsentKeySeedRhs(TMutator::Mult));
+  /* Deferred (no current demand; identity all-ones): And. */
   EXPECT_FALSE(IsAbsentKeySeedRhs(TMutator::And));
   /* Never seedable. */
   EXPECT_FALSE(IsAbsentKeySeedRhs(TMutator::Assign));

--- a/tests/lang_tests/general/.mult_upsert.orly.test.state
+++ b/tests/lang_tests/general/.mult_upsert.orly.test.state
@@ -1,0 +1,21 @@
+[
+  0,
+  [
+    [],
+    [
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++"
+    ],
+    [
+      "Running tests"
+    ],
+    [
+      "Tests done"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/mult_upsert.orly
+++ b/tests/lang_tests/general/mult_upsert.orly
@@ -1,0 +1,57 @@
+/* <orly/lang_tests/general/mult_upsert.orly>
+
+   Issue #213 (PR2): close the absent-key upsert gap for `*=` (mult).
+
+   mult is already a working commutative merge op for existing keys (it
+   folds and composes through the deferred-commutative path like `+=`).
+   Its only gap was the first write: `*= n` on a key that was NEVER
+   created used to throw, because mult's monoid identity is 1 -- NOT the
+   default-constructed 0 -- so the old auto-seed could not materialise it.
+
+   The #213 identity/seed refactor seeds an absent key DIRECTLY from the
+   RHS (the fold of mult over a single element is that element: 1 * n = n),
+   so the bare `*= n` now upserts a fresh key just like `+= n`.
+
+   NB: a PLAIN read of an absent key still throws -- only the LHS of a
+   commutative mutate auto-seeds. Every read below happens AFTER a first
+   write to its key.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+read_int = (*<[n]>::(int)) where {
+  n = given::(int);
+};
+
+/* Bare `*= x` -- NO `is known` guard, NO `new <-`. On an absent key this
+   used to throw; with #213 PR2 it seeds from x (== 1 * x) and multiplies. */
+mult_int = ((true) effecting {
+  *<[n]>::(int) *= x;
+}) where {
+  n = given::(int);
+  x = given::(int);
+};
+
+/* Mult on a totally fresh key: seed 6, then 6*3 = 18, then 18*2 = 36. */
+test {
+  t1: mult_int(.n: 400, .x: 6) {
+    t2: read_int(.n: 400) == 6;
+    t3: mult_int(.n: 400, .x: 3) {
+      t4: read_int(.n: 400) == 18;
+      t5: mult_int(.n: 400, .x: 2) {
+        t6: read_int(.n: 400) == 36;
+      };
+    };
+  };
+};


### PR DESCRIPTION
Follow-up to #214 (PR1 of #213). **Stacked on `feature/min-max-merge-213`** — review/merge that first; the base will retarget to `master` once PR1 lands.

## What

`*=` (mult) was already a working commutative merge op for *existing* keys — defer-safe, composes via `Augment`, `TInt`/`TReal` implement it. Its only gap was the **first write**: `*= n` on a key that was never created threw, because mult's monoid identity is `1`, not the default-constructed `0`, so the old auto-seed could not materialise the base.

Riding the #214 identity/seed refactor, an absent key is seeded **directly from the RHS** (the fold of mult over a single element is that element: `1 * n = n`). So this PR adds `Mult` to `IsAbsentKeySeedRhs` — it flips exactly one predicate plus its docs. No new syntax, runtime, or type-check.

```
*<[k]>::(int) *= 6;   // on a fresh key: seeds 6, then *= 3 -> 18, *= 2 -> 36
```

## Tests

- `var/mutation.test.cc` — `UpsertEmptyBase_Mult_Int` / `_ThenMult`, and the updated `IsAbsentKeySeedRhs` membership (Mult now true).
- `indy/context_fold.test.cc` — `MultDeferredFold` drives the real indy fold for mult (absent-key seed, fold, assign-masking).
- `tests/lang_tests/general/mult_upsert.orly` — end-to-end orlyc bare `*= n` upsert of a fresh key (with `.state` baseline).

Kept separate from PR1 deliberately: two op-additions on the core merge path at once doubles the review blast radius (per the #213 plan).