### PR TITLE
Ignore stray go-build binaries in four example demos

### DIFF
--- a/examples/agent-swarm/.gitignore
+++ b/examples/agent-swarm/.gitignore
@@ -1,0 +1,2 @@
+# Stray go-build output from `go build ./...` in this dir.
+agent-swarm

--- a/examples/crdt-text/.gitignore
+++ b/examples/crdt-text/.gitignore
@@ -1,0 +1,2 @@
+# Stray go-build output from `go build ./...` in this dir.
+crdt-text

--- a/examples/grc20-pov/.gitignore
+++ b/examples/grc20-pov/.gitignore
@@ -1,0 +1,2 @@
+# Stray go-build output from `go build ./...` in this dir.
+grc20-pov

--- a/examples/wikipedia-pageviews/.gitignore
+++ b/examples/wikipedia-pageviews/.gitignore
@@ -1,0 +1,2 @@
+# Stray go-build output from `go build ./...` in this dir.
+wikipedia-pageviews


### PR DESCRIPTION
The `agent-swarm`, `crdt-text`, `grc20-pov` and `wikipedia-pageviews` demos each ship a Go driver. Running `go build ./...` in the demo dir drops an executable named after the directory, which then shows up as untracked.

The older Go demos (`bitcoin-time-travel`, `wikipedia-categories`, …) already `.gitignore` this stray binary; these four were added without it. This adds the same per-directory `.gitignore` to match the existing convention.

Pure repo hygiene — no code or build changes.