### PR TITLE
Track clients/ts/package-lock.json

### DIFF
--- a/clients/ts/package-lock.json
+++ b/clients/ts/package-lock.json
@@ -1,0 +1,54 @@
+{
+  "name": "orly",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "orly",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "typescript": "^5.0.0",
+        "ws": "^8.0.0"
+      },
+      "optionalDependencies": {
+        "ws": "^8.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The TypeScript client (`clients/ts`) was committed with `package.json` but no lockfile. The `package-lock.json` only materialised once `npm install` ran, and it is not covered by `clients/ts/.gitignore` (which ignores only `node_modules/` and `dist/`), so it sat untracked.

Commit it so the dependency versions (`typescript`, `ws`) are pinned for reproducible installs across machines and CI — the standard npm convention of tracking the lockfile. `lockfileVersion: 3`, no secrets, ~1.4 KB.