### PR TITLE
agent-swarm: transitive graph traversal over the coordination-free graph (#219)

### DIFF
--- a/examples/agent-swarm/README.md
+++ b/examples/agent-swarm/README.md
@@ -51,7 +51,25 @@ Exit code is non-zero if the verifier finds any tag provenance set, mention coun
 
 - **No lost extractions under contention.** Hot entities (Python, OpenAI, Anthropic, Claude, GPT-4, Microsoft, Google) appear in many docs; agents are assigned docs round-robin so multiple agents hit the same entity concurrently. Every `add_tag` / `add_mention` / `add_cooccur` call lands.
 - **Tag provenance sets converge.** Different docs assign different tags to the same entity (Python picks up `language` from some docs, `popular` from others), and different agents independently corroborate the same tag. The on-disk set of `(tag, agent)` records after ingest equals the union derived from the corpus — every contributing agent is preserved.
-- **No driver-side merge logic.** The driver never reads-then-writes. It only ever calls the three field-call functions in [`graph.orly`](graph.orly). Aggregation is the engine's job.
+- **No driver-side merge logic.** The driver never reads-then-writes. It only ever calls the field-call functions in [`graph.orly`](graph.orly). Aggregation is the engine's job.
+
+## Traversing the graph
+
+A knowledge graph you can only point-query is half a graph database. The co-occurrences the agents stream form an **undirected graph** — entities are nodes, a shared document is an edge. `add_cooccur` writes that edge **both ways** as a symmetric adjacency, so a node's neighbours are one prefix scan:
+
+```orly
+*<['adj', a, b]>::(int) += 1   # both directions, still a coordination-free field call
+*<['adj', b, a]>::(int) += 1
+```
+
+That trailing-`free` shape is exactly what Orly's sorted index seeks straight to — **index-free adjacency** ([issue #219](https://github.com/orlyatomics/orly/issues/219)), the thing graph engines are built on. On top of it, transitive traversal needs **no new engine primitive** — a `reduce` over a depth range, accumulating a visited set (so cycles terminate):
+
+```orly
+neighbors = (keys (int) @ <['adj', e, free::(str)]>) reduce start (empty {str}) | {that.2}   # one hop
+reach     = [1..k] reduce grow(.v: start ({seed}))                                            # k-hop closure
+```
+
+The driver verifies `reach(seed, k)` against a plain-Python BFS over the same graph, then showcases a neighbourhood — e.g. from **Claude**, ~92% of the graph is reachable within 3 hops. The point: the graph was assembled by N agents with **zero coordination**, and it's still **traversable transitively** — concurrent construction *and* graph queries in one store, which Neo4j (single-primary writes) and Cayley (a query layer over a store) don't combine.
 
 ## Related demos
 

--- a/examples/agent-swarm/demo.go
+++ b/examples/agent-swarm/demo.go
@@ -300,6 +300,94 @@ func cooccurCount(c *orly.Client, pov, a, b string) int {
 	return asInt(must(c.Call(pov, "graph", "cooccur_count", map[string]any{"a": a, "b": b})))
 }
 
+// --- graph traversal (mirrors demo.py) ---
+
+type strSet map[string]bool
+
+func decodeStrSet(raw json.RawMessage) strSet {
+	out := strSet{}
+	if string(raw) == "null" {
+		return out
+	}
+	var xs []string
+	if err := json.Unmarshal(raw, &xs); err != nil {
+		die(fmt.Sprintf("expected array-of-strings, got %s", raw))
+	}
+	for _, x := range xs {
+		out[x] = true
+	}
+	return out
+}
+
+func neighbors(c *orly.Client, pov, entity string) strSet {
+	return decodeStrSet(must(c.Call(pov, "graph", "neighbors", map[string]any{"e": entity})))
+}
+
+func reach(c *orly.Client, pov, seed string, k int) strSet {
+	return decodeStrSet(must(c.Call(pov, "graph", "reach", map[string]any{"seed": seed, "k": k})))
+}
+
+// buildAdjacency derives the symmetric adjacency from the canonical
+// cooccurrence pairs -- mirrors graph.orly's both-directions
+// <['adj', a, b]> / <['adj', b, a]> writes.
+func buildAdjacency(expectedCooccur map[pairKey]int) map[string]strSet {
+	adj := map[string]strSet{}
+	add := func(a, b string) {
+		if adj[a] == nil {
+			adj[a] = strSet{}
+		}
+		adj[a][b] = true
+	}
+	for pk := range expectedCooccur {
+		add(pk.a, pk.b)
+		add(pk.b, pk.a)
+	}
+	return adj
+}
+
+// reachWithin is the plain-Go mirror of graph.orly's reach: k hops,
+// expanding the whole visited set each step, inclusive of seed.
+func reachWithin(adj map[string]strSet, seed string, k int) strSet {
+	visited := strSet{seed: true}
+	for i := 0; i < k; i++ {
+		next := strSet{}
+		for n := range visited {
+			next[n] = true
+		}
+		for n := range visited {
+			for m := range adj[n] {
+				next[m] = true
+			}
+		}
+		if len(next) == len(visited) {
+			break
+		}
+		visited = next
+	}
+	return visited
+}
+
+func strSetEqual(a, b strSet) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if !b[k] {
+			return false
+		}
+	}
+	return true
+}
+
+func sortedSet(s strSet) []string {
+	out := make([]string, 0, len(s))
+	for k := range s {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // agentDoc is one (docID, doc) pair assigned to an agent.
 type agentDoc struct {
 	id  int
@@ -564,6 +652,59 @@ func main() {
 		fmt.Printf("  %-32s  %4d  (want %d)  %s\n", label, got, want, marker)
 	}
 
+	// Graph traversal: verify neighbours + k-hop reachability against a
+	// plain-Go BFS over the same ground-truth graph, then showcase a
+	// neighbourhood. graph.orly does this with no new engine primitive --
+	// a trailing-free prefix scan for adjacency, a reduce-over-depth for
+	// the bounded transitive closure.
+	adj := buildAdjacency(expectedCooccurCount)
+	seeds := []string{}
+	for _, s := range []string{"Python", "OpenAI", "Claude", "Rust", "Llama"} {
+		if adj[s] != nil {
+			seeds = append(seeds, s)
+		}
+	}
+	for _, s := range seeds {
+		if !strSetEqual(neighbors(boot, pov, s), adj[s]) {
+			failures = append(failures, fmt.Sprintf(
+				"neighbors(%s): mismatch vs ground truth", s))
+		}
+		for _, k := range []int{1, 2, 3} {
+			if !strSetEqual(reach(boot, pov, s, k), reachWithin(adj, s, k)) {
+				failures = append(failures, fmt.Sprintf(
+					"reach(%s, %d): mismatch vs Go BFS", s, k))
+			}
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("=== graph traversal: k-hop reachability over the cooccurrence graph ===")
+	showcase := ""
+	for _, s := range []string{"Claude", "Python", "OpenAI"} {
+		if adj[s] != nil {
+			showcase = s
+			break
+		}
+	}
+	if showcase == "" && len(seeds) > 0 {
+		showcase = seeds[0]
+	}
+	if showcase != "" {
+		total := len(adj)
+		nbrs := sortedSet(neighbors(boot, pov, showcase))
+		fmt.Printf("  seed: %s   (graph has %d entities)\n", showcase, total)
+		fmt.Printf("  %-20s: %3d  (%s)\n", "direct neighbours", len(nbrs), strings.Join(nbrs, ", "))
+		for _, k := range []int{1, 2, 3} {
+			r := sortedSet(reach(boot, pov, showcase, k))
+			tail := ""
+			if len(r) <= 14 {
+				tail = "  (" + strings.Join(r, ", ") + ")"
+			}
+			fmt.Printf("  within %d hop(s)%-7s: %3d  %3d%% of the graph%s\n",
+				k, "", len(r), len(r)*100/total, tail)
+		}
+	}
+
 	fmt.Println()
 	fmt.Println("=== the trick ===")
 	fmt.Printf("  %d concurrent agents all wrote into the same knowledge\n", numAgents)
@@ -571,6 +712,9 @@ func main() {
 	fmt.Println("  provenance) union into one set per entity, and the per-entity")
 	fmt.Println("  / per-pair counters aggregate correctly: this is the shape")
 	fmt.Println("  multi-agent LLM extraction pipelines keep reinventing badly.")
+	fmt.Println("  And the graph they built is traversable transitively -- the")
+	fmt.Println("  k-hop reachability above runs over that same coordination-free")
+	fmt.Println("  adjacency, with no new engine primitive (issue #219).")
 
 	check(boot.Exit())
 	boot.Close()
@@ -595,4 +739,5 @@ func main() {
 	fmt.Println("\n=== self-check OK ===")
 	fmt.Printf("  verified %d tag provenance records across %d entities + %d mention counters + %d cooccurrence counters across %d concurrent agents\n",
 		totalTagRecords, len(expectedTagRecords), len(expectedMentionCount), len(expectedCooccurCount), numAgents)
+	fmt.Printf("  + transitive k-hop reachability over the cooccurrence graph for %d seed entities, matching a Go BFS\n", len(seeds))
 }

--- a/examples/agent-swarm/demo.py
+++ b/examples/agent-swarm/demo.py
@@ -238,6 +238,41 @@ def cooccur_count(c, pov, a, b):
     return int(c.call(pov, "graph", "cooccur_count", {"a": a, "b": b}))
 
 
+def neighbors(c, pov, entity):
+    # graph.orly returns a set {str}; WS wire form is a JSON array.
+    return set(c.call(pov, "graph", "neighbors", {"e": entity}) or [])
+
+
+def reach(c, pov, seed, k):
+    return set(c.call(pov, "graph", "reach", {"seed": seed, "k": k}) or [])
+
+
+def build_adjacency(expected_cooccur):
+    """Symmetric adjacency from the canonical cooccurrence pairs: every
+    pair (a, b) is one undirected edge -- matches the both-directions
+    <['adj', a, b]> / <['adj', b, a]> writes in graph.orly's add_cooccur."""
+    adj = {}
+    for (a, b) in expected_cooccur:
+        adj.setdefault(a, set()).add(b)
+        adj.setdefault(b, set()).add(a)
+    return adj
+
+
+def reach_within(adj, seed, k):
+    """k-hop reachable set, inclusive of seed. Plain-Python mirror of
+    graph.orly's `reach`: each hop expands the whole visited set by its
+    neighbours; cycles terminate because the set saturates."""
+    visited = {seed}
+    for _ in range(k):
+        nxt = set(visited)
+        for n in visited:
+            nxt |= adj.get(n, set())
+        if nxt == visited:
+            break
+        visited = nxt
+    return visited
+
+
 def agent(agent_id, pov, docs):
     """One agent: open a fresh WebSocket, open a session, ingest its
     slice of (doc_id, extraction) pairs into the shared POV. Every tag
@@ -380,6 +415,46 @@ def main():
         marker = "✓" if got == want else "✗"
         print(f"  {a + ' & ' + b:<32}  {got:>4}  (want {want})  {marker}")
 
+    # ------------------------------------------------------------------
+    # Graph traversal. The cooccurrence adjacency was assembled by N
+    # concurrent agents with zero coordination; now traverse it
+    # transitively. Verify 1-hop neighbours + k-hop reachability against a
+    # plain-Python BFS over the same ground-truth graph -- then showcase a
+    # neighbourhood. (graph.orly does this with no new engine primitive:
+    # a trailing-free prefix scan for adjacency, a reduce-over-depth for
+    # the bounded transitive closure.)
+    # ------------------------------------------------------------------
+    adj = build_adjacency(expected_cooccur_count)
+    seeds = [s for s in ("Python", "OpenAI", "Claude", "Rust", "Llama")
+             if s in adj]
+    for s in seeds:
+        want_nbrs = adj.get(s, set())
+        got_nbrs = neighbors(boot, pov, s)
+        if got_nbrs != want_nbrs:
+            failures.append(
+                f"neighbors({s}): got {sorted(got_nbrs)}, want {sorted(want_nbrs)}")
+        for k in (1, 2, 3):
+            want_r = reach_within(adj, s, k)
+            got_r = reach(boot, pov, s, k)
+            if got_r != want_r:
+                failures.append(
+                    f"reach({s}, {k}): got {sorted(got_r)}, want {sorted(want_r)}")
+
+    print()
+    print("=== graph traversal: k-hop reachability over the cooccurrence graph ===")
+    showcase = next((s for s in ("Claude", "Python", "OpenAI") if s in adj),
+                    seeds[0] if seeds else None)
+    if showcase:
+        nbrs = sorted(neighbors(boot, pov, showcase))
+        total = len(adj)
+        print(f"  seed: {showcase}   (graph has {total} entities)")
+        print(f"  {'direct neighbours':<20}: {len(nbrs):>3}  ({', '.join(nbrs)})")
+        for k in (1, 2, 3):
+            r = sorted(reach(boot, pov, showcase, k))
+            tail = f"  ({', '.join(r)})" if len(r) <= 14 else ""
+            print(f"  within {k} hop{'s' if k > 1 else ' '}{'':<13}: "
+                  f"{len(r):>3}  {len(r) * 100 // total:>3}% of the graph{tail}")
+
     print()
     print("=== the trick ===")
     print(f"  {NUM_AGENTS} concurrent agents all wrote into the same knowledge")
@@ -387,6 +462,9 @@ def main():
     print(f"  provenance) union into one set per entity, and the per-entity")
     print(f"  / per-pair counters aggregate correctly: this is the shape")
     print(f"  multi-agent LLM extraction pipelines keep reinventing badly.")
+    print(f"  And the graph they built is traversable transitively -- the")
+    print(f"  k-hop reachability above runs over that same coordination-free")
+    print(f"  adjacency, with no new engine primitive (issue #219).")
 
     boot.exit()
 
@@ -404,6 +482,8 @@ def main():
           f"{len(expected_mention_count)} mention counters + "
           f"{len(expected_cooccur_count)} cooccurrence counters across "
           f"{NUM_AGENTS} concurrent agents")
+    print(f"  + transitive k-hop reachability over the cooccurrence graph "
+          f"for {len(seeds)} seed entities, matching a Python BFS")
 
 
 if __name__ == "__main__":

--- a/examples/agent-swarm/graph.orly
+++ b/examples/agent-swarm/graph.orly
@@ -101,9 +101,41 @@ cooccur_count = (((*<['cooccur', a, b]>::(int)) if *<['cooccur', a, b]>::(int?) 
 
 add_cooccur = ((1) effecting {
   *<['cooccur', a, b]>::(int) += 1;
+  /* Symmetric adjacency for traversal: store BOTH directions so a node's
+     neighbours are always a trailing-free prefix scan <['adj', n, *]> --
+     the efficient index-free-adjacency shape (issue #219). Still
+     coordination-free: the edge weight accumulates via += like every
+     other field call, so concurrent agents asserting the same edge land
+     correctly with no read-modify-write. */
+  *<['adj', a, b]>::(int) += 1;
+  *<['adj', b, a]>::(int) += 1;
 }) where {
   a = given::(str);
   b = given::(str);
+};
+
+/* ---------- graph traversal over the cooccurrence adjacency ---------- */
+
+/* Out-neighbours of entity e: one prefix scan of <['adj', e, *]>, folding
+   each neighbour (tuple element .2) into a set. Index-free adjacency --
+   the sorted index seeks straight to the e-prefix run (issue #219). */
+neighbors = (((keys (int) @ <['adj', e, free::(str)]>) reduce start (empty {str}) | {that.2})) where {
+  e = given::(str);
+};
+
+/* One BFS hop: the frontier set V plus the union of every frontier node's
+   neighbours. */
+grow = ((v | ((**v) reduce start (empty {str}) | neighbors(.e: that)))) where {
+  v = given::({str});
+};
+
+/* Every entity reachable from `seed` within `k` cooccurrence hops
+   (inclusive of seed): k applications of `grow`. The accumulating visited
+   set makes cycles terminate -- a coordination-free knowledge graph,
+   traversed transitively, with no new engine primitive. */
+reach = (([1..k] reduce grow(.v: start ({seed})))) where {
+  seed = given::(str);
+  k    = given::(int);
 };
 
 /* ---------- inline tests ---------- */
@@ -160,6 +192,31 @@ test {
       t24: cooccur_count(.a: "Python", .b: "GPT-4") == 2;
       /* Reversed-order pair is a DIFFERENT key (driver canonicalises). */
       t25: cooccur_count(.a: "GPT-4", .b: "Python") == 0;
+    };
+  };
+};
+
+/* ---------- traversal over a graph built through add_cooccur ---------- */
+
+/* Triangle A-B-C plus pendant D-A, assembled through the REAL ingest
+   path (each add_cooccur writes the symmetric adjacency), then traversed.
+   This is the end-to-end shape the driver exercises concurrently. */
+test {
+  t30: add_cooccur(.a: "A", .b: "B") == 1 {
+    t31: add_cooccur(.a: "B", .b: "C") == 1 {
+      t32: add_cooccur(.a: "A", .b: "C") == 1 {
+        t33: add_cooccur(.a: "A", .b: "D") == 1 {
+          /* one prefix-scan adjacency, both directions present */
+          t34: neighbors(.e: "A") == {"B", "C", "D"};
+          t35: neighbors(.e: "D") == {"A"};
+          /* k-hop transitive reachability (inclusive of seed) */
+          t36: reach(.seed: "A", .k: 1) == {"A", "B", "C", "D"};
+          t37: reach(.seed: "D", .k: 1) == {"D", "A"};
+          t38: reach(.seed: "D", .k: 2) == {"A", "B", "C", "D"};
+          /* the A-B-C cycle terminates: extra hops add nothing */
+          t39: reach(.seed: "D", .k: 5) == {"A", "B", "C", "D"};
+        };
+      };
     };
   };
 };

--- a/tests/lang_tests/general/.graph_traversal.orly.test.state
+++ b/tests/lang_tests/general/.graph_traversal.orly.test.state
@@ -1,0 +1,21 @@
+[
+  0,
+  [
+    [],
+    [
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++"
+    ],
+    [
+      "Running tests"
+    ],
+    [
+      "Tests done"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/graph_traversal.orly
+++ b/tests/lang_tests/general/graph_traversal.orly
@@ -1,0 +1,37 @@
+/* Graph traversal (#219): bounded transitive reachability expressed in
+   orlyscript with NO new engine primitive. A directed graph stored as
+   edge-existence keys; adjacency via a trailing-free prefix scan; bounded
+   reachability as a reduce over a depth range, accumulating a visited set
+   (which gives cycle handling for free). The agent-swarm example does the
+   same over a coordination-free knowledge graph. */
+
+/* out-neighbours of n: scan all <['edge', n, *]> keys, fold the dst
+   (tuple element .2) into a set. */
+neighbors = (((keys (bool) @ <['edge', n, free::(int)]>) reduce start (empty {int}) | {that.2})) where {
+  n = given::(int);
+};
+
+/* one hop: V together with the union of every frontier node's neighbours. */
+expand = ((v | ((**v) reduce start (empty {int}) | neighbors(.n: that)))) where {
+  v = given::({int});
+};
+
+/* all nodes reachable from seed within k hops (k applications of expand). */
+reach = (([1..k] reduce expand(.v: start ({seed})))) where {
+  seed = given::(int);
+  k    = given::(int);
+};
+
+/* graph:  1 -> 2 -> 3 -> 1 (cycle),  1 -> 4 */
+with {
+  <['edge', 1, 2]> <- true;
+  <['edge', 2, 3]> <- true;
+  <['edge', 3, 1]> <- true;
+  <['edge', 1, 4]> <- true;
+} test {
+  t1: neighbors(.n: 1) == {2, 4};
+  t2: reach(.seed: 1, .k: 1) == {1, 2, 4};
+  t3: reach(.seed: 1, .k: 2) == {1, 2, 3, 4};
+  t4: reach(.seed: 1, .k: 5) == {1, 2, 3, 4};   /* cycle does not loop forever */
+  t5: reach(.seed: 4, .k: 5) == {4};            /* sink */
+};


### PR DESCRIPTION
Phase 1 of #219 (graph traversal layer). **Pure orlyscript + driver — no engine changes**, so zero core-path risk.

## What

The agent-swarm knowledge graph was point-query only; this makes it **traversable**. The co-occurrences the agents stream form an undirected graph (entities = nodes, a shared doc = edge). `add_cooccur` now also writes a **symmetric adjacency** both ways, so neighbours are a single trailing-`free` prefix scan — the index-free-adjacency shape the sorted index seeks straight to (verified in #219):

```orly
*<['"'"'adj'"'"', a, b]>::(int) += 1;   // both directions, still a coordination-free field call
*<['"'"'adj'"'"', b, a]>::(int) += 1;
```

Transitive traversal needs **no new engine primitive** — it falls out of existing pieces (a `free`-scan + a `reduce` over a depth range + a visited set for cycle termination):

```orly
neighbors = (keys (int) @ <['"'"'adj'"'"', e, free::(str)]>) reduce start (empty {str}) | {that.2}
reach     = [1..k] reduce grow(.v: start ({seed}))
```

## The payoff

Both drivers verify `reach(seed, k)` against a plain-language BFS over the same ground-truth graph, then showcase a neighbourhood:

```
=== graph traversal: k-hop reachability over the cooccurrence graph ===
  seed: Claude   (graph has 25 entities)
  direct neighbours   :   4  (Anthropic, GPT-4, GitHub, Transformer)
  within 1 hop        :   5   20% of the graph
  within 2 hops       :  11   44% of the graph
  within 3 hops       :  23   92% of the graph
```

A graph assembled by N agents with **zero coordination** is still **traversable transitively** — concurrent construction *and* graph queries in one store, which Neo4j (single-primary writes) and Cayley (a query layer over a store) don't combine. That is the moat.

## Tests

- `tests/lang_tests/general/graph_traversal.orly` — CI-guarded regression (examples are not run by `make test_lang`) proving bounded reachability is expressible with no primitive, incl. a cycle that terminates.
- `graph.orly` inline tests `t30`-`t39` — adjacency + k-hop reach through the real `add_cooccur` path.
- Full `make test_lang` green (160 pass / 2 tracked xfail). Both `demo.py` and `demo.go` pass end-to-end at `DEMO_SCALE=small` with identical output (Python/Go parity kept).

## Follow-ups (grounded by this working code, tracked in #219)
- A `reach … via … depth k` surface sugar that lowers to the above.
- A frontier-delta planner: the current `reach` re-expands the whole visited set each hop — O(k · |visited| · degree); a real BFS expands only the new frontier per level — O(edges).
