### PR TITLE
Add the union_map sequence operator (#219 phase 2)

### DIFF
--- a/examples/agent-swarm/README.md
+++ b/examples/agent-swarm/README.md
@@ -62,11 +62,12 @@ A knowledge graph you can only point-query is half a graph database. The co-occu
 *<['adj', b, a]>::(int) += 1
 ```
 
-That trailing-`free` shape is exactly what Orly's sorted index seeks straight to — **index-free adjacency** ([issue #219](https://github.com/orlyatomics/orly/issues/219)), the thing graph engines are built on. On top of it, transitive traversal needs **no new engine primitive** — a `reduce` over a depth range, accumulating a visited set (so cycles terminate):
+That trailing-`free` shape is exactly what Orly's sorted index seeks straight to — **index-free adjacency** ([issue #219](https://github.com/orlyatomics/orly/issues/219)), the thing graph engines are built on. On top of it, transitive traversal needs **no new storage or engine capability** — just a `reduce` over a depth range, accumulating a visited set (so cycles terminate). `union_map` (map each element of a sequence to a set, union the results) is the terse surface for the per-hop frontier expansion; it desugars to `reduce start (empty {T}) | …`:
 
 ```orly
-neighbors = (keys (int) @ <['adj', e, free::(str)]>) reduce start (empty {str}) | {that.2}   # one hop
-reach     = [1..k] reduce grow(.v: start ({seed}))                                            # k-hop closure
+neighbors = (keys (int) @ <['adj', e, free::(str)]>) union_map {that.2}   # one hop
+grow      = v | ((**v) union_map neighbors(.e: that))                     # expand a frontier
+reach     = [1..k] reduce grow(.v: start ({seed}))                        # k-hop closure
 ```
 
 The driver verifies `reach(seed, k)` against a plain-Python BFS over the same graph, then showcases a neighbourhood — e.g. from **Claude**, ~92% of the graph is reachable within 3 hops. The point: the graph was assembled by N agents with **zero coordination**, and it's still **traversable transitively** — concurrent construction *and* graph queries in one store, which Neo4j (single-primary writes) and Cayley (a query layer over a store) don't combine.

--- a/examples/agent-swarm/demo.go
+++ b/examples/agent-swarm/demo.go
@@ -654,9 +654,9 @@ func main() {
 
 	// Graph traversal: verify neighbours + k-hop reachability against a
 	// plain-Go BFS over the same ground-truth graph, then showcase a
-	// neighbourhood. graph.orly does this with no new engine primitive --
-	// a trailing-free prefix scan for adjacency, a reduce-over-depth for
-	// the bounded transitive closure.
+	// neighbourhood. graph.orly does this over already-index-free
+	// adjacency -- a trailing-free prefix scan -- with `union_map` as the
+	// terse surface for each hop's frontier expansion.
 	adj := buildAdjacency(expectedCooccurCount)
 	seeds := []string{}
 	for _, s := range []string{"Python", "OpenAI", "Claude", "Rust", "Llama"} {
@@ -714,7 +714,8 @@ func main() {
 	fmt.Println("  multi-agent LLM extraction pipelines keep reinventing badly.")
 	fmt.Println("  And the graph they built is traversable transitively -- the")
 	fmt.Println("  k-hop reachability above runs over that same coordination-free")
-	fmt.Println("  adjacency, with no new engine primitive (issue #219).")
+	fmt.Println("  adjacency (already index-free), expanded one hop at a time with")
+	fmt.Println("  union_map -- a one-line surface over a reduce (issue #219).")
 
 	check(boot.Exit())
 	boot.Close()

--- a/examples/agent-swarm/demo.py
+++ b/examples/agent-swarm/demo.py
@@ -420,9 +420,9 @@ def main():
     # concurrent agents with zero coordination; now traverse it
     # transitively. Verify 1-hop neighbours + k-hop reachability against a
     # plain-Python BFS over the same ground-truth graph -- then showcase a
-    # neighbourhood. (graph.orly does this with no new engine primitive:
-    # a trailing-free prefix scan for adjacency, a reduce-over-depth for
-    # the bounded transitive closure.)
+    # neighbourhood. (graph.orly does this over already-index-free
+    # adjacency -- a trailing-free prefix scan -- with `union_map` as the
+    # terse surface for each hop's frontier expansion.)
     # ------------------------------------------------------------------
     adj = build_adjacency(expected_cooccur_count)
     seeds = [s for s in ("Python", "OpenAI", "Claude", "Rust", "Llama")
@@ -464,7 +464,8 @@ def main():
     print(f"  multi-agent LLM extraction pipelines keep reinventing badly.")
     print(f"  And the graph they built is traversable transitively -- the")
     print(f"  k-hop reachability above runs over that same coordination-free")
-    print(f"  adjacency, with no new engine primitive (issue #219).")
+    print(f"  adjacency (already index-free), expanded one hop at a time with")
+    print(f"  union_map -- a one-line surface over a reduce (issue #219).")
 
     boot.exit()
 

--- a/examples/agent-swarm/graph.orly
+++ b/examples/agent-swarm/graph.orly
@@ -116,23 +116,27 @@ add_cooccur = ((1) effecting {
 
 /* ---------- graph traversal over the cooccurrence adjacency ---------- */
 
-/* Out-neighbours of entity e: one prefix scan of <['adj', e, *]>, folding
-   each neighbour (tuple element .2) into a set. Index-free adjacency --
-   the sorted index seeks straight to the e-prefix run (issue #219). */
-neighbors = (((keys (int) @ <['adj', e, free::(str)]>) reduce start (empty {str}) | {that.2})) where {
+/* Out-neighbours of entity e: one prefix scan of <['adj', e, *]>, mapping
+   each key to its neighbour (tuple element .2) and unioning. Index-free
+   adjacency -- the sorted index seeks straight to the e-prefix run, and
+   `union_map` collapses the scan-and-collect into one step (issue #219). */
+neighbors = (((keys (int) @ <['adj', e, free::(str)]>) union_map {that.2})) where {
   e = given::(str);
 };
 
 /* One BFS hop: the frontier set V plus the union of every frontier node's
-   neighbours. */
-grow = ((v | ((**v) reduce start (empty {str}) | neighbors(.e: that)))) where {
+   neighbours -- `union_map` maps each frontier node to its neighbour set
+   and unions them. */
+grow = ((v | ((**v) union_map neighbors(.e: that)))) where {
   v = given::({str});
 };
 
 /* Every entity reachable from `seed` within `k` cooccurrence hops
    (inclusive of seed): k applications of `grow`. The accumulating visited
    set makes cycles terminate -- a coordination-free knowledge graph,
-   traversed transitively, with no new engine primitive. */
+   traversed transitively. The adjacency needed no new storage (it is
+   already index-free); `union_map` is just the terse surface for the
+   per-hop frontier expansion (it desugars to a reduce). */
 reach = (([1..k] reduce grow(.v: start ({seed})))) where {
   seed = given::(str);
   k    = given::(int);

--- a/orly/code_gen/builder.cc
+++ b/orly/code_gen/builder.cc
@@ -37,6 +37,7 @@
 #include <orly/code_gen/variant_ctor.h>
 #include <orly/code_gen/reduce.h>
 #include <orly/code_gen/skip.h>
+#include <orly/code_gen/union_map.h>
 #include <orly/code_gen/split.h>
 #include <orly/code_gen/symbol_func.h>
 #include <orly/code_gen/take.h>
@@ -174,6 +175,7 @@ bool IsCoreSeq(const Expr::TExpr::TPtr &expr) {
     virtual void operator()(const Expr::TToLower       *) const {}
     virtual void operator()(const Expr::TToUpper       *) const {}
     virtual void operator()(const Expr::TUnion         *) const {}
+    virtual void operator()(const Expr::TUnionMap      *) const {}
     virtual void operator()(const Expr::TUnknown       *) const {}
     virtual void operator()(const Expr::TUserId        *) const {}
     virtual void operator()(const Expr::TVariantCtor   *) const {}
@@ -653,6 +655,18 @@ TInline::TPtr Orly::CodeGen::Build(const L0::TPackage *package, const Expr::TExp
       //TODO: Intern this (Functions aren't interned, so doing it now doesn't make sense.
       Res = TReduce::New(Package, ReturnType, BuildInline(Package, that->GetLhs(), false),
           Build(Package, that->GetStart()->GetExpr(), false), func);
+    }
+
+    virtual void operator()(const Expr::TUnionMap *that) const {
+      // Map func: each element `that` -> a set (the rhs body). The element
+      // scope binds `that`, exactly like filter's predicate.
+      TImplicitFunc::TPtr func = TImplicitFunc::New(Package, TImplicitFunc::TCause::Map,
+          that->GetRhs()->GetType(), {{"that", that->GetThatType()}}, that->GetRhs(), false);
+      /* Map ctx */ {
+        TFilterCtx ctx(func->GetArg("that"));
+        func->Build();
+      }
+      Res = TUnionMap::New(Package, ReturnType, BuildInline(Package, that->GetLhs(), false), func);
     }
     virtual void operator()(const Expr::TRef *that) const {
       class TVisitor : public Symbol::TDef::TVisitor {

--- a/orly/code_gen/union_map.cc
+++ b/orly/code_gen/union_map.cc
@@ -1,0 +1,55 @@
+/* <orly/code_gen/union_map.cc>
+
+   Implements <orly/code_gen/union_map.h>
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <orly/code_gen/union_map.h>
+
+#include <orly/code_gen/implicit_func.h>
+
+using namespace Orly::CodeGen;
+
+
+TUnionMap::TPtr TUnionMap::New(const L0::TPackage *package,
+                               const Type::TType &ret_type,
+                               const TInline::TPtr &seq,
+                               const TImplicitFunc::TPtr &map_func) {
+  return TPtr(new TUnionMap(package, ret_type, seq, map_func));
+}
+
+void TUnionMap::WriteExpr(TCppPrinter &out) const {
+  /* The trailing `RetType()` is the empty-set start: it gives the runtime
+     UnionMap its result type by deduction (the map func alone can't), and
+     IS the union identity. */
+  out << "UnionMap(" << Seq << ", ";
+  Func->WriteName(out);
+  out << ", " << GetReturnType() << "())";
+}
+
+TUnionMap::TUnionMap(const L0::TPackage *package,
+                     const Type::TType &ret_type,
+                     const TInline::TPtr &seq,
+                     const TImplicitFunc::TPtr &map_func)
+  : TInline(package, ret_type),
+    Func(map_func),
+    Seq(seq) {}
+
+void TUnionMap::AppendDependsOn(std::unordered_set<TInline::TPtr> &dependency_set) const {
+  dependency_set.insert(Seq);
+  Seq->AppendDependsOn(dependency_set);
+  dependency_set.insert(Func->GetBody());
+  Func->GetBody()->AppendDependsOn(dependency_set);
+}

--- a/orly/code_gen/union_map.h
+++ b/orly/code_gen/union_map.h
@@ -1,0 +1,60 @@
+/* <orly/code_gen/union_map.h>
+
+   `TUnionMap` emits a `seq union_map elem` expression: map each
+   element of `Seq` to a set via `Func` (a `TImplicitFunc` over the
+   `that` element) and union the results, from an empty-set start.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#pragma once
+
+#include <orly/code_gen/inline.h>
+
+namespace Orly {
+
+  namespace CodeGen {
+
+    class TImplicitFunc;
+
+    class TUnionMap : public TInline {
+      NO_COPY(TUnionMap);
+      public:
+
+      typedef std::shared_ptr<TUnionMap> TPtr;
+      typedef std::shared_ptr<TImplicitFunc> TFuncPtr;
+
+      static TPtr New(const L0::TPackage *package,
+                      const Type::TType &ret_type,
+                      const TInline::TPtr &seq,
+                      const TFuncPtr &map_func);
+
+      void WriteExpr(TCppPrinter &out) const;
+
+      /* Dependency graph */
+      virtual void AppendDependsOn(std::unordered_set<TInline::TPtr> &dependency_set) const override;
+
+      private:
+      TUnionMap(const L0::TPackage *package,
+                const Type::TType &ret_type,
+                const TInline::TPtr &seq,
+                const TFuncPtr &map_func);
+
+      TFuncPtr Func;
+      TInline::TPtr Seq;
+    }; // TUnionMap
+
+  } // CodeGen
+
+} // Orly

--- a/orly/expr.h
+++ b/orly/expr.h
@@ -53,6 +53,7 @@
 #include <orly/expr/read.h>
 #include <orly/expr/reduce.h>
 #include <orly/expr/ref.h>
+#include <orly/expr/union_map.h>
 #include <orly/expr/reverse_of.h>
 #include <orly/expr/sequence_of.h>
 #include <orly/expr/session_id.h>

--- a/orly/expr/addr_walker.cc
+++ b/orly/expr/addr_walker.cc
@@ -139,6 +139,7 @@ class expr_visitor_t
   virtual void operator()(const TSymmetricDiff *that)   const { Binary(that); }
   virtual void operator()(const TTake *that)            const { Binary(that); }
   virtual void operator()(const TUnion *that)           const { Binary(that); }
+  virtual void operator()(const TUnionMap *that)        const { Binary(that); }
   virtual void operator()(const TWhile *that)           const { Binary(that); }
   virtual void operator()(const TXor *that)             const { Binary(that); }
   // Nary
@@ -361,6 +362,7 @@ class expr_visitor_t
     virtual void operator()(const TSymmetricDiff *that)   const { Binary(that); }
     virtual void operator()(const TTake *that)            const { Binary(that); }
     virtual void operator()(const TUnion *that)           const { Binary(that); }
+    virtual void operator()(const TUnionMap *that)        const { Binary(that); }
     virtual void operator()(const TWhile *that)           const { Binary(that); }
     virtual void operator()(const TXor *that)             const { Binary(that); }
     // Nary

--- a/orly/expr/union_map.cc
+++ b/orly/expr/union_map.cc
@@ -1,0 +1,61 @@
+/* <orly/expr/union_map.cc>
+
+   Implements <orly/expr/union_map.h>.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <orly/expr/union_map.h>
+
+#include <orly/error.h>
+#include <orly/expr/visitor.h>
+#include <orly/pos_range.h>
+#include <orly/type/seq.h>
+#include <orly/type/set.h>
+#include <orly/type/unwrap.h>
+#include <orly/type/util.h>
+
+using namespace Orly;
+using namespace Orly::Expr;
+
+TUnionMap::TPtr TUnionMap::New(
+    const TExpr::TPtr &lhs,
+    const TPosRange &pos_range) {
+  return TUnionMap::TPtr(new TUnionMap(lhs, pos_range));
+}
+
+TUnionMap::TUnionMap(
+    const TExpr::TPtr &lhs,
+    const TPosRange &pos_range)
+      : TThatableBinary(lhs, pos_range) {}
+
+void TUnionMap::Accept(const TVisitor &visitor) const {
+  visitor(this);
+}
+
+Type::TType TUnionMap::GetTypeImpl() const {
+  if (!GetLhs()->GetType().Is<Type::TSeq>()) {
+    throw TExprError(HERE, GetPosRange(),
+        "The lhs of a union_map expression must be a sequence");
+  }
+  assert(GetRhs());
+  /* The per-element body maps `that` to a set; the whole expression is the
+     union of those sets, so its type IS that set type. */
+  Type::TType elem_type = Type::Unwrap(GetRhs()->GetType());
+  if (!elem_type.Is<Type::TSet>()) {
+    throw TExprError(HERE, GetPosRange(),
+        "The rhs of a union_map expression must be a set (it is unioned across the sequence)");
+  }
+  return elem_type;
+}

--- a/orly/expr/union_map.h
+++ b/orly/expr/union_map.h
@@ -1,0 +1,55 @@
+/* <orly/expr/union_map.h>
+
+   The `union_map` expression (#219): `seq union_map elem` maps each
+   element of `seq` to a set (the `elem` body references `that`) and
+   unions the results, from an implicit empty-set identity. Equivalent to
+   `seq reduce start (empty {T}) | elem` but without spelling out the
+   identity, so the per-element set type T is inferred here at type-check.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#pragma once
+
+#include <memory>
+
+#include <base/class_traits.h>
+#include <orly/expr/thatable_binary.h>
+
+namespace Orly {
+
+  namespace Expr {
+
+    class TUnionMap
+        : public TThatableBinary {
+      NO_COPY(TUnionMap);
+      public:
+
+      typedef std::shared_ptr<TUnionMap> TPtr;
+
+      static TPtr New(const TExpr::TPtr &lhs, const TPosRange &pos_range);
+
+      virtual void Accept(const TVisitor &visitor) const;
+
+      virtual Type::TType GetTypeImpl() const override;
+
+      private:
+
+      TUnionMap(const TExpr::TPtr &lhs, const TPosRange &pos_range);
+
+    };  // TUnionMap
+
+  }  // Expr
+
+}  // Orly

--- a/orly/expr/visitor.h
+++ b/orly/expr/visitor.h
@@ -109,6 +109,7 @@ namespace Orly {
     class TToLower;
     class TToUpper;
     class TUnion;
+    class TUnionMap;
     class TUnknown;
     class TUserId;
     class TVariantCtor;
@@ -205,6 +206,7 @@ namespace Orly {
       virtual void operator()(const TToLower       *) const = 0;
       virtual void operator()(const TToUpper       *) const = 0;
       virtual void operator()(const TUnion         *) const = 0;
+      virtual void operator()(const TUnionMap      *) const = 0;
       virtual void operator()(const TUnknown       *) const = 0;
       virtual void operator()(const TUserId        *) const = 0;
       virtual void operator()(const TVariantCtor   *) const = 0;

--- a/orly/expr/walker.cc
+++ b/orly/expr/walker.cc
@@ -298,6 +298,9 @@ void Orly::Expr::ForEachExpr(const TExpr::TPtr &root, const TCb &cb, bool includ
     virtual void operator()(const TUnion *that) const {
       Binary(that);
     }
+    virtual void operator()(const TUnionMap *that) const {
+      BinaryRhsInnerFunc(that);
+    }
     virtual void operator()(const TToLower *that) const {
       Unary(that);
     }

--- a/orly/orly.nycr
+++ b/orly/orly.nycr
@@ -149,6 +149,7 @@ time_obj_kwd	  = '"time_obj"';
 time_pnt_kwd      = '"time_pnt"';
 to_lower_kwd      = '"to_lower"';
 to_upper_kwd      = '"to_upper"';
+union_map_kwd     = '"union_map"' lowest_prec left;
 unknown_kwd       = '"unknown"' unary_prec right;
 user_id_kwd       = '"user_id"';
 using_kwd         = '"using"';
@@ -603,6 +604,11 @@ db_keys_expr : expr -> keys_kwd open_paren type close_paren at_sign open_addr op
 collated_by_expr : expr -> seq:expr collated_by_kwd reduce:expr having_kwd having:expr;
 
 collected_by_expr : expr -> seq:expr collected_by_kwd collect:expr;
+
+/* union_map (#219): map each element of a sequence to a set, union the
+   results. `seq union_map elem` == `seq reduce start (empty {T}) | elem`,
+   but the empty-set identity is implicit so the surface stays terse. */
+union_map_expr : expr -> seq:expr union_map_kwd elem:expr;
 
 /* ------------------------------------------------------------------------------------------------------------------------------------------------
     STATEMENTS

--- a/orly/rt.h
+++ b/orly/rt.h
@@ -29,6 +29,7 @@
 #include <orly/rt/collected_by.h>
 #include <orly/rt/desc.h>
 #include <orly/rt/generator.h>
+#include <orly/rt/union_map.h>
 #include <orly/rt/mutable.h>
 #include <orly/rt/opt.h>
 #include <orly/rt/runtime_error.h>

--- a/orly/rt/union_map.h
+++ b/orly/rt/union_map.h
@@ -1,0 +1,50 @@
+/* <orly/rt/union_map.h>
+
+   `UnionMap(gen, map_fn, start)` -- map each element of `gen` to a set
+   via `map_fn` and union the results, starting from `start` (the empty
+   set). Code-gen for orlyscript's `seq union_map elem` operator (#219).
+   `start` is passed (rather than default-constructed inside) so the
+   result type TRes is deducible at the call site, exactly as Reduce
+   deduces it from its start argument.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#pragma once
+
+#include <functional>
+
+#include <orly/rt/containers.h>
+#include <orly/rt/generator.h>
+
+namespace Orly {
+
+  namespace Rt {
+
+    template <typename TRes, typename TSrc>
+    using TUnionMapFunc = std::function<TRes (const TSrc &that)>;
+
+    template <typename TRes, typename TSrc>
+    TRes UnionMap(const typename TGenerator<TSrc>::TPtr &gen,
+                  const TUnionMapFunc<TRes, TSrc> &map_func,
+                  TRes start) {
+      for (auto it = gen->NewCursor(); it; ++it) {
+        start = start | map_func(*it);
+      }
+      return start;
+    }
+
+  }  // Rt
+
+}  // Orly

--- a/orly/spa/checkpoint.cc
+++ b/orly/spa/checkpoint.cc
@@ -173,6 +173,7 @@ class TExprVisitor : public Orly::Checkpoint::Syntax::TExpr::TVisitor {
   virtual void operator()(const Orly::Checkpoint::Syntax::TBuiltInToUpper *) const {NOT_IMPLEMENTED();}
   virtual void operator()(const Orly::Checkpoint::Syntax::TCollatedByExpr *) const {NOT_IMPLEMENTED();}
   virtual void operator()(const Orly::Checkpoint::Syntax::TCollectedByExpr *) const {NOT_IMPLEMENTED();}
+  virtual void operator()(const Orly::Checkpoint::Syntax::TUnionMapExpr *) const {NOT_IMPLEMENTED();}
   virtual void operator()(const Orly::Checkpoint::Syntax::TInfixBitwiseOr *) const {NOT_IMPLEMENTED();}
   virtual void operator()(const Orly::Checkpoint::Syntax::TInfixDiv *) const {NOT_IMPLEMENTED();}
   virtual void operator()(const Orly::Checkpoint::Syntax::TInfixLogicalOr *) const {NOT_IMPLEMENTED();}

--- a/orly/spa/command.cc
+++ b/orly/spa/command.cc
@@ -181,6 +181,7 @@ namespace FooBar {
     virtual void operator()(const Syntax::TBuiltInToLower *) const {NOT_IMPLEMENTED();}
     virtual void operator()(const Syntax::TCollatedByExpr *) const {NOT_IMPLEMENTED();}
     virtual void operator()(const Syntax::TCollectedByExpr *) const {NOT_IMPLEMENTED();}
+    virtual void operator()(const Syntax::TUnionMapExpr *) const {NOT_IMPLEMENTED();}
     virtual void operator()(const Syntax::TBuiltInToUpper *) const {NOT_IMPLEMENTED();}
     virtual void operator()(const Syntax::TInfixBitwiseOr *) const {NOT_IMPLEMENTED();}
     virtual void operator()(const Syntax::TInfixDiv *) const {NOT_IMPLEMENTED();}

--- a/orly/synth/get_pos_range.cc
+++ b/orly/synth/get_pos_range.cc
@@ -232,6 +232,10 @@ TPosRange Orly::Synth::GetPosRange(const Package::Syntax::TInfixReduce *that) {
   return Orly::Synth::GetPosRange(that->GetLhs(), that->GetRhs());
 }
 
+TPosRange Orly::Synth::GetPosRange(const Package::Syntax::TUnionMapExpr *that) {
+  return Orly::Synth::GetPosRange(that->GetSeq(), that->GetElem());
+}
+
 template <>
 TPosRange Orly::Synth::GetPosRange(const Package::Syntax::TInfixSort *that) {
   return Orly::Synth::GetPosRange(that->GetLhs(), that->GetRhs());
@@ -634,6 +638,7 @@ TPosRange Orly::Synth::GetPosRange(const Package::Syntax::TExpr *expr) {
     virtual void operator()(const Package::Syntax::TInfixOrElse          *that) const { PosRange = Orly::Synth::GetPosRange(that); }
     virtual void operator()(const Package::Syntax::TInfixPlus            *that) const { PosRange = Orly::Synth::GetPosRange(that); }
     virtual void operator()(const Package::Syntax::TInfixReduce          *that) const { PosRange = Orly::Synth::GetPosRange(that); }
+    virtual void operator()(const Package::Syntax::TUnionMapExpr          *that) const { PosRange = Orly::Synth::GetPosRange(that); }
     virtual void operator()(const Package::Syntax::TInfixSort            *that) const { PosRange = Orly::Synth::GetPosRange(that); }
     virtual void operator()(const Package::Syntax::TInfixTake            *that) const { PosRange = Orly::Synth::GetPosRange(that); }
     virtual void operator()(const Package::Syntax::TInfixSkip            *that) const { PosRange = Orly::Synth::GetPosRange(that); }

--- a/orly/synth/get_pos_range.h
+++ b/orly/synth/get_pos_range.h
@@ -160,6 +160,7 @@ namespace Orly {
 
     template <>
     TPosRange GetPosRange(const Package::Syntax::TInfixReduce *that);
+    TPosRange GetPosRange(const Package::Syntax::TUnionMapExpr *that);
 
     template <>
     TPosRange GetPosRange(const Package::Syntax::TInfixSort *that);

--- a/orly/synth/given_collector.h
+++ b/orly/synth/given_collector.h
@@ -152,6 +152,7 @@ namespace Orly {
       virtual void operator()(const Package::Syntax::TInfixOrElse *that) const { Push(that->GetLhs(), that->GetRhs()); }
       virtual void operator()(const Package::Syntax::TInfixPlus *that) const { Push(that->GetLhs(), that->GetRhs()); }
       virtual void operator()(const Package::Syntax::TInfixReduce *that) const { Push(that->GetLhs(), that->GetRhs()); }
+      virtual void operator()(const Package::Syntax::TUnionMapExpr *that) const { Push(that->GetSeq(), that->GetElem()); }
       virtual void operator()(const Package::Syntax::TInfixSort *that) const { Push(that->GetLhs(), that->GetRhs()); }
       virtual void operator()(const Package::Syntax::TInfixTake *that) const { Push(that->GetLhs(), that->GetRhs()); }
       virtual void operator()(const Package::Syntax::TInfixSkip *that) const { Push(that->GetLhs(), that->GetRhs()); }

--- a/orly/synth/new_expr.cc
+++ b/orly/synth/new_expr.cc
@@ -60,6 +60,7 @@
 #include <orly/synth/read_expr.h>
 #include <orly/synth/reduce_expr.h>
 #include <orly/synth/ref_expr.h>
+#include <orly/synth/union_map_expr.h>
 #include <orly/synth/rhs_expr.h>
 #include <orly/synth/set_ctor.h>
 #include <orly/synth/session_id_expr.h>
@@ -171,6 +172,7 @@ TExpr *TExprFactory::NewExpr(const Package::Syntax::TExpr *root) const {
     virtual void operator()(const Syntax::TInfixOrElse *that) const { OnInfix(that->GetLhs(), that->GetRhs(), Expr::TOrElse::New, GetPosRange(that)); }
     virtual void operator()(const Syntax::TInfixPlus *that) const { OnInfix(that->GetLhs(), that->GetRhs(), Expr::TAdd::New, GetPosRange(that)); }
     virtual void operator()(const Syntax::TInfixReduce *that) const { Out = new TReduceExpr(ExprFactory, that); }
+    virtual void operator()(const Syntax::TUnionMapExpr *that) const { Out = new TUnionMapExpr(ExprFactory, that); }
     virtual void operator()(const Syntax::TInfixSort *that) const { Out = new TSortExpr(ExprFactory, that); }
     virtual void operator()(const Syntax::TInfixTake *that) const { OnInfix(that->GetLhs(), that->GetRhs(), Expr::TTake::New, GetPosRange(that)); }
     virtual void operator()(const Syntax::TInfixSkip *that) const { OnInfix(that->GetLhs(), that->GetRhs(), Expr::TSkip::New, GetPosRange(that)); }

--- a/orly/synth/union_map_expr.cc
+++ b/orly/synth/union_map_expr.cc
@@ -1,0 +1,79 @@
+/* <orly/synth/union_map_expr.cc>
+
+   Implements <orly/synth/union_map_expr.h>.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <orly/synth/union_map_expr.h>
+
+#include <cassert>
+
+#include <base/assert_true.h>
+#include <orly/synth/get_pos_range.h>
+#include <orly/synth/new_expr.h>
+
+using namespace Orly;
+using namespace Orly::Synth;
+
+TUnionMapExpr::TUnionMapExpr(const TExprFactory *expr_factory, const Package::Syntax::TUnionMapExpr *union_map_expr)
+    : UnionMapExpr(Base::AssertTrue(union_map_expr)), Lhs(nullptr), Rhs(nullptr) {
+  assert(expr_factory);
+  try {
+    Lhs = expr_factory->NewExpr(UnionMapExpr->GetSeq());
+    TExprFactory local_expr_factory = *expr_factory;
+    local_expr_factory.ThatableExpr = this;
+    Rhs = local_expr_factory.NewExpr(UnionMapExpr->GetElem());
+  } catch (...) {
+    delete Lhs;
+    delete Rhs;
+    throw;
+  }
+}
+
+TUnionMapExpr::~TUnionMapExpr() {
+  delete Lhs;
+  delete Rhs;
+}
+
+Expr::TExpr::TPtr TUnionMapExpr::Build() const {
+  assert(!Symbol);
+  // NOTE: rhs is set separately so the inner `that` can resolve to this
+  // symbol -- see <orly/synth/thatable_expr.h>.
+  Symbol = Expr::TUnionMap::New(Lhs->Build(), GetPosRange(UnionMapExpr));
+  Symbol->SetRhs(Rhs->Build());
+  return Symbol;
+}
+
+void TUnionMapExpr::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
+  assert(cb);
+  Lhs->ForEachInnerScope(cb);
+  Rhs->ForEachInnerScope(cb);
+}
+
+void TUnionMapExpr::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
+  assert(cb);
+  Lhs->ForEachRef(cb);
+  Rhs->ForEachRef(cb);
+}
+
+const Expr::TUnionMap::TPtr &TUnionMapExpr::GetSymbol() const {
+  assert(Symbol);
+  return Symbol;
+}
+
+Expr::TThatable::TPtr TUnionMapExpr::GetThatableSymbol() const {
+  assert(Symbol);
+  return Symbol;
+}

--- a/orly/synth/union_map_expr.h
+++ b/orly/synth/union_map_expr.h
@@ -1,0 +1,84 @@
+/* <orly/synth/union_map_expr.h>
+
+   Synth-layer node for `seq union_map elem` expressions. Holds the
+   sequence (lhs) and the per-element set body (rhs). Implements
+   `TThatableExpr` so the body's `that` resolves here. Lowers to
+   `Expr::TUnionMap`.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#pragma once
+
+#include <cassert>
+
+#include <base/class_traits.h>
+#include <orly/expr/thatable.h>
+#include <orly/expr/union_map.h>
+#include <orly/orly.package.cst.h>
+#include <orly/synth/thatable_expr.h>
+
+namespace Orly {
+
+  namespace Synth {
+
+    /* TODO */
+    class TExprFactory;
+
+    /* TODO */
+    class TUnionMapExpr
+        : public TThatableExpr {
+      NO_COPY(TUnionMapExpr);
+      public:
+
+      /* TODO */
+      TUnionMapExpr(const TExprFactory *expr_factory, const Package::Syntax::TUnionMapExpr *union_map_expr);
+
+      /* TODO */
+      virtual ~TUnionMapExpr();
+
+      /* TODO */
+      virtual Expr::TExpr::TPtr Build() const;
+
+      /* TODO */
+      virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
+
+      /* TODO */
+      virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
+
+      /* TODO */
+      const Expr::TUnionMap::TPtr &GetSymbol() const;
+
+      /* TODO */
+      virtual Expr::TThatable::TPtr GetThatableSymbol() const;
+
+      private:
+
+      /* TODO */
+      const Package::Syntax::TUnionMapExpr *UnionMapExpr;
+
+      /* TODO */
+      TExpr *Lhs;
+
+      /* TODO */
+      TExpr *Rhs;
+
+      /* TODO */
+      mutable Expr::TUnionMap::TPtr Symbol;
+
+    };  // TUnionMapExpr
+
+  }  // Synth
+
+}  // Orly

--- a/tests/lang_tests/general/.union_map.orly.test.state
+++ b/tests/lang_tests/general/.union_map.orly.test.state
@@ -1,0 +1,21 @@
+[
+  0,
+  [
+    [],
+    [
+      "Synth + Symbols"
+    ],
+    [
+      "Code Gen"
+    ],
+    [
+      "Compiling C++"
+    ],
+    [
+      "Running tests"
+    ],
+    [
+      "Tests done"
+    ]
+  ]
+]

--- a/tests/lang_tests/general/union_map.orly
+++ b/tests/lang_tests/general/union_map.orly
@@ -1,0 +1,45 @@
+/* union_map (#219): `seq union_map elem` maps each element of `seq` to a
+   set (the `elem` body references `that`) and unions the results, from an
+   implicit empty-set identity. Equivalent to
+   `seq reduce start (empty {T}) | elem` but terser, and it is the sugar
+   the agent-swarm graph traversal uses to expand a frontier in one hop.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+/* maps each n to {n} -- union is just the set of elements. A list param
+   is spread with ** into a sequence first, exactly like reduce. */
+to_set = (**s union_map {that}) where {
+  s = given::([int]);
+};
+
+/* maps each n to {n, n*10}; the unions overlap-free here. */
+fan = ([1..3] union_map {that, that * 10});
+
+test {
+  /* identity-ish: union of singletons == the set of elements. */
+  t1: ([1..5] union_map {that}) == {1, 2, 3, 4, 5};
+  /* duplicates in the sequence collapse (set union is idempotent). */
+  t2: (**[2, 2, 3, 3, 3] union_map {that}) == {2, 3};
+  /* each element fans out to a 2-element set; all unioned. */
+  t3: fan == {1, 10, 2, 20, 3, 30};
+  /* empty sequence -> empty set (the implicit identity). */
+  t4: (**empty [int] union_map {that}) == empty {int};
+  /* overlapping per-element sets union without double-counting. */
+  t5: ([1..3] union_map {that, that + 1}) == {1, 2, 3, 4};
+  /* string elements work too. */
+  t6: (**["a", "b"] union_map {that, "x"}) == {"a", "b", "x"};
+  /* helper-call form. */
+  t7: to_set(.s: [7, 8, 9]) == {7, 8, 9};
+};


### PR DESCRIPTION
Phase 2 of #219. Adds the **`union_map`** sequence operator — the terse surface the graph-traversal RFC called for — and adopts it in the agent-swarm demo.

## What

`seq union_map elem` maps each element of a sequence to a set (the `elem` body references `that`) and unions the results, from an implicit empty-set identity. It is exactly `seq reduce start (empty {T}) | elem` but without spelling out the identity, so the per-element set type `T` is inferred at type-check.

It is **pure ergonomics** — no new storage, runtime capability, or engine path; it lowers to a map + a union-fold over existing machinery. The phase-1 traversal gets noticeably terser:

```orly
# before (phase 1)
neighbors = (keys (int) @ <['"'"'adj'"'"', e, free::(str)]>) reduce start (empty {str}) | {that.2}
grow      = v | ((**v) reduce start (empty {str}) | neighbors(.e: that))

# after (union_map)
neighbors = (keys (int) @ <['"'"'adj'"'"', e, free::(str)]>) union_map {that.2}
grow      = v | ((**v) union_map neighbors(.e: that))
```

## Implementation

Mirrors `filter` (a thatable infix binary, **not** startable — the empty-set identity is implicit, which is why it has to be its own typed node: `T` is inferred at type-check, not synth):

- `union_map` token + `union_map_expr` grammar production.
- `Expr::TUnionMap` — type-check: lhs is a sequence, rhs is a set `{T}`, result `{T}`.
- Synth `TUnionMapExpr`; codegen `TUnionMap` emitting a new `Rt::UnionMap` runtime that folds `acc = acc | map_fn(*it)` from an empty-set start (passed so the result type is deducible, exactly as `Reduce` does).
- New case threaded through every `Expr` / `Command::Syntax` / `Checkpoint::Syntax` visitor.

## Tests

- `tests/lang_tests/general/union_map.orly` — singletons, idempotent union over duplicates, fan-out, empty-sequence identity, overlapping per-element sets, strings, helper-call form.
- `examples/agent-swarm/{graph.orly,demo.py,demo.go,README.md}` — adopt `union_map` for `neighbors`/`grow`; both drivers pass end-to-end and still verify k-hop reachability against a BFS.
- Full `make test` and `make test_lang` green (161 lang tests pass, 2 tracked xfail).

Phase 1 was #220. Remaining #219 follow-ups (a `reach … via … depth k` sugar, a frontier-delta planner) are unchanged. `tests/lang_tests/general/graph_traversal.orly` deliberately keeps its `reduce`-based form as the "expressible with no primitive" proof.
