### PR TITLE
agent-swarm: frontier-delta BFS for reach (#219 phase 3)

### DIFF
--- a/examples/agent-swarm/README.md
+++ b/examples/agent-swarm/README.md
@@ -66,9 +66,17 @@ That trailing-`free` shape is exactly what Orly's sorted index seeks straight to
 
 ```orly
 neighbors = (keys (int) @ <['adj', e, free::(str)]>) union_map {that.2}   # one hop
-grow      = v | ((**v) union_map neighbors(.e: that))                     # expand a frontier
-reach     = [1..k] reduce grow(.v: start ({seed}))                        # k-hop closure
 ```
+
+The naive closure folds a whole-set expansion `k` times — correct, but it re-reads already-settled nodes every hop (O(k · |visited| · degree)). [`graph.orly`](graph.orly)'s `reach` is instead a proper **frontier-delta BFS**: the accumulator carries `<{.seen, .frontier}>`, and each step expands *only* the frontier, so each node's adjacency is read exactly once (O(edges)):
+
+```orly
+step  = <{.seen: acc.seen | fresh, .frontier: fresh}>            # fresh = frontier's new neighbours
+        where { fresh = ((**acc.frontier) union_map neighbors(.e: that)) - acc.seen; ... }
+reach = ([1..k] reduce step(.acc: start (<{.seen: {seed}, .frontier: {seed}}>))).seen
+```
+
+The inline tests assert the delta BFS returns the same set as the naive whole-set fold, hop for hop.
 
 The driver verifies `reach(seed, k)` against a plain-Python BFS over the same graph, then showcases a neighbourhood — e.g. from **Claude**, ~92% of the graph is reachable within 3 hops. The point: the graph was assembled by N agents with **zero coordination**, and it's still **traversable transitively** — concurrent construction *and* graph queries in one store, which Neo4j (single-primary writes) and Cayley (a query layer over a store) don't combine.
 

--- a/examples/agent-swarm/graph.orly
+++ b/examples/agent-swarm/graph.orly
@@ -124,20 +124,40 @@ neighbors = (((keys (int) @ <['adj', e, free::(str)]>) union_map {that.2})) wher
   e = given::(str);
 };
 
-/* One BFS hop: the frontier set V plus the union of every frontier node's
-   neighbours -- `union_map` maps each frontier node to its neighbour set
-   and unions them. */
+/* One NAIVE BFS hop: the whole set V plus the union of every node's
+   neighbours. Simple and correct, but re-reads already-settled nodes on
+   every call -- kept as the readable reference that `reach` matches. */
 grow = ((v | ((**v) union_map neighbors(.e: that)))) where {
   v = given::({str});
 };
 
+/* Naive k-hop reachability: fold `grow` over a depth range. Correct, and
+   the accumulating visited set makes cycles terminate -- but it re-expands
+   the ENTIRE visited set every hop, so it costs O(k * |visited| * degree). */
+reach_naive = (([1..k] reduce grow(.v: start ({seed})))) where {
+  seed = given::(str);
+  k    = given::(int);
+};
+
+/* One FRONTIER-DELTA BFS step. The accumulator carries
+   <{.seen, .frontier}>; each step expands ONLY the frontier (not all of
+   seen), and the newly-discovered nodes (`fresh` = the frontier's
+   neighbours minus what we've already seen) become the next frontier. So
+   every node's adjacency is read exactly once across the whole traversal.
+   An empty frontier makes further steps no-ops, so cycles still terminate.
+   (`fresh`, not `new` -- `new` is the reserved create-statement keyword.) */
+step = ((<{.seen: acc.seen | fresh, .frontier: fresh}>)) where {
+  acc   = given::(<{.seen: {str}, .frontier: {str}}>);
+  fresh = (((**acc.frontier) union_map neighbors(.e: that)) - acc.seen);
+};
+
 /* Every entity reachable from `seed` within `k` cooccurrence hops
-   (inclusive of seed): k applications of `grow`. The accumulating visited
-   set makes cycles terminate -- a coordination-free knowledge graph,
-   traversed transitively. The adjacency needed no new storage (it is
-   already index-free); `union_map` is just the terse surface for the
-   per-hop frontier expansion (it desugars to a reduce). */
-reach = (([1..k] reduce grow(.v: start ({seed})))) where {
+   (inclusive of seed), as a proper BFS: fold `step` over the depth range
+   carrying (seen, frontier), then read the accumulated `seen`. Same result
+   as `reach_naive`, but O(edges) total instead of O(k * edges) -- each
+   node is expanded once, which is what makes traversal scale past toy
+   graphs. The drivers call this. */
+reach = ((([1..k] reduce step(.acc: start (<{.seen: {seed}, .frontier: {seed}}>))).seen)) where {
   seed = given::(str);
   k    = given::(int);
 };
@@ -219,6 +239,12 @@ test {
           t38: reach(.seed: "D", .k: 2) == {"A", "B", "C", "D"};
           /* the A-B-C cycle terminates: extra hops add nothing */
           t39: reach(.seed: "D", .k: 5) == {"A", "B", "C", "D"};
+          /* the frontier-delta BFS agrees with the naive whole-set fold,
+             hop for hop -- same reachable set, each node expanded once. */
+          t40: reach(.seed: "D", .k: 1) == reach_naive(.seed: "D", .k: 1);
+          t41: reach(.seed: "D", .k: 2) == reach_naive(.seed: "D", .k: 2);
+          t42: reach(.seed: "A", .k: 3) == reach_naive(.seed: "A", .k: 3);
+          t43: reach(.seed: "B", .k: 5) == reach_naive(.seed: "B", .k: 5);
         };
       };
     };

--- a/tests/lang_tests/general/graph_traversal.orly
+++ b/tests/lang_tests/general/graph_traversal.orly
@@ -3,7 +3,13 @@
    edge-existence keys; adjacency via a trailing-free prefix scan; bounded
    reachability as a reduce over a depth range, accumulating a visited set
    (which gives cycle handling for free). The agent-swarm example does the
-   same over a coordination-free knowledge graph. */
+   same over a coordination-free knowledge graph.
+
+   `reach` here uses no new primitive (a plain reduce). `reach_delta` below
+   is the frontier-delta BFS (#219 phase 3): same result, but it expands
+   only the new frontier each hop -- O(edges) instead of O(k*edges) -- and
+   uses `union_map` (#219 phase 2) to expand a frontier in one step. The
+   tests assert the two agree. */
 
 /* out-neighbours of n: scan all <['edge', n, *]> keys, fold the dst
    (tuple element .2) into a set. */
@@ -22,6 +28,20 @@ reach = (([1..k] reduce expand(.v: start ({seed})))) where {
   k    = given::(int);
 };
 
+/* Frontier-delta BFS (#219 phase 3): same reachable set as `reach`, but
+   each step expands ONLY the new frontier (not the whole visited set), so
+   each node's adjacency is read once -- O(edges) instead of O(k*edges).
+   Uses union_map (#219 phase 2) to expand the frontier in one step. */
+step = ((<{.seen: acc.seen | fresh, .frontier: fresh}>)) where {
+  acc   = given::(<{.seen: {int}, .frontier: {int}}>);
+  fresh = (((**acc.frontier) union_map neighbors(.n: that)) - acc.seen);
+};
+
+reach_delta = ((([1..k] reduce step(.acc: start (<{.seen: {seed}, .frontier: {seed}}>))).seen)) where {
+  seed = given::(int);
+  k    = given::(int);
+};
+
 /* graph:  1 -> 2 -> 3 -> 1 (cycle),  1 -> 4 */
 with {
   <['edge', 1, 2]> <- true;
@@ -34,4 +54,10 @@ with {
   t3: reach(.seed: 1, .k: 2) == {1, 2, 3, 4};
   t4: reach(.seed: 1, .k: 5) == {1, 2, 3, 4};   /* cycle does not loop forever */
   t5: reach(.seed: 4, .k: 5) == {4};            /* sink */
+  /* the frontier-delta BFS agrees with the naive whole-set fold. */
+  t6: reach_delta(.seed: 1, .k: 1) == reach(.seed: 1, .k: 1);
+  t7: reach_delta(.seed: 1, .k: 2) == reach(.seed: 1, .k: 2);
+  t8: reach_delta(.seed: 1, .k: 5) == reach(.seed: 1, .k: 5);
+  t9: reach_delta(.seed: 4, .k: 5) == reach(.seed: 4, .k: 5);
+  t10: reach_delta(.seed: 1, .k: 2) == {1, 2, 3, 4};
 };


### PR DESCRIPTION
Phase 3 of #219 — the frontier-delta planner, as a **pure-orlyscript algorithm change, no engine work** (interpretation A: a smarter BFS, not a compiler query optimizer).

## What

Phase-1 `reach` re-expanded the **entire** visited set every hop, re-reading already-settled nodes `k` times — `O(k · |visited| · degree)`. This rewrites it as a proper **frontier-delta BFS**: the accumulator carries `<{.seen, .frontier}>`, and each step expands *only* the frontier:

```orly
step  = <{.seen: acc.seen | fresh, .frontier: fresh}>
        where { fresh = ((**acc.frontier) union_map neighbors(.e: that)) - acc.seen; ... }
reach = ([1..k] reduce step(.acc: start (<{.seen: {seed}, .frontier: {seed}}>))).seen
```

So each node's adjacency is read **exactly once** across the whole traversal — `O(edges)`, not `O(k · edges)`. An empty frontier makes further steps no-ops, so cycles still terminate. This is what lets traversal scale past toy graphs; the 25-node demo result is unchanged (Claude still reaches ~92% within 3 hops).

## Correctness

The naive whole-set fold is kept as `reach_naive` (the readable reference), and the tests assert **`reach == reach_naive` hop for hop**:
- `graph.orly` inline tests `t40`–`t43` (run by the demo).
- `tests/lang_tests/general/graph_traversal.orly` `t6`–`t10` — the CI-guarded equivalence (examples aren't in `make test_lang`).

No driver change — `reach`'s signature is unchanged; both demos still verify k-hop reachability against a BFS and pass end-to-end. Full `make test_lang` green (161 pass / 2 tracked xfail).

Builds on `union_map` (#221) to expand a frontier in one step. Remaining #219 items (a `reach … via … depth k` keyword surface, shortest-path/distances, secondary indexes) stay deferred/gated.
