### PR TITLE
agent-swarm: write-scaling benchmark — reproduction for #227

### DIFF
--- a/examples/agent-swarm/README.md
+++ b/examples/agent-swarm/README.md
@@ -78,6 +78,10 @@ reach = ([1..k] reduce step(.acc: start (<{.seen: {seed}, .frontier: {seed}}>)))
 
 The inline tests assert the delta BFS returns the same set as the naive whole-set fold, hop for hop.
 
+### Scale (and a known limitation)
+
+[`benchmark.py`](benchmark.py) (run via [`run-bench.sh`](run-bench.sh)) was built to measure traversal at non-toy scale. It instead surfaced [**#227**](https://github.com/orlyatomics/orly/issues/227): writing N distinct keys to a POV is **O(N²)** — the mem→disk merge is enqueued only on the empty→non-empty edge, so under sustained writes the memory layer grows unbounded and every write pays an O(layer-size) scan. The benchmark is the reproduction: it shows per-write latency climbing as writes accumulate (and *not* resetting after an idle pause), with a verdict that flips from `GROWING` to `FLAT` once #227 is fixed. Until then you cannot build a large enough graph to benchmark the traversal itself — fixing the write path is the prerequisite for any "scales past toy graphs" claim.
+
 The driver verifies `reach(seed, k)` against a plain-Python BFS over the same graph, then showcases a neighbourhood — e.g. from **Claude**, ~92% of the graph is reachable within 3 hops. The point: the graph was assembled by N agents with **zero coordination**, and it's still **traversable transitively** — concurrent construction *and* graph queries in one store, which Neo4j (single-primary writes) and Cayley (a query layer over a store) don't combine.
 
 ## Related demos

--- a/examples/agent-swarm/benchmark.py
+++ b/examples/agent-swarm/benchmark.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Reproduction for issue #227 -- writing N keys to a POV is O(N^2).
+
+This started as a scale benchmark for the #219 graph traversal and instead
+surfaced a more fundamental problem: the per-write commit cost grows linearly
+with the number of updates already accumulated in the POV's memory layer, so
+writing N keys is O(N^2). The mem->disk merge is enqueued only on the
+empty->non-empty edge (`orly/indy/repo.cc:301-304`), so under sustained writes
+the layer is never re-merged and grows unbounded, and every write pays an
+O(layer-size) linear scan over the mem layer's OrderedList. See #227.
+
+It reuses `graph.orly`'s `add_mention` (one `*<['mention',e,d]>::(int) += 1`
+per call). NOT a CI demo -- run manually via ./run-bench.sh. It does not assert
+a failure (it documents a known bug); it prints the per-write trend and a
+verdict that flips from "GROWING" to "FLAT" once #227 is fixed.
+
+  DISTINCT keys: a new key each write. Shows the per-write cost climbing.
+  SAME key:      one hot key, repeated +=. Also climbs -- so the cost tracks
+                 the accumulated update count, not key cardinality.
+  PAUSE:         an idle gap mid-run. The cost does NOT reset, because under
+                 the empty->non-empty trigger nothing is queued to merge.
+"""
+
+import os
+import time
+
+import orly
+
+TOTAL = int(os.environ.get("BENCH_WRITES", "2000"))
+WINDOW = max(TOTAL // 8, 50)
+
+
+def p(*a):
+    print(*a, flush=True)
+
+
+def run_burst(c, pov, key_for, total):
+    """Write `total` keys, returning (ms/write of the first window, of the
+    last window, and the full per-window list)."""
+    windows = []
+    t0 = time.monotonic()
+    last_t, last_i = t0, 0
+    for i in range(1, total + 1):
+        c.call(pov, "graph", "add_mention", key_for(i))
+        if i % WINDOW == 0:
+            now = time.monotonic()
+            ms = (now - last_t) * 1000 / (i - last_i)
+            windows.append((i, ms))
+            p(f"    {i:>6} writes:  {ms:>7.1f} ms/write")
+            last_t, last_i = now, i
+    return windows
+
+
+def verdict(windows, label):
+    first = windows[0][1]
+    last = windows[-1][1]
+    ratio = last / first if first else float("inf")
+    # O(N) per write => the last window is many times the first. Bounded
+    # (O(1)/O(log N)) per write => roughly flat.
+    state = "GROWING  (O(N) per write -- #227 present)" if ratio >= 2.0 else "FLAT  (bounded -- #227 fixed)"
+    p(f"  -> {label}: first {first:.1f} ms/write, last {last:.1f} ms/write, {ratio:.1f}x  => {state}")
+    return ratio
+
+
+def main():
+    p(f"=== #227 write-scaling reproduction (TOTAL={TOTAL}, window={WINDOW}) ===\n")
+    c = orly.connect()
+    c.new_session()
+    c.install("graph", 1)
+
+    p("A. DISTINCT keys -- a new key every write:")
+    pov = c.new_pov()
+    w = run_burst(c, pov, lambda i: {"e": f"e{i}", "d": i}, TOTAL)
+    verdict(w, "distinct")
+
+    p("\nB. SAME key -- one hot key, repeated +=:")
+    pov = c.new_pov()
+    w = run_burst(c, pov, lambda i: {"e": "hot", "d": 0}, TOTAL)
+    verdict(w, "same-key")
+
+    p("\nC. PAUSE mid-run -- does an idle gap let the merge catch up?")
+    pov = c.new_pov()
+    half = TOTAL // 2
+    run_burst(c, pov, lambda i: {"e": f"p{i}", "d": i}, half)
+    p("    --- idle 8s (background merge would run here) ---")
+    time.sleep(8)
+    p("    resuming:")
+    # continue with fresh key ids so we keep adding distinct keys
+    t0 = time.monotonic()
+    last_t, last_i = t0, 0
+    for j in range(1, half + 1):
+        c.call(pov, "graph", "add_mention", {"e": f"p{half + j}", "d": half + j})
+        if j % WINDOW == 0:
+            now = time.monotonic()
+            p(f"    {half + j:>6} writes:  {(now - last_t) * 1000 / (j - last_i):>7.1f} ms/write")
+            last_t, last_i = now, j
+    p("  -> if the post-pause cost continues the pre-pause trend (no reset),")
+    p("     the merge is not bounding the layer (#227).")
+
+    c.exit()
+    p("\nWhen #227 is fixed (size/level-triggered merge and/or a seekable mem")
+    p("layer), A and B flip to FLAT and a 10k+-key graph becomes loadable.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agent-swarm/run-bench.sh
+++ b/examples/agent-swarm/run-bench.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Scale benchmark for the #219 frontier-delta traversal. Mirrors run.sh but
+# runs benchmark.py instead of demo.py. Deliberately NOT named run.sh / run-go.sh
+# so the CI examples job (which invokes those by name) does not run it -- this is
+# a manual benchmark, not a gated demo.
+set -e
+
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../.. && pwd)"
+ORLY_OUT="${ORLY_OUT:-$REPO_ROOT/../out_orly/debug}"
+ORLYI="$ORLY_OUT/orly/server/orlyi"
+ORLYC="$ORLY_OUT/orly/orlyc"
+
+for bin in "$ORLYI" "$ORLYC"; do
+  if [ ! -x "$bin" ]; then
+    echo "missing: $bin"
+    exit 1
+  fi
+done
+
+WORK="$(mktemp -d)"
+trap 'kill -9 $ORLYI_PID 2>/dev/null || true; rm -rf "$WORK"' EXIT
+
+echo "[1/5] compile graph.orly"
+"$ORLYC" -o "$WORK" graph.orly
+
+echo "[2/5] populate packages/"
+mkdir "$WORK/packages"
+touch "$WORK/packages/__orly__"
+cp "$WORK/graph.1.so" "$WORK/packages/"
+
+pkill -9 -f 'instance_name=agent_swarm_bench' 2>/dev/null || true
+sleep 1
+
+echo "[3/5] start fresh orlyi"
+"$ORLYI" --mem_sim --create=true \
+         --port_number=19400 --slave_port_number=19401 \
+         --connection_backlog=10 \
+         --instance_name=agent_swarm_bench \
+         --starting_state=SOLO \
+         --package_dir="$WORK/packages" \
+         --max_parallel_frames 4000 \
+         --page_cache_size 256 \
+         --block_cache_size 64 \
+         > "$WORK/orlyi.log" 2>&1 &
+ORLYI_PID=$!
+
+echo "[4/5] wait for WebSocket port 8082"
+for _ in $(seq 1 60); do
+  if ss -tln 2>/dev/null | grep -q ':8082'; then
+    break
+  fi
+  sleep 1
+done
+if ! ss -tln 2>/dev/null | grep -q ':8082'; then
+  echo "orlyi failed to come up; last log lines:"
+  tail -20 "$WORK/orlyi.log"
+  exit 1
+fi
+
+echo "[5/5] run benchmark.py"
+if ! PYTHONPATH="$REPO_ROOT/clients/python:$PYTHONPATH" python3 benchmark.py; then
+  echo ""
+  echo "benchmark.py failed; dumping orlyi.log for diagnosis:"
+  echo "=========================================================="
+  cat "$WORK/orlyi.log"
+  echo "=========================================================="
+  exit 1
+fi


### PR DESCRIPTION
The committed reproduction for #227 (the O(N²) write-scaling bug found while building a #219 traversal scale benchmark).

`benchmark.py` (run via `run-bench.sh` — deliberately **not** named `run.sh`/`run-go.sh`, so the CI examples job won't run it) reuses `graph.orly`'s `add_mention` (one `+=` per call) and reports the per-write trend across three probes:

- **A. distinct keys** — a new key each write; per-write cost climbs (~8× across 1.2k writes).
- **B. same key** — one hot key; *also* climbs, so the cost tracks the accumulated update count, not key cardinality.
- **C. pause** — an idle 8s gap does **not** reset the cost (nothing is queued to merge under the empty→non-empty trigger).

It prints a verdict that flips from `GROWING (O(N) per write — #227 present)` to `FLAT (bounded — #227 fixed)`, so it doubles as the regression check once #227 is addressed. The agent-swarm README documents the limitation honestly (you can't build a large graph to benchmark traversal until the write path is fixed).

No CHANGELOG entry: this is a dev/repro tool, not a change to Orly itself; the fix for #227 will get the Fixed entry.
