### PR TITLE
Add .mailmap to canonicalize author name spelling (Patrick O'Reilly)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,7 @@
+# Canonicalize author/committer display names without rewriting history
+# (see git-shortlog(1), "MAPPING AUTHORS"). Older commits from the 2014/ASF
+# era used "Patrick Reilly <preilly@php.net>"; the correct spelling is
+# "Patrick O'Reilly". Mapping the display name keeps the original email, so
+# GitHub attribution is unchanged — only the spelling is corrected everywhere
+# (git log / blame / shortlog and GitHub's UI).
+Patrick O'Reilly <preilly@php.net>


### PR DESCRIPTION
Commits from the 2014/ASF era were authored and committed as `Patrick Reilly <preilly@php.net>`; the correct spelling is **Patrick O'Reilly**. This adds a one-line `.mailmap` that maps the display name across all of history — `git log`, `git blame`, `git shortlog`, and GitHub's UI — **without rewriting any commits**, keeping the original email so GitHub attribution is unchanged.

`git shortlog -sne` after this shows no remaining "Patrick Reilly" entries; all variants collapse to `Patrick O'Reilly`.

Why a mailmap and not a history rewrite: rewriting author names would change every commit hash from 2014 forward, require a force-push of `master`, break every clone/fork/PR reference, and rewrite co-authors' commits too. The mailmap is the standard, non-destructive fix.