### PR TITLE
docs: link tracking issue #234 in the concurrent-merge RFC

### DIFF
--- a/docs/design/concurrent-merge-throughput.md
+++ b/docs/design/concurrent-merge-throughput.md
@@ -1,8 +1,9 @@
 # Design: Concurrent write throughput — the single-threaded global merge
 
-> Status: **gated RFC** (verified findings + design; not yet scheduled). Same
-> bar as the merge/graph RFCs — do not implement until there is demand, and
-> implement in a fresh session behind the TSan gate (#201).
+> Status: **gated RFC** (verified findings + design; not yet scheduled),
+> tracked by **issue #234**. Same bar as the merge/graph RFCs — do not
+> implement until there is demand, and implement in a fresh session behind the
+> TSan gate (#201).
 
 ## 0. The key realization
 


### PR DESCRIPTION
Adds the tracking issue reference (#234) to the status line of `docs/design/concurrent-merge-throughput.md`, so the gated RFC, its design doc, and the tracking issue are fully cross-linked (matching the #218/#219 convention).

Docs-only, one line.