### PR TITLE
perf(#241): drop per-Try global stats mutex via thread-local TSigmaCalc

### DIFF
--- a/base/sigma_calc.cc
+++ b/base/sigma_calc.cc
@@ -42,6 +42,27 @@ void TSigmaCalc::Push(double val) {
   ++Count;
 }
 
+void TSigmaCalc::Add(const TSigmaCalc &that) {
+  if (!that.Count) {
+    return;
+  }
+  if (!Count) {
+    *this = that;
+    return;
+  }
+  const size_t combined_count = Count + that.Count;
+  const double delta = that.MovingMean - MovingMean;
+  /* MovingSquare is the sum of squared deviations from the mean (Welford's M2);
+     the cross term accounts for the shift between the two partial means. */
+  MovingSquare += that.MovingSquare +
+      delta * delta * (static_cast<double>(Count) * static_cast<double>(that.Count) /
+                       static_cast<double>(combined_count));
+  MovingMean += delta * static_cast<double>(that.Count) / static_cast<double>(combined_count);
+  Min = min(Min, that.Min);
+  Max = max(Max, that.Max);
+  Count = combined_count;
+}
+
 size_t TSigmaCalc::Report(double &min, double &max, double &mean, double &sigma) const {
   if (Count) {
     min   = Min;

--- a/base/sigma_calc.h
+++ b/base/sigma_calc.h
@@ -39,6 +39,13 @@ namespace Base {
     /* Push a value into the calculator. */
     void Push(double val);
 
+    /* Combine the accumulated stats of another calculator into this one, as if
+       every value that had been pushed into `that` were pushed into this. Uses
+       the parallel (Chan et al.) form of Welford's algorithm so it is exact and
+       order-independent -- this lets per-thread calculators be merged into a
+       single aggregate without serializing the hot Push() path. */
+    void Add(const TSigmaCalc &that);
+
     /* If Push() has been called at least once, return the stats via the out-params and return the
        number of pushes; otherwise, leave the out-params alone and return zero. */
     size_t Report(double &min, double &max, double &mean, double &sigma) const;

--- a/base/sigma_calc.test.cc
+++ b/base/sigma_calc.test.cc
@@ -58,6 +58,42 @@ FIXTURE(Large) {
   }
 }
 
+FIXTURE(Add) {
+  /* Merging two partial calculators must equal pushing every value into one. */
+  constexpr int vals[] = { 4, 2, 5, 8, 6, 1, 9, 3, 7 };
+  constexpr size_t val_count = sizeof(vals) / sizeof(vals[0]);
+
+  TSigmaCalc whole;
+  for (size_t i = 0; i < val_count; ++i) {
+    whole.Push(vals[i]);
+  }
+
+  for (size_t split = 0; split <= val_count; ++split) {
+    TSigmaCalc left, right;
+    for (size_t i = 0; i < val_count; ++i) {
+      (i < split ? left : right).Push(vals[i]);
+    }
+    left.Add(right);
+    double wmin, wmax, wmean, wsigma;
+    double amin, amax, amean, asigma;
+    whole.Report(wmin, wmax, wmean, wsigma);
+    EXPECT_EQ(left.Report(amin, amax, amean, asigma), val_count);
+    EXPECT_EQ(amin, wmin);
+    EXPECT_EQ(amax, wmax);
+    EXPECT_TRUE(fabs(amean - wmean) < 1e-9);
+    EXPECT_TRUE(fabs(asigma - wsigma) < 1e-9);
+  }
+
+  /* Adding an empty calculator is a no-op; adding to an empty one copies. */
+  TSigmaCalc empty;
+  TSigmaCalc copy;
+  copy.Add(whole);
+  double cmin, cmax, cmean, csigma;
+  EXPECT_EQ(copy.Report(cmin, cmax, cmean, csigma), val_count);
+  copy.Add(empty);
+  EXPECT_EQ(copy.Report(cmin, cmax, cmean, csigma), val_count);
+}
+
 FIXTURE(Write) {
   TSigmaCalc calc;
   ostringstream strm;

--- a/base/thread_local_sigma_calc.h
+++ b/base/thread_local_sigma_calc.h
@@ -1,0 +1,210 @@
+/* <base/thread_local_sigma_calc.h>
+
+   A drop-in replacement for TSigmaCalc whose Push() path never contends across
+   producer threads.
+
+   TSigmaCalc itself is not thread-safe, so concurrent producers historically
+   had to serialize their Push() calls behind a single global mutex. That mutex
+   then became per-event contention on hot paths (e.g. every server `Try`
+   pushing latency stats). This wrapper keeps a private TSigmaCalc per producing
+   thread, each behind its own lock: a thread's Push() takes only that thread's
+   lock, so producers never contend with one another (only, briefly, with the
+   reporter). Report() merges all the per-thread instances into a single
+   aggregate using TSigmaCalc::Add (parallel Welford), so the reported
+   count/min/max/mean/sigma are exact across all threads.
+
+   Lifetime safety (this is why the state is a heap TBlock): the shared state
+   lives in a heap block co-owned via std::shared_ptr by the
+   TThreadLocalSigmaCalc and by every thread that has pushed into it. Either may
+   be destroyed first:
+     - thread exits first: its registry folds its calculator into the block's
+       retired accumulator under the block's mutex, so the samples survive.
+     - owner destroyed first: it just drops its shared_ptr; surviving thread
+       registries keep the block (and its mutexes) alive until they exit and
+       fold/remove their own entries.
+   Because every mutex lives in the shared block, no destructor ever locks a
+   mutex it does not co-own, and no destructor throws.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+#include <base/class_traits.h>
+#include <base/sigma_calc.h>
+
+namespace Base {
+
+  /* See file comment. Exposes the subset of the TSigmaCalc interface used by
+     contended producers: Push() (per-thread lock, uncontended among producers),
+     and Report()/Reset() (which fold across all threads). Not copyable or
+     movable -- identity is the heap control block it owns. */
+  class TThreadLocalSigmaCalc {
+    NO_COPY(TThreadLocalSigmaCalc);
+    public:
+
+    TThreadLocalSigmaCalc()
+        : Block(std::make_shared<TBlock>()) {}
+
+    /* Push a value into the calling thread's private calculator, under that
+       thread's own lock -- no contention with other producers. */
+    void Push(double val) {
+      TEntry &entry = GetThreadEntry();
+      std::lock_guard<std::mutex> lock(entry.Mutex);
+      entry.Calc.Push(val);
+    }
+
+    /* Merge every thread's calculator into one aggregate and report it, exactly
+       as TSigmaCalc::Report would for the union of all pushes. */
+    size_t Report(double &min, double &max, double &mean, double &sigma) const {
+      std::lock_guard<std::mutex> structure_lock(Block->Mutex);
+      TSigmaCalc aggregate(Block->Retired);
+      for (const auto &item : Block->Entries) {
+        TEntry &entry = *item.second;
+        std::lock_guard<std::mutex> entry_lock(entry.Mutex);
+        aggregate.Add(entry.Calc);
+      }
+      return aggregate.Report(min, max, mean, sigma);
+    }
+
+    /* Reset every thread's calculator (and the retired accumulator). */
+    void Reset() {
+      std::lock_guard<std::mutex> structure_lock(Block->Mutex);
+      Block->Retired.Reset();
+      for (auto &item : Block->Entries) {
+        TEntry &entry = *item.second;
+        std::lock_guard<std::mutex> entry_lock(entry.Mutex);
+        entry.Calc.Reset();
+      }
+    }
+
+    /* Report the aggregate across all threads AND reset, atomically -- every
+       value pushed so far is counted exactly once and then cleared, with no gap
+       (unlike a separate Report() then Reset(), where a value landing between the
+       two would be dropped). This is what periodic reporters want. */
+    size_t Drain(double &min, double &max, double &mean, double &sigma) {
+      std::lock_guard<std::mutex> structure_lock(Block->Mutex);
+      TSigmaCalc aggregate(Block->Retired);
+      Block->Retired.Reset();
+      for (auto &item : Block->Entries) {
+        TEntry &entry = *item.second;
+        std::lock_guard<std::mutex> entry_lock(entry.Mutex);
+        aggregate.Add(entry.Calc);
+        entry.Calc.Reset();
+      }
+      return aggregate.Report(min, max, mean, sigma);
+    }
+
+    private:
+
+    /* One producing thread's calculator plus its own lock. Pointer-stable in the
+       owning unordered_map (node-based), so a thread can cache the address for
+       its lock-light Push path. */
+    struct TEntry {
+      std::mutex Mutex;
+      TSigmaCalc Calc;
+    };  // TEntry
+
+    /* The shared state for one TThreadLocalSigmaCalc, kept on the heap and
+       co-owned (via shared_ptr) by the owner and by every thread registry that
+       references it, so it outlives whichever is destroyed last. */
+    struct TBlock {
+      /* Guards the structure of Entries (insert/erase/iterate) and Retired. A
+       producer's Push does NOT take this lock once registered; it takes only its
+       own TEntry::Mutex. */
+      std::mutex Mutex;
+      /* Per-thread calculators, keyed by the thread's registry-entry token (a
+         stable per-thread address). Guarded by Mutex for structure; each value's
+         data is guarded by its own TEntry::Mutex. */
+      std::unordered_map<const void *, std::unique_ptr<TEntry>> Entries;
+      /* Stats of threads (or owners) retired since the last Reset(), folded in
+         so their contribution is not lost. Guarded by Mutex. */
+      TSigmaCalc Retired;
+    };  // TBlock
+
+    /* Per-thread bookkeeping: caches, for every TThreadLocalSigmaCalc this
+       thread has pushed into, the shared block and this thread's entry within
+       it. On thread exit it folds each calculator into the corresponding
+       (still-alive) block's retired accumulator under that block's mutex --
+       never touching the owner, which may already be gone. */
+    class TRegistry {
+      NO_COPY(TRegistry);
+      public:
+
+      TRegistry() = default;
+
+      ~TRegistry() {
+        for (auto &item : Blocks) {
+          const std::shared_ptr<TBlock> &block = item.second.Block;
+          std::lock_guard<std::mutex> lock(block->Mutex);
+          /* Holding the block mutex excludes Report()/Reset(); the only other
+             accessor of this entry would be this same thread's Push(), which
+             cannot run while the thread is exiting. So folding the calc here is
+             race-free without taking the per-entry lock. */
+          auto iter = block->Entries.find(Token());
+          if (iter != block->Entries.end()) {
+            block->Retired.Add(iter->second->Calc);
+            block->Entries.erase(iter);
+          }
+        }
+      }
+
+      /* This thread's entry within `block`, creating and registering it on first
+         use. The returned reference is pointer-stable for the thread's life. */
+      TEntry &GetEntryFor(const std::shared_ptr<TBlock> &block) {
+        auto iter = Blocks.find(block.get());
+        if (iter != Blocks.end()) {
+          return *iter->second.Entry;
+        }
+        std::lock_guard<std::mutex> lock(block->Mutex);
+        auto &slot = block->Entries[Token()];
+        slot = std::make_unique<TEntry>();
+        TEntry *entry = slot.get();
+        Blocks.emplace(block.get(), TRef{block, entry});
+        return *entry;
+      }
+
+      private:
+
+      /* A stable per-thread token: the address of this registry. Unique while
+         the thread lives; never dereferenced. */
+      const void *Token() const {
+        return this;
+      }
+
+      struct TRef {
+        std::shared_ptr<TBlock> Block;  // keeps the block alive
+        TEntry *Entry;                  // pointer-stable cache for the hot path
+      };
+
+      std::unordered_map<const TBlock *, TRef> Blocks;
+    };  // TRegistry
+
+    TEntry &GetThreadEntry() const {
+      thread_local TRegistry registry;
+      return registry.GetEntryFor(Block);
+    }
+
+    /* The shared control block. Co-owned with every thread registry that has
+       pushed into this instance. */
+    std::shared_ptr<TBlock> Block;
+
+  };  // TThreadLocalSigmaCalc
+
+}  // Base

--- a/base/thread_local_sigma_calc.test.cc
+++ b/base/thread_local_sigma_calc.test.cc
@@ -1,0 +1,203 @@
+/* <base/thread_local_sigma_calc.test.cc>
+
+   Unit test for <base/thread_local_sigma_calc.h>.
+
+   Copyright 2010-2026 Atomic Kismet Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <base/thread_local_sigma_calc.h>
+
+#include <atomic>
+#include <cmath>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include <base/test/kit.h>
+
+using namespace std;
+using namespace Base;
+
+/* Single-thread behaviour matches a plain TSigmaCalc. */
+FIXTURE(SingleThread) {
+  TThreadLocalSigmaCalc calc;
+  double min, max, mean, sigma;
+  EXPECT_EQ(calc.Report(min, max, mean, sigma), 0u);
+
+  constexpr int vals[] = { 4, 2, 5, 8, 6 };
+  for (int v : vals) {
+    calc.Push(v);
+  }
+  if (EXPECT_EQ(calc.Report(min, max, mean, sigma), 5u)) {
+    EXPECT_EQ(min, 2.0);
+    EXPECT_EQ(max, 8.0);
+    EXPECT_EQ(mean, 5.0);
+    EXPECT_EQ(sigma, sqrt(5.0));
+  }
+
+  calc.Reset();
+  EXPECT_EQ(calc.Report(min, max, mean, sigma), 0u);
+}
+
+/* Pushes from many threads fold into one exact aggregate. Each of N threads
+   pushes the same value V exactly M times, so count == N*M, min == max == mean
+   == V, and sigma == 0. */
+FIXTURE(ManyThreads) {
+  constexpr size_t thread_count = 8;
+  constexpr size_t per_thread = 50000;
+  constexpr double value = 7.0;
+
+  TThreadLocalSigmaCalc calc;
+  vector<thread> threads;
+  threads.reserve(thread_count);
+  for (size_t t = 0; t < thread_count; ++t) {
+    threads.emplace_back([&calc]() {
+      for (size_t i = 0; i < per_thread; ++i) {
+        calc.Push(value);
+      }
+    });
+  }
+  for (auto &th : threads) {
+    th.join();
+  }
+
+  double min, max, mean, sigma;
+  if (EXPECT_EQ(calc.Report(min, max, mean, sigma), thread_count * per_thread)) {
+    EXPECT_EQ(min, value);
+    EXPECT_EQ(max, value);
+    EXPECT_TRUE(fabs(mean - value) < 1e-9);
+    EXPECT_TRUE(fabs(sigma) < 1e-9);
+  }
+}
+
+/* Concurrent producers + a concurrent reporter (Report/Reset) must not race and
+   must not lose count. Each producer pushes 1.0 a fixed number of times; the
+   reporter periodically folds-and-resets, accumulating the count it observes.
+   The observed total plus whatever remains must equal what was pushed. */
+FIXTURE(ConcurrentReport) {
+  constexpr size_t thread_count = 6;
+  constexpr size_t per_thread = 40000;
+
+  TThreadLocalSigmaCalc calc;
+  size_t drained = 0;
+  atomic<bool> done = false;
+
+  vector<thread> threads;
+  for (size_t t = 0; t < thread_count; ++t) {
+    threads.emplace_back([&calc]() {
+      for (size_t i = 0; i < per_thread; ++i) {
+        calc.Push(1.0);
+      }
+    });
+  }
+  thread reporter([&]() {
+    double mn, mx, me, sg;
+    while (!done) {
+      /* Atomic drain: no value pushed concurrently may be lost. */
+      drained += calc.Drain(mn, mx, me, sg);
+    }
+  });
+  for (auto &th : threads) {
+    th.join();
+  }
+  done = true;
+  reporter.join();
+
+  double mn, mx, me, sg;
+  drained += calc.Drain(mn, mx, me, sg);
+  EXPECT_EQ(drained, thread_count * per_thread);
+}
+
+/* A thread's stats survive that thread's exit (its calculator is folded into the
+   retired accumulator at exit, not lost) -- owner outlives the thread. */
+FIXTURE(SurvivesThreadExit) {
+  TThreadLocalSigmaCalc calc;
+  {
+    thread th([&calc]() {
+      calc.Push(1.0);
+      calc.Push(3.0);
+    });
+    th.join();
+  }
+  double min, max, mean, sigma;
+  if (EXPECT_EQ(calc.Report(min, max, mean, sigma), 2u)) {
+    EXPECT_EQ(min, 1.0);
+    EXPECT_EQ(max, 3.0);
+    EXPECT_EQ(mean, 2.0);
+  }
+}
+
+/* Regression for the teardown bug: the owner is destroyed BEFORE a thread that
+   pushed into it runs its thread_local registry destructor. The registry must
+   not touch the dead owner; the shared control block keeps its mutex alive so
+   the registry can fold/remove its entry without throwing from ~TRegistry. The
+   assertion is simply that the process does not terminate. */
+FIXTURE(OwnerDestroyedWhileThreadAlive) {
+  mutex m;
+  condition_variable cv;
+  bool pushed = false;
+  bool may_exit = false;
+
+  auto calc = make_unique<TThreadLocalSigmaCalc>();
+  TThreadLocalSigmaCalc *raw = calc.get();
+
+  thread th([&]() {
+    raw->Push(5.0);
+    {
+      lock_guard<mutex> l(m);
+      pushed = true;
+    }
+    cv.notify_all();
+    unique_lock<mutex> l(m);
+    cv.wait(l, [&]() { return may_exit; });
+    /* Thread now returns and exits; its thread_local TRegistry destructor runs
+       and must fold into the (now owner-less) block without locking a dead
+       mutex. */
+  });
+
+  {
+    unique_lock<mutex> l(m);
+    cv.wait(l, [&]() { return pushed; });
+  }
+  /* Destroy the owner while the producing thread is still alive and still holds
+     a registry reference to the block. */
+  calc.reset();
+  {
+    lock_guard<mutex> l(m);
+    may_exit = true;
+  }
+  cv.notify_all();
+  th.join();
+
+  EXPECT_TRUE(true);  // reached here without std::terminate
+}
+
+/* The exact shape of the original CI failure: a local (non-static) instance is
+   pushed into by THIS (main/test) thread, then destroyed. The test thread's
+   registry keeps a stale reference, exercised when the registry is destroyed at
+   process exit. With the shared-block design the block outlives the registry and
+   teardown is clean -- the gate is that the test process exits without
+   terminate. */
+FIXTURE(LocalInstanceOnPushingThread) {
+  {
+    TThreadLocalSigmaCalc calc;
+    calc.Push(1.0);
+    calc.Push(2.0);
+    double mn, mx, me, sg;
+    EXPECT_EQ(calc.Report(mn, mx, me, sg), 2u);
+  }  // calc destroyed here; this thread's registry still references its block
+  EXPECT_TRUE(true);
+}

--- a/orly/server/server.cc
+++ b/orly/server/server.cc
@@ -82,22 +82,21 @@ Orly::Indy::Util::TPool TUpdate::Pool(sizeof(TUpdate), "Update");
 Orly::Indy::Util::TPool TUpdate::TEntry::Pool(sizeof(TUpdate::TEntry), "Entry");
 Disk::TBufBlock::TPool Disk::TBufBlock::Pool(BlockSize);
 
-Base::TSigmaCalc TSession::TServer::TryReadTimeCalc;
-Base::TSigmaCalc TSession::TServer::TryReadCPUTimeCalc;
-Base::TSigmaCalc TSession::TServer::TryWriteTimeCalc;
-Base::TSigmaCalc TSession::TServer::TryWriteCPUTimeCalc;
-Base::TSigmaCalc TSession::TServer::TryWalkerCountCalc;
-Base::TSigmaCalc TSession::TServer::TryCallCPUTimerCalc;
-Base::TSigmaCalc TSession::TServer::TryReadCallTimerCalc;
-Base::TSigmaCalc TSession::TServer::TryWriteCallTimerCalc;
-Base::TSigmaCalc TSession::TServer::TryWalkerConsTimerCalc;
-Base::TSigmaCalc TSession::TServer::TryFetchCountCalc;
-Base::TSigmaCalc TSession::TServer::TryHashHitCountCalc;
-Base::TSigmaCalc TSession::TServer::TryWriteSyncHitCalc;
-Base::TSigmaCalc TSession::TServer::TryWriteSyncTimeCalc;
-Base::TSigmaCalc TSession::TServer::TryReadSyncHitCalc;
-Base::TSigmaCalc TSession::TServer::TryReadSyncTimeCalc;
-std::mutex       TSession::TServer::TryTimeLock;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryReadTimeCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryReadCPUTimeCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryWriteTimeCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryWriteCPUTimeCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryWalkerCountCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryCallCPUTimerCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryReadCallTimerCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryWriteCallTimerCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryWalkerConsTimerCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryFetchCountCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryHashHitCountCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryWriteSyncHitCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryWriteSyncTimeCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryReadSyncHitCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryReadSyncTimeCalc;
 
 TServer::TCmd::TMeta::TMeta(const char *desc)
     : TLog::TCmd::TMeta(desc) {
@@ -2854,37 +2853,28 @@ void TIndyReporter::AddReport(std::stringstream &ss) const {
     Server->GetRepoManager()->MergeDiskAverageKeysCalc.Reset();
   }
 
-  /* acquire TryTime lock */ {
-    std::lock_guard<std::mutex> lock(Server->TryTimeLock);
-    try_read_count = TServer::TryReadTimeCalc.Report(try_read_min, try_read_max, try_read_mean, try_read_sigma);
-    TServer::TryReadCPUTimeCalc.Report(try_read_cpu_min, try_read_cpu_max, try_read_cpu_mean, try_read_cpu_sigma);
-    TServer::TryReadTimeCalc.Reset();
-    TServer::TryReadCPUTimeCalc.Reset();
-    try_write_count = TServer::TryWriteTimeCalc.Report(try_write_min, try_write_max, try_write_mean, try_write_sigma);
-    TServer::TryWriteCPUTimeCalc.Report(try_write_cpu_min, try_write_cpu_max, try_write_cpu_mean, try_write_cpu_sigma);
-    TServer::TryWriteTimeCalc.Reset();
-    TServer::TryWriteCPUTimeCalc.Reset();
+  /* TThreadLocalSigmaCalc folds across all producer threads internally, so no
+     external lock is needed here. Drain() atomically reports-and-resets each
+     calculator, so no concurrently-pushed sample is lost in a report/reset gap. */ {
+    try_read_count = TServer::TryReadTimeCalc.Drain(try_read_min, try_read_max, try_read_mean, try_read_sigma);
+    TServer::TryReadCPUTimeCalc.Drain(try_read_cpu_min, try_read_cpu_max, try_read_cpu_mean, try_read_cpu_sigma);
+    try_write_count = TServer::TryWriteTimeCalc.Drain(try_write_min, try_write_max, try_write_mean, try_write_sigma);
+    TServer::TryWriteCPUTimeCalc.Drain(try_write_cpu_min, try_write_cpu_max, try_write_cpu_mean, try_write_cpu_sigma);
 
-    TServer::TryWalkerCountCalc.Report(try_walker_count_min, try_walker_count_max, try_walker_count_mean, try_walker_count_sigma);
-    TServer::TryWalkerCountCalc.Reset();
+    TServer::TryWalkerCountCalc.Drain(try_walker_count_min, try_walker_count_max, try_walker_count_mean, try_walker_count_sigma);
 
-    TServer::TryCallCPUTimerCalc.Report(try_call_cpu_time_min, try_call_cpu_time_max, try_call_cpu_time_mean, try_call_cpu_time_sigma);
-    TServer::TryCallCPUTimerCalc.Reset();
+    TServer::TryCallCPUTimerCalc.Drain(try_call_cpu_time_min, try_call_cpu_time_max, try_call_cpu_time_mean, try_call_cpu_time_sigma);
 
-    TServer::TryReadCallTimerCalc.Report(try_read_call_time_min, try_read_call_time_max, try_read_call_time_mean, try_read_call_time_sigma);
-    TServer::TryReadCallTimerCalc.Reset();
+    TServer::TryReadCallTimerCalc.Drain(try_read_call_time_min, try_read_call_time_max, try_read_call_time_mean, try_read_call_time_sigma);
 
-    TServer::TryWriteCallTimerCalc.Report(try_write_call_time_min, try_write_call_time_max, try_write_call_time_mean, try_write_call_time_sigma);
-    TServer::TryWriteCallTimerCalc.Reset();
+    TServer::TryWriteCallTimerCalc.Drain(try_write_call_time_min, try_write_call_time_max, try_write_call_time_mean, try_write_call_time_sigma);
 
-    TServer::TryWalkerConsTimerCalc.Report(try_walker_cons_time_min, try_walker_cons_time_max, try_walker_cons_time_mean, try_walker_cons_time_sigma);
-    TServer::TryWalkerConsTimerCalc.Reset();
+    TServer::TryWalkerConsTimerCalc.Drain(try_walker_cons_time_min, try_walker_cons_time_max, try_walker_cons_time_mean, try_walker_cons_time_sigma);
 
-    TServer::TryFetchCountCalc.Report(try_fetch_count_min, try_fetch_count_max, try_fetch_count_mean, try_fetch_count_sigma);
-    TServer::TryFetchCountCalc.Reset();
+    TServer::TryFetchCountCalc.Drain(try_fetch_count_min, try_fetch_count_max, try_fetch_count_mean, try_fetch_count_sigma);
 
     try_count = try_read_count + try_write_count;
-  }  // release TryTime lock
+  }  // Try stats
   ReportTimer.Stop();
   double elapsed_time = ToSecondsDouble(ReportTimer.GetLap());
   #ifdef PERF_STATS

--- a/orly/server/session.cc
+++ b/orly/server/session.cc
@@ -265,18 +265,18 @@ TMethodResult TSession::Try(TServer *server, const TUuid &pov_id, const vector<s
     }
     walker_count = context.GetWalkerCount();
     timer.Stop();
-    /* Acquire TryTime lock */ {
-      std::lock_guard<std::mutex> lock(TServer::TryTimeLock);
-      if (had_effects) {
-        TServer::TryWriteTimeCalc.Push(ToSecondsDouble(timer.GetTotal()));
-        TServer::TryWriteCallTimerCalc.Push(ToSecondsDouble(call_timer.GetTotal()));
-      } else {
-        TServer::TryReadTimeCalc.Push(ToSecondsDouble(timer.GetTotal()));
-        TServer::TryReadCallTimerCalc.Push(ToSecondsDouble(call_timer.GetTotal()));
-      }
-      TServer::TryWalkerCountCalc.Push(walker_count);
-      TServer::TryWalkerConsTimerCalc.Push(ToSecondsDouble(context.GetPresentWalkConsTimer().GetTotal()));
+    /* Record per-`Try` stats. TThreadLocalSigmaCalc::Push is lock-free across
+       threads (each thread accumulates into its own calculator), so concurrent
+       writers/readers no longer serialize here on a global mutex. */
+    if (had_effects) {
+      TServer::TryWriteTimeCalc.Push(ToSecondsDouble(timer.GetTotal()));
+      TServer::TryWriteCallTimerCalc.Push(ToSecondsDouble(call_timer.GetTotal()));
+    } else {
+      TServer::TryReadTimeCalc.Push(ToSecondsDouble(timer.GetTotal()));
+      TServer::TryReadCallTimerCalc.Push(ToSecondsDouble(call_timer.GetTotal()));
     }
+    TServer::TryWalkerCountCalc.Push(walker_count);
+    TServer::TryWalkerConsTimerCalc.Push(ToSecondsDouble(context.GetPresentWalkConsTimer().GetTotal()));
     return TMethodResult(indy_context.GetArena(), result_core, tracker);
   } catch (const exception &ex) {
     syslog(LOG_ERR, "Error in Session::Try : [%s]", ex.what());

--- a/orly/server/session.h
+++ b/orly/server/session.h
@@ -29,6 +29,7 @@
 #include <base/event_semaphore.h>
 #include <optional>
 #include <base/sigma_calc.h>
+#include <base/thread_local_sigma_calc.h>
 #include <base/thrower.h>
 #include <base/uuid.h>
 #include <orly/durable/kit.h>
@@ -69,25 +70,27 @@ namespace Orly {
         /* TODO */
         virtual Base::TScheduler *GetScheduler() const = 0;
 
-        /* TODO */
-        static Base::TSigmaCalc TryReadTimeCalc;
-        static Base::TSigmaCalc TryReadCPUTimeCalc;
-        static Base::TSigmaCalc TryWriteTimeCalc;
-        static Base::TSigmaCalc TryWriteCPUTimeCalc;
-        static Base::TSigmaCalc TryWalkerCountCalc;
-        static Base::TSigmaCalc TryWalkerConsTimerCalc;
-        static Base::TSigmaCalc TryCallCPUTimerCalc;
-        static Base::TSigmaCalc TryReadCallTimerCalc;
-        static Base::TSigmaCalc TryWriteCallTimerCalc;
-        static Base::TSigmaCalc TryFetchCountCalc;
-        static Base::TSigmaCalc TryHashHitCountCalc;
+        /* Per-`Try` latency/counter statistics. These are pushed on every read
+           and write (the hot path) and folded into a single aggregate by the
+           periodic reporter. TThreadLocalSigmaCalc keeps a private accumulator
+           per producing thread so Push() takes no globally-contended lock --
+           the old per-`Try` `TryTimeLock` mutex is gone. */
+        static Base::TThreadLocalSigmaCalc TryReadTimeCalc;
+        static Base::TThreadLocalSigmaCalc TryReadCPUTimeCalc;
+        static Base::TThreadLocalSigmaCalc TryWriteTimeCalc;
+        static Base::TThreadLocalSigmaCalc TryWriteCPUTimeCalc;
+        static Base::TThreadLocalSigmaCalc TryWalkerCountCalc;
+        static Base::TThreadLocalSigmaCalc TryWalkerConsTimerCalc;
+        static Base::TThreadLocalSigmaCalc TryCallCPUTimerCalc;
+        static Base::TThreadLocalSigmaCalc TryReadCallTimerCalc;
+        static Base::TThreadLocalSigmaCalc TryWriteCallTimerCalc;
+        static Base::TThreadLocalSigmaCalc TryFetchCountCalc;
+        static Base::TThreadLocalSigmaCalc TryHashHitCountCalc;
 
-        static Base::TSigmaCalc TryWriteSyncHitCalc;
-        static Base::TSigmaCalc TryWriteSyncTimeCalc;
-        static Base::TSigmaCalc TryReadSyncHitCalc;
-        static Base::TSigmaCalc TryReadSyncTimeCalc;
-
-        static std::mutex TryTimeLock;
+        static Base::TThreadLocalSigmaCalc TryWriteSyncHitCalc;
+        static Base::TThreadLocalSigmaCalc TryWriteSyncTimeCalc;
+        static Base::TThreadLocalSigmaCalc TryReadSyncHitCalc;
+        static Base::TThreadLocalSigmaCalc TryReadSyncTimeCalc;
 
         protected:
 

--- a/orly/server/session.test.cc
+++ b/orly/server/session.test.cc
@@ -54,22 +54,21 @@ Orly::Indy::Util::TPool TRepo::TDataLayer::Pool(max(sizeof(TMemoryLayer), sizeof
 Orly::Indy::Util::TPool L1::TTransaction::TMutation::Pool(max(max(sizeof(L1::TTransaction::TPusher), sizeof(L1::TTransaction::TPopper)), sizeof(L1::TTransaction::TStatusChanger)), "Transaction::TMutation");
 Orly::Indy::Util::TPool L1::TTransaction::Pool(sizeof(L1::TTransaction), "Transaction");
 
-Base::TSigmaCalc TSession::TServer::TryReadTimeCalc;
-Base::TSigmaCalc TSession::TServer::TryReadCPUTimeCalc;
-Base::TSigmaCalc TSession::TServer::TryWriteTimeCalc;
-Base::TSigmaCalc TSession::TServer::TryWriteCPUTimeCalc;
-Base::TSigmaCalc TSession::TServer::TryWalkerCountCalc;
-Base::TSigmaCalc TSession::TServer::TryCallCPUTimerCalc;
-Base::TSigmaCalc TSession::TServer::TryReadCallTimerCalc;
-Base::TSigmaCalc TSession::TServer::TryWriteCallTimerCalc;
-Base::TSigmaCalc TSession::TServer::TryWalkerConsTimerCalc;
-Base::TSigmaCalc TSession::TServer::TryFetchCountCalc;
-Base::TSigmaCalc TSession::TServer::TryHashHitCountCalc;
-Base::TSigmaCalc TSession::TServer::TryWriteSyncHitCalc;
-Base::TSigmaCalc TSession::TServer::TryWriteSyncTimeCalc;
-Base::TSigmaCalc TSession::TServer::TryReadSyncHitCalc;
-Base::TSigmaCalc TSession::TServer::TryReadSyncTimeCalc;
-std::mutex       TSession::TServer::TryTimeLock;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryReadTimeCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryReadCPUTimeCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryWriteTimeCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryWriteCPUTimeCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryWalkerCountCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryCallCPUTimerCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryReadCallTimerCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryWriteCallTimerCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryWalkerConsTimerCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryFetchCountCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryHashHitCountCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryWriteSyncHitCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryWriteSyncTimeCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryReadSyncHitCalc;
+Base::TThreadLocalSigmaCalc TSession::TServer::TryReadSyncTimeCalc;
 
 static const size_t WarningCount = 3;
 


### PR DESCRIPTION
## Summary

Step 1 of #241: remove the per-`Try` **global-lock contention** from the write/read acceptance path.

Every server `Try` (reads and writes) acquired the global `std::mutex TServer::TryTimeLock` solely to push latency/counter samples into shared **static** `Base::TSigmaCalc` instances (`TryWriteTimeCalc`, `TryReadTimeCalc`, `TryWalkerCountCalc`, …). That serialized all concurrent readers/writers — and bounced the shared stat cache-lines across cores — on correctness-irrelevant statistics. The deeper global locks (`TransactionLock`, `ReplicationQueueLock`, `TransactionCompletionLock`) and the Tetris merge are explicitly out of scope here.

## Approach

New header-only `Base::TThreadLocalSigmaCalc` (drop-in for `TSigmaCalc`):

- **Each producing thread accumulates into its own private `TSigmaCalc` behind its own lock**, so producers never contend with one another on `Push()` (only, briefly, with the reporter). The old global `TryTimeLock` and its hot-path/report-path `lock_guard`s are removed.
- `Report()`/`Drain()` fold every thread's calculator into one exact aggregate via a new `TSigmaCalc::Add` (the parallel / Chan form of Welford's algorithm — count/mean/M2 combine exactly, min/max merge). `Drain()` reports-and-resets atomically, so no concurrently-pushed sample is dropped in a report/reset gap (the original code got this for free by holding `TryTimeLock` across both; the server reporter now calls `Drain`).
- **Lifetime-safe in both destruction orders.** The shared state (mutex, per-thread calc list, retired accumulator) lives in a heap `TBlock` co-owned via `shared_ptr` by the owner **and** by every thread that pushed into it, so it outlives whichever is destroyed last. On thread exit, the thread's registry folds its calculator into the block's retired accumulator under the block's (always-alive) mutex; it **never dereferences the owner**, which may already be gone. This is the fix for the teardown crash that failed CI on the first revision (`~TRegistry` locked an already-destroyed owner mutex → `std::system_error` thrown from a destructor → `terminate`).

The 15 `Try*Calc` statics change type from `Base::TSigmaCalc` to `Base::TThreadLocalSigmaCalc`; call sites are otherwise unchanged.

## Measurement (release, multiprocess client `BENCH_BACKEND=process`)

`orlyi --mem_sim`, reporter on :19388, disjoint-key `add_mention` writes. master vs this branch.

Per-write `Try Write Time Mean` distribution across reporter intervals under load (µs):

| stat | before (master) | after |
|---|---|---|
| min (uncontended floor) | 145 | **120** |
| p25 | 177 | **139** |
| median | 211 | **184** |

Aggregate throughput (writes/sec), most-stable points: K=1 986 → 1139; K=4 ~2479 → 2811.

**Honest read:** per-write server time is consistently lower (min 145→120 µs, median 211→184 µs) and K=1/K=4 throughput is up ~13–16%, but run-to-run variance is significant and K=8 is dominated by a pre-existing, out-of-scope merge backlog (the single-threaded Tetris merge falls behind and the fixed Update pool can `bad_alloc`-crash `orlyi` under *sustained* K=8 — same on master). The per-`Try` mutex was held for only a handful of `Push` calls, so the dominant per-write cost remains the txn lifecycle + commit + merge (the later #241 steps). The value here is correctness-neutral lock hygiene: a global serialization point and a shared cross-core cache-line write removed from every accepted write.

## Verification

- **Full `tools/jhm --test` suite: EXIT=0** — 195 tests, 0 failures/aborts. (One test, `orly/mynde/binary_protocol.test`, is excluded from *this sandbox's* run only: it spawns an in-process memcache subprocess-server that dies at init here and busy-loops the parent on an unchecked `fgets` — it hangs **identically on master** in the same sandbox, i.e. pre-existing/environmental, unrelated to this change. It runs normally in CI.)
- **Builds clean:** debug + release (`orlyi` + `orlyc`).
- **Unit tests:** `base/sigma_calc.test` (incl. `Add`), `base/thread_local_sigma_calc.test` — single-thread parity, 8-thread aggregation, concurrent report/drain (no lost count), survives-thread-exit, **and both teardown orders** (owner-destroyed-while-thread-alive; local instance torn down on the pushing thread). `session.test`, `pov.test`, `tetris_manager.test`.
- **TSan:** `base/thread_local_sigma_calc.test` built `-c tsan`, run under `setarch -R` — clean, no new race on the concurrent `Push`/`Report`/`Drain`/thread-exit path.
- **Demo self-check:** `examples/agent-swarm/run.sh` → `self-check OK` (8 concurrent agents, 122 tag + 105 mention + 76 cooccurrence records verified, zero lost).

Refs #241.