### PR TITLE
fix: binary_protocol.test core-vector regression + fgets hang (from #242)

### DIFF
--- a/orly/mynde/binary_protocol.test.cc
+++ b/orly/mynde/binary_protocol.test.cc
@@ -56,9 +56,23 @@ class TSubprocServer final {
     }
     auto *f = fdopen(Subprocess->GetStdErrFromChild(), "r");
     char line[2048];
-    do {
-      fgets(line, sizeof(line), f);
-    } while (!strstr(line, "TServer::Init end"));
+    std::string captured;
+    bool ready = false;
+    while (fgets(line, sizeof(line), f)) {
+      captured += line;
+      if (strstr(line, "TServer::Init end")) {
+        ready = true;
+        break;
+      }
+    }
+    if (!ready) {
+      /* The child closed its stderr before announcing readiness, i.e. the
+         server failed to start. Fail fast with the child's output instead of
+         spinning forever on fgets() returning EOF (which previously hung the
+         whole `make test` job to the 30-minute CI timeout). */
+      throw std::runtime_error(
+          "orly server subprocess exited before 'TServer::Init end'; child stderr:\n" + captured);
+    }
     // NOTE: We're leaking f.  Big deal.
   }
 
@@ -85,6 +99,11 @@ class TSubprocServer final {
         MemorySimMB = 512;
         MemorySimSlowMB = 256;
         EnableMemcache = true;
+        /* Populate the hardware-derived core assignment. orlyi does this
+           post-Parse via ResolveCoreVecDefaults() (#240/#242); a TServer::TCmd
+           built directly here must call it too, else the core vectors are empty
+           and TServer construction aborts with "SlowCoreVec is required ...". */
+        ResolveCoreVecDefaults();
       }
     } cmd;
     TLog log(cmd);


### PR DESCRIPTION
## What's breaking

`make debug + make test` has been **cancelled at the 30-minute CI timeout** on every push since #242 (master's latest run, the #242 merge, and PR #244 all show it). The job's orphan process at cancellation is `orly/mynde/binary_protocol.test`.

**Not a flake — a deterministic regression from #242.** #242 (the `--fast_cores` override fix) moved the hardware core-vector defaults out of the `TServer::TCmd` constructor into `ResolveCoreVecDefaults()`, called only from `orlyi.cc` after `Parse()`. `binary_protocol.test` builds a `TServer::TCmd` subclass **directly** and never called it, so its `FastCoreVec`/`SlowCoreVec` were empty → `TServer` construction aborts at init:

```
job threw standard exception; SlowCoreVec is required to have at least NumSlowRunners cores
```

The child server dies before printing `"TServer::Init end"`, and the test's readiness wait —

```cpp
do { fgets(line, sizeof(line), f); } while (!strstr(line, "TServer::Init end"));
```

— never checks `fgets`, so on the dead child's EOF it **busy-loops forever**, hanging the whole job.

## Fix

1. **Root cause:** `cmd_t`'s constructor now calls `ResolveCoreVecDefaults()` (mirrors what `orlyi.cc` does post-Parse), so a directly-built `TServer::TCmd` gets populated core vectors. (Verified: this is the *only* direct-construction site — `cold_start`/`failover` tests don't build a `TServer`.)
2. **Defense-in-depth:** the readiness loop now checks `fgets()` and throws with the child's captured stderr if the server exits before signalling ready — so any future startup failure fails *fast and diagnosably* instead of timing out the job.

## Verification

`binary_protocol.test`: **passed 1, failed 0** (was: hang → 30-min cancel). Test-only change; no engine code touched, so #240's `--fast_cores` override behaviour is unaffected.

This fixes master's `make test` and unblocks #244 (which carries the same #242 change) once #244 includes it.