### PR TITLE
ci: retry examples demos once on a WebSocketTimeout (#247)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,12 +277,12 @@ jobs:
       # self-check the full 72-value balance trajectory across both
       # branches; any divergence fails CI.
       - name: run.sh (python driver)
-        run: ./run.sh
+        run: ../retry-on-ws-timeout.sh ./run.sh
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         working-directory: examples/bitcoin-time-travel
 
       - name: run-go.sh (go driver)
-        run: ./run-go.sh
+        run: ../retry-on-ws-timeout.sh ./run-go.sh
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         working-directory: examples/bitcoin-time-travel
 
@@ -290,12 +290,12 @@ jobs:
       # of integer addition. Demonstrates the polymorphic-monoid claim
       # from that demo's README: same fold pattern, different operator.
       - name: wikipedia-categories run.sh (python driver)
-        run: ./run.sh
+        run: ../retry-on-ws-timeout.sh ./run.sh
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         working-directory: examples/wikipedia-categories
 
       - name: wikipedia-categories run-go.sh (go driver)
-        run: ./run-go.sh
+        run: ../retry-on-ws-timeout.sh ./run-go.sh
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         working-directory: examples/wikipedia-categories
 
@@ -307,14 +307,14 @@ jobs:
       # workload; the default (large) is the 8-writer / 2000-event
       # local-showcase mode used in the README / tweet captures.
       - name: wikipedia-pageviews run.sh (python driver, concurrent +=)
-        run: ./run.sh
+        run: ../retry-on-ws-timeout.sh ./run.sh
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         working-directory: examples/wikipedia-pageviews
         env:
           DEMO_SCALE: small
 
       - name: wikipedia-pageviews run-go.sh (go driver, concurrent +=)
-        run: ./run-go.sh
+        run: ../retry-on-ws-timeout.sh ./run-go.sh
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         working-directory: examples/wikipedia-pageviews
         env:
@@ -329,14 +329,14 @@ jobs:
       # LLM-extraction pipelines need. DEMO_SCALE=small uses 4 agents
       # over 20 docs for CI tractability.
       - name: agent-swarm run.sh (python driver, concurrent |= and +=)
-        run: ./run.sh
+        run: ../retry-on-ws-timeout.sh ./run.sh
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         working-directory: examples/agent-swarm
         env:
           DEMO_SCALE: small
 
       - name: agent-swarm run-go.sh (go driver, concurrent |= and +=)
-        run: ./run-go.sh
+        run: ../retry-on-ws-timeout.sh ./run-go.sh
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         working-directory: examples/agent-swarm
         env:
@@ -349,12 +349,12 @@ jobs:
       # relations / concurrent race on the same attribute. Self-checks
       # that both race events land in history.
       - name: grc20-pov run.sh (python driver, event-sourced KG)
-        run: ./run.sh
+        run: ../retry-on-ws-timeout.sh ./run.sh
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         working-directory: examples/grc20-pov
 
       - name: grc20-pov run-go.sh (go driver, event-sourced KG)
-        run: ./run-go.sh
+        run: ../retry-on-ws-timeout.sh ./run-go.sh
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         working-directory: examples/grc20-pov
 
@@ -365,12 +365,12 @@ jobs:
       # same-spot race / delete+insert). Self-checks convergence across three
       # independent readers, no lost concurrent edits, and stable time-travel.
       - name: crdt-text run.sh (python driver, collaborative CRDT)
-        run: ./run.sh
+        run: ../retry-on-ws-timeout.sh ./run.sh
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         working-directory: examples/crdt-text
 
       - name: crdt-text run-go.sh (go driver, collaborative CRDT)
-        run: ./run-go.sh
+        run: ../retry-on-ws-timeout.sh ./run-go.sh
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         working-directory: examples/crdt-text
 
@@ -381,12 +381,12 @@ jobs:
       # dynamic-var/WS marshaling path that the C++ lang_test (a native-read
       # harness) cannot reach.
       - name: recursive-variants run.sh (python driver, recursive storage)
-        run: ./run.sh
+        run: ../retry-on-ws-timeout.sh ./run.sh
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         working-directory: examples/recursive-variants
 
       - name: recursive-variants run-go.sh (go driver, recursive storage)
-        run: ./run-go.sh
+        run: ../retry-on-ws-timeout.sh ./run-go.sh
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         working-directory: examples/recursive-variants
 

--- a/examples/retry-on-ws-timeout.sh
+++ b/examples/retry-on-ws-timeout.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# CI helper: run a demo command and retry it ONCE if (and only if) it failed
+# with a WebSocket timeout.
+#
+# The examples job intermittently hits an orlyi read hang under the loaded
+# 2-core CI runner: a read call blocks ~120s and the client raises
+# `WebSocketTimeoutException: Connection timed out`. It is rare (~2/25 runs),
+# load-sensitive, and NOT a regression -- it first appeared on a docs-only PR.
+# Tracked as a real bug in #247; this wrapper is only a band-aid so the flake
+# does not red the build.
+#
+# Crucially, ANY OTHER failure (a correctness mismatch, a crash, a non-WS
+# timeout, "orlyi failed to come up", ...) is propagated immediately and is NOT
+# retried, so genuine regressions still fail on the first attempt.
+#
+# Usage:  retry-on-ws-timeout.sh ./run.sh      (from a demo's working dir)
+set -uo pipefail
+
+out=$("$@" 2>&1); rc=$?
+printf '%s\n' "$out"
+
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qiE 'WebSocketTimeout|Connection timed out'; then
+  echo "::warning title=examples flake (#247)::demo hit a WebSocketTimeout -- retrying once"
+  sleep 3   # let the previous orlyi fully exit and release port 8082
+  "$@"
+  exit $?
+fi
+
+exit "$rc"


### PR DESCRIPTION
Band-aid for the intermittent examples-job flake tracked in #247.

## Problem
`examples/* end-to-end` intermittently fails with `WebSocketTimeoutException: Connection timed out` — a demo's **read** call hangs ~120s under the loaded 2-core CI runner. Rare (~2/25 runs), load-sensitive, and **not a regression** (first appeared on a docs-only PR, #239, with everything before it green). Hit `agent-swarm` (#239) and `grc20-pov` (#244); not demo-specific.

## This change
Adds `examples/retry-on-ws-timeout.sh`, which runs a demo command and retries it **once if and only if** it failed with a WebSocket timeout. Every other failure — correctness mismatch, crash, non-WS timeout, `orlyi failed to come up` — is **propagated immediately and never retried**, so real regressions still red the build on the first attempt.

All **14** examples demo steps (python + go drivers across the 7 demos) are wrapped via the step's `working-directory`. The prediction-market browser e2e job is unaffected.

## Verified
- Wrapper logic tested locally: success passes through; a non-WS failure runs once and propagates; a WS-timeout failure runs twice.
- `ci.yml` validated (`yaml.safe_load`); wrapper path resolves from each demo's working-directory.

## Scope
This is a **band-aid** so the flake stops reddening master/PRs. **#247** tracks root-causing the read hang itself (I couldn't reproduce it locally even at true 2-core with gdb armed; full notes in the issue).