### PR TITLE
chore(build): make clean removes compile_commands.json; jhm honors JHM_COMPILER_LAUNCHER

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ clean:
 	rm -rf ../.jhm
 	rm -f tools/jhm
 	rm -f tools/make_dep_file
+	# jhm unions the per-job *.compdb.json into compile_commands.json at the
+	# repo root (not under ../out_orly/), so wipe it too or clangd keeps
+	# resolving against a stale, just-deleted build tree.
+	rm -f compile_commands.json
 
 install: release
 	install -d $(BINDIR) $(PACKAGE_DIR) $(DATA_DIR)

--- a/jhm/jobs/compile_c_family.cc
+++ b/jhm/jobs/compile_c_family.cc
@@ -16,6 +16,7 @@
 
 #include <jhm/jobs/compile_c_family.h>
 
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <optional>
@@ -147,6 +148,19 @@ vector<string> TCompileCFamily::GetCmd() {
     std::filesystem::create_directories(entry_path.parent_path(), ec);
     std::ofstream out(entry_path);
     out << TJson(std::move(entry));
+  }
+
+  // Optional compiler launcher (e.g. JHM_COMPILER_LAUNCHER=ccache): prepended
+  // to the invocation so the real compile runs as `<launcher> g++ ...`. This
+  // is the first-class equivalent of CMake's *_COMPILER_LAUNCHER -- it lets a
+  // caching/distributing wrapper sit in front of the compiler without the
+  // PATH-symlink masquerade jhm otherwise forces (jhm execs g++/gcc by bare
+  // name). Applied only to compiles, not links (ccache caches compiles), and
+  // added AFTER the compile-DB entry above so clangd still sees the compiler
+  // itself as argument[0]. A single token (the launcher executable); unset or
+  // empty leaves the command byte-for-byte unchanged.
+  if (const char *launcher = std::getenv("JHM_COMPILER_LAUNCHER"); launcher && *launcher) {
+    cmd.insert(cmd.begin(), launcher);
   }
 
   return cmd;


### PR DESCRIPTION
Two small build-system papercuts noticed while working in the tree.

## `make clean` left `compile_commands.json` behind

`clean` removed `../out_orly/`, `../.jhm`, and the bootstrap binaries, but jhm unions the per-job `*.compdb.json` into **`./compile_commands.json` at the repo root** (not under `out_orly/`), so a `make clean` left a stale compile DB pointing at a just-deleted build tree — clangd then resolves against nothing. Added `rm -f compile_commands.json` to the target, so `make clean && make debug` is a true clean rebuild.

## jhm honors `JHM_COMPILER_LAUNCHER` (first-class compiler launcher)

jhm execs the compiler by bare name (`g++`/`gcc`), so routing compiles through a wrapper like **ccache** required the PATH-symlink "masquerade" (the CI jobs do this). Now, if `JHM_COMPILER_LAUNCHER` is set, the compile runs as `<launcher> g++ ...` — the equivalent of CMake's `*_COMPILER_LAUNCHER`. Details:

- Applied to **compiles only** (not links — ccache caches compiles).
- Inserted **after** the compile-DB entry is written, so clangd still sees the compiler as `arguments[0]` (verified).
- Unset/empty ⇒ command byte-for-byte unchanged.

**CI is intentionally left on the masquerade** — it also routes **orlyc's** package compiles through ccache, which the jhm-only hook doesn't. The env var is the cleaner primitive for local dev (`JHM_COMPILER_LAUNCHER=ccache jhm ...`) and a future CI could adopt it for the jhm build step if the orlyc-compile caching tradeoff is acceptable.

## Verification

- Stub launcher is invoked as `<stub> g++ ...`; `compile_commands.json` still names `g++` as `arguments[0]`; a no-launcher build is unchanged.
- End-to-end with real ccache (no masquerade): cold build = 1 miss, warm rebuild of the same object = 1 **hit**.
