### PR TITLE
fix(#259): data races in SPA flux_capacitor POV/Tetris

### DIFF
--- a/orly/spa/flux_capacitor/flux_capacitor.cc
+++ b/orly/spa/flux_capacitor/flux_capacitor.cc
@@ -121,10 +121,21 @@ TParentPov::TChildPovCursor &TParentPov::TChildPovCursor::operator++() {
 bool TParentPov::PlayTetris(int timeout) {
   vector<TSync::TExclusiveLock *> child_locks;
   unordered_set<TUpdate *> updates;
-  epoll_event events[ChildPovCount];
+  /* #259: ChildPovCount is mutated by the TChildPov ctor/dtor under
+     ChildListMutex; snapshot it under the same lock before sizing the epoll
+     array rather than reading it unsynchronized. We release the lock before
+     epoll_wait so this never blocks POV create/destroy -- epoll_ctl from
+     Join/PartTetris is thread-safe against a concurrent epoll_wait, and a child
+     added after the snapshot is simply picked up on the next round. */
+  int child_pov_count;
+  {
+    lock_guard<recursive_mutex> lock(ChildListMutex);
+    child_pov_count = ChildPovCount;
+  }
+  epoll_event events[child_pov_count];
   try {
     int ready_count;
-    Util::IfLt0(ready_count = epoll_wait(TetrisWaitHandle, events, ChildPovCount, timeout));
+    Util::IfLt0(ready_count = epoll_wait(TetrisWaitHandle, events, child_pov_count, timeout));
     for (int i = 0; i < ready_count; ++i) {
       TChildPov *child_pov = static_cast<TChildPov *>(events[i].data.ptr);
       assert(child_pov);
@@ -188,9 +199,10 @@ TChildPov::TChildPov(TParentPov *parent_pov, const TOnFail& on_fail, bool paused
     : FlowState(paused ? Paused : Running), IsJoinedToTetris(false), OnFail(on_fail), ParentPov(parent_pov) {
   assert(parent_pov);
   lock_guard<recursive_mutex> lock(parent_pov->ChildListMutex);
-  if (!paused) {
-    JoinTetris();
-  }
+  /* #259: do NOT JoinTetris here -- that would publish `this` to the parent's
+     epoll set (and thus the Tetris thread) before the most-derived ctor has
+     finished. The most-derived child POV ctor calls FinishConstruction() as its
+     last step instead. We still link into the child list under ChildListMutex. */
   Root = parent_pov->GetRoot();
   GlobalPov = parent_pov->GlobalPov;
   NextChildPov = 0;
@@ -198,6 +210,12 @@ TChildPov::TChildPov(TParentPov *parent_pov, const TOnFail& on_fail, bool paused
   (PrevChildPov ? PrevChildPov->NextChildPov : parent_pov->FirstChildPov) = this;
   parent_pov->LastChildPov = this;
   ++(parent_pov->ChildPovCount);
+}
+
+void TChildPov::FinishConstruction() {
+  if (FlowState == Running) {
+    JoinTetris();
+  }
 }
 
 TChildPov::~TChildPov() {
@@ -266,6 +284,7 @@ void TGlobalPov::Fail() {
 TPrivatePov::TPrivatePov(TParentPov *parent_pov, const TOnFail &on_fail, bool paused)
     : TChildPov(parent_pov, on_fail, paused) {
   Leaf = new TLeaf(this);
+  FinishConstruction();  // #259: join Tetris only once fully constructed
 }
 
 TPrivatePov::~TPrivatePov() {
@@ -469,7 +488,19 @@ TUpdate::TUpdate(
   for (auto iter = shared_lock_vec.rbegin(); iter != shared_lock_vec.rend(); ++iter) {
     delete *iter;
   }
-  SyncWithPov();
+  /* #259: link into Pov's trailing-update list under Pov's exclusive Sync. The
+     Tetris thread reads/unlinks this list under the same exclusive lock
+     (TParentPov::PlayTetris / TUpdate::Promote), so this main-thread write must
+     take it too. Safe here: the cause shared-locks above are already released
+     (no exclusive-after-shared on this target) and SyncWithPov -> LinkToPov /
+     UnlinkFromPov touch only Pov's own list -- no nested POV locks, no cascade
+     into OnLocalCause* -- so this adds no lock-order edge. TSync is per-thread
+     recursive, so the Tetris side (already holding this Sync via Promote) is
+     unaffected. */
+  {
+    TSync::TExclusiveLock lock(Pov->GetSync());
+    SyncWithPov();
+  }
 }
 
 bool TUpdate::Assert(TContext &ctxt) const {

--- a/orly/spa/flux_capacitor/flux_capacitor.h
+++ b/orly/spa/flux_capacitor/flux_capacitor.h
@@ -407,6 +407,15 @@ namespace Orly {
            Take the parent's graph root as our own. */
         TChildPov(TParentPov *parent_pov, const TOnFail& on_fail, bool paused=false);
 
+        /* Publish this child to its parent's Tetris game (#259). The base ctor
+           used to JoinTetris() directly, but that makes the child reachable by
+           the Tetris thread (via epoll in TParentPov::PlayTetris) BEFORE the
+           most-derived ctor has finished -- so PlayTetris could touch a
+           half-constructed POV (vtable / Leaf still being set). Each most-derived
+           child POV ctor must call this as its last step instead; it joins
+           Tetris only if not constructed paused. */
+        void FinishConstruction();
+
         /* Also detaches from our parent pov. */
         virtual ~TChildPov();
 
@@ -519,9 +528,11 @@ namespace Orly {
         NO_COPY(TSharedPov);
         public:
 
-        /* Do-nothing. */
+        /* Join Tetris only once fully constructed (#259). */
         TSharedPov(TParentPov *parent_pov, const TOnFail &on_fail, bool paused=false)
-            : TChildPov(parent_pov, on_fail, paused) {}
+            : TChildPov(parent_pov, on_fail, paused) {
+          FinishConstruction();
+        }
 
         /* Destructor for a shared pov. We have to call DeleteAllTrailingUpdate
            before the base class destructs. */


### PR DESCRIPTION
Fixes #259 — the SPA `flux_capacitor` POV/Tetris data races ThreadSanitizer surfaced during `orlyc`'s compile-time `test {}` execution.

## Context

`orlyc` runs a package's `test {}` block on its **main thread** while a background `TTetrisHandler` thread (`api.h`) **asynchronously promotes** the resulting updates — `NewUpdateAndWait` blocks on a promise waiting for that promotion. So the concurrency is by design; the bug was three pieces of shared state crossed between those two threads with no synchronization. (These fire only in the orlyc/`spa` path, **not** the indy server `orlyi`.)

## The three races

**1. `ChildPovCount` (cluster A).** `TParentPov::PlayTetris` read `ChildPovCount` to size its `epoll_event[]` VLA with no lock, while `TChildPov`'s ctor/dtor mutate it under `ChildListMutex`. → snapshot it under `ChildListMutex` (released before `epoll_wait`, which is thread-safe against concurrent `epoll_ctl`, so POV create/destroy isn't blocked).

**2. POV trailing-update list (cluster B).** The Tetris thread reads/unlinks a POV's trailing-update list under the POV's **exclusive Sync** (`PlayTetris`/`Promote`), but the main-thread write path — `TUpdate` ctor → `SyncWithPov` → `LinkToPov` — mutated `First`/`Next`/`PrevTrailingUpdate` with **no lock**. → take the POV's exclusive Sync around that `SyncWithPov`. Safe because: the cause shared-locks are already released (no exclusive-after-shared, which `TSync` forbids), `SyncWithPov`→`LinkToPov`/`UnlinkFromPov` touch only this POV's own list (no nested POV locks, no `OnLocalCause*` cascade → no new lock-order edge), and `TSync` is **per-thread recursive** so the Tetris side already holding this Sync is unaffected.

**3. Publish-before-construct.** The `TChildPov` *base* ctor called `JoinTetris()`, publishing the child to its parent's epoll set (and thus the Tetris thread) **before the most-derived ctor finished** — so `PlayTetris` could touch a half-constructed POV (vtable / `Leaf` mid-init). → move the join into `FinishConstruction()`, called as the **last step** of each most-derived child POV ctor (`TPrivatePov`, `TSharedPov`); it joins only if not paused (unchanged behavior). The child still links into the child list under `ChildListMutex` in the base ctor — only the epoll *publish* is deferred.

## Validation

- **All 7 reported races gone**: 0 TSan warnings compiling `graph.orly`, `views.orly`, `bitcoin.orly`, `grc20.orly` under a TSan-built `orlyc` (each runs its test block through the changed SPA path).
- **`lang_test`**: 0 unexpected, 156 passed, 2 xfail (baseline) — the POV-construction restructure + added locking doesn't change orlyc test-execution results.
- **Curated TSan set still 0**: `flux_capacitor/sync.test`, `flux_capacitor/tetris_piece.test`, `context_fold`, `context_xrepo`, `scheduler`, `fiber_lock` — all 0 warnings, all pass.
- Debug + TSan builds clean.

(Note: the full agent-swarm-under-TSan run now gets *past* the orlyc compile cleanly and only stops because the TSan-instrumented `orlyi` **server** is too slow to bind its port within the demo script's 60s window — an unrelated startup-speed artifact of running the whole indy server under TSan, not a regression.)

Closes #259.
