### PR TITLE
fix(tetris/fiber): make tetris_manager.test TSan-clean, rejoin the gate (#268, #269)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,11 +532,8 @@ jobs:
           orly/indy/fiber/algorithm.test
           orly/indy/context_fold.test
           orly/indy/context_xrepo.test
+          orly/server/tetris_manager.test
           "
-          # NOTE: the SPA flux_capacitor sync/tetris_piece TSan tests were
-          # removed with the engine (#262 P5). Re-adding indy Tetris coverage
-          # (orly/server/tetris_manager.test) to this gate is a follow-up,
-          # pending a TSan-clean check of that test.
           PATH="$PWD/tools:$PATH" tools/jhm -c tsan $TESTS
 
           mkdir -p tsan-logs

--- a/base/thread_local_global_pool.h
+++ b/base/thread_local_global_pool.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cassert>
 #include <condition_variable>
 #include <mutex>
@@ -89,9 +90,17 @@ namespace Base {
         #ifndef NDEBUG
         static_cast<TObj *>(obj)->AssertCanFree();
         #endif
+        /* Treiber-stack push onto the cross-thread free list. FreeQueue is a
+           std::atomic so this read-modify-write doesn't race the atomic
+           exchange-pop in TryAllocUncommon (the plain read here used to be a
+           data race vs that exchange, even though the CAS made it benign on
+           hardware -- TSan #269 follow-up). Release pairs with the acquire on
+           the pop so the popper sees this object's NextObj link. */
+        TObjBase *head = FreeQueue.load(std::memory_order_relaxed);
         do {
-          obj->NextObj = FreeQueue;
-        } while (!__sync_bool_compare_and_swap(&FreeQueue, obj->NextObj, obj));
+          obj->NextObj = head;
+        } while (!FreeQueue.compare_exchange_weak(
+            head, obj, std::memory_order_release, std::memory_order_relaxed));
       }
 
       /* TODO */
@@ -121,7 +130,7 @@ namespace Base {
       TObjBase *TryAllocUncommon() {
         TObjBase *alloc_obj = nullptr;
         /* let's swap in our free queue and try to allocate from that. */
-        TObjBase *cur_tail = __sync_lock_test_and_set(&FreeQueue, nullptr);
+        TObjBase *cur_tail = FreeQueue.exchange(nullptr, std::memory_order_acquire);
         if (cur_tail) {
           /* There were element(s) on the free queue. */
           assert(AvailableQueue == nullptr);
@@ -156,7 +165,7 @@ namespace Base {
                 }
               }
               if (&pool != this) {
-                cur_tail = __sync_lock_test_and_set(&pool.FreeQueue, nullptr);
+                cur_tail = pool.FreeQueue.exchange(nullptr, std::memory_order_acquire);
                 if (cur_tail) {
                   /* There were element(s) on the other pool's free queue. */
                   assert(AvailableQueue == nullptr);
@@ -197,8 +206,10 @@ namespace Base {
         #endif
       }
 
-      /* TODO */
-      mutable TObjBase *FreeQueue;
+      /* Cross-thread free list (Treiber stack). Atomic because Free() (push,
+         any thread) races TryAllocUncommon()'s exchange-pop (this or a
+         neighbor pool stealing work). */
+      mutable std::atomic<TObjBase *> FreeQueue;
 
       /* TODO */
       TObjBase *AvailableQueue;

--- a/orly/indy/fiber/fiber.h
+++ b/orly/indy/fiber/fiber.h
@@ -71,6 +71,13 @@ namespace Orly {
         inline void *Create() { return __tsan_create_fiber(0); }
         inline void Destroy(void *fiber) { __tsan_destroy_fiber(fiber); }
         inline void SwitchTo(void *fiber) { __tsan_switch_to_fiber(fiber, 0); }
+        /* Establish a happens-before edge across a custom fiber wait/wake
+           handoff (e.g. TSafeSync). Release() publishes the calling fiber's
+           prior writes into the sync object identified by addr; a later
+           Acquire(addr) on the woken fiber observes them, so ThreadSanitizer
+           tracks the ordering the primitive really provides. */
+        inline void Acquire(void *addr) { __tsan_acquire(addr); }
+        inline void Release(void *addr) { __tsan_release(addr); }
       }  // TSanFiber
     }  // Fiber
   }  // Indy
@@ -85,6 +92,8 @@ namespace Orly {
         inline void *Create() { return nullptr; }
         inline void Destroy(void *) {}
         inline void SwitchTo(void *) {}
+        inline void Acquire(void *) {}
+        inline void Release(void *) {}
       }  // TSanFiber
     }  // Fiber
   }  // Indy
@@ -1314,10 +1323,20 @@ namespace Orly {
         assert(Finished.load() <= WaitingFor.load());
         //Base::TSpinLock::TLock lock(SpinLock);
         /* fall through */
+        /* Acquire the happens-before published by every Complete() (paired
+           release below) so ThreadSanitizer sees the completers' writes as
+           ordered-before this fiber's continuation across the wait/wake
+           handoff -- which the fiber switch alone does not convey (#269). */
+        TSanFiber::Acquire(this);
         assert(safety_runner == TRunner::LocalRunner);
       }
 
       inline void TSafeSync::Complete() {
+        /* Release this completer's prior writes into the sync object; the
+           waiter's Acquire() in Sync() (above) pairs with it. Released on
+           every Complete() so a multi-completer sync (WaitForMore > 1)
+           accumulates each contributor's happens-before (#269). */
+        TSanFiber::Release(this);
         size_t prev = std::atomic_fetch_add(&Finished, 1UL);
         if ((prev + 1UL) == WaitingFor.load()) {
           Base::TSpinLock::TLock lock(SpinLock);

--- a/orly/server/tetris_manager.h
+++ b/orly/server/tetris_manager.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cassert>
 #include <mutex>
 #include <unordered_map>
@@ -140,8 +141,9 @@ namespace Orly {
         TTetrisManager *TetrisManager;
 
         /* The number of children currently joined to us.  This starts at one, as we must be constructed with a single child.
-           Main() will run as long as this value is non-zero. */
-        size_t ChildCount;
+           Main() will run as long as this value is non-zero. Atomic because Join/Part mutate it under the manager's
+           FiberMutex while the player's own Main() fiber reads it unlocked each round (#262 follow-up: TSan data race). */
+        std::atomic<size_t> ChildCount;
 
         /* Usually this pointer is null; however, Stop() points us at a semaphore we are to push in our destructor.  That's
            how we unblock Stop(). */


### PR DESCRIPTION
## What

Make `orly/server/tetris_manager.test` TSan-clean and re-add it to the curated ThreadSanitizer gate, replacing the SPA flux Tetris tests removed with the engine in #262 P5. Three races stood in the way; this PR fixes all of them.

Closes #268 (ChildCount race) and #269 (TSafeSync visibility).

## 1. `TPlayer::ChildCount` data race (#268)

`TTetrisManager::Join` / `Part` mutate `ChildCount` (`++` / `--`) under the manager's `FiberMutex`, while the player's own `Main()` fiber reads it **unlocked** each round to decide whether to keep playing (`else if (ChildCount)`, `tetris_manager.cc:217`). A plain `size_t` read concurrent with a write is a genuine data race (UB). Made it `std::atomic<size_t>` — the `++` / `--` / bool-read sites all work unchanged.

## 2. `TSafeSync` wait/wake happens-before not visible to TSan (#269)

With the ChildCount race gone, TSan still flagged teardown: `~TTetrisManager` deleting a `TPov` vs a player fiber's last `Play()`. That one is **not a real race** — `TPlayer::Stop()` synchronously drains the player through the `StoppedSync` handshake (sets `ChildCount = 0`, blocks on `StoppedSync.Sync()`; `~TPlayer` calls `StoppedSync.Complete()` after `Main()` exits), so the last `Play()` genuinely happens-before the delete. TSan just can't see the ordering because it travels through the custom `TSafeSync` fiber primitive and the scheduler's wait/wake handoff (same class as #194/#200).

Fix: annotate the handoff with `__tsan_acquire` / `__tsan_release` (no-ops off TSan, mirroring the existing fiber-switch annotations):

- `TSafeSync::Complete()` **releases** each completer's prior writes into the sync object — on *every* call, so a multi-completer sync (`WaitForMore > 1`) accumulates each contributor's edge.
- `TSafeSync::Sync()` **acquires** them on return (both the parked and already-finished paths).

This grants exactly the happens-before the primitive already guarantees — it adds no ordering the code doesn't enforce, so it **cannot mask a genuine race**. It also covers `orly/indy/fiber/algorithm.h`, whose parallel sort/merge runs on the same `TSafeSync::Sync`/`Complete`.

## 3. `TThreadLocalGlobalPoolManager` free list — plain read vs atomic RMW (real UB race)

Re-adding the test to the gate then exposed a **third, pre-existing** race (intermittent, ~50% of runs) — distinct from the two above, in the lock-free frame pool. `TThreadLocalPool::Free()` seeded its Treiber-stack CAS with a **plain** read of `FreeQueue` (`obj->NextObj = FreeQueue;`, `thread_local_global_pool.h:93`) while `TryAllocUncommon()` pops the list with an atomic exchange (`__sync_lock_test_and_set`, `:124`), and a neighbor pool can steal via the same exchange. A non-atomic read racing an atomic RMW is a data race (UB) — benign on hardware (the CAS is the source of truth) but real to TSan. `tetris_manager.test` hits it because it churns `TFrame`s across runner threads (the borrow-from-neighbor path) where the lighter curated tests don't.

Fix: make `FreeQueue` a `std::atomic<TObjBase*>` and use the canonical lock-free idiom — relaxed-load seed + **release** CAS on push, **acquire** exchange on pop. Algorithm and the steal path are unchanged; benefits every frame-pool user.

## 4. Re-add to the TSan gate

`.github/workflows/ci.yml`: add `orly/server/tetris_manager.test` to the curated `TESTS` list and drop the now-stale NOTE.

## Validation

- `tetris_manager.test` under `setarch -R`: **16/16 TSan-clean** (was ~6/12 failing before the pool fix), functional test passes.
- **Full curated TSan set (11 tests): 0 warnings, two full passes** — no regression, no over-suppression.
- Debug (non-TSan) build of the pool / fiber / Tetris tests passes.
- `lang_test`: **0 unexpected, 156 passed, 2 xfail** (#74/#75) — the `orlyc`→`orlyi` path exercises the frame pool, so this gates the foundational `base/` change.