### PR TITLE
chore: strip bare /* TODO */ doc-stub placeholders (5677 lines)

### DIFF
--- a/base/chrono.cc
+++ b/base/chrono.cc
@@ -33,7 +33,6 @@ using namespace Base::Chrono;
 /* Convenience macro to wrap the Read function. */
 #define READ(part, delimiter) Read(converter, part, #part, delimiter)
 
-/* TODO */
 template <typename TVal>
 static void Read(TConverter &converter, TVal &part, const char *name, const char delimiter) {
   converter.Read(part);
@@ -47,19 +46,15 @@ static void Read(TConverter &converter, TVal &part, const char *name, const char
   }
 }
 
-/* TODO */
 namespace NumNanosecond {
 
   /* Was 1000 for milliseconds, changed to 1000000000 for Nano */
   constexpr uint64_t Second = 1000000000;
 
-  /* TODO */
   constexpr uint64_t Minute = Second * 60;
 
-  /* TODO */
   constexpr uint64_t Hour = Minute * 60;
 
-  /* TODO */
   constexpr uint64_t Day = Hour * 24;
 
 }  // NumSecond
@@ -104,7 +99,6 @@ TTimeDiffInfo::TTimeDiffInfo(
         Second(second),
 	Nanosecond(nanosecond) {}
 
-/* TODO */
 TTimeDiffInfo::TTimeDiffInfo(const std::string &str) {
   TConverter converter(AsPiece(str));
   std::optional<bool> sign = converter.TryReadSign();
@@ -121,7 +115,6 @@ TTimeDiffInfo::TTimeDiffInfo(const std::string &str) {
   }
 }
 
-/* TODO */
 TTimeDiffInfo::TTimeDiffInfo(const TTimeDiff &time_diff)
     : Nanosecond(time_diff.count()) {
   IsForward = (Nanosecond >= 0);
@@ -135,14 +128,12 @@ TTimeDiffInfo::TTimeDiffInfo(const TTimeDiff &time_diff)
   Nanosecond %= NumNanosecond::Second;
 }
 
-/* TODO */
 std::string TTimeDiffInfo::AsString() const {
   std::ostringstream strm;
   Write(strm);
   return strm.str();
 }
 
-/* TODO */
 TTimeDiff TTimeDiffInfo::AsTimeDiff() const {
   return TTimeDiff((Day * NumNanosecond::Day +
                     Hour * NumNanosecond::Hour +
@@ -151,7 +142,6 @@ TTimeDiff TTimeDiffInfo::AsTimeDiff() const {
 		    Nanosecond) * (IsForward ? 1 : -1));
 }
 
-/* TODO */
 void TTimeDiffInfo::Write(std::ostream &strm) const {
   strm
     << (IsForward ? '+' : '-')
@@ -177,7 +167,6 @@ TTimePntInfo::TTimePntInfo(
   Validate(HERE);
 }
 
-/* TODO */
 TTimePntInfo::TTimePntInfo(const std::string &str)
     : UtcOffset(0) {
   TConverter converter(AsPiece(str));
@@ -231,14 +220,12 @@ TTimePntInfo::TTimePntInfo(const TTimePnt &time_pnt)
   Validate(HERE);
 }
 
-/* TODO */
 std::string TTimePntInfo::AsString() const {
   std::ostringstream strm;
   Write(strm);
   return strm.str();
 }
 
-/* TODO */
 TTimePnt TTimePntInfo::AsTimePnt() const {
 
   std::tm tm_obj;
@@ -263,7 +250,6 @@ std::tm &TTimePntInfo::AsTmObj(std::tm &out) const {
   return out;
 }
 
-/* TODO */
 void TTimePntInfo::Validate(const TCodeLocation &here) const {
   if (Year < 1900) {
     throw TChronoError(here, "Year prior to 1900 is not supported");
@@ -291,7 +277,6 @@ void TTimePntInfo::Validate(const TCodeLocation &here) const {
   }
 }
 
-/* TODO */
 void TTimePntInfo::Write(std::ostream &strm) const {
   strm
     << Year << '-'
@@ -329,7 +314,6 @@ TTimeDiff Base::Chrono::CreateTimeDiff(
   return TTimeDiffInfo(is_forward, day, hour, minute, second, nanosecond).AsTimeDiff();
 }
 
-/* TODO */
 TTimePnt Base::Chrono::CreateTimePnt(
     uint64_t year, uint64_t month, uint64_t day,
     uint64_t hour, uint64_t minute, uint64_t second,
@@ -337,5 +321,4 @@ TTimePnt Base::Chrono::CreateTimePnt(
   return TTimePntInfo(year, month, day, hour, minute, second, nanosecond, utc_offset).AsTimePnt();
 }
 
-/* TODO */
 TTimePnt Base::Chrono::Now() { return TimePntCast(TClock::now()); }

--- a/base/chrono.h
+++ b/base/chrono.h
@@ -41,11 +41,9 @@ namespace Base {
     /* convenience typedef for std::chrono::time_point */
     typedef std::chrono::time_point<TClock, TTimeDiff> TTimePnt;
 
-    /* TODO */
     class TTimeDiffInfo {
       public:
 
-      /* TODO */
       TTimeDiffInfo(
           bool is_forward,
           uint64_t day,
@@ -54,19 +52,14 @@ namespace Base {
           uint64_t second,
 	        uint64_t nanosecond);
 
-      /* TODO */
       TTimeDiffInfo(const std::string &str);
 
-      /* TODO */
       TTimeDiffInfo(const TTimeDiff &time_diff);
 
-      /* TODO */
       std::string AsString() const;
 
-      /* TODO */
       TTimeDiff AsTimeDiff() const;
 
-      /* TODO */
       void Write(std::ostream &strm) const;
 
       /* Accessors */
@@ -96,10 +89,8 @@ namespace Base {
 
       private:
 
-      /* TODO */
       bool IsForward;
 
-      /* TODO */
       int64_t Day, Hour, Minute, Second, Nanosecond;
 
     };  // TTimeDiffInfo
@@ -108,29 +99,22 @@ namespace Base {
     class TTimePntInfo {
       public:
 
-      /* TODO */
       TTimePntInfo(
           uint64_t year, uint64_t month, uint64_t day,
           uint64_t hour, uint64_t minute, uint64_t second,
           uint64_t nanosecond,
           int64_t utc_offset);
 
-      /* TODO */
       TTimePntInfo(const std::string &str);
 
-      /* TODO */
       TTimePntInfo(const TTimePnt &time_pnt);
 
-      /* TODO */
       std::string AsString() const;
 
-      /* TODO */
       TTimePnt AsTimePnt() const;
 
-      /* TODO */
       void Validate(const TCodeLocation &here) const;
 
-      /* TODO */
       void Write(std::ostream &strm) const;
 
       /* Accessors */
@@ -168,13 +152,10 @@ namespace Base {
 
       private:
 
-      /* TODO */
       std::tm &AsTmObj(std::tm &out) const;
 
-      /* TODO */
       uint64_t Year, Month, Day, Hour, Minute, Second, Nanosecond;
 
-      /* TODO */
       int64_t UtcOffset;
 
     };  // TTimePntInfo
@@ -184,7 +165,6 @@ namespace Base {
       return std::chrono::duration_cast<TTimeDiff>(time_diff);
     }
 
-    /* TODO */
     template <typename TVal>
     TTimePnt TimePntCast(const std::chrono::time_point<TVal> &time_pnt) {
       return std::chrono::time_point_cast<TTimeDiff, TClock>(time_pnt);
@@ -192,7 +172,6 @@ namespace Base {
 
     /* These are the built_in functions that are used in code gen */
 
-    /* TODO */
     TTimeDiff CreateTimeDiff(
         bool is_forward,
         uint64_t day,
@@ -209,7 +188,6 @@ namespace Base {
 	uint64_t nanosecond,
         int64_t utc_offset);
 
-    /* TODO */
     TTimePnt Now();
 
     inline std::ostream &operator<<(std::ostream &strm, const TTimeDiff &that) {

--- a/base/convert.h
+++ b/base/convert.h
@@ -183,17 +183,14 @@ namespace Base {
       return *this;
     }
 
-    /* TODO */
     /* Parse bool  (see jhm.py fod valid methods of expression) */
     bool TryReadBool(bool &output);
     void ReadBool(bool &output);
 
-    /* TODO */
     /* Parse float */
     bool TryReadFloat(float &output, bool sign_required=false);
     void ReadFloat(float &output, bool sign_required=false);
 
-    /* TODO */
     /* Parse double */
     bool TryReadDouble(double &output, bool sign_required=false);
     void ReadDouble(double &output, bool sign_required=false);

--- a/base/epoll.h
+++ b/base/epoll.h
@@ -63,7 +63,6 @@ namespace Base {
       return Fd;
     }
 
-    /* TODO */
     size_t GetFdCount() const {
       return FdCount;
     }
@@ -94,16 +93,12 @@ namespace Base {
 
     private:
 
-    /* TODO */
     void Control(int fd, int flags, int op);
 
-    /* TODO */
     TFd Fd;
 
-    /* TODO */
     epoll_event *Events;
 
-    /* TODO */
     size_t MaxEventCount, EventCount, FdCount;
 
   };  // TEpoll

--- a/base/event_counter.h
+++ b/base/event_counter.h
@@ -24,26 +24,20 @@
 
 namespace Base {
 
-  /* TODO */
   class TEventCounter {
     NO_COPY(TEventCounter);
     public:
 
-    /* TODO */
     TEventCounter(uint64_t initial_count = 0);
 
-    /* TODO */
     const TFd &GetFd() const;
 
-    /* TODO */
     uint64_t Pop();
 
-    /* TODO */
     void Push(uint64_t count = 1);
 
     private:
 
-    /* TODO */
     TFd Fd;
 
   };  // TEventCounter

--- a/base/event_semaphore.h
+++ b/base/event_semaphore.h
@@ -30,15 +30,12 @@
 
 namespace Base {
 
-  /* TODO */
   class TEventSemaphore {
     NO_COPY(TEventSemaphore);
     public:
 
-    /* TODO */
     TEventSemaphore(uint64_t initial_count = 0, bool nonblocking = false);
 
-    /* TODO */
     const TFd &GetFd() const {
       return Fd;
     }
@@ -50,12 +47,10 @@ namespace Base {
        returns true. */
     bool Pop();
 
-    /* TODO */
     void Push(uint64_t count = 1);
 
     private:
 
-    /* TODO */
     TFd Fd;
 
   };  // TEventSemaphore

--- a/base/gz/input_producer.h
+++ b/base/gz/input_producer.h
@@ -31,21 +31,17 @@
 
 namespace Gz {
 
-  /* TODO */
   class TInputProducer final
       : public Io::TInputProducer {
     NO_COPY(TInputProducer);
     public:
 
-    /* TODO */
     using TChunk = Io::TChunk;
     using TPool  = Io::TPool;
 
-    /* TODO */
     TInputProducer(const char *path, const char *mode, const TPool::TArgs &args = TPool::TArgs())
         : File(path, mode), Pool(std::make_shared<TPool>(args)) {}
 
-    /* TODO */
     TInputProducer(Base::TFd &&fd, const char *mode, const TPool::TArgs &args = TPool::TArgs())
         : File(std::move(fd), mode), Pool(std::make_shared<TPool>(args)) {}
 
@@ -54,10 +50,8 @@ namespace Gz {
 
     private:
 
-    /* TODO */
     TFile File;
 
-    /* TODO */
     std::shared_ptr<TPool> Pool;
 
   };  // TInputProducer

--- a/base/gz/output_consumer.h
+++ b/base/gz/output_consumer.h
@@ -29,16 +29,13 @@
 
 namespace Gz {
 
-  /* TODO */
   class TOutputConsumer final
       : public Io::TOutputConsumer {
     NO_COPY(TOutputConsumer);
     public:
 
-    /* TODO */
     using TChunk = Io::TChunk;
 
-    /* TODO */
     TOutputConsumer(const char *path, const char *mode)
         : File(path, mode) {}
 
@@ -47,7 +44,6 @@ namespace Gz {
 
     private:
 
-    /* TODO */
     TFile File;
 
   };  // TOutputConsumer

--- a/base/interner.h
+++ b/base/interner.h
@@ -33,7 +33,6 @@
 
 namespace Base {
 
-  /* TODO */
   template <typename TObj, typename... TArgs>
   class TInterner {
     NO_COPY(TInterner);
@@ -42,10 +41,8 @@ namespace Base {
     typedef std::shared_ptr<const TObj> TPtr;
     typedef std::weak_ptr<const TObj> TWeak;
 
-    /* TODO */
     TInterner() {}
 
-    /* TODO */
     template <typename... TCompatArgs>
     TPtr Get(TCompatArgs &&... args) {
 
@@ -60,10 +57,8 @@ namespace Base {
 
     private:
 
-    /* TODO */
     typedef std::tuple<TArgs...> TKey;
 
-    /* TODO */
     std::unordered_map<TKey, TWeak> ObjByKey;
 
   };  // TInterner<TObj, TArgs...>

--- a/base/inv_con/atomic_ordered_list.h
+++ b/base/inv_con/atomic_ordered_list.h
@@ -60,7 +60,6 @@ namespace InvCon {
         return Collector;
       }
 
-      /* TODO */
       void ForEach(const std::function<bool (const TMember &)> &cb) {
         bool keep_going = true;
         TTypedMembership *prev_membership = 0;
@@ -132,7 +131,6 @@ namespace InvCon {
       /* See accessors. */
       TTypedMembership *FirstMembership, *LastMembership;
 
-      /* TODO */
       std::atomic_flag FirstLock, LastLock;
 
       /* For Collector, FirstMembership, and LastMembership. */
@@ -316,7 +314,6 @@ namespace InvCon {
       /* See accessors. */
       TMembership *PrevMembership, *NextMembership;
 
-      /* TODO */
       std::atomic_flag PrevLock, NextLock;
 
       /* For ~TMembership(), Insert(), Remove(), and Member. */

--- a/base/inv_con/atomic_unordered_list.h
+++ b/base/inv_con/atomic_unordered_list.h
@@ -61,7 +61,6 @@ namespace InvCon {
         return Collector;
       }
 
-      /* TODO */
       void ForEach(const std::function<bool (const TMember &)> &cb) {
         bool keep_going = true;
         TTypedMembership *prev_membership = 0;
@@ -86,7 +85,6 @@ namespace InvCon {
         }
       }
 
-      /* TODO */
       template <typename... TVal>
       void ForEach(const std::function<bool (const TMember &, TVal &...)> &cb, TVal &...out_param) {
         bool keep_going = true;
@@ -155,7 +153,6 @@ namespace InvCon {
 
       private:
 
-      /* TODO */
       std::atomic_flag FirstLock, LastLock;
 
       /* See accessors. */
@@ -332,7 +329,6 @@ namespace InvCon {
         PrevMembership = 0;
       }
 
-      /* TODO */
       std::atomic_flag PrevLock, NextLock;
 
       /* See accessors. */

--- a/base/inv_con/ordered_list.h
+++ b/base/inv_con/ordered_list.h
@@ -121,7 +121,6 @@ namespace InvCon {
         return (membership && !(membership->Key < key)) ? membership : 0;
       }
 
-      /* TODO */
       bool IsEmpty() const {
         return FirstMembership == 0;
       }
@@ -156,7 +155,6 @@ namespace InvCon {
         membership->Insert(this);
       }
 
-      /* TODO */
       void ReverseInsert(TTypedMembership *membership) {
         assert(membership);
         membership->ReverseInsert(this);
@@ -304,7 +302,6 @@ namespace InvCon {
         }
       }
 
-      /* TODO */
       void ReverseInsert(TTypedCollection *collection) {
         assert(collection);
         TMembership

--- a/base/inv_con/unordered_list.h
+++ b/base/inv_con/unordered_list.h
@@ -88,7 +88,6 @@ namespace InvCon {
         return LastMembership;
       }
 
-      /* TODO */
       bool IsEmpty() const {
         return FirstMembership == 0;
       }

--- a/base/inv_con/unordered_multimap.h
+++ b/base/inv_con/unordered_multimap.h
@@ -78,7 +78,6 @@ namespace InvCon {
         return result;
       }
 
-      /* TODO */
       static size_t GetBucketSize() {
         return sizeof(TBucket);
       }
@@ -144,7 +143,6 @@ namespace InvCon {
         return GetBucket(key)->TryGetLastMembership(key);
       }
 
-      /* TODO */
       bool IsEmpty() const {
         for (size_t i = 0; i < BucketCount; ++i) {
           if (!BucketArray[i].IsEmpty()) {
@@ -209,16 +207,13 @@ namespace InvCon {
 
       private:
 
-      /* TODO */
       class TBucket {
         NO_COPY(TBucket);
         public:
 
-        /* TODO */
         TBucket()
             : Collection(0), Idx(0), FirstMembership(0), LastMembership(0) {}
 
-        /* TODO */
         ~TBucket() {
           RemoveEachMember();
         }
@@ -241,7 +236,6 @@ namespace InvCon {
           }
         }
 
-        /* TODO */
         TBucket *GetPrevNonEmptyBucket() {
           TBucket *bucket = this;
           for (;;) {
@@ -257,7 +251,6 @@ namespace InvCon {
           return bucket;
         }
 
-        /* TODO */
         TBucket *GetNextNonEmptyBucket() {
           TBucket *bucket = this;
           for (;;) {
@@ -273,7 +266,6 @@ namespace InvCon {
           return bucket;
         }
 
-        /* TODO */
         void Init(TCollection *collection, size_t idx) {
           Collection = collection;
           Idx = idx;
@@ -320,7 +312,6 @@ namespace InvCon {
           return membership;
         }
 
-        /* TODO */
         static TBucket *GetFirstNonEmptyBucket(const TCollection *collection) {
           assert(collection);
           TBucket *bucket = collection->BucketArray;
@@ -330,7 +321,6 @@ namespace InvCon {
           return bucket;
         }
 
-        /* TODO */
         static TBucket *GetLastNonEmptyBucket(const TCollection *collection) {
           assert(collection);
           TBucket *bucket = collection->BucketArray + (collection->BucketCount - 1);
@@ -342,10 +332,8 @@ namespace InvCon {
 
         private:
 
-        /* TODO */
         TCollection *Collection;
 
-        /* TODO */
         size_t Idx;
 
         /* See accessors. */
@@ -356,7 +344,6 @@ namespace InvCon {
 
       };  // TBucket
 
-      /* TODO */
       TBucket *GetBucket(const TKey &key) const {
         return BucketArray + (Hash(key) % BucketCount);
       }
@@ -370,7 +357,6 @@ namespace InvCon {
       /* The number of buckets in BucketArray. */
       size_t BucketCount;
 
-      /* TODO */
       std::hash<TKey> Hash;
 
       /* For Collector, GetBucket(), and TBucket. */
@@ -550,7 +536,6 @@ namespace InvCon {
 
       private:
 
-      /* TODO */
       typedef typename TTypedCollection::TBucket TBucket;
 
       /* The fixup pointers before and after us in our collection.

--- a/base/io/binary_input_stream.h
+++ b/base/io/binary_input_stream.h
@@ -48,7 +48,6 @@ namespace Io {
     NO_COPY(TBinaryInputStream);
     public:
 
-    /* TODO */
     using TInputConsumer::ReadExactly;
 
     /* If someone wants to be able to consume this data in chunks without copying it. */
@@ -156,7 +155,6 @@ namespace Io {
 
     };  // TTupleHelper
 
-    /* TODO */
     template <typename TVal>
     class TypeHelper;
 
@@ -193,29 +191,24 @@ namespace Io {
 
   };  // TBinaryInputStream
 
-  /* TODO */
   template <typename TVal>
   class TBinaryInputStream::TypeHelper {
     NO_CONSTRUCTION(TypeHelper);
     public:
 
-    /* TODO */
     typedef TVal TType;
 
   };  // TypeHelper
 
-  /* TODO */
   template <typename TFirst, typename TSecond>
   class TBinaryInputStream::TypeHelper<std::pair<const TFirst, TSecond>> {
     NO_CONSTRUCTION(TypeHelper);
     public:
 
-    /* TODO */
     typedef std::pair<TFirst, TSecond> TType;
 
   };
 
-  /* TODO */
   template <typename TThat>
   void TBinaryInputStream::ReadInsertableContainer(TThat &that) {
     size_t size;

--- a/base/io/binary_output_stream.h
+++ b/base/io/binary_output_stream.h
@@ -51,7 +51,6 @@ namespace Io {
     /* Flushing is publicly available. */
     using TOutputProducer::Flush;
 
-    /* TODO */
     using TOutputProducer::WriteExactly;
 
     /* Write built-in types. */

--- a/base/io/chunk_and_pool.h
+++ b/base/io/chunk_and_pool.h
@@ -237,7 +237,6 @@ namespace Io {
          If this is zero, the pool will be of fixed size. */
       size_t AdditionalChunkCount;
 
-      /* TODO */
       std::shared_ptr<std::function<TChunk *()>> NextChunkCb;
 
     };  // Args
@@ -290,7 +289,6 @@ namespace Io {
     /* The queue of free chunks.  This may be empty.  It will never contains nulls. */
     std::queue<TChunk *> FreeChunks;
 
-    /* TODO */
     std::shared_ptr<std::function<TChunk *()>> NextChunkCb;
 
   };  // TPool

--- a/base/io/input_consumer.h
+++ b/base/io/input_consumer.h
@@ -71,7 +71,6 @@ namespace Io {
       return InputProducer;
     }
 
-    /* TODO */
     bool HasBufferedData() const;
 
     /* True iff. we have reached the end of the input stream. */

--- a/base/io/recorder_and_player.h
+++ b/base/io/recorder_and_player.h
@@ -93,7 +93,6 @@ namespace Io {
        If this is >= the size of the collection, then we have run out of chunks. */
     size_t Idx;
 
-    /* TODO */
     std::shared_ptr<std::function<std::shared_ptr<const TChunk> ()>> NextChunkCb;
 
   };  // TPlayer

--- a/base/mini_cache.h
+++ b/base/mini_cache.h
@@ -40,16 +40,13 @@
 
 namespace Base {
 
-  /* TODO */
   template <size_t MaxSize, typename TKey, typename TVal>
   class TMiniCache {
     NO_COPY(TMiniCache);
     public:
 
-    /* TODO */
     TMiniCache(size_t bucket_count = MaxSize) : ElemMap(this, bucket_count), LRUList(this), NumElem(0) {}
 
-    /* TODO */
     ~TMiniCache() {
       // destroy all the elements
       for (size_t i = 0; i < NumElem; ++i) {
@@ -93,11 +90,9 @@ namespace Base {
     /* Forward declarations. */
     class TElem;
 
-    /* TODO */
     using TElemMap = InvCon::UnorderedMultimap::TCollection<TMiniCache, TElem, TKey>;
     using TElemList = InvCon::UnorderedList::TCollection<TMiniCache, TElem>;
 
-    /* TODO */
     class TElem {
       NO_COPY(TElem);
       public:
@@ -108,7 +103,6 @@ namespace Base {
         return T(std::get<Is>(std::move(ts))...);
       }
 
-      /* TODO */
       using TMapMembership = InvCon::UnorderedMultimap::TMembership<TElem, TMiniCache, TKey>;
       using TListMembership = InvCon::UnorderedList::TMembership<TElem, TMiniCache>;
 
@@ -127,28 +121,23 @@ namespace Base {
 
       private:
 
-      /* TODO */
       typename TMapMembership::TImpl CacheMembership;
       typename TListMembership::TImpl LRUMembership;
 
-      /* TODO */
       TVal Val;
 
       friend class TMiniCache;
 
     };  // TElem
 
-    /* TODO */
     mutable typename TElemMap::TImpl ElemMap;
 
-    /* TODO */
     mutable typename TElemList::TImpl LRUList;
 
     union {
       TElem ElemSpace[MaxSize];
     };
 
-    /* TODO */
     size_t NumElem;
 
   };  // TMiniCache

--- a/base/mpl/type_set.h
+++ b/base/mpl/type_set.h
@@ -40,7 +40,6 @@ namespace Mpl {
 
   };  // TTypeSetImpl<TTypeList<TElems...>>
 
-  /* TODO */
   template <typename... TElems>
   struct TTypeSet : public TTypeSetImpl<TGetUnique<TTypeList<TElems...>>> {};
 

--- a/base/no_throw.h
+++ b/base/no_throw.h
@@ -16,5 +16,4 @@
 
 #pragma once
 
-/* TODO */
 #define NO_THROW throw()

--- a/base/peekable.h
+++ b/base/peekable.h
@@ -29,31 +29,25 @@ namespace Base {
 
   DEFINE_ERROR(TPeekablePastEndError, std::runtime_error, "past end")
 
-  /* TODO */
   template <typename TVal>
   class TPeekable {
     NO_COPY(TPeekable);
     public:
 
-    /* TODO */
     typedef std::function<bool (TVal &)> TProducingFunc;
 
-    /* TODO */
     TPeekable(const TProducingFunc &producing_func)
         : ProducingFunc(producing_func), State(Unknown) {}
 
-    /* TODO */
     operator bool() const {
       return TryRefresh();
     }
 
-    /* TODO */
     TVal &operator*() const {
       Refresh();
       return Val;
     }
 
-    /* TODO */
     void operator++() {
       Refresh();
       State = Unknown;
@@ -61,17 +55,14 @@ namespace Base {
 
     private:
 
-    /* TODO */
     enum TState { Unknown, Ready, Done };
 
-    /* TODO */
     void Refresh() const {
       if (!TryRefresh()) {
         throw TPeekablePastEndError(HERE);
       }
     }
 
-    /* TODO */
     bool TryRefresh() const {
       bool is_ready;
       switch (State) {
@@ -93,13 +84,10 @@ namespace Base {
       return is_ready;
     }
 
-    /* TODO */
     TProducingFunc ProducingFunc;
 
-    /* TODO */
     mutable TState State;
 
-    /* TODO */
     mutable TVal Val;
 
   };  // TPeekable<TVal>

--- a/base/rpc/rpc.h
+++ b/base/rpc/rpc.h
@@ -206,7 +206,6 @@ namespace Rpc {
     TContext(const TProtocol &protocol)
         : Protocol(protocol), NextRequestId(1), UnhandledRequestCount(0) {}
 
-    /* TODO */
     void FailAllFutures(const std::string &error_msg);
 
     /* See accessor. */

--- a/base/sigma_calc.h
+++ b/base/sigma_calc.h
@@ -50,19 +50,14 @@ namespace Base {
        number of pushes; otherwise, leave the out-params alone and return zero. */
     size_t Report(double &min, double &max, double &mean, double &sigma) const;
 
-    /* TODO */
     inline size_t GetCount() const;
 
-    /* TODO */
     inline double GetMin() const;
 
-    /* TODO */
     inline double GetMax() const;
 
-    /* TODO */
     inline double GetMean() const;
 
-    /* TODO */
     inline double GetSigma() const;
 
     /* Go back to being empty. */

--- a/base/spin_lock.h
+++ b/base/spin_lock.h
@@ -27,39 +27,32 @@
 
 namespace Base {
 
-  /* TODO */
   class TSpinLock {
     NO_COPY(TSpinLock);
     public:
 
-    /* TODO */
     class TLock {
       NO_COPY(TLock);
       public:
 
-      /* TODO */
       TLock(const TSpinLock &spin_lock) : SpinLock(spin_lock) {
         while (spin_lock.Lock.test_and_set(std::memory_order_acquire));
       }
 
-      /* TODO */
       ~TLock() {
         SpinLock.Lock.clear(std::memory_order_release);
       }
 
       private:
 
-      /* TODO */
       const TSpinLock &SpinLock;
 
     };
 
-    /* TODO */
     class TSoftLock {
       NO_COPY(TSoftLock);
       public:
 
-      /* TODO */
       TSoftLock(const TSpinLock &spin_lock) : SpinLock(spin_lock) {
         size_t tries = 0UL;
         while (spin_lock.Lock.test_and_set(std::memory_order_acquire)) {
@@ -73,27 +66,22 @@ namespace Base {
         }
       }
 
-      /* TODO */
       ~TSoftLock() {
         SpinLock.Lock.clear(std::memory_order_release);
       }
 
       private:
 
-      /* TODO */
       const TSpinLock &SpinLock;
 
-      /* TODO */
       static const size_t YieldCount = 20UL;
 
     };
 
-    /* TODO */
     TSpinLock() : Lock(ATOMIC_FLAG_INIT) {}
 
     private:
 
-    /* TODO */
     mutable std::atomic_flag Lock;
 
   };

--- a/base/test/app.h
+++ b/base/test/app.h
@@ -29,7 +29,6 @@
 
 namespace Test {
 
-  /* TODO */
   class TFixture;
 
   class TApp final {
@@ -59,24 +58,20 @@ namespace Test {
       bool VerboseMember;
     };
 
-    /* TODO */
     class TLogger {
       NO_COPY(TLogger);
       public:
 
-      /* TODO */
       TLogger(bool is_critical = false) {
         Enabled = is_critical || TApp::IsVerbose();
       }
 
-      /* TODO */
       ~TLogger() {
         if (Enabled) {
           std::cout << std::endl;
         }
       }
 
-      /* TODO */
       template <typename TVal>
       const TLogger &Write(const TVal &val) const {
         if (Enabled) {
@@ -87,30 +82,23 @@ namespace Test {
 
       private:
 
-      /* TODO */
       bool Enabled;
     };
 
-    /* TODO */
     class TRunner {
       NO_COPY(TRunner);
       public:
 
-      /* TODO */
       virtual ~TRunner();
 
-      /* TODO */
       virtual operator bool() const = 0;
 
-      /* TODO */
       static void Run(TApp *app, const TFixture *fixture);
 
       protected:
 
-      /* TODO */
       TRunner(TApp *app) : App(app) {}
 
-      /* TODO */
       void PreDtor();
 
       TApp *App;

--- a/base/test/expect.h
+++ b/base/test/expect.h
@@ -116,18 +116,14 @@
 
 namespace Test {
 
-  /* TODO */
   class TExpect : public TRunner::TExpect {
     NO_COPY(TExpect);
     public:
 
-    /* TODO */
     enum TInfixOp { Lt, Le, Gt, Ge };
 
-    /* TODO */
     enum TEqOp {Eq, Ne};
 
-    /* TODO */
     template <typename TLhs, typename TRhs>
     TExpect(
         const Base::TCodeLocation &code_location,
@@ -154,10 +150,8 @@ namespace Test {
       WriteInfixOp(lhs_str, lhs, op_str, rhs_str, rhs);
     }
 
-    /* TODO */
     enum TPrefixOp { IsTrue, IsFalse };
 
-    /* TODO */
     template <typename TLhs, typename TRhs>
     TExpect(
         const Base::TCodeLocation &code_location,
@@ -194,7 +188,6 @@ namespace Test {
       WriteInfixOp(lhs_str, lhs, op_str, rhs_str, rhs);
     }
 
-    /* TODO */
     template <typename TArg>
     TExpect(
         const Base::TCodeLocation &code_location,
@@ -242,15 +235,12 @@ namespace Test {
     }
 
 
-    /* TODO */
     virtual ~TExpect();
 
-    /* TODO */
     operator bool() const {
       return Pass;
     }
 
-    /* TODO */
     template <typename TVal>
     const TExpect &Write(const TVal &val) const {
       Explanation << val;
@@ -295,22 +285,17 @@ namespace Test {
       Expression = strm.str();
     }
 
-    /* TODO */
     template <typename TArg>
     static void WriteType(std::ostream &strm) {
       strm << '(' << Base::Demangle<TArg>() << ')';
     }
 
-    /* TODO */
     Base::TCodeLocation CodeLocation;
 
-    /* TODO */
     bool Pass;
 
-    /* TODO */
     std::string Source, Expression;
 
-    /* TODO */
     mutable std::ostringstream Explanation;
   };
 

--- a/base/test/fixture.h
+++ b/base/test/fixture.h
@@ -30,53 +30,41 @@
 
 namespace Test {
 
-  /* TODO */
   class TFixture {
     NO_COPY(TFixture);
     public:
 
-    /* TODO */
     typedef void (*TFunc)();
 
-    /* TODO */
     TFixture(
         const Base::TCodeLocation &code_location, const char *name, TFunc func);
 
-    /* TODO */
     TFunc GetFunc() const {
       return Func;
     }
 
-    /* TODO */
     const char *GetName() const {
       return Name;
     }
 
-    /* TODO */
     const TFixture *GetNextFixture() const {
       return NextFixture;
     }
 
-    /* TODO */
     static const TFixture *GetFirstFixture() {
       return FirstFixture;
     }
 
     private:
 
-    /* TODO */
     Base::TCodeLocation CodeLocation;
 
-    /* TODO */
     const char *Name;
 
-    /* TODO */
     TFunc Func;
 
-    /* TODO */
     mutable const TFixture *NextFixture;
 
-    /* TODO */
     static const TFixture *FirstFixture, *LastFixture;
   };
 

--- a/base/test/runner.h
+++ b/base/test/runner.h
@@ -26,57 +26,43 @@
 
 namespace Test {
 
-  /* TODO */
   class TFixture;
 
-  /* TODO */
   class TRunner : public TApp::TRunner {
     NO_COPY(TRunner);
     public:
 
-    /* TODO */
     class TExpect {
       NO_COPY(TExpect);
       public:
 
-      /* TODO */
       virtual ~TExpect();
 
-      /* TODO */
       virtual operator bool() const = 0;
 
       protected:
 
-      /* TODO */
       TExpect() {}
 
-      /* TODO */
       void PreDtor();
     };
 
-    /* TODO */
     TRunner(TApp *app, const TFixture *fixture);
 
-    /* TODO */
     virtual ~TRunner();
 
-    /* TODO */
     virtual operator bool() const;
 
-    /* TODO */
     void Run();
 
-    /* TODO */
     static TRunner *GetRunner() {
       return Base::AssertTrue(Runner);
     }
 
     private:
 
-    /* TODO */
     void OnExpectDtor(const TExpect *expect);
 
-    /* TODO */
     const TFixture *Fixture;
 
     /* The fixture's running pass/fail state. A multi-threaded fixture fires
@@ -88,7 +74,6 @@ namespace Test {
        idempotent relaxed store and de-noises every multi-threaded test. */
     std::atomic<bool> Pass;
 
-    /* TODO */
     static TRunner *Runner;
   };
 

--- a/base/thread_local_global_pool.h
+++ b/base/thread_local_global_pool.h
@@ -35,7 +35,6 @@
 
 namespace Base {
 
-  /* TODO */
   template <typename TObj, typename... TArgs>
   class TThreadLocalGlobalPoolManager {
     NO_COPY(TThreadLocalGlobalPoolManager);
@@ -44,20 +43,17 @@ namespace Base {
     /* Forward Declaration. */
     class TThreadLocalPool;
 
-    /* TODO */
     class TObjBase {
       NO_COPY(TObjBase);
       public:
 
       protected:
 
-      /* TODO */
       TObjBase()
           : NextObj(nullptr) {}
 
       private:
 
-      /* TODO */
       TObjBase *NextObj;
 
       friend class TThreadLocalPool;
@@ -65,27 +61,21 @@ namespace Base {
 
     };  // TObjBase
 
-    /* TODO */
     class TThreadLocalPool {
       NO_COPY(TThreadLocalPool);
       public:
 
-      /* TODO */
       static_assert(std::is_base_of<TObjBase, TObj>::value, "TThreadLocalPool requires TObj to be derived from TObjBase");
 
-      /* TODO */
       typedef InvCon::AtomicUnorderedList::TMembership<TThreadLocalPool, TThreadLocalGlobalPoolManager> TManagerMembership;
 
-      /* TODO */
       TThreadLocalPool(TThreadLocalGlobalPoolManager *manager)
           : FreeQueue(nullptr), AvailableQueue(nullptr), Manager(manager), ManagerMembership(this, &Base::AssertTrue(manager)->PoolCollection) {
         assert(manager);
       }
 
-      /* TODO */
       virtual ~TThreadLocalPool() {}
 
-      /* TODO */
       inline void Free(TObjBase *obj) {
         #ifndef NDEBUG
         static_cast<TObj *>(obj)->AssertCanFree();
@@ -103,7 +93,6 @@ namespace Base {
             head, obj, std::memory_order_release, std::memory_order_relaxed));
       }
 
-      /* TODO */
       inline TObj *Alloc() {
         TObjBase *alloc_obj = AvailableQueue;
         if (alloc_obj) {
@@ -119,14 +108,12 @@ namespace Base {
         return static_cast<TObj *>(alloc_obj);
       }
 
-      /* TODO */
       inline TThreadLocalGlobalPoolManager *GetPoolManager() const {
         return Manager;
       }
 
       private:
 
-      /* TODO */
       TObjBase *TryAllocUncommon() {
         TObjBase *alloc_obj = nullptr;
         /* let's swap in our free queue and try to allocate from that. */
@@ -189,7 +176,6 @@ namespace Base {
         return alloc_obj;
       }
 
-      /* TODO */
       inline void MakeStackAvailable(TObjBase *cur_tail) {
         /* fast pop */
         AvailableQueue = cur_tail;
@@ -211,21 +197,16 @@ namespace Base {
          neighbor pool stealing work). */
       mutable std::atomic<TObjBase *> FreeQueue;
 
-      /* TODO */
       TObjBase *AvailableQueue;
 
-      /* TODO */
       TThreadLocalGlobalPoolManager *Manager;
 
-      /* TODO */
       TObj *MyAlloc;
 
-      /* TODO */
       typename TManagerMembership::TImpl ManagerMembership;
 
     };  // TThreadLocalPool
 
-    /* TODO */
     TThreadLocalGlobalPoolManager(size_t num_elems, const TArgs &... args)
         : NumElems(num_elems), Alloc(nullptr), PoolCollection(this) {
       Alloc = reinterpret_cast<TObj *>(malloc(sizeof(TObj) * num_elems));
@@ -243,7 +224,6 @@ namespace Base {
       FreeQueue = prev_base;
     }
 
-    /* TODO */
     ~TThreadLocalGlobalPoolManager() {
       size_t counter = 0UL;
       PoolCollection.ForEach([&counter](const TThreadLocalPool &){++counter; return true;});
@@ -259,7 +239,6 @@ namespace Base {
 
     private:
 
-    /* TODO */
     inline TObjBase *TryAlloc() {
       TObjBase *obj = nullptr;
       /* for now we use a spin lock. Anyone allocating from here will contend for this. The idea is that we finely distribute objects to the thread
@@ -273,20 +252,15 @@ namespace Base {
       return obj;
     }
 
-    /* TODO */
     typedef InvCon::AtomicUnorderedList::TCollection<TThreadLocalGlobalPoolManager, TThreadLocalPool> TPoolCollection;
 
-    /* TODO */
     const size_t NumElems;
 
-    /* TODO */
     TObj *Alloc;
 
-    /* TODO */
     Base::TSpinLock FreeQueueLock;
     TObjBase *FreeQueue;
 
-    /* TODO */
     mutable typename TPoolCollection::TImpl PoolCollection;
 
   };  // TThreadLocalGlobalPoolManager

--- a/base/thread_local_registered_pool.h
+++ b/base/thread_local_registered_pool.h
@@ -47,7 +47,6 @@
 
 namespace Base {
 
-  /* TODO */
   template <typename TObj, typename... TArgs>
   class TThreadLocalPoolManager {
     NO_COPY(TThreadLocalPoolManager);
@@ -56,38 +55,31 @@ namespace Base {
     /* Forward Declaration. */
     class TThreadLocalRegisteredPool;
 
-    /* TODO */
     class TObjBase {
       NO_COPY(TObjBase);
       public:
 
       protected:
 
-      /* TODO */
       TObjBase()
           : NextObj(nullptr) {}
 
       private:
 
-      /* TODO */
       TObjBase *NextObj;
 
       friend class TThreadLocalRegisteredPool;
 
     };  // TObjBase
 
-    /* TODO */
     class TThreadLocalRegisteredPool {
       NO_COPY(TThreadLocalRegisteredPool);
       public:
 
-      /* TODO */
       static_assert(std::is_base_of<TObjBase, TObj>::value, "TThreadLocalRegisteredPool requires TObj to be derived from TObjBase");
 
-      /* TODO */
       typedef InvCon::AtomicUnorderedList::TMembership<TThreadLocalRegisteredPool, TThreadLocalPoolManager> TManagerMembership;
 
-      /* TODO */
       TThreadLocalRegisteredPool(TThreadLocalPoolManager *manager, size_t num_elems, const TArgs &... args)
           : FreeQueue(nullptr), AvailableQueue(nullptr), Manager(manager), MyAlloc(nullptr), ManagerMembership(this, &manager->PoolCollection) {
         assert(num_elems > 0);
@@ -103,10 +95,8 @@ namespace Base {
         AvailableQueue = prev_base;
       }
 
-      /* TODO */
       virtual ~TThreadLocalRegisteredPool() {}
 
-      /* TODO */
       inline void Free(TObjBase *obj) {
         #ifndef NDEBUG
         static_cast<TObj *>(obj)->AssertCanFree();
@@ -116,7 +106,6 @@ namespace Base {
         } while (!__sync_bool_compare_and_swap(&FreeQueue, obj->NextObj, obj));
       }
 
-      /* TODO */
       inline TObj *Alloc() {
         TObjBase *alloc_obj = AvailableQueue;
         if (alloc_obj) {
@@ -132,14 +121,12 @@ namespace Base {
         return static_cast<TObj *>(alloc_obj);
       }
 
-      /* TODO */
       inline TThreadLocalPoolManager *GetPoolManager() const {
         return Manager;
       }
 
       private:
 
-      /* TODO */
       TObjBase *TryAllocUncommon() {
         TObjBase *alloc_obj = nullptr;
         /* let's swap in our free queue and try to allocate from that. */
@@ -198,7 +185,6 @@ namespace Base {
         return alloc_obj;
       }
 
-      /* TODO */
       inline void MakeStackAvailable(TObjBase *cur_tail) {
         /* fast pop */
         AvailableQueue = cur_tail;
@@ -215,28 +201,21 @@ namespace Base {
         #endif
       }
 
-      /* TODO */
       mutable TObjBase *FreeQueue;
 
-      /* TODO */
       TObjBase * AvailableQueue;
 
-      /* TODO */
       TThreadLocalPoolManager *Manager;
 
-      /* TODO */
       TObj *MyAlloc;
 
-      /* TODO */
       typename TManagerMembership::TImpl ManagerMembership;
 
     };  // TThreadLocalRegisteredPool
 
-    /* TODO */
     TThreadLocalPoolManager()
         : PoolCollection(this) {}
 
-    /* TODO */
     ~TThreadLocalPoolManager() {
       size_t counter = 0UL;
       PoolCollection.ForEach([&counter](const TThreadLocalRegisteredPool &){++counter; return true;});
@@ -254,10 +233,8 @@ namespace Base {
 
     private:
 
-    /* TODO */
     typedef InvCon::AtomicUnorderedList::TCollection<TThreadLocalPoolManager, TThreadLocalRegisteredPool> TPoolCollection;
 
-    /* TODO */
     TObj *AllocateSpace(size_t num_elems) {
       TObj *alloc = reinterpret_cast<TObj *>(malloc(sizeof(TObj) * num_elems));
       if (unlikely(!alloc)) {
@@ -268,13 +245,10 @@ namespace Base {
       return alloc;
     }
 
-    /* TODO */
     std::mutex AllocateMutex;
 
-    /* TODO */
     std::vector<std::pair<TObj *, size_t>> AllocVec;
 
-    /* TODO */
     mutable typename TPoolCollection::TImpl PoolCollection;
 
   };  // ThreadLocalPoolManager

--- a/base/timer_fd.h
+++ b/base/timer_fd.h
@@ -29,25 +29,20 @@
 
 namespace Base {
 
-  /* TODO */
   class TTimerFd {
     NO_COPY(TTimerFd);
     public:
 
-    /* TODO */
     TTimerFd(std::chrono::milliseconds milliseconds);
 
-    /* TODO */
     const TFd &GetFd() const {
       return Fd;
     }
 
-    /* TODO */
     uint64_t Pop();
 
     private:
 
-    /* TODO */
     TFd Fd;
 
   };  // TTimerFd

--- a/base/usage_meter.h
+++ b/base/usage_meter.h
@@ -25,7 +25,6 @@
 
 namespace Base {
 
-  /* TODO */
   class TUsageMeter {
     NO_COPY(TUsageMeter);
     public:
@@ -35,27 +34,22 @@ namespace Base {
       getrusage(Who, &StartU);
     }
 
-    /* TODO */
     void Start() {
       getrusage(Who, &StartU);
     }
 
-    /* TODO */
     void Stop() {
       getrusage(Who, &StopU);
     }
 
-    /* TODO */
     double GetTotalUserCPU() const {
       return (((StopU.ru_utime.tv_sec - StartU.ru_utime.tv_sec) * 1000000L) + (StopU.ru_utime.tv_usec - StartU.ru_utime.tv_usec)) / 1000000.0;
     }
 
-    /* TODO */
     double GetTotalSystemCPU() const {
       return (((StopU.ru_stime.tv_sec - StartU.ru_stime.tv_sec) * 1000000L) + (StopU.ru_stime.tv_usec - StartU.ru_stime.tv_usec)) / 1000000.0;
     }
 
-    /* TODO */
     size_t GetVoluntary() const {
       return StopU.ru_nvcsw - StartU.ru_nvcsw;
     }
@@ -66,13 +60,10 @@ namespace Base {
 
     private:
 
-    /* TODO */
     int Who;
 
-    /* TODO */
     struct rusage StartU;
 
-    /* TODO */
     struct rusage StopU;
 
   };  // TUsageMeter

--- a/base/uuid.cc
+++ b/base/uuid.cc
@@ -31,7 +31,6 @@ bool TUuid::IsValidUuid(const char *s) {
 }
 
 TUuid::TUuid(TAlgo that) {
-  /* TODO */
   static std::mt19937_64 TwisterEngine(std::chrono::system_clock::now().time_since_epoch().count());
   static Base::TSpinLock TwisterLock;
 

--- a/base/uuid.h
+++ b/base/uuid.h
@@ -244,7 +244,6 @@ namespace Base {
       return *reinterpret_cast<size_t *>(const_cast<unsigned char *>(Data));
     }
 
-    /* TODO */
     const uuid_t &GetRaw() const {
       return Data;
     }

--- a/base/web/half_latch.h
+++ b/base/web/half_latch.h
@@ -25,31 +25,24 @@
 
 namespace Server {
 
-  /* TODO */
   class THalfLatch {
     NO_COPY(THalfLatch);
     public:
 
-    /* TODO */
     THalfLatch();
 
-    /* TODO */
     int GetWaitHandle() const {
       return RecvFd;
     }
 
-    /* TODO */
     void Recv();
 
-    /* TODO */
     void Send();
 
     private:
 
-    /* TODO */
     bool IsSet;
 
-    /* TODO */
     Base::TFd RecvFd, SendFd;
 
   };  // THalfLatch

--- a/orly/atom/core_vector_builder.h
+++ b/orly/atom/core_vector_builder.h
@@ -78,7 +78,6 @@ namespace Orly {
       /* Write the vector to the given stream. */
       void Write(Io::TBinaryOutputStream &strm) const;
 
-      /* TODO */
       inline size_t GetNumArenaBytes() const {
         assert(Arena);
         return Arena->GetNumBytes();
@@ -103,7 +102,6 @@ namespace Orly {
         /* See base class. */
         virtual TOffset Propose(TNote *proposed_note) override;
 
-        /* TODO */
         inline size_t GetNumBytes() {
           return NumBytes;
         }

--- a/orly/atom/kit2.h
+++ b/orly/atom/kit2.h
@@ -87,12 +87,10 @@ namespace Orly {
 
         TOrderedArenaCompare(TArena *arena) : Arena(arena) {}
 
-        /* TODO */
         bool operator()(const TCore &lhs, const TCore &rhs) const;
 
         private:
 
-        /* TODO */
         TArena *const Arena;
 
       };  // TOrderedArenaCompare
@@ -135,10 +133,8 @@ namespace Orly {
       /* True if we're a free. */
       inline bool IsFree() const;
 
-      /* TODO */
       inline size_t ForceGetIndirectHash() const;
 
-      /* TODO */
       inline bool TryGetQuickHash(size_t &out_hash) const;
 
       /* Returns true if this core stored the hash value inside it's local storage. If so, out_hash is set to the stored value. */
@@ -151,16 +147,12 @@ namespace Orly {
          This will return false if the core is a direct core. */
       inline bool TrySetStoredHash(size_t hash_val);
 
-      /* TODO */
       inline bool TryQuickOrderComparison(TArena *this_arena, const TCore &that_core, TArena *that_arena, Atom::TComparison &comp) const;
 
-      /* TODO */
       inline bool MatchType(TArena *this_arena, const TCore &that_core, TArena *that_arena) const;
 
-      /* TODO */
       inline Orly::Sabot::TMatchResult PrefixMatch(TArena *this_arena, const TCore &that_core, TArena *that_arena) const;
 
-      /* TODO */
       inline const uint32_t *TryGetElemCount() const;
 
       /* Get a sabot around our type. */
@@ -460,10 +452,8 @@ namespace Orly {
              and should not use the offset for comparison. */
           bool UsesFullNote;
 
-          /* TODO */
           bool StoresHash;
 
-          /* TODO */
           size_t HashVal;
 
         } IndirectCoreArray;
@@ -545,62 +535,50 @@ namespace Orly {
 
       };  // TArena::TPin
 
-      /* TODO */
       class TFinalPin final
           : public TPin {
         public:
 
-        /* TODO */
         class TWrapper {
           public:
 
-          /* TODO */
           TWrapper(TFinalPin *pin) : FinalPin(pin) {}
 
-          /* TODO */
           ~TWrapper() {
             if (FinalPin) {
               FinalPin->~TFinalPin();
             }
           }
 
-          /* TODO */
           TFinalPin *operator->() const {
             return FinalPin;
           }
 
-          /* TODO */
           const TFinalPin &operator*() const {
             return *FinalPin;
           }
 
-          /* TODO */
           operator TFinalPin *() const {
             return FinalPin;
           }
 
-          /* TODO */
           TFinalPin *get() const {
             return FinalPin;
           }
 
           private:
 
-          /* TODO */
           TFinalPin *FinalPin;
 
         };  // TWrapper
 
-        /* TODO */
         virtual ~TFinalPin() {}
 
         private:
 
-        /* TODO */
         TFinalPin(TArena *arena, TOffset offset)
             : TPin(arena, offset) {}
 
-        /* TODO */
         TFinalPin(TArena *arena, TOffset offset, size_t known_size)
             : TPin(arena, offset, known_size) {}
 
@@ -618,7 +596,6 @@ namespace Orly {
       /* Pin the note with the given offset into memory.  If the note doesn't exist, throw. */
       TFinalPin *Pin(TOffset offset, size_t known_size, void *alloc);
 
-      /* TODO */
       bool IsOrdered() const {
         return IsOrderedFlag;
       }
@@ -643,7 +620,6 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       const bool IsOrderedFlag;
 
     };  // TArena
@@ -677,17 +653,14 @@ namespace Orly {
       class TOrderedArenaCompare {
         public:
 
-        /* TODO */
         TOrderedArenaCompare(TArena *arena) : OrderedCoreCompare(arena) {
           assert(!arena || arena->IsOrdered());
         }
 
-        /* TODO */
         bool operator()(const TNote &lhs, const TNote &rhs) const;
 
         private:
 
-        /* TODO */
         const TCore::TOrderedArenaCompare OrderedCoreCompare;
 
       };  // TOrderedArenaCompare
@@ -786,7 +759,6 @@ namespace Orly {
       /* Construct a copy of another note. */
       static TNote *New(const TNote *that);
 
-      /* TODO */
       static void operator delete(void *ptr, size_t);
 
       private:
@@ -1736,7 +1708,6 @@ namespace Orly {
           : public TArena::TPin, public State::TBlob::TPin {
         public:
 
-        /* TODO */
         TPin(TArena *arena, TOffset offset, size_t min_size)
             : TArena::TPin(arena, offset, sizeof(Atom::TCore::TNote) + min_size), State::TBlob::TPin(GetNote()->GetStart<TVal>(), GetNote()->GetLimit<TVal>()) {
           size_t size = GetLimit() - GetStart();
@@ -1747,7 +1718,6 @@ namespace Orly {
           #endif
         }
 
-        /* TODO */
         TPin(const uint8_t *start, const uint8_t *limit)
             : TArena::TPin(), State::TBlob::TPin(start, limit) {}
 
@@ -1807,7 +1777,6 @@ namespace Orly {
           : public TArena::TPin, public State::TStr::TPin {
         public:
 
-        /* TODO */
         TPin(TArena *arena, TOffset offset, size_t min_size)
             : TArena::TPin(arena, offset, sizeof(Atom::TCore::TNote) + min_size + 1/* add 1 for null term*/), State::TStr::TPin(GetNote()->GetStart<TVal>(), GetNote()->GetLimit<TVal>() - 1) {
           #ifndef NDEBUG
@@ -1818,7 +1787,6 @@ namespace Orly {
           #endif
         }
 
-        /* TODO */
         TPin(const char *start, const char *limit)
             : TArena::TPin(), State::TStr::TPin(start, limit) {}
 
@@ -1851,7 +1819,6 @@ namespace Orly {
       TArrayOfTypes(TArena *arena, const TCore *core)
           : Arena(arena), Core(core) {}
 
-      /* TODO */
       void PostCtor() {
         #ifndef NDEBUG
         if (Core->IndirectCoreArray.ElemCount < 1) {
@@ -1881,7 +1848,6 @@ namespace Orly {
           : public TArena::TPin, public TBase::TPin {
         public:
 
-        /* TODO */
         TPin(const TArrayOfTypes *owner)
             : TArena::TPin(owner->Arena, owner->Core->IndirectCoreArray.Offset, owner->GetComputedSize()),
               TBase::TPin(), Owner(owner) {
@@ -1897,15 +1863,12 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         virtual Type::TAny *NewElem(void *type_alloc) const override {
           return Cores[0].GetType(Owner->Arena, type_alloc);
         }
 
-        /* TODO */
         const TArrayOfTypes *Owner;
 
-        /* TODO */
         const TCore *Cores;
 
       };  // TCore::ST::TArrayOfTypes::TPin
@@ -1958,7 +1921,6 @@ namespace Orly {
       TArrayOfStates(TArena *arena, const TCore *core)
           : Arena(arena), Core(core) {}
 
-      /* TODO */
       void PostCtor() {
         #ifndef NDEBUG
         if (Core->IndirectCoreArray.ElemCount < 1) {
@@ -1988,7 +1950,6 @@ namespace Orly {
           : public TArena::TPin, public TBase::TPin {
         public:
 
-        /* TODO */
         TPin(const TArrayOfStates *owner)
             : TArena::TPin(owner->Arena, owner->Core->IndirectCoreArray.Offset, owner->GetComputedSize()),
               TBase::TPin(owner), Owner(owner) {
@@ -2004,15 +1965,12 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         virtual State::TAny *NewElemInRange(size_t elem_idx, void *state_alloc) const override {
           return Cores[elem_idx].NewState(Owner->Arena, state_alloc);
         }
 
-        /* TODO */
         const TArrayOfStates *Owner;
 
-        /* TODO */
         const TCore *Cores;
 
       };  // TCore::SS::TArrayOfStates::TPin
@@ -2107,7 +2065,6 @@ namespace Orly {
       TArrayOfPairsOfTypes(TArena *arena, const TCore *core)
           : Arena(arena), Core(core) {}
 
-      /* TODO */
       void PostCtor() {
         #ifndef NDEBUG
         if (Core->IndirectCoreArray.ElemCount < 1) {
@@ -2137,7 +2094,6 @@ namespace Orly {
           : public TArena::TPin, public TBase::TPin {
         public:
 
-        /* TODO */
         TPin(const TArrayOfPairsOfTypes *owner)
             : TArena::TPin(owner->Arena, owner->Core->IndirectCoreArray.Offset, owner->GetComputedSize()),
               TBase::TPin(), Owner(owner) {
@@ -2153,20 +2109,16 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         virtual Type::TAny *NewLhs(void *type_alloc) const override {
           return PairsOfCores[0].first.GetType(Owner->Arena, type_alloc);
         }
 
-        /* TODO */
         virtual Type::TAny *NewRhs(void *type_alloc) const override {
           return PairsOfCores[0].second.GetType(Owner->Arena, type_alloc);
         }
 
-        /* TODO */
         const TArrayOfPairsOfTypes *Owner;
 
-        /* TODO */
         const TNote::TPairOfCores *PairsOfCores;
 
       };  // TCore::ST::TArrayOfPairsOfTypes::TPin
@@ -2215,7 +2167,6 @@ namespace Orly {
       TArrayOfPairsOfStates(TArena *arena, const TCore *core)
           : Arena(arena), Core(core) {}
 
-      /* TODO */
       void PostCtor() {
         #ifndef NDEBUG
         if (Core->IndirectCoreArray.ElemCount < 1) {
@@ -2245,7 +2196,6 @@ namespace Orly {
           : public TArena::TPin, public TBase::TPin {
         public:
 
-        /* TODO */
         TPin(const TArrayOfPairsOfStates *owner)
             : TArena::TPin(owner->Arena, owner->Core->IndirectCoreArray.Offset, owner->GetComputedSize()),
               TBase::TPin(owner), Owner(owner) {
@@ -2261,20 +2211,16 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         virtual State::TAny *NewLhsInRange(size_t elem_idx, void *state_alloc) const override {
           return PairsOfCores[elem_idx].first.NewState(Owner->Arena, state_alloc);
         }
 
-        /* TODO */
         virtual State::TAny *NewRhsInRange(size_t elem_idx, void *state_alloc) const override {
           return PairsOfCores[elem_idx].second.NewState(Owner->Arena, state_alloc);
         }
 
-        /* TODO */
         const TArrayOfPairsOfStates *Owner;
 
-        /* TODO */
         const TNote::TPairOfCores *PairsOfCores;
 
       };  // TCore::SS::TArrayOfPairsOfStates::TPin
@@ -2351,7 +2297,6 @@ namespace Orly {
             public Type::TRecord::TPin {
         public:
 
-        /* TODO */
         TPin(const TRecord *owner)
             : TArena::TPin(owner->Arena, owner->Core->IndirectCoreArray.Offset, owner->GetComputedSize()),
               Type::TRecord::TPin(owner),
@@ -2366,29 +2311,24 @@ namespace Orly {
           #endif
         }
 
-        /* TODO */
         virtual Type::TAny *NewElem(size_t elem_idx, std::string &field_name, void *type_alloc) const override {
           PairsOfCores[elem_idx].first.CopyOut(Owner->Arena, field_name);
           return PairsOfCores[elem_idx].second.GetType(Owner->Arena, type_alloc);
         }
 
-        /* TODO */
         virtual TAny *NewElem(size_t elem_idx, void *&out_field_name_state, void *field_name_state_alloc, void *type_alloc) const override {
           out_field_name_state = PairsOfCores[elem_idx].first.NewState(Owner->Arena, field_name_state_alloc);
           return PairsOfCores[elem_idx].second.GetType(Owner->Arena, type_alloc);
         }
 
-        /* TODO */
         virtual Type::TAny *NewElem(size_t elem_idx, void *type_alloc) const override {
           return PairsOfCores[elem_idx].second.GetType(Owner->Arena, type_alloc);
         }
 
         private:
 
-        /* TODO */
         const TRecord *Owner;
 
-        /* TODO */
         const TNote::TPairOfCores *PairsOfCores;
 
       };  // TCore::ST::TRecord::TPin
@@ -2437,7 +2377,6 @@ namespace Orly {
         return new (alloc) TPin(this);
       }
 
-      /* TODO */
       virtual size_t GetElemCount() const override {
         return Core->IndirectCoreArray.ElemCount;
       }
@@ -2455,7 +2394,6 @@ namespace Orly {
             public State::TRecord::TPin {
         public:
 
-        /* TODO */
         TPin(const TRecord *owner)
             : TArena::TPin(owner->Arena, owner->Core->IndirectCoreArray.Offset, owner->GetComputedSize()),
               State::TRecord::TPin(owner),
@@ -2472,15 +2410,12 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         virtual State::TAny *NewElemInRange(size_t elem_idx, void *state_alloc) const override {
           return PairsOfCores[elem_idx].second.NewState(Owner->Arena, state_alloc);
         }
 
-        /* TODO */
         const TRecord *Owner;
 
-        /* TODO */
         const TNote::TPairOfCores *PairsOfCores;
 
       };  // TCore::SS::TRecord::TPin
@@ -2536,7 +2471,6 @@ namespace Orly {
             public Type::TTuple::TPin {
         public:
 
-        /* TODO */
         TPin(const TTuple *owner)
             : TArena::TPin(owner->Arena,
                            owner->Core->IndirectCoreArray.Offset,
@@ -2555,15 +2489,12 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         virtual Type::TAny *NewElem(size_t elem_idx, void *type_alloc) const override {
           return Cores[elem_idx].GetType(Owner->Arena, type_alloc);
         }
 
-        /* TODO */
         const TTuple *Owner;
 
-        /* TODO */
         const TCore *Cores;
 
       };  // TCore::ST::TTuple::TPin
@@ -2611,7 +2542,6 @@ namespace Orly {
         return new (alloc) TPin(this);
       }
 
-      /* TODO */
       virtual size_t GetElemCount() const override {
         return Core->IndirectCoreArray.ElemCount;
       }
@@ -2624,7 +2554,6 @@ namespace Orly {
             public State::TTuple::TPin {
         public:
 
-        /* TODO */
         TPin(const TTuple *owner)
             : TArena::TPin(owner->Arena,
                            owner->Core->IndirectCoreArray.Offset,
@@ -2643,15 +2572,12 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         virtual State::TAny *NewElemInRange(size_t elem_idx, void *state_alloc) const override {
           return Cores[elem_idx].NewState(Owner->Arena, state_alloc);
         }
 
-        /* TODO */
         const TTuple *Owner;
 
-        /* TODO */
         const TCore *Cores;
 
       };  // TCore::SS::TTuple::TPin

--- a/orly/atom/note_interner2.h
+++ b/orly/atom/note_interner2.h
@@ -35,7 +35,6 @@ namespace Orly {
       NO_COPY(TNoteInterner);
       public:
 
-      /* TODO */
       typedef std::unordered_set<const TCore::TNote *, TCore::TNote::THash, TCore::TNote::TIsEq> TNotes;
 
       /* Do-little. */
@@ -44,7 +43,6 @@ namespace Orly {
       /* Delete the notes when we go. */
       ~TNoteInterner();
 
-      /* TODO */
       inline const TNotes &GetNotes() const;
 
       /* The number of notes interned. */

--- a/orly/atom/suprena.h
+++ b/orly/atom/suprena.h
@@ -44,7 +44,6 @@ namespace Orly {
       /* The number of notes we contain. */
       inline size_t GetSize() const;
 
-      /* TODO */
       inline const TNoteInterner::TNotes &GetNotes() const;
 
       /* See base class. */

--- a/orly/atom/transport_arena2.h
+++ b/orly/atom/transport_arena2.h
@@ -35,7 +35,6 @@ namespace Orly {
 
   namespace Atom {
 
-    /* TODO */
     class TTransportArena final
         : public TCore::TArena {
       NO_COPY(TTransportArena);

--- a/orly/balancer/balancer.h
+++ b/orly/balancer/balancer.h
@@ -34,7 +34,6 @@ namespace Orly {
 
   namespace Balancer {
 
-    /* TODO */
     class TBalancer {
       NO_COPY(TBalancer);
       public:
@@ -82,12 +81,10 @@ namespace Orly {
 
       };  // TCmd
 
-      /* TODO */
       virtual ~TBalancer();
 
       protected:
 
-      /* TODO */
       TBalancer(Base::TScheduler *scheduler, const TCmd &cmd);
 
       /* Accepts connections from clients on our main socket.  Launched as a thread by the constructor. */
@@ -96,10 +93,8 @@ namespace Orly {
       /* Serves a client on the given fd.  Launched as a thread by AcceptClientConnections() when a client connects. */
       void ServeClient(Base::TFd &fd, const Socket::TAddress &client_address);
 
-      /* TODO */
       virtual const Socket::TAddress &ChooseHost() = 0;
 
-      /* TODO */
       virtual void OnError(const std::exception &ex) = 0;
 
       private:

--- a/orly/balancer/failover_test_balancer.h
+++ b/orly/balancer/failover_test_balancer.h
@@ -31,50 +31,38 @@ namespace Orly {
 
   namespace Balancer {
 
-    /* TODO */
     class TFailoverTestBalancer
         : public TBalancer {
       NO_COPY(TFailoverTestBalancer);
       public:
 
-      /* TODO */
       TFailoverTestBalancer(Base::TScheduler *scheduler,
                             const TBalancer::TCmd &cmd,
                             std::chrono::milliseconds interval);
 
-      /* TODO */
       virtual ~TFailoverTestBalancer();
 
-      /* TODO */
       virtual const Socket::TAddress &ChooseHost();
 
-      /* TODO */
       void RegisterHost(const Socket::TAddress &addr);
 
       private:
 
-      /* TODO */
       void CheckHosts();
 
-      /* TODO */
       bool CheckHost(const Socket::TAddress &addr) const;
 
-      /* TODO */
       virtual void OnError(const std::exception &ex);
 
-      /* TODO */
       std::unordered_set<Socket::TAddress> HostSet;
       std::optional<Socket::TAddress> MasterHost;
       std::mutex HostMutex;
       std::condition_variable HostCond;
 
-      /* TODO */
       std::chrono::milliseconds Interval;
 
-      /* TODO */
       bool Running;
 
-      /* TODO */
       Base::TEventSemaphore ErrorSem;
 
     };  // TFailoverTestBalancer

--- a/orly/client/client.h
+++ b/orly/client/client.h
@@ -46,134 +46,99 @@ namespace Orly {
       NO_COPY(TClient);
       public:
 
-      /* TODO */
       virtual ~TClient();
 
-      /* TODO */
       std::shared_ptr<Rpc::TFuture<std::string>> Echo(const std::string &msg);
 
-      /* TODO */
       std::shared_ptr<Rpc::TFuture<void>> InstallPackage(const std::vector<std::string> &package_name, uint64_t version);
 
-      /* TODO */
       std::shared_ptr<Rpc::TFuture<void>> UnInstallPackage(const std::vector<std::string> &package_name, uint64_t version);
 
-      /* TODO */
       std::shared_ptr<Rpc::TFuture<Base::TUuid>> NewFastPrivatePov(const std::optional<Base::TUuid> &parent_pov_id,
                                                                    const std::chrono::seconds &ttl = std::chrono::seconds(600));
 
-      /* TODO */
       std::shared_ptr<Rpc::TFuture<Base::TUuid>> NewSafePrivatePov(const std::optional<Base::TUuid> &parent_pov_id,
                                                                    const std::chrono::seconds &ttl = std::chrono::seconds(600));
 
-      /* TODO */
       std::shared_ptr<Rpc::TFuture<Base::TUuid>> NewFastSharedPov(const std::optional<Base::TUuid> &parent_pov_id,
                                                                   const std::chrono::seconds &ttl = std::chrono::seconds(600));
 
-      /* TODO */
       std::shared_ptr<Rpc::TFuture<Base::TUuid>> NewSafeSharedPov(const std::optional<Base::TUuid> &parent_pov_id,
                                                                   const std::chrono::seconds &ttl = std::chrono::seconds(600));
 
-      /* TODO */
       std::shared_ptr<Rpc::TFuture<void>> PausePov(const Base::TUuid &pov_id);
 
-      /* TODO */
       std::shared_ptr<Rpc::TFuture<void>> UnpausePov(const Base::TUuid &pov_id);
 
-      /* TODO */
       std::shared_ptr<Rpc::TFuture<void>> SetUserId(const Base::TUuid &user_id);
 
-      /* TODO */
       std::shared_ptr<Rpc::TFuture<void>> SetTimeToLive(const Base::TUuid &durable_id, const std::chrono::seconds &time_to_live);
 
-      /* TODO */
       std::shared_ptr<Rpc::TFuture<TMethodResult>> Try(const Base::TUuid &pov_id, const std::vector<std::string> &fq_name, const TClosure &closure);
 
-      /* TODO */
       std::shared_ptr<Rpc::TFuture<void>> BeginImport();
 
-      /* TODO */
       std::shared_ptr<Rpc::TFuture<void>> EndImport();
 
-      /* TODO */
       std::shared_ptr<Rpc::TFuture<void>> TailGlobalPov();
 
-      /* TODO */
       std::shared_ptr<Rpc::TFuture<std::string>> ImportCoreVector(const std::string &file_pattern, const std::string &pkg_name, int64_t num_load_threads, int64_t num_merge_threads, int64_t merge_simultaneous);
 
-      /* TODO */
       const std::optional<Base::TUuid> &GetSessionId() const {
         return SessionId;
       }
 
-      /* TODO */
       const std::chrono::seconds &GetTimeToLive() const {
         return TimeToLive;
       }
 
       protected:
 
-      /* TODO */
       TClient(const Socket::TAddress &server_address, const std::optional<Base::TUuid> &session_id, const std::chrono::seconds &time_to_live);
 
-      /* TODO */
       virtual void OnPovFailed(const Base::TUuid &repo_id) = 0;
 
-      /* TODO */
       virtual void OnUpdateAccepted(const Base::TUuid &repo_id, const Base::TUuid &tracking_id) = 0;
 
-      /* TODO */
       virtual void OnUpdateReplicated(const Base::TUuid &repo_id, const Base::TUuid &tracking_id) = 0;
 
-      /* TODO */
       virtual void OnUpdateDurable(const Base::TUuid &repo_id, const Base::TUuid &tracking_id) = 0;
 
-      /* TODO */
       virtual void OnUpdateSemiDurable(const Base::TUuid &repo_id, const Base::TUuid &tracking_id) = 0;
 
       private:
 
-      /* TODO */
       class TProtocol
           : public Rpc::TProtocol {
         NO_COPY(TProtocol);
         public:
 
-        /* TODO */
         static const TProtocol Protocol;
 
         private:
 
-        /* TODO */
         TProtocol();
 
       };  // TClient::TProtocol
 
-      /* TODO */
       void DispatchMain();
 
       /* Handles background I/O with the server. */
       void IoMain();
 
-      /* TODO */
       Socket::TAddress ServerAddress;
 
-      /* TODO */
       std::optional<Base::TUuid> SessionId;
 
-      /* TODO */
       std::chrono::seconds TimeToLive;
 
-      /* TODO */
       std::shared_ptr<Io::TDevice> Device;
 
-      /* TODO */
       Base::TFd InternalSocket;
 
       /* Runs IoMain(). */
       std::thread DispatchThread, IoThread;
 
-      /* TODO */
       Base::TEventSemaphore Destructing;
 
     };  // TClient

--- a/orly/client/program/parse_image.h
+++ b/orly/client/program/parse_image.h
@@ -32,19 +32,14 @@ namespace Orly {
 
     namespace Program {
 
-      /* TODO */
       using TForXact = std::function<bool (const TXact *)>;
 
-      /* TODO */
       using TForKv = std::function<bool (const Sabot::State::TAny *lhs, const Sabot::State::TAny *rhs)>;
 
-      /* TODO */
       bool ParseImageFile(const char *path, const TForXact &cb);
 
-      /* TODO */
       bool ParseImageStr(const char *str, const TForXact &cb);
 
-      /* TODO */
       bool TranslateXact(const TXact *xact, const TForKv &cb);
 
     }  // Program

--- a/orly/client/program/parse_stmt.h
+++ b/orly/client/program/parse_stmt.h
@@ -29,13 +29,10 @@ namespace Orly {
 
     namespace Program {
 
-      /* TODO */
       using TForStmt = std::function<void (const TStmt *)>;
 
-      /* TODO */
       void ParseStmtFile(const char *path, const TForStmt &cb);
 
-      /* TODO */
       void ParseStmtStr(const char *str, const TForStmt &cb);
 
     }  // Program

--- a/orly/client/program/throw_syntax_errors.h
+++ b/orly/client/program/throw_syntax_errors.h
@@ -29,7 +29,6 @@ namespace Orly {
 
     namespace Program {
 
-      /* TODO */
       void ThrowSyntaxErrors(const Tools::Nycr::TContext &ctx);
 
     }  // Program

--- a/orly/client/program/translate_expr.h
+++ b/orly/client/program/translate_expr.h
@@ -46,53 +46,42 @@ namespace Orly {
       /* Convert a Name List expression into a vector of string. */
       void TranslatePathName(std::vector<std::string> &path_name, const TNameList *expr);
 
-      /* TODO */
       Sabot::Type::TAny *NewTypeSabot(const TType *type, void *alloc);
 
-      /* TODO */
       Sabot::Type::TAny *NewTypeSabot(const TExpr *expr, void *alloc);
 
-      /* TODO */
       Sabot::State::TAny *NewStateSabot(const TExpr *expr, void *alloc);
 
-      /* TODO */
       Atom::TCore *TranslateExpr(Atom::TCore::TExtensibleArena *arena, void *core_alloc, const TExpr *expr);
 
       namespace Type {
 
-        /* TODO */
         template <typename TBase>
         class TUnaryExpr final
             : public TBase {
           public:
 
-          /* TODO */
           using TBasePin = typename TBase::TPin;
 
-          /* TODO */
           class TPin final
               : public TBasePin {
             public:
 
-            /* TODO */
             TPin(const TUnaryExpr *unary)
                 : UnaryExpr(unary) {
               assert(unary);
             }
 
-            /* TODO */
             virtual Sabot::Type::TAny *NewElem(void *type_alloc) const override {
               return NewTypeSabot(UnaryExpr->Expr, type_alloc);
             }
 
             private:
 
-            /* TODO */
             const TUnaryExpr *UnaryExpr;
 
           };  // TUnaryExpr<TCst, TBase>::TPin
 
-          /* TODO */
           TUnaryExpr(const TExpr *expr)
               : Expr(expr) {
             assert(expr);
@@ -105,44 +94,36 @@ namespace Orly {
 
           private:
 
-          /* TODO */
           const TExpr *Expr;
 
         };  // Type::TUnaryExpr<TBase>
 
-        /* TODO */
         template <typename TBase>
         class TUnaryType final
             : public TBase {
           public:
 
-          /* TODO */
           using TBasePin = typename TBase::TPin;
 
-          /* TODO */
           class TPin final
               : public TBasePin {
             public:
 
-            /* TODO */
             TPin(const TUnaryType *unary)
                 : UnaryType(unary) {
               assert(unary);
             }
 
-            /* TODO */
             virtual Sabot::Type::TAny *NewElem(void *type_alloc) const override {
               return NewTypeSabot(UnaryType->Type, type_alloc);
             }
 
             private:
 
-            /* TODO */
             const TUnaryType *UnaryType;
 
           };  // TUnaryType<TCst, TBase>::TPin
 
-          /* TODO */
           TUnaryType(const TType *type)
               : Type(type) {
             assert(type);
@@ -155,49 +136,40 @@ namespace Orly {
 
           private:
 
-          /* TODO */
           const TType *Type;
 
         };  // Type::TUnaryType<TBase>
 
-        /* TODO */
         template <typename TBase>
         class TBinaryExpr final
             : public TBase {
           public:
 
-          /* TODO */
           using TBasePin = typename TBase::TPin;
 
-          /* TODO */
           class TPin final
               : public TBasePin {
             public:
 
-            /* TODO */
             TPin(const TBinaryExpr *binary)
                 : BinaryExpr(binary) {
               assert(binary);
             }
 
-            /* TODO */
             virtual Sabot::Type::TAny *NewLhs(void *type_alloc) const override {
               return NewTypeSabot(BinaryExpr->Lhs, type_alloc);
             }
 
-            /* TODO */
             virtual Sabot::Type::TAny *NewRhs(void *type_alloc) const override {
               return NewTypeSabot(BinaryExpr->Rhs, type_alloc);
             }
 
             private:
 
-            /* TODO */
             const TBinaryExpr *BinaryExpr;
 
           };  // TBinaryExpr<TCst, TBase>::TPin
 
-          /* TODO */
           TBinaryExpr(const TExpr *lhs, const TExpr *rhs)
               : Lhs(lhs), Rhs(rhs) {
             assert(lhs);
@@ -211,49 +183,40 @@ namespace Orly {
 
           private:
 
-          /* TODO */
           const TExpr *Lhs, *Rhs;
 
         };  // Type::TBinaryExpr<TBase>
 
-        /* TODO */
         template <typename TBase>
         class TBinaryType final
             : public TBase {
           public:
 
-          /* TODO */
           using TBasePin = typename TBase::TPin;
 
-          /* TODO */
           class TPin final
               : public TBasePin {
             public:
 
-            /* TODO */
             TPin(const TBinaryType *binary)
                 : BinaryType(binary) {
               assert(binary);
             }
 
-            /* TODO */
             virtual Sabot::Type::TAny *NewLhs(void *type_alloc) const override {
               return NewTypeSabot(BinaryType->Lhs, type_alloc);
             }
 
-            /* TODO */
             virtual Sabot::Type::TAny *NewRhs(void *type_alloc) const override {
               return NewTypeSabot(BinaryType->Rhs, type_alloc);
             }
 
             private:
 
-            /* TODO */
             const TBinaryType *BinaryType;
 
           };  // TBinaryType<TCst, TBase>::TPin
 
-          /* TODO */
           TBinaryType(const TType *lhs, const TType *rhs)
               : Lhs(lhs), Rhs(rhs) {
             assert(lhs);
@@ -267,189 +230,144 @@ namespace Orly {
 
           private:
 
-          /* TODO */
           const TType *Lhs, *Rhs;
 
         };  // Type::TBinaryType<TBase>
 
-        /* TODO */
         class TRecordType final
             : public Sabot::Type::TRecord {
           public:
 
-          /* TODO */
           using TPinBase = Sabot::Type::TRecord::TPin;
 
-          /* TODO */
           class TPin final
               : public TPinBase {
             public:
 
-            /* TODO */
             TPin(const TRecordType *record_type);
 
-            /* TODO */
             virtual Sabot::Type::TAny *NewElem(size_t elem_idx, std::string &name, void *type_alloc) const override;
 
-            /* TODO */
             virtual Sabot::Type::TAny *NewElem(
                 size_t elem_idx, void *&out_field_name_sabot_state, void *field_name_state_alloc, void *type_alloc) const override;
 
-            /* TODO */
             virtual Sabot::Type::TAny *NewElem(size_t elem_idx, void *type_alloc) const override;
 
             private:
 
-            /* TODO */
             const TRecordType *RecordType;
 
           };  // TRecordType::TPin
 
-          /* TODO */
           TRecordType(const TObjType *type);
 
-          /* TODO */
           virtual size_t GetElemCount() const override;
 
-          /* TODO */
           virtual TPinBase *Pin(void *alloc) const override;
 
           private:
 
-          /* TODO */
           std::vector<const TObjTypeMember *> Members;
 
         };  // Type::TRecordType
 
-        /* TODO */
         class TRecordExpr final
             : public Sabot::Type::TRecord {
           public:
 
-          /* TODO */
           using TPinBase = Sabot::Type::TRecord::TPin;
 
-          /* TODO */
           class TPin final
               : public TPinBase {
             public:
 
-            /* TODO */
             TPin(const TRecordExpr *record_expr);
 
-            /* TODO */
             virtual Sabot::Type::TAny *NewElem(size_t elem_idx, std::string &name, void *type_alloc) const override;
 
-            /* TODO */
             virtual Sabot::Type::TAny *NewElem(
                 size_t elem_idx, void *&out_field_name_sabot_state, void *field_name_state_alloc, void *type_alloc) const override;
 
-            /* TODO */
             virtual Sabot::Type::TAny *NewElem(size_t elem_idx, void *type_alloc) const override;
 
             private:
 
-            /* TODO */
             const TRecordExpr *RecordExpr;
 
           };  // TRecordExpr::TPin
 
-          /* TODO */
           TRecordExpr(const TObjExpr *expr);
 
-          /* TODO */
           virtual size_t GetElemCount() const override;
 
-          /* TODO */
           virtual TPinBase *Pin(void *alloc) const override;
 
           private:
 
-          /* TODO */
           std::vector<const TObjMember *> Members;
 
         };  // Type::TRecordExpr
 
-        /* TODO */
         class TTupleType final
             : public Sabot::Type::TTuple {
           public:
 
-          /* TODO */
           using TPinBase = Sabot::Type::TTuple::TPin;
 
-          /* TODO */
           class TPin final
               : public TPinBase {
             public:
 
-            /* TODO */
             TPin(const TTupleType *tuple_type);
 
-            /* TODO */
             virtual Sabot::Type::TAny *NewElem(size_t elem_idx, void *type_alloc) const override;
 
             private:
 
-            /* TODO */
             const TTupleType *TupleType;
 
           };  // TTupleType::TPin
 
-          /* TODO */
           TTupleType(const TAddrType *type);
 
-          /* TODO */
           virtual size_t GetElemCount() const override;
 
-          /* TODO */
           virtual TPinBase *Pin(void *alloc) const override;
 
           private:
 
-          /* TODO */
           std::vector<const TAddrTypeMember *> Members;
 
         };  // Type::TTupleType
 
-        /* TODO */
         class TTupleExpr final
             : public Sabot::Type::TTuple {
           public:
 
-          /* TODO */
           using TPinBase = Sabot::Type::TTuple::TPin;
 
-          /* TODO */
           class TPin final
               : public TPinBase {
             public:
 
-            /* TODO */
             TPin(const TTupleExpr *tuple_expr);
 
-            /* TODO */
             virtual Sabot::Type::TAny *NewElem(size_t elem_idx, void *type_alloc) const override;
 
             private:
 
-            /* TODO */
             const TTupleExpr *TupleExpr;
 
           };  // TTupleExpr::TPin
 
-          /* TODO */
           TTupleExpr(const TAddrExpr *expr);
 
-          /* TODO */
           virtual size_t GetElemCount() const override;
 
-          /* TODO */
           virtual TPinBase *Pin(void *alloc) const override;
 
           private:
 
-          /* TODO */
           std::vector<const TAddrMember *> Members;
 
         };  // Type::TTupleExpr
@@ -458,525 +376,394 @@ namespace Orly {
 
       namespace State {
 
-        /* TODO */
         class TBool final
             : public Sabot::State::TBool {
           public:
 
-          /* TODO */
           TBool(const TTrueExpr *);
 
-          /* TODO */
           TBool(const TFalseExpr *);
 
-          /* TODO */
           virtual const bool &Get() const override;
 
-          /* TODO */
           virtual Sabot::Type::TBool *GetBoolType(void *type_alloc) const override;
 
           private:
 
-          /* TODO */
           bool Val;
 
         };  // State::TBool
 
-        /* TODO */
         class TInt final
             : public Sabot::State::TInt64 {
           public:
 
-          /* TODO */
           TInt(const TIntExpr *expr);
 
-          /* TODO */
           virtual const int64_t &Get() const override;
 
-          /* TODO */
           virtual Sabot::Type::TInt64 *GetInt64Type(void *type_alloc) const override;
 
           private:
 
-          /* TODO */
           int64_t Val;
 
         };  // State::TInt
 
-        /* TODO */
         class TReal final
             : public Sabot::State::TDouble {
           public:
 
-          /* TODO */
           TReal(const TRealExpr *expr);
 
-          /* TODO */
           virtual const double &Get() const override;
 
-          /* TODO */
           virtual Sabot::Type::TDouble *GetDoubleType(void *type_alloc) const override;
 
           private:
 
-          /* TODO */
           double Val;
 
         };  // State::TReal
 
-        /* TODO */
         class TId final
             : public Sabot::State::TUuid {
           public:
 
-          /* TODO */
           TId(const TIdExpr *expr);
 
-          /* TODO */
           virtual const Base::TUuid &Get() const override;
 
-          /* TODO */
           virtual Sabot::Type::TUuid *GetUuidType(void *type_alloc) const override;
 
           private:
 
-          /* TODO */
           Base::TUuid Val;
 
         };  // State::TId
 
-        /* TODO */
         class TTimePnt final
             : public Sabot::State::TTimePoint {
           public:
 
-          /* TODO */
           TTimePnt(const TTimePntExpr *expr);
 
-          /* TODO */
           virtual const Sabot::TStdTimePoint &Get() const override;
 
-          /* TODO */
           virtual Sabot::Type::TTimePoint *GetTimePointType(void *type_alloc) const override;
 
           private:
 
-          /* TODO */
           Sabot::TStdTimePoint Val;
 
         };  // State::TTimePnt
 
-        /* TODO */
         class TTimeDiff final
             : public Sabot::State::TDuration {
           public:
 
-          /* TODO */
           TTimeDiff(const TTimeDiffExpr *expr);
 
-          /* TODO */
           virtual const Sabot::TStdDuration &Get() const override;
 
-          /* TODO */
           virtual Sabot::Type::TDuration *GetDurationType(void *type_alloc) const override;
 
           private:
 
-          /* TODO */
           Sabot::TStdDuration Val;
 
         };  // State::TTimeDiff
 
-        /* TODO */
         class TStr final
             : public Sabot::State::TStr {
           public:
 
-          /* TODO */
           using TPinBase = Sabot::State::TStr::TPin;
 
-          /* TODO */
           class TPin final
               : public TPinBase {
             public:
 
-            /* TODO */
             TPin(const TStr *str);
 
           };  // TStr::TPin
 
-          /* TODO */
           TStr(const TSingleQuotedStrExpr *expr);
 
-          /* TODO */
           TStr(const TDoubleQuotedStrExpr *expr);
 
-          /* TODO */
           TStr(const TSingleQuotedRawStrExpr *expr);
 
-          /* TODO */
           TStr(const TDoubleQuotedRawStrExpr *expr);
 
-          /* TODO */
           virtual size_t GetSize() const override;
 
-          /* TODO */
           virtual Sabot::Type::TStr *GetStrType(void *type_alloc) const override;
 
-          /* TODO */
           virtual TPinBase *Pin(void *alloc) const override;
 
           private:
 
-          /* TODO */
           std::string Val;
 
         };  // State::TStr
 
-        /* TODO */
         class TOpt final
             : public Sabot::State::TOpt {
           public:
 
-          /* TODO */
           using TPinBase = Sabot::State::TOpt::TPin;
 
-          /* TODO */
           class TPin final
               : public TPinBase {
             public:
 
-            /* TODO */
             TPin(const TOpt *opt);
 
             private:
 
-            /* TODO */
             virtual Sabot::State::TAny *NewElemInRange(size_t elem_idx, void *state_alloc) const override;
 
-            /* TODO */
             const TExpr *Expr;
 
           };  // TOpt::TPin
 
-          /* TODO */
           TOpt(const TOptExpr *expr);
 
-          /* TODO */
           TOpt(const TUnknownExpr *expr);
 
-          /* TODO */
           virtual size_t GetElemCount() const override;
 
-          /* TODO */
           virtual Sabot::Type::TOpt *GetOptType(void *type_alloc) const override;
 
-          /* TODO */
           virtual TPinBase *Pin(void *alloc) const override;
 
           private:
 
-          /* TODO */
           const TExpr *Expr;
 
-          /* TODO */
           const TType *Type;
 
         };  // State::TOpt
 
-        /* TODO */
         class TDesc final
             : public Sabot::State::TDesc {
           public:
 
-          /* TODO */
           using TPinBase = Sabot::State::TDesc::TPin;
 
-          /* TODO */
           class TPin final
               : public TPinBase {
             public:
 
-            /* TODO */
             TPin(const TDesc *set);
 
             private:
 
-            /* TODO */
             virtual Sabot::State::TAny *NewElemInRange(size_t elem_idx, void *state_alloc) const override;
 
-            /* TODO */
             const TDesc *Desc;
 
           };  // TDesc::TPin
 
-          /* TODO */
           TDesc(const TExpr *expr);
 
-          /* TODO */
           virtual size_t GetElemCount() const override;
 
-          /* TODO */
           virtual Sabot::Type::TDesc *GetDescType(void *type_alloc) const override;
 
-          /* TODO */
           virtual TPinBase *Pin(void *alloc) const override;
 
           private:
 
-          /* TODO */
           const TExpr *Expr;
 
         };  // State::TDesc
 
-        /* TODO */
         class TSet final
             : public Sabot::State::TSet {
           public:
 
-          /* TODO */
           using TPinBase = Sabot::State::TSet::TPin;
 
-          /* TODO */
           class TPin final
               : public TPinBase {
             public:
 
-            /* TODO */
             TPin(const TSet *set);
 
             private:
 
-            /* TODO */
             virtual Sabot::State::TAny *NewElemInRange(size_t elem_idx, void *state_alloc) const override;
 
-            /* TODO */
             const TSet *Set;
 
           };  // TSet::TPin
 
-          /* TODO */
           TSet(const TSetExpr *expr);
 
-          /* TODO */
           TSet(const TSetType *type);
 
-          /* TODO */
           virtual size_t GetElemCount() const override;
 
-          /* TODO */
           virtual Sabot::Type::TSet *GetSetType(void *type_alloc) const override;
 
-          /* TODO */
           virtual TPinBase *Pin(void *alloc) const override;
 
           private:
 
-          /* TODO */
           std::vector<const TExpr *> Members;
 
-          /* TODO */
           const TType *Type;
 
         };  // State::TSet
 
-        /* TODO */
         class TList final
             : public Sabot::State::TVector {
           public:
 
-          /* TODO */
           using TPinBase = Sabot::State::TVector::TPin;
 
-          /* TODO */
           class TPin final
               : public TPinBase {
             public:
 
-            /* TODO */
             TPin(const TList *list);
 
             private:
 
-            /* TODO */
             virtual Sabot::State::TAny *NewElemInRange(size_t elem_idx, void *state_alloc) const override;
 
-            /* TODO */
             const TList *List;
 
           };  // TList::TPin
 
-          /* TODO */
           TList(const TListExpr *expr);
 
-          /* TODO */
           TList(const TListType *type);
 
-          /* TODO */
           virtual size_t GetElemCount() const override;
 
-          /* TODO */
           virtual Sabot::Type::TVector *GetVectorType(void *type_alloc) const override;
 
-          /* TODO */
           virtual TPinBase *Pin(void *alloc) const override;
 
           private:
 
-          /* TODO */
           std::vector<const TExpr *> Members;
 
-          /* TODO */
           const TType *Type;
 
         };  // State::TList
 
-        /* TODO */
         class TDict final
             : public Sabot::State::TMap {
           public:
 
-          /* TODO */
           using TPinBase = Sabot::State::TMap::TPin;
 
-          /* TODO */
           class TPin final
               : public TPinBase {
             public:
 
-            /* TODO */
             TPin(const TDict *list);
 
             private:
 
-            /* TODO */
             virtual Sabot::State::TAny *NewLhsInRange(size_t elem_idx, void *state_alloc) const override;
 
-            /* TODO */
             virtual Sabot::State::TAny *NewRhsInRange(size_t elem_idx, void *state_alloc) const override;
 
-            /* TODO */
             const TDict *Dict;
 
           };  // TDict::TPin
 
-          /* TODO */
           TDict(const TDictExpr *expr);
 
-          /* TODO */
           TDict(const TDictType *type);
 
-          /* TODO */
           virtual size_t GetElemCount() const override;
 
-          /* TODO */
           virtual Sabot::Type::TMap *GetMapType(void *type_alloc) const override;
 
-          /* TODO */
           virtual TPinBase *Pin(void *alloc) const override;
 
           private:
 
-          /* TODO */
           std::vector<const TDictMember *> Members;
 
-          /* TODO */
           const TType *LhsType, *RhsType;
 
         };  // State::TDict
 
-        /* TODO */
         class TObj final
             : public Sabot::State::TRecord {
           public:
 
-          /* TODO */
           using TPinBase = Sabot::State::TRecord::TPin;
 
-          /* TODO */
           class TPin final
               : public TPinBase {
             public:
 
-            /* TODO */
             TPin(const TObj *obj);
 
             private:
 
-            /* TODO */
             virtual Sabot::State::TAny *NewElemInRange(size_t elem_idx, void *state_alloc) const override;
 
-            /* TODO */
             const TObj *Obj;
 
           };  // TObj::TPin
 
-          /* TODO */
           TObj(const TObjExpr *expr);
 
-          /* TODO */
           virtual size_t GetElemCount() const override;
 
-          /* TODO */
           virtual Sabot::Type::TRecord *GetRecordType(void *type_alloc) const override;
 
-          /* TODO */
           virtual TPinBase *Pin(void *alloc) const override;
 
           private:
 
-          /* TODO */
           const TObjExpr *Expr;
 
-          /* TODO */
           std::vector<const TObjMember *> Members;
 
         };  // State::TObj
 
-        /* TODO */
         class TAddr final
             : public Sabot::State::TTuple {
           public:
 
-          /* TODO */
           using TPinBase = Sabot::State::TTuple::TPin;
 
-          /* TODO */
           class TPin final
               : public TPinBase {
             public:
 
-            /* TODO */
             TPin(const TAddr *addr);
 
             private:
 
-            /* TODO */
             virtual Sabot::State::TAny *NewElemInRange(size_t elem_idx, void *state_alloc) const override;
 
-            /* TODO */
             const TAddr *Addr;
 
           };  // TAddr::TPin
 
-          /* TODO */
           TAddr(const TAddrExpr *expr);
 
-          /* TODO */
           virtual size_t GetElemCount() const override;
 
-          /* TODO */
           virtual Sabot::Type::TTuple *GetTupleType(void *type_alloc) const override;
 
-          /* TODO */
           virtual TPinBase *Pin(void *alloc) const override;
 
           private:
 
-          /* TODO */
           const TAddrExpr *Expr;
 
-          /* TODO */
           std::vector<const TAddrMember *> Members;
 
         };  // State::TAddr

--- a/orly/client/repl.h
+++ b/orly/client/repl.h
@@ -49,30 +49,23 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       class TClient final
           : public Client::TClient {
         public:
 
-        /* TODO */
         TClient(const Socket::TAddress &server_address, const std::optional<Base::TUuid> &session_id, const std::chrono::seconds &time_to_live)
             : Client::TClient(server_address, session_id, time_to_live) {}
 
         private:
 
-        /* TODO */
         virtual void OnPovFailed(const Base::TUuid &repo_id) override;
 
-        /* TODO */
         virtual void OnUpdateAccepted(const Base::TUuid &repo_id, const Base::TUuid &tracking_id) override;
 
-        /* TODO */
         virtual void OnUpdateReplicated(const Base::TUuid &repo_id, const Base::TUuid &tracking_id) override;
 
-        /* TODO */
         virtual void OnUpdateDurable(const Base::TUuid &repo_id, const Base::TUuid &tracking_id) override;
 
-        /* TODO */
         virtual void OnUpdateSemiDurable(const Base::TUuid &repo_id, const Base::TUuid &tracking_id) override;
 
       };  // TRepl::TClient

--- a/orly/closure.h
+++ b/orly/closure.h
@@ -36,11 +36,9 @@
 
 namespace Orly {
 
-  /* TODO */
   class TClosure {
     public:
 
-    /* TODO */
     DEFINE_ERROR(TUnknownArgName, std::invalid_argument, "the closure contains no argument by the given name");
 
     /* Convenience. */
@@ -190,27 +188,22 @@ namespace Orly {
 
     };  // TState
 
-    /* TODO */
     TClosure() {
       Reset();
     }
 
-    /* TODO */
     explicit TClosure(const std::string &method_name);
 
-    /* TODO */
     template <typename... TPairs>
     TClosure(const std::string &method_name, const TPairs &... pairs)
         : TClosure(method_name) {
       ArgsAdder<TPairs...>::AddArgs(this, pairs...);
     }
 
-    /* TODO */
     void AddArgBySabot(const std::string &name, const Sabot::State::TAny *state) {
       AddCore(name, Atom::TCore(Arena.get(), state));
     }
 
-    /* TODO */
     template <typename TVal>
     TVal &GetArg(const std::string &name, TVal &out) const {
       void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
@@ -219,42 +212,33 @@ namespace Orly {
       return out;
     }
 
-    /* TODO */
     const std::shared_ptr<Atom::TSuprena> &GetArena() const {
       return Arena;
     }
 
-    /* TODO */
     size_t GetArgCount() const {
       return CoreByName.size();
     }
 
-    /* TODO */
     const TCoreByName &GetCoreByName() const {
       return CoreByName;
     }
 
-    /* TODO */
     const std::string &GetMethodName() const {
       return MethodName;
     }
 
-    /* TODO */
     void Read(Io::TBinaryInputStream &strm);
 
-    /* TODO */
     void Reset();
 
-    /* TODO */
     void Write(Io::TBinaryOutputStream &strm) const;
 
     private:
 
-    /* TODO */
     template <typename... TArgs>
     class ArgsAdder;
 
-    /* TODO */
     template <typename TVal>
     bool AddArg(const std::string &name, const TVal &val) {
       void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
@@ -262,42 +246,32 @@ namespace Orly {
       return AddCore(name, Atom::TCore(Arena.get(), state));
     }
 
-    /* TODO */
     bool AddCore(const std::string &name, const Atom::TCore &core);
 
-    /* TODO */
     const Atom::TCore *GetCore(const std::string &name) const;
 
-    /* TODO */
     const Atom::TCore *TryGetCore(const std::string &name) const;
 
-    /* TODO */
     std::shared_ptr<Atom::TSuprena> Arena;
 
-    /* TODO */
     std::string MethodName;
 
-    /* TODO */
     TCoreByName CoreByName;
 
   };  // TClosure
 
-  /* TODO */
   template <>
   class TClosure::ArgsAdder<> {
     public:
 
-    /* TODO */
     static void AddArgs(TClosure *) {}
 
   };  // TClosure::ArgsAdder<>
 
-  /* TODO */
   template <typename TVal, typename... TMorePairs>
   class TClosure::ArgsAdder<std::string, TVal, TMorePairs...> {
     public:
 
-    /* TODO */
     static void AddArgs(TClosure *closure, const std::string &name, const TVal &val, const TMorePairs &... more_pairs) {
       closure->AddArg(name, val);
       ArgsAdder<TMorePairs...>::AddArgs(closure, more_pairs...);

--- a/orly/code_gen/exists.h
+++ b/orly/code_gen/exists.h
@@ -27,21 +27,17 @@ namespace Orly {
 
   namespace CodeGen {
 
-    /* TODO */
     class TExists : public TInline {
       NO_COPY(TExists);
       public:
 
-      /* TODO */
       typedef std::shared_ptr<const TExists> TPtr;
 
-      /* TODO */
       TExists(const L0::TPackage *package,
               const Type::TType &ret_type,
               const Type::TType &val_type,
               const TInline::TPtr &expr);
 
-      /* TODO */
       void WriteExpr(TCppPrinter &out) const;
 
       /* Dependency graph */
@@ -52,10 +48,8 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       TInline::TPtr Expr;
 
-      /* TODO */
       Type::TType ValType;
 
     }; // TExists

--- a/orly/code_gen/function.h
+++ b/orly/code_gen/function.h
@@ -153,7 +153,6 @@ namespace Orly {
       TCodeScope CodeScope;
       std::unordered_set<std::shared_ptr<TInlineFunc>> ChildFuncs;
 
-      /* TODO */
       const L0::TPackage *Package;
 
       private:

--- a/orly/code_gen/interner.h
+++ b/orly/code_gen/interner.h
@@ -167,7 +167,6 @@ namespace Orly {
         //TODO: The redundant storage of a scope pointer in each holder is less than ideal.
         TStorage() = default;
 
-        /* TODO */
         std::unordered_map<TKey, std::weak_ptr<const TObj>> ObjByKey;
       };
 

--- a/orly/code_gen/package_base.h
+++ b/orly/code_gen/package_base.h
@@ -39,19 +39,15 @@ namespace Orly {
     /* Dependency injection for package to expose enough context to build functions. */
     namespace L0 {
 
-      /* TODO */
       class TPackage {
         NO_COPY(TPackage);
         public:
 
-        /* TODO */
         typedef std::unordered_map<Base::TUuid, std::pair<Orly::Type::TType, Orly::Type::TType>> TAddrMap;
         typedef std::unordered_map<std::pair<Orly::Type::TType, Orly::Type::TType>, Base::TUuid> TRevAddrMap;
 
-        /* TODO */
         virtual ~TPackage() {}
 
-        /* TODO */
         inline const Base::TUuid &GetIndexIdFor(const Type::TType &addr, const Type::TType &val) const {
           auto pos = ReverseAddrMap.find(
               std::make_pair(Type::UnwrapSequence(addr),
@@ -60,17 +56,14 @@ namespace Orly {
           return pos->second;
         }
 
-        /* TODO */
         inline const TAddrMap &GetAddrMap() const {
           return AddrMap;
         }
 
-        /* TODO */
         inline const TRevAddrMap &GetReverseAddrMap() const {
           return ReverseAddrMap;
         }
 
-        /* TODO */
         inline const Package::TName &GetName() const {
           assert(Symbol);
           return Symbol->GetName();
@@ -78,16 +71,12 @@ namespace Orly {
 
         protected:
 
-        /* TODO */
         TPackage(const Symbol::TPackage::TPtr &package) : Symbol(package) {}
 
-        /* TODO */
         Symbol::TPackage::TPtr Symbol;
 
-        /* TODO */
         TAddrMap AddrMap;
 
-        /* TODO */
         TRevAddrMap ReverseAddrMap;
 
       };  // TPackage

--- a/orly/code_gen/while.h
+++ b/orly/code_gen/while.h
@@ -43,7 +43,6 @@ namespace Orly {
 
       void WriteExpr(TCppPrinter &out) const;
 
-      /* TODO */
       virtual void AppendDependsOn(std::unordered_set<TInline::TPtr> &dependency_set) const override {
         dependency_set.insert(Seq);
         Seq->AppendDependsOn(dependency_set);

--- a/orly/context_base.h
+++ b/orly/context_base.h
@@ -29,32 +29,25 @@
 
 namespace Orly {
 
-  /* TODO */
   class TContextBase {
     NO_COPY(TContextBase);
     public:
 
-    /* TODO */
     virtual ~TContextBase() {}
 
-    /* TODO */
     virtual Indy::TKey operator[](const Indy::TIndexKey &key) = 0;
 
-    /* TODO */
     virtual bool Exists(const Indy::TIndexKey &key) = 0;
 
-    /* TODO */
     inline Atom::TCore::TExtensibleArena *GetArena() const {
       return Arena;
     }
 
     protected:
 
-    /* TODO */
     TContextBase(Atom::TCore::TExtensibleArena *arena)
         : Arena(arena) {}
 
-    /* TODO */
     Atom::TCore::TExtensibleArena *Arena;
 
     private:

--- a/orly/core_import.cc
+++ b/orly/core_import.cc
@@ -60,13 +60,10 @@ class TCmd final
 
   string ImportPkg;
 
-  /* TODO */
   int64_t NumLoadThreads = 0;
 
-  /* TODO */
   int64_t NumMergeThreads = 0;
 
-  /* TODO */
   int64_t NumSimMerge = 0;
 
   private:

--- a/orly/data/core_vector_generator.h
+++ b/orly/data/core_vector_generator.h
@@ -36,13 +36,11 @@ namespace Orly {
 
   namespace Data {
 
-    /* TODO */
     template <typename TKey, typename TVal>
     class TCoreVectorGenerator {
       NO_COPY(TCoreVectorGenerator);
       public:
 
-      /* TODO */
       explicit TCoreVectorGenerator(const std::string &file_name = "out", size_t max_kvs_per_file = 50000) : TCoreVectorGenerator(file_name, "", max_kvs_per_file) {}
 
       explicit TCoreVectorGenerator(const std::string &file_name, const std::string &prefix, size_t max_kvs_per_file = 50000)
@@ -56,7 +54,6 @@ namespace Orly {
         InitBuilder();
       }
 
-      /* TODO */
       ~TCoreVectorGenerator() {
         if (Count > 0) {
           Flush();
@@ -76,7 +73,6 @@ namespace Orly {
         return FileNum;
       }
 
-      /* TODO */
       void Push(const TKey &key, const TVal &val) {
         if (unlikely(Finalized)) {
           throw std::runtime_error("Can not Push() after Finalize() has been called");
@@ -95,7 +91,6 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       void Flush() {
         assert(Count > 0);
         std::stringstream ss;
@@ -114,7 +109,6 @@ namespace Orly {
         InitBuilder();
       }
 
-      /* TODO */
       void InitBuilder() {
         Count = 0UL;
         Builder = std::make_unique<Atom::TCoreVectorBuilder>();
@@ -125,21 +119,16 @@ namespace Orly {
 
       bool Finalized;
 
-      /* TODO */
       Base::TUuid IndexId;
 
-      /* TODO */
       int64_t Count;
 
-      /* TODO */
       const std::string Prefix;
       const std::string FileName;
       size_t FileNum;
 
-      /* TODO */
       const int64_t MaxKVPerFile;
 
-      /* TODO */
       std::unique_ptr<Atom::TCoreVectorBuilder> Builder;
 
     };  // TCoreVectorGenerator

--- a/orly/data/twitter_query.cc
+++ b/orly/data/twitter_query.cc
@@ -71,7 +71,6 @@ class TCmd final
    Parse(argc, argv, TMeta());
  }
 
- /* TODO  */
  Socket::TAddress Addr;
 
  private:

--- a/orly/desc.h
+++ b/orly/desc.h
@@ -67,7 +67,6 @@ namespace Orly {
     }
 
     #if 0
-    /* TODO */
     operator const TVal &() const {
       return Val;
     }

--- a/orly/durable/kit.h
+++ b/orly/durable/kit.h
@@ -225,10 +225,8 @@ namespace Orly {
       template <typename TSomeObj>
       TPtr<TSomeObj> Open(const TId &id);
 
-      /* TODO */
       void Clear();
 
-      /* TODO */
       virtual void RunLayerCleaner() = 0;
 
       protected:

--- a/orly/durable/test_manager.h
+++ b/orly/durable/test_manager.h
@@ -27,26 +27,21 @@ namespace Orly {
 
   namespace Durable {
 
-    /* TODO */
     class TTestManager final
         : public TManager {
       public:
 
-      /* TODO */
       TTestManager(size_t max_cache_size)
           : TManager(max_cache_size) {}
 
       private:
 
-      /* TODO */
       virtual bool CanLoad(const TId &id) override {
         return BlobById.find(id) != BlobById.end();
       }
 
-      /* TODO */
       virtual void RunLayerCleaner() override {}
 
-      /* TODO */
       virtual void CleanDisk(const TDeadline &now, TSem *sem) override {
         assert(sem);
         std::unordered_map<TId, std::pair<TDeadline, std::string>> temp;
@@ -59,7 +54,6 @@ namespace Orly {
         sem->Push();
       }
 
-      /* TODO */
       virtual void Delete(const TId &id, TSem *sem) override {
         assert(sem);
         auto erased_count = BlobById.erase(id);
@@ -67,14 +61,12 @@ namespace Orly {
         sem->Push();
       }
 
-      /* TODO */
       virtual void Save(const TId &id, const TDeadline &deadline, const TTtl &/*ttl*/, const std::string &blob, TSem *sem) override {
         assert(sem);
         BlobById[id] = std::make_pair(deadline, blob);
         sem->Push();
       }
 
-      /* TODO */
       virtual bool TryLoad(const TId &id, std::string &blob) override {
         auto iter = BlobById.find(id);
         bool success = (iter != BlobById.end());
@@ -86,7 +78,6 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       std::unordered_map<TId, std::pair<TDeadline, std::string>> BlobById;
 
     };  //TTestManager

--- a/orly/expr/skip.cc
+++ b/orly/expr/skip.cc
@@ -30,11 +30,9 @@ class TSkipTypeVisitor
     : public Type::TType::TDoubleVisitor {
   public:
 
-  /* TODO */
   TSkipTypeVisitor(Type::TType &type, const TPosRange &pos_range)
       : PosRange(pos_range), Type(type) {}
 
-  /* TODO */
   virtual void operator()(const Type::TAddr *, const Type::TAddr *) const { throw TExprError(HERE, PosRange); }
   virtual void operator()(const Type::TAddr *, const Type::TAny *) const { throw TExprError(HERE, PosRange); }
   virtual void operator()(const Type::TAddr *, const Type::TBool *) const { throw TExprError(HERE, PosRange); }
@@ -364,10 +362,8 @@ class TSkipTypeVisitor
 
   private:
 
-  /* TODO */
   const TPosRange &PosRange;
 
-  /* TODO */
   Type::TType &Type;
 
 };  // TSkipTypeVisitor

--- a/orly/expr/take.cc
+++ b/orly/expr/take.cc
@@ -30,11 +30,9 @@ class TTakeTypeVisitor
     : public Type::TType::TDoubleVisitor {
   public:
 
-  /* TODO */
   TTakeTypeVisitor(Type::TType &type, const TPosRange &pos_range)
       : PosRange(pos_range), Type(type) {}
 
-  /* TODO */
   virtual void operator()(const Type::TAddr *, const Type::TAddr *) const { throw TExprError(HERE, PosRange); }
   virtual void operator()(const Type::TAddr *, const Type::TAny *) const { throw TExprError(HERE, PosRange); }
   virtual void operator()(const Type::TAddr *, const Type::TBool *) const { throw TExprError(HERE, PosRange); }
@@ -364,10 +362,8 @@ class TTakeTypeVisitor
 
   private:
 
-  /* TODO */
   const TPosRange &PosRange;
 
-  /* TODO */
   Type::TType &Type;
 
 };  // TTakeTypeVisitor

--- a/orly/indy/context.h
+++ b/orly/indy/context.h
@@ -42,7 +42,6 @@ namespace Orly {
 
   namespace Indy {
 
-    /* TODO */
     class TContext
         : public TContextBase {
       NO_COPY(TContext);
@@ -52,46 +51,35 @@ namespace Orly {
       class TKeyCursor;
       struct TKeyCursorCollector;
 
-      /* TODO */
       typedef InvCon::UnorderedList::TCollection<TKeyCursorCollector, TKeyCursor> TKeyCursorCollection;
 
       private:
 
-      /* TODO */
       typedef std::vector<std::pair<Indy::L0::TManager::TPtr<TRepo>, std::unique_ptr<TRepo::TView>>> TRepoTree;
 
-      /* TODO */
       class TPresentWalker {
         NO_COPY(TPresentWalker);
         public:
 
-        /* TODO */
         using TItem = Orly::Indy::TPresentWalker::TItem;
 
-        /* TODO */
         /* exact_point true => fully-bound point read (operator[]/Exists), so
            layers may seek instead of head-scanning (#257). The TKeyCursor path
            leaves it false because its pattern may be a prefix. */
         TPresentWalker(TContext *context, const TRepoTree &repo_tree, const TIndexKey &key, bool exact_point = false);
 
-        /* TODO */
         TPresentWalker(TContext *context, const TRepoTree &repo_tree, const TIndexKey &from, const TIndexKey &to);
 
-        /* TODO */
         ~TPresentWalker();
 
-        /* TODO */
         inline operator bool() const;
 
-        /* TODO */
         inline const TItem &operator*() const;
 
-        /* TODO */
         inline TPresentWalker &operator++();
 
         private:
 
-        /* TODO */
         void Refresh();
 
         /* Phase 3 of #49: fold consecutive same-mutator commutative
@@ -100,16 +88,12 @@ namespace Orly {
            pre-#49-phase-2 in-tree code ever produced). */
         void ApplyDeferredFold();
 
-        /* TODO */
         std::vector<std::shared_ptr<Indy::TPresentWalker>> WalkerVec;
 
-        /* TODO */
         Util::TMinHeap<Indy::TPresentWalker::TItem, size_t> MinHeap;
 
-        /* TODO */
         bool Valid;
 
-        /* TODO */
         mutable TItem Item;
 
         /* Arena that owns folded Op TCores. Borrowed from the enclosing
@@ -120,124 +104,91 @@ namespace Orly {
 
       public:
 
-      /* TODO */
       class TKeyCursor
           : public Orly::TKeyCursor {
         NO_COPY(TKeyCursor);
         public:
 
-        /* TODO */
         typedef InvCon::UnorderedList::TMembership<TKeyCursor, TKeyCursorCollector> TContextMembership;
 
-        /* TODO */
         TKeyCursor(TContext *context, const Indy::TIndexKey &pattern);
 
-        /* TODO */
         TKeyCursor(TContext *context, const Indy::TIndexKey &from, const Indy::TIndexKey &to);
 
-        /* TODO */
         virtual ~TKeyCursor();
 
-        /* TODO */
         virtual operator bool() const override;
 
-        /* TODO */
         virtual const Indy::TKey &operator*() const override;
 
-        /* TODO */
         virtual const Indy::TKey *operator->() const override;
 
-        /* TODO */
         virtual TKeyCursor &operator++() override;
 
-        /* TODO */
         const TContext::TPresentWalker::TItem &GetVal() const;
 
         private:
 
-        /* TODO */
         void Refresh() const;
 
-        /* TODO */
         Indy::TIndexKey Key;
 
-        /* TODO */
         Indy::TIndexKey To;
 
-        /* TODO */
         mutable bool Valid;
 
-        /* TODO */
         mutable bool Cached;
 
-        /* TODO */
         mutable TPresentWalker Csr;
 
-        /* TODO */
         mutable Indy::TKey Item;
 
-        /* TODO */
         mutable TContextMembership::TImpl ContextMembership;
 
       };  // TKeyCursor
 
-      /* TODO */
       TContext(const Indy::L0::TManager::TPtr<TRepo> &private_repo, Atom::TCore::TExtensibleArena *arena);
 
-      /* TODO */
       virtual ~TContext();
 
-      /* TODO */
       virtual Indy::TKey operator[](const Indy::TIndexKey &key) override;
 
-      /* TODO */
       virtual bool Exists(const Indy::TIndexKey &key) override;
 
-      /* TODO */
       inline size_t GetWalkerCount() const {
         return WalkerCount;
       }
 
-      /* TODO */
       const Base::TTimer &GetPresentWalkConsTimer() const {
         return PresentWalkConsTimer;
       }
 
-      /* TODO */
       struct TKeyCursorCollector {
         NO_COPY(TKeyCursorCollector);
 
-        /* TODO */
         TKeyCursorCollector() : KeyCursorCollection(this) {}
 
-        /* TODO */
         TKeyCursorCollection::TImpl KeyCursorCollection;
 
       };  // TKeyCursorCollector
 
       private:
 
-      /* TODO */
       TRepoTree RepoTree;
 
-      /* TODO */
       size_t WalkerCount;
 
-      /* TODO */
       Base::TTimer PresentWalkConsTimer;
 
-      /* TODO */
       friend class TIndyContext;
 
     };  // TContext
 
-    /* TODO */
     class TIndyContext
           : public Orly::Package::TContext {
       NO_COPY(TIndyContext);
       public:
 
-      /* TODO */
       TIndyContext(
           const Rt::TOpt<Base::TUuid> &user_id,
           const Base::TUuid &session_id,
@@ -248,12 +199,10 @@ namespace Orly {
           Rt::TOpt<uint32_t> seed)
           : Orly::Package::TContext(user_id, session_id, arena, scheduler, now, seed), DataContext(context) {}
 
-      /* TODO */
       virtual Orly::TContextBase &GetFlux() override{
         return DataContext;
       }
 
-      /* TODO */
       virtual TKeyCursor *NewKeyCursor(TContextBase *context, const Indy::TIndexKey &pattern) const override {
         auto data_context = dynamic_cast<Indy::TContext *>(context);
 
@@ -266,7 +215,6 @@ namespace Orly {
         return new Indy::TContext::TKeyCursor(data_context, pattern);
       }
 
-      /* TODO */
       virtual TKeyCursor *NewKeyCursor(TContextBase *context, const Indy::TIndexKey &from, const Indy::TIndexKey &to) const override {
         auto data_context = dynamic_cast<Indy::TContext *>(context);
 
@@ -281,7 +229,6 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       Indy::TContext &DataContext;
 
     };  // TIndyContext

--- a/orly/indy/disk/block_hit_counter.h
+++ b/orly/indy/disk/block_hit_counter.h
@@ -39,12 +39,10 @@ namespace Orly {
 
     namespace Disk {
 
-      /* TODO */
       class TBlockHitCounter {
         NO_COPY(TBlockHitCounter);
         public:
 
-        /* TODO */
         TBlockHitCounter(size_t block_size, size_t num_blocks)
             : BlockSize(block_size),
               NumBlocks(num_blocks),
@@ -54,7 +52,6 @@ namespace Orly {
           FlushBuf = Base::MemAlignedAllocZeroInitialized<uint8_t>(getpagesize(), GetNumBytes());
         }
 
-        /* TODO */
         inline void AddHits(size_t block_num, size_t num_hits) {
           std::lock_guard<std::mutex> lock(CountLock);
           uint8_t *val = WorksetBuf.get() + block_num;
@@ -62,13 +59,11 @@ namespace Orly {
           *val = std::min(std::numeric_limits<uint8_t>::max(), static_cast<uint8_t>(floor(cur)));
         }
 
-        /* TODO */
         inline uint8_t GetNumHits(size_t block_num) const {
           std::lock_guard<std::mutex> lock(CountLock);
           return *(WorksetBuf.get() + block_num);
         }
 
-        /* TODO */
         inline void Reset(size_t block_num) {
           std::lock_guard<std::mutex> lock(CountLock);
           *(WorksetBuf.get() + block_num) = 0;
@@ -76,24 +71,18 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         inline size_t GetNumBytes() const {
           return ceil(static_cast<double>(NumBlocks) / BlockSize) * BlockSize;
         }
 
-        /* TODO */
         const size_t BlockSize;
 
-        /* TODO */
         const size_t NumBlocks;
 
-        /* TODO */
         std::unique_ptr<uint8_t> WorksetBuf;
 
-        /* TODO */
         std::unique_ptr<uint8_t> FlushBuf;
 
-        /* TODO */
         mutable std::mutex CountLock;
 
       };  // TBlockHitCounter

--- a/orly/indy/disk/buf_block.h
+++ b/orly/indy/disk/buf_block.h
@@ -40,17 +40,14 @@ namespace Orly {
 
     namespace Disk {
 
-      /* TODO */
       class TBufBlock {
         NO_COPY(TBufBlock);
         public:
 
-        /* TODO */
         class TPool {
           NO_COPY(TPool);
           public:
 
-          /* TODO */
           TPool(size_t block_size, size_t block_count = 0UL)
               : BlockSize(block_size), Blob(nullptr), FirstBlock(nullptr), NumBlocksUsed(0UL), MaxBlocks(0UL) {
             assert(block_size % getpagesize() == 0);
@@ -59,17 +56,14 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           size_t GetNumBlocksUsed() const {
             return NumBlocksUsed;
           }
 
-          /* TODO */
           size_t GetMaxBlocks() const {
             return MaxBlocks;
           }
 
-          /* TODO */
           void Init(size_t block_count) {
             assert(MaxBlocks == 0UL);
             MaxBlocks = block_count;
@@ -94,7 +88,6 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           void *Alloc() {
             //syslog(LOG_INFO, "BufBlock [%ld] / [%ld]", NumBlocksUsed, MaxBlocks);
             void *ptr = TryAlloc();
@@ -114,7 +107,6 @@ namespace Orly {
             return ptr;
           }
 
-          /* TODO */
           void Free(void *ptr) {
             assert(ptr);
             TBlock *block = static_cast<TBlock *>(ptr);
@@ -126,7 +118,6 @@ namespace Orly {
             Cond.notify_one();
           }
 
-          /* TODO */
           void *TryAlloc() {
             //Base::TSpinLock::TSoftLock lock(SpinLock);
             std::lock_guard<std::mutex> lock(Lock);
@@ -143,62 +134,47 @@ namespace Orly {
 
           private:
 
-          /* TODO */
           struct TBlock {
-            /* TODO */
             TBlock *NextBlock;
 
           };  // TBlock
 
-          /* TODO */
           const size_t BlockSize;
 
-          /* TODO */
           std::unique_ptr<TBlock> Blob;
 
-          /* TODO */
           TBlock *FirstBlock;
 
-          /* TODO */
           //Base::TSpinLock SpinLock;
           std::mutex Lock;
           std::condition_variable Cond;
 
-          /* TODO */
           size_t NumBlocksUsed;
 
-          /* TODO */
           size_t MaxBlocks;
 
         };  // TPool
 
-        /* TODO */
         TBufBlock() {}
 
-        /* TODO */
         ~TBufBlock() {}
 
-        /* TODO */
         static void *operator new(size_t /*size*/) {
           return Pool.Alloc();
         }
 
-        /* TODO */
         static void operator delete(void *ptr) {
           Pool.Free(ptr);
         }
 
-        /* TODO */
         static TPool Pool;
 
-        /* TODO */
         char *GetData() const {
           return &Buf;
         }
 
         private:
 
-        /* TODO */
         mutable char Buf;
 
       };  // TBufBlock

--- a/orly/indy/disk/data_file.cc
+++ b/orly/indy/disk/data_file.cc
@@ -107,26 +107,20 @@ class TIndexFile
 
   };  // TOrderedNote
 
-  /* TODO */
   class THashObj {
     public:
 
-    /* TODO */
     THashObj(const Atom::TCore &core, size_t hash, size_t offset)
         : Core(core), Hash(hash), Offset(offset) {}
 
-    /* TODO */
     bool operator<(const THashObj &that) const {
       return Hash < that.Hash;
     }
 
-    /* TODO */
     Atom::TCore Core;
 
-    /* TODO */
     size_t Hash;
 
-    /* TODO */
     size_t Offset;
 
   };  // THashObj
@@ -335,7 +329,6 @@ class TIndexFile
 
   private:
 
-  /* TODO */
   virtual size_t GetFileLength() const override {
     return FileSize;
     /* we can't do this because we may not have written this far yet. this would cause problems with prefetch or checkbuf()
@@ -354,7 +347,6 @@ class TIndexFile
     throw std::logic_error("TIndexFile::ReadMeta not implemented: TIndexFile is write-only and never read back (the indy L0 reload-from-disk path was never ported, #173).");
   }
 
-  /* TODO */
   virtual size_t FindPageIdOfByte(size_t offset) const override {
     assert(offset <= GetFileLength());
     //return (((*BlockVec)[offset / Disk::Util::LogicalBlockSize]) * Disk::Util::PagesPerBlock) + ((offset % Disk::Util::LogicalBlockSize) / Disk::Util::LogicalPageSize);
@@ -363,7 +355,6 @@ class TIndexFile
 
 };  // TIndexFile
 
-/* TODO */
 size_t MakeArena(Disk::Util::TEngine *engine,
                  Disk::Util::TVolume::TDesc::TStorageSpeed storage_speed,
                  DiskPriority priority,

--- a/orly/indy/disk/data_file.h
+++ b/orly/indy/disk/data_file.h
@@ -34,38 +34,30 @@ namespace Orly {
 
     namespace Disk {
 
-      /* TODO */
         class TRemapObj {
         public:
 
-        /* TODO */
         TRemapObj(Atom::TCore::TArena *arena, Atom::TCore::TOffset old_key, Atom::TCore::TOffset new_key)
             : Arena(arena),
               OldKey(old_key),
               NewKey(new_key) {}
 
-        /* TODO */
         bool operator==(const TRemapObj &that) const {
           return Arena == that.Arena && OldKey == that.OldKey;
         }
 
-        /* TODO */
         bool operator!=(const TRemapObj &that) const {
           return Arena != that.Arena || OldKey != that.OldKey;
         }
 
-        /* TODO */
         size_t GetHash() const {
           return reinterpret_cast<size_t>(Arena) ^ OldKey;
         }
 
-        /* TODO */
         Atom::TCore::TArena *Arena;
 
-        /* TODO */
         Atom::TCore::TOffset OldKey;
 
-        /* TODO */
         Atom::TCore::TOffset NewKey;
 
       };  // TRemapObj
@@ -98,7 +90,6 @@ namespace Orly {
 
     namespace Disk {
 
-      /* TODO */
       class TDataFile {
         NO_COPY(TDataFile);
         public:
@@ -107,11 +98,9 @@ namespace Orly {
         using TDataInStream = TStream<Disk::Util::LogicalBlockSize, Disk::Util::LogicalBlockSize, Disk::Util::PhysicalBlockSize, Disk::Util::PageCheckedBlock, LocalCacheSize>;
         typedef TOutStream<Disk::Util::LogicalPageSize, Disk::Util::LogicalBlockSize, Disk::Util::PhysicalBlockSize, Disk::Util::PageCheckedBlock> TDataOutStream;
 
-        /* TODO */
         class TUpdateObj {
           public:
 
-          /* TODO */
           TUpdateObj(TSequenceNumber seq_num, const Atom::TCore &metadata, const Atom::TCore &id, size_t offset, bool is_current, const Base::TUuid &index_id)
               : SequenceNumber(seq_num),
                 Metadata(metadata),
@@ -120,32 +109,24 @@ namespace Orly {
                 IsCurrent(is_current),
                 IndexId(index_id) {}
 
-          /* TODO */
           bool operator<(const TUpdateObj &that) const {
             return SequenceNumber < that.SequenceNumber;
           }
 
-          /* TODO */
           TSequenceNumber SequenceNumber;
 
-          /* TODO */
           Atom::TCore Metadata;
 
-          /* TODO */
           Atom::TCore Id;
 
-          /* TODO */
           size_t Offset;
 
-          /* TODO */
           bool IsCurrent;
 
-          /* TODO */
           Base::TUuid IndexId;
 
         };  // TUpdateObj
 
-        /* TODO */
         typedef Disk::Util::TIndexManager<TUpdateObj, Util::SortBufSize, Util::SortBufMinParallelSize> TUpdateCollector;
         typedef std::unordered_set<TRemapObj> TRemapIndex;
         typedef Indy::Util::TBlockVec TBlockVec;
@@ -178,7 +159,6 @@ namespace Orly {
         */
         //static const size_t NumMetaFields = 10UL;
 
-        /* TODO */
         TDataFile(Util::TEngine *engine,
                   Disk::Util::TVolume::TDesc::TStorageSpeed storage_speed,
                   TMemoryLayer *memory_layer,
@@ -188,64 +168,48 @@ namespace Orly {
                   TSequenceNumber release_up_to,
                   DiskPriority priority);
 
-        /* TODO */
         inline size_t GetNumKeys() const {
           return NumKeys;
         }
 
-        /* TODO */
         inline TSequenceNumber GetLowestSequence() const {
           return LowestSeq;
         }
 
-        /* TODO */
         inline TSequenceNumber GetHighestSequence() const {
           return HighestSeq;
         }
 
         private:
 
-        /* TODO */
         Util::TEngine *Engine;
 
-        /* TODO */
         Disk::Util::TVolume::TDesc::TStorageSpeed StorageSpeed;
 
-        /* TODO */
         DiskPriority Priority;
 
-        /* TODO */
         size_t NumUpdates;
 
-        /* TODO */
         size_t MainArenaByteOffset;
         TRemapIndex MainArenaRemapIndex;
         TTypeBoundaryOffsetVec MainArenaTypeBoundaryOffsetVec;
 
-        /* TODO */
         size_t NumKeys;
         TSequenceNumber LowestSeq;
         TSequenceNumber HighestSeq;
 
-        /* TODO */
         size_t TempFileConsolThresh;
 
-        /* TODO */
         size_t StartingBlockId;
 
-        /* TODO */
         size_t StartingBlockOffset;
 
-        /* TODO */
         size_t FileLength;
 
-        /* TODO */
         TBlockVec BlockVec;
 
-        /* TODO */
         TUpdateCollector UpdateCollector;
 
-        /* TODO */
         #ifndef NDEBUG
         std::unordered_set<size_t> WrittenBlockSet;
         #endif

--- a/orly/indy/disk/disk_test.h
+++ b/orly/indy/disk/disk_test.h
@@ -101,7 +101,6 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         std::unique_ptr<TArena> Arena;
 
       };  // TReader

--- a/orly/indy/disk/durable_manager.h
+++ b/orly/indy/disk/durable_manager.h
@@ -67,30 +67,23 @@ namespace Orly {
     }
 
 
-    /* TODO */
     namespace DurableManager {
 
-      /* TODO */
       class TManager
           : public Fiber::TRunnable {
         NO_COPY(TManager);
         public:
 
-        /* TODO */
         virtual TDurableReplication *NewDurableReplication(const Durable::TId &id, const Durable::TTtl &ttl, const std::string &serialized_form) const = 0;
 
-        /* TODO */
         virtual void DeleteDurableReplication(TDurableReplication *durable_replication) NO_THROW = 0;
 
-        /* TODO */
         virtual void EnqueueDurable(TDurableReplication *durable_replication) NO_THROW = 0;
 
         protected:
 
-        /* TODO */
         TManager() {}
 
-        /* TODO */
         virtual ~TManager() {}
 
       };  // TManager
@@ -115,7 +108,6 @@ namespace Orly {
         std::chrono::steady_clock::time_point Next;
       };
 
-      /* TODO */
       class TDurableManager
           : public Durable::TManager {
         NO_COPY(TDurableManager);
@@ -124,26 +116,20 @@ namespace Orly {
         /* Forward Declarations. */
         class TDurableLayer;
 
-        /* TODO */
         typedef InvCon::UnorderedList::TCollection<TDurableManager, TDurableLayer> TRemovalCollection;
 
         public:
 
-        /* TODO */
         typedef uint64_t TSequenceNumber;
         typedef uint32_t TSerializedSize;
 
-        /* TODO */
         typedef TStream<Util::LogicalPageSize, Util::LogicalBlockSize, Util::PhysicalBlockSize, Util::CheckedPage, 64UL> TInStream;
         typedef TOutStream<Disk::Util::LogicalPageSize, Disk::Util::LogicalBlockSize, Disk::Util::PhysicalBlockSize, Disk::Util::PageCheckedBlock> TDataOutStream;
 
-        /* TODO */
         enum TOutcome { Survived, Expired, WasSuperceded };
 
-        /* TODO */
         using TNotify = std::function<void (TSequenceNumber, Base::TUuid, TOutcome)>;
 
-        /* TODO */
         TDurableManager(Base::TScheduler *scheduler,
                         Fiber::TRunner::TRunnerCons &runner_cons,
                         Base::TThreadLocalGlobalPoolManager<Indy::Fiber::TFrame, size_t, Indy::Fiber::TRunner *> *frame_pool_manager,
@@ -157,74 +143,56 @@ namespace Orly {
                         bool create,
                         const TNotify *notify = nullptr);
 
-        /* TODO */
         virtual ~TDurableManager();
 
-        /* TODO */
         virtual bool CanLoad(const Durable::TId &id) override;
 
-        /* TODO */
         virtual void CleanDisk(const Durable::TDeadline &now, Durable::TSem *sem) override;
 
-        /* TODO */
         virtual void Delete(const Durable::TId &id, Durable::TSem *sem) override;
 
-        /* TODO */
         virtual void RunLayerCleaner() override;
 
-        /* TODO */
         virtual void Save(const Durable::TId &id, const Durable::TDeadline &deadline, const TTtl &ttl, const std::string &serialized_form, Durable::TSem *sem) override;
 
-        /* TODO */
         virtual bool TryLoad(const Durable::TId &id, std::string &serialized_form_out) override;
 
-        /* TODO */
         void RunWriter();
 
-        /* TODO */
         void RunMerger();
 
-        /* TODO */
         void static InitMappingPool(size_t num_obj) {
           TMapping::Pool.Init(num_obj);
         }
 
-        /* TODO */
         static constexpr size_t GetMappingSize() {
           return sizeof(TMapping);
         }
 
-        /* TODO */
         void static InitMappingEntryPool(size_t num_obj) {
           TMapping::TEntry::Pool.Init(num_obj);
         }
 
-        /* TODO */
         static constexpr size_t GetMappingEntrySize() {
           return sizeof(TMapping::TEntry);
         }
 
-        /* TODO */
         void static InitDurableLayerPool(size_t num_obj) {
           TDurableLayer::Pool.Init(num_obj);
         }
 
-        /* TODO */
         static constexpr size_t GetDurableLayerSize() {
           return sizeof(TDurableLayer);
         }
 
-        /* TODO */
         void static InitMemEntryPool(size_t num_obj) {
           TMemSlushLayer::TDurableEntry::Pool.Init(num_obj);
         }
 
-        /* TODO */
         static constexpr size_t GetMemEntrySize() {
           return sizeof(TMemSlushLayer::TDurableEntry);
         }
 
-        /* TODO */
         static const Base::TUuid DurableByIdFileId;
 
         private:
@@ -233,12 +201,10 @@ namespace Orly {
         class TMemSlushLayer;
         class TMergeSortedByIdFile;
 
-        /* TODO */
         class TSortedByIdFile {
           NO_COPY(TSortedByIdFile);
           public:
 
-          /* TODO */
           TSortedByIdFile(TMemSlushLayer *mem_layer,
                           Util::TEngine *engine,
                           Disk::Util::TVolume::TDesc::TStorageSpeed storage_speed,
@@ -247,7 +213,6 @@ namespace Orly {
                           size_t temp_file_consol_thresh,
                           DiskPriority priority);
 
-          /* TODO */
           inline size_t GetNumDurable() const;
 
           /*
@@ -272,33 +237,26 @@ namespace Orly {
 
           private:
 
-          /* TODO */
           class THashObj {
             public:
 
-            /* TODO */
             THashObj(const uuid_t &id, size_t hash, size_t offset)
                 : Hash(hash), Offset(offset) {
               uuid_copy(Id, id);
             }
 
-            /* TODO */
             bool operator<(const THashObj &that) const {
               return Hash < that.Hash;
             }
 
-            /* TODO */
             uuid_t Id;
 
-            /* TODO */
             size_t Hash;
 
-            /* TODO */
             size_t Offset;
 
           };  // THashObj
 
-          /* TODO */
           typedef Util::TIndexManager<THashObj, Disk::Util::SortBufSize, Disk::Util::SortBufMinParallelSize> THashSorter;
 
           template <typename TOwner>
@@ -307,68 +265,53 @@ namespace Orly {
             NO_COPY(TMyFileTemp);
             public:
 
-            /* TODO */
             TMyFileTemp(TOwner *file) : File(file) {}
 
-            /* TODO */
             virtual ~TMyFileTemp() {}
 
             private:
 
-            /* TODO */
             virtual size_t GetFileLength() const override {
               return File->FileSize;
             }
 
-            /* TODO */
             virtual size_t GetStartingBlock() const override {
               assert(File->BlockVec.Size() > 0);
               return File->BlockVec.Front();
             }
 
-            /* TODO */
             virtual void ReadMeta(size_t , size_t &) const override {
               throw;
             }
 
-            /* TODO */
             virtual size_t FindPageIdOfByte(size_t offset) const override {
               assert(offset <= GetFileLength());
               return ((File->BlockVec[offset / Disk::Util::LogicalBlockSize]) * Disk::Util::PagesPerBlock) + ((offset % Disk::Util::LogicalBlockSize) / Disk::Util::LogicalPageSize);
             }
 
-            /* TODO */
             TOwner *File;
 
           };  // TMyFileTemp
 
-          /* TODO */
           typedef TMyFileTemp<TSortedByIdFile> TMyFile;
 
-          /* TODO */
           Util::TEngine *const Engine;
 
-          /* TODO */
           const Disk::Util::TVolume::TDesc::TStorageSpeed StorageSpeed;
 
-          /* TODO */
           Indy::Util::TBlockVec BlockVec;
           size_t FileSize;
 
-          /* TODO */
           size_t NumDurable;
 
-          /* TODO */
           friend class TMergeSortedByIdFile;
 
         };  // TSortedByIdFile
 
-        /* TODO */
         class TMergeSortedByIdFile {
           NO_COPY(TMergeSortedByIdFile);
           public:
 
-          /* TODO */
           TMergeSortedByIdFile(const std::vector<size_t> &gen_vec,
                                Util::TEngine *engine,
                                Disk::Util::TVolume::TDesc::TStorageSpeed storage_speed,
@@ -379,48 +322,36 @@ namespace Orly {
                                const TNotify *notify);
 
 
-          /* TODO */
           inline size_t GetNumDurable() const;
 
           private:
 
-          /* TODO */
           typedef TSortedByIdFile::THashObj THashObj;
 
-          /* TODO */
           typedef TSortedByIdFile::THashSorter THashSorter;
 
-          /* TODO */
           typedef TSortedByIdFile::TMyFileTemp<TMergeSortedByIdFile> TMyFile;
 
-          /* TODO */
           Util::TEngine *Engine;
 
-          /* TODO */
           Disk::Util::TVolume::TDesc::TStorageSpeed StorageSpeed;
 
-          /* TODO */
           size_t NumDurable;
 
-          /* TODO */
           Indy::Util::TBlockVec BlockVec;
           size_t FileSize;
 
-          /* TODO */
           static const size_t LocalCacheSize = 64;
 
-          /* TODO */
           friend TMyFile;
 
         };  // TMergeSortedByIdFile
 
-        /* TODO */
         class TSortedInFile
             : public TInFile {
           NO_COPY(TSortedInFile);
           public:
 
-          /* TODO */
           TSortedInFile(Util::TPageCache *page_cache,
                         DiskPriority priority,
                         size_t gen_id,
@@ -428,74 +359,52 @@ namespace Orly {
                         size_t starting_block_offset,
                         size_t file_length);
 
-          /* TODO */
           TSortedInFile(Util::TEngine *engine, DiskPriority priority, size_t gen_id);
 
-          /* TODO */
           virtual ~TSortedInFile();
 
-          /* TODO */
           virtual size_t GetFileLength() const override;
 
-          /* TODO */
           virtual size_t GetStartingBlock() const override;
 
-          /* TODO */
           virtual void ReadMeta(size_t offset, size_t &out) const override;
 
-          /* TODO */
           virtual size_t FindPageIdOfByte(size_t offset) const override;
 
-          /* TODO */
           inline size_t GetNumEntries() const;
 
-          /* TODO */
           inline size_t GetNumBlocks() const;
 
-          /* TODO */
           inline size_t GetStartOfDurableByIdIndex() const;
 
-          /* TODO */
           inline size_t GetStartOfHashIndex() const;
 
-          /* TODO */
           void FindInHash(TSequenceNumber &cur_max_seq_num, const Durable::TId &id, std::string &serialized_form_out) const;
 
           private:
 
-          /* TODO */
           Util::TPageCache *PageCache;
 
-          /* TODO */
           size_t FileLength;
 
-          /* TODO */
           size_t StartingBlockId;
 
-          /* TODO */
           size_t StartingBlockOffset;
 
-          /* TODO */
           size_t NumEntries;
 
-          /* TODO */
           size_t NumBlocks;
 
-          /* TODO */
           size_t HashIndexOffset;
 
-          /* TODO */
           size_t HashFieldSize;
 
-          /* TODO */
           std::unique_ptr<TInStream> InStream;
 
-          /* TODO */
           static const size_t LocalCacheSize = 64;
 
         };  // TSortedInFile
 
-        /* TODO */
         class TMapping {
           NO_COPY(TMapping);
           public:
@@ -503,62 +412,47 @@ namespace Orly {
           /* Forward Declarations. */
           class TEntry;
 
-          /* TODO */
           typedef InvCon::UnorderedList::TMembership<TMapping, TDurableManager> TManagerMembership;
 
-          /* TODO */
           typedef InvCon::UnorderedList::TCollection<TMapping, TEntry> TEntryCollection;
 
-          /* TODO */
           class TEntry {
             NO_COPY(TEntry);
             public:
 
-            /* TODO */
             typedef InvCon::UnorderedList::TMembership<TEntry, TMapping> TMappingMembership;
 
-            /* TODO */
             inline TEntry(TMapping *mapping, TDurableLayer *layer);
 
-            /* TODO */
             inline ~TEntry();
 
-            /* TODO */
             inline TDurableLayer *GetLayer() const;
 
-            /* TODO */
             static void *operator new(size_t size) {
               return Pool.Alloc(size);
             }
 
-            /* TODO */
             static void operator delete(void *ptr, size_t) {
               Pool.Free(ptr);
             }
 
             private:
 
-            /* TODO */
             TMappingMembership::TImpl MappingMembership;
 
-            /* TODO */
             TDurableLayer *Layer;
 
-            /* TODO */
             static Indy::Util::TLocklessPool Pool;
 
-            /* TODO */
             friend class TDurableManager;
             friend class Server::TIndyReporter;
 
           };  // TEntry
 
-          /* TODO */
           class TView {
             NO_COPY(TView);
             public:
 
-            /* TODO */
             TView(TDurableManager *manager)
                 : Manager(manager) {
               std::lock_guard<std::mutex> data_lock(Manager->DataLock);
@@ -570,347 +464,254 @@ namespace Orly {
               Mapping->Incr();
             }
 
-            /* TODO */
             ~TView() {
               CurMemLayer->Decr();
               std::lock_guard<std::mutex> mapping_lock(Manager->MappingLock);
               Mapping->Decr();
             }
 
-            /* TODO */
             inline TMapping *GetMapping() const;
 
-            /* TODO */
             inline TMemSlushLayer *GetCurLayer() const;
 
             private:
 
-            /* TODO */
             TDurableManager *Manager;
 
-            /* TODO */
             TMapping *Mapping;
 
-            /* TODO */
             TMemSlushLayer *CurMemLayer;
 
           };  // TView
 
-          /* TODO */
           inline TMapping(TDurableManager *manager);
 
-          /* TODO */
           ~TMapping();
 
-          /* TODO */
           inline void Incr();
 
-          /* TODO */
           inline void Decr();
 
-          /* TODO */
           inline size_t GetRefCount() const;
 
-          /* TODO */
           TEntryCollection *GetEntryCollection() const;
 
-          /* TODO */
           static void *operator new(size_t size) {
             return Pool.Alloc(size);
           }
 
-          /* TODO */
           static void operator delete(void *ptr, size_t) {
             Pool.Free(ptr);
           }
 
           private:
 
-          /* TODO */
           TManagerMembership::TImpl ManagerMembership;
 
-          /* TODO */
           mutable TEntryCollection::TImpl EntryCollection;
 
-          /* TODO */
           size_t RefCount;
 
-          /* TODO */
           bool MarkedForDelete;
 
-          /* TODO */
           static Indy::Util::TLocklessPool Pool;
 
-          /* TODO */
           friend class TDurableManager;
           friend class Server::TIndyReporter;
 
         };  // TMapping
 
-        /* TODO */
         typedef InvCon::UnorderedList::TCollection<TDurableManager, TMapping> TMappingCollection;
 
-        /* TODO */
         class TDurableLayer {
           NO_COPY(TDurableLayer);
           public:
 
-          /* TODO */
           typedef InvCon::UnorderedList::TMembership<TDurableLayer, TDurableManager> TRemovalMembership;
 
-          /* TODO */
           enum TKind {MemSlush, DiskOrdered};
 
-          /* TODO */
           inline virtual ~TDurableLayer();
 
-          /* TODO */
           inline void Incr();
 
-          /* TODO */
           inline void Decr();
 
-          /* TODO */
           inline void RemoveFromCollection();
 
-          /* TODO */
           virtual TKind GetKind() const = 0;
 
-          /* TODO */
           inline bool GetMarkedTaken() const;
 
-          /* TODO */
           inline void MarkTaken();
 
-          /* TODO */
           inline bool GetMarkedForDelete() const;
 
-          /* TODO */
           inline void MarkForDelete();
 
-          /* TODO */
           virtual void FindMax(TSequenceNumber &cur_max_seq, const Base::TUuid &id, std::string &serialized_form_out) const = 0;
 
-          /* TODO */
           static void *operator new(size_t size) {
             return Pool.Alloc(size);
           }
 
-          /* TODO */
           static void operator delete(void *ptr, size_t) {
             Pool.Free(ptr);
           }
 
           protected:
 
-          /* TODO */
           inline TDurableLayer(TDurableManager *manager);
 
           private:
 
-          /* TODO */
           TDurableManager *Manager;
 
-          /* TODO */
           TRemovalMembership::TImpl RemovalMembership;
 
-          /* TODO */
           size_t RefCount;
 
-          /* TODO */
           bool MarkedForDelete;
 
-          /* TODO */
           bool MarkedTaken;
 
-          /* TODO */
           static Indy::Util::TPool Pool;
 
-          /* TODO */
           friend class TDurableManager;
           friend class Server::TIndyReporter;
 
         };  // TDurableLayer
 
-        /* TODO */
         void AddMapping(TDurableLayer *layer);
 
-        /* TODO */
         class TMemSlushLayer
             : public TDurableLayer {
           NO_COPY(TMemSlushLayer);
           public:
 
-          /* TODO */
           class TDurableEntry {
             NO_COPY(TDurableEntry);
             public:
 
-            /* TODO */
             class TKey {
               public:
 
-              /* TODO */
               inline TKey(const uuid_t &id, TSequenceNumber seq_num);
 
-              /* TODO */
               inline bool operator==(const TKey &that) const;
 
-              /* TODO */
               inline bool operator!=(const TKey &that) const;
 
-              /* TODO */
               inline bool operator<=(const TKey &that) const;
 
               private:
 
-              /* TODO */
               uuid_t Id;
 
-              /* TODO */
               const TSequenceNumber SeqNum;
 
-              /* TODO */
               friend class TDurableEntry;
 
             };  // TKey
 
-            /* TODO */
             typedef InvCon::OrderedList::TMembership<TDurableEntry, TMemSlushLayer, TDurableEntry::TKey> TSlushMembership;
 
-            /* TODO */
             inline TDurableEntry(TMemSlushLayer *mem_layer, const Base::TUuid &id, const Durable::TDeadline &deadline, std::string &&serialized_form, TSequenceNumber seq_num);
 
-            /* TODO */
             inline const uuid_t &GetId() const;
 
-            /* TODO */
             inline TSequenceNumber GetSeqNum() const;
 
-            /* TODO */
             inline size_t GetDeadlineCount() const;
 
-            /* TODO */
             inline TSerializedSize GetSerializedSize() const;
 
-            /* TODO */
             inline const std::string &GetSerializedForm() const;
 
-            /* TODO */
             static void *operator new(size_t size) {
               return Pool.Alloc(size);
             }
 
-            /* TODO */
             static void operator delete(void *ptr, size_t) {
               Pool.Free(ptr);
             }
 
             private:
 
-            /* TODO */
             TSlushMembership::TImpl SlushMembership;
 
-            /* TODO */
             const size_t DeadlineCount;
 
-            /* TODO */
             std::string SerializedForm;
 
-            /* TODO */
             static Indy::Util::TPool Pool;
 
-            /* TODO */
             friend class TDurableManager;
             friend class Server::TIndyReporter;
 
           };  // TDurableEntry
 
-          /* TODO */
           typedef InvCon::OrderedList::TCollection<TMemSlushLayer, TDurableEntry, TDurableEntry::TKey> TEntryCollection;
 
-          /* TODO */
           virtual TKind GetKind() const {
             return TDurableLayer::MemSlush;
           }
 
-          /* TODO */
           inline TMemSlushLayer(TDurableManager *manager);
 
-          /* TODO */
           virtual ~TMemSlushLayer();
 
-          /* TODO */
           inline size_t GetNumEntries() const;
 
-          /* TODO */
           inline size_t GetTotalSerializedSize() const;
 
-          /* TODO */
           inline TEntryCollection *GetEntryCollection() const;
 
-          /* TODO */
           virtual void FindMax(TSequenceNumber &cur_max_seq, const Base::TUuid &id, std::string &serialized_form_out) const;
 
           private:
 
-          /* TODO */
           mutable TEntryCollection::TImpl EntryCollection;
 
-          /* TODO */
           size_t NumEntries;
 
-          /* TODO */
           size_t TotalSerializedSize;
 
-          /* TODO */
           friend class TDurableManager;
 
         };  // TMemSlushLayer
 
-        /* TODO */
         class TDiskOrderedLayer
             : public TDurableLayer {
           NO_COPY(TDiskOrderedLayer);
           public:
 
-          /* TODO */
           virtual TKind GetKind() const {
             return TDurableLayer::DiskOrdered;
           }
 
-          /* TODO */
           TDiskOrderedLayer(TDurableManager *manager, Util::TEngine *engine, size_t gen_id, size_t num_durable);
 
-          /* TODO */
           virtual ~TDiskOrderedLayer();
 
-          /* TODO */
           inline size_t GetGenId() const;
 
-          /* TODO */
           inline size_t GetNumDurable() const;
 
-          /* TODO */
           virtual void FindMax(TSequenceNumber &cur_max_seq, const Base::TUuid &id, std::string &serialized_form_out) const;
 
           private:
 
-          /* TODO */
           Util::TEngine *const Engine;
 
-          /* TODO */
           size_t GenId;
 
-          /* TODO */
           size_t NumDurable;
 
         };  // TDiskOrderedLayer
 
-        /* TODO */
         DurableManager::TManager *const Manager;
 
-        /* TODO */
         Fiber::TRunner MergerScheduler;
         Fiber::TRunner WriterScheduler;
         Fiber::TFrame *MergerFrame;
@@ -918,50 +719,37 @@ namespace Orly {
         Fiber::TSingleSem MergerFinishedSem;
         Fiber::TSingleSem WriterFinishedSem;
 
-        /* TODO */
         Util::TEngine *const Engine;
 
-        /* TODO */
         std::mutex DataLock;
         TMemSlushLayer *CurMemoryLayer;
 
-        /* TODO */
         TSequenceNumber SeqNum;
 
-        /* TODO */
         size_t NextSlushGenId;
 
-        /* TODO */
         size_t NextDurableByIdGenId;
 
-        /* TODO */
         size_t TempFileConsolThresh;
 
-        /* TODO */
         std::chrono::milliseconds DurableWriteDelay;
         std::chrono::milliseconds DurableMergeDelay;
 
-        /* TODO */
         bool ShutDown;
         Fiber::TSingleSem SlushSem;
         Fiber::TSingleSem MergeSem;
 
-        /* TODO */
         mutable TMappingCollection::TImpl MappingCollection;
 
-        /* TODO */
         mutable TRemovalCollection::TImpl RemovalCollection;
         Base::TTimerFd LayerCleanerTimer;
 
         std::mutex RemovalLock;
 
-        /* TODO */
         std::mutex MappingLock;
 
-        /* TODO */
         const TNotify *Notify;
 
-        /* TODO */
         friend class Server::TIndyReporter;
         friend class Util::TDiskEngine;
 

--- a/orly/indy/disk/file_service.h
+++ b/orly/indy/disk/file_service.h
@@ -43,13 +43,11 @@ namespace Orly {
 
     namespace Disk {
 
-      /* TODO */
       class TFileService
           : public TFileServiceBase, public Fiber::TRunnable {
         NO_COPY(TFileService);
         public:
 
-        /* TODO */
         typedef std::function<bool (TFileObj::TKind /*file kind*/,
                                     const Base::TUuid &/*file_uid*/,
                                     size_t /*gen_id*/,
@@ -57,7 +55,6 @@ namespace Orly {
                                     size_t /*starting block offset*/,
                                     size_t /*file_length*/)> TFileInitCb;
 
-        /* TODO */
         TFileService(Base::TScheduler *scheduler,
                      Fiber::TRunner::TRunnerCons &runner_cons,
                      Base::TThreadLocalGlobalPoolManager<Indy::Fiber::TFrame, size_t, Indy::Fiber::TRunner *> *frame_pool_manager,
@@ -69,10 +66,8 @@ namespace Orly {
                      bool create = false,
                      bool abort_on_append_log_scan = true);
 
-        /* TODO */
         ~TFileService();
 
-        /* TODO */
         virtual void InsertFile(const Base::TUuid &file_uid,
                                 TFileObj::TKind file_kind,
                                 size_t file_gen,
@@ -84,12 +79,10 @@ namespace Orly {
                                 TSequenceNumber highest_seq,
                                 TCompletionTrigger &completion_trigger) override;
 
-        /* TODO */
         virtual void RemoveFile(const Base::TUuid &file_uid,
                                 size_t file_gen,
                                 TCompletionTrigger &completion_trigger) override;
 
-        /* TODO */
         virtual bool FindFile(const Base::TUuid &file_uid,
                               size_t file_gen,
                               size_t &out_block_id,
@@ -97,94 +90,69 @@ namespace Orly {
                               size_t &out_file_size,
                               size_t &out_num_keys) const override;
 
-        /* TODO */
         virtual void AppendFileGenSet(const Base::TUuid &file_uid,
                                       std::vector<TFileObj> &out_vec) override;
 
-        /* TODO */
         virtual bool ForEachFile(const std::function<bool (const Base::TUuid &file_uid, const TFileObj &)> &cb) override;
 
-        /* TODO */
         inline size_t GetNumFiles() const;
 
         private:
 
-        /* TODO */
         typedef std::unordered_map<Base::TUuid, std::unordered_map<size_t, TFileObj>> TFileMap;
 
         /* Forward Declarations. */
         class TOp;
 
-        /* TODO */
         typedef InvCon::UnorderedList::TCollection<TFileService, TOp> TOpQueue;
 
-        /* TODO */
         class TOp {
           NO_COPY(TOp);
           public:
 
-          /* TODO */
           enum TKind {
             InsertFile,
             RemoveFile
           };
 
-          /* TODO */
           typedef InvCon::UnorderedList::TMembership<TOp, TFileService> TQueueMembership;
 
-          /* TODO */
           inline TOp(TKind kind, const Base::TUuid &file_uid, TFileObj &&fil_obj, TCompletionTrigger &trigger);
 
-          /* TODO */
           inline ~TOp();
 
-          /* TODO */
           inline void Apply(size_t *buf) const;
 
-          /* TODO */
           inline void Apply(TFileMap &file_map, size_t &num_elem_in_file_map) const;
 
-          /* TODO */
           inline TQueueMembership *GetQueueMembership();
 
-          /* TODO */
           inline void Remove();
 
-          /* TODO */
           inline void Complete(TDiskResult result, const char *err_str);
 
           private:
 
-          /* TODO */
           TQueueMembership::TImpl QueueMembership;
 
-          /* TODO */
           TKind Kind;
 
-          /* TODO */
           Base::TUuid FileUUID;
 
-          /* TODO */
           TFileObj FileObj;
 
-          /* TODO */
           TCompletionTrigger &Trigger;
 
         };  // TOp
 
-        /* TODO */
         void Runner();
 
-        /* TODO */
         bool TryLoadFromBaseImage(size_t base_image_block, const size_t *cur_buf, TBufBlock *cur_buf_block);
 
-        /* TODO */
         void ZeroImageBlocks(size_t image_1_block_id, size_t image_2_block_id);
 
-        /* TODO */
         void ZeroAppendLog();
 
-        /* TODO */
         static void AddToMap(TFileMap &file_map,
                              const Base::TUuid &file_uid,
                              TFileObj::TKind file_kind,
@@ -196,40 +164,31 @@ namespace Orly {
                              TSequenceNumber lowest_seq,
                              TSequenceNumber highest_seq);
 
-        /* TODO */
         static void RemoveFromMap(TFileMap &file_map,
                                   const Base::TUuid &file_uid,
                                   size_t file_gen);
 
-        /* TODO */
         static void ApplyDeltasToMap(TFileMap &file_map,
                                      const size_t *buf,
                                      size_t &num_files_in_map);
 
-        /* TODO */
         static void ApplyImageBlock(TFileMap &file_map,
                                     const size_t *buf,
                                     size_t &num_files_in_map);
 
-        /* TODO */
         Fiber::TFrame *Frame;
         Fiber::TRunner BGScheduler;
 
-        /* TODO */
         Util::TVolumeManager *VolMan;
 
-        /* TODO */
         mutable std::mutex Mutex;
 
-        /* TODO */
         TFileMap Map;
         size_t NumFiles;
 
-        /* TODO */
         TFileMap RunnerCopyMap;
         size_t NumRunnerCopyFiles;
 
-        /* TODO */
         std::vector<size_t> Image1BlockIdVec;
         std::vector<size_t> Image2BlockIdVec;
         std::vector<size_t> AppendLogBlockVec;
@@ -238,45 +197,34 @@ namespace Orly {
         size_t CurBaseImageCounter;
         size_t CurRingSector;
 
-        /* TODO */
         std::mutex QueueLock;
 
-        /* TODO */
         mutable TOpQueue::TImpl OpQueue;
 
-        /* TODO */
         Base::TEventSemaphore RunSem;
         bool ShuttingDown;
 
         /* A flag used to test abort on append log corruption */
         bool AbortOnAppendLogScan;
 
-        /* TODO */
         static constexpr size_t VersionSize = sizeof(uint64_t);
 
-        /* TODO */
         static constexpr size_t NextBlockSize = sizeof(uint64_t);
 
-        /* TODO */
         static constexpr size_t EntrySize = 10UL;
 
-        /* TODO */
         static constexpr size_t OpSize = 1UL;
 
-        /* TODO */
         static constexpr size_t EntryByteSize = EntrySize * sizeof(uint64_t);
         static_assert(sizeof(TFileObj) + sizeof(Base::TUuid) == EntryByteSize, "TFileObj size mismatch");
 
-        /* TODO */
         static constexpr size_t OpByteSize = sizeof(uint64_t);
 
         /* Sector size, less version number */
         static constexpr size_t NumFilesPerRingBuf = (Util::LogicalSectorSize - VersionSize) / (EntryByteSize + OpByteSize);
 
-        /* TODO */
         static constexpr size_t NumSectorsPerBlock = Util::PhysicalBlockSize / Util::PhysicalSectorSize;
 
-        /* TODO */
         static constexpr size_t NumElemPerBaseImageBlock = (Util::LogicalCheckedBlockSize - VersionSize - NextBlockSize) / EntryByteSize;
 
       };  // TFileService

--- a/orly/indy/disk/file_service_base.h
+++ b/orly/indy/disk/file_service_base.h
@@ -32,17 +32,14 @@ namespace Orly {
 
     namespace Disk {
 
-      /* TODO */
       class TFileObj {
         public:
 
-        /* TODO */
         enum TKind {
           DataFile,
           DurableFile
         };
 
-        /* TODO */
         inline TFileObj(TKind kind,
                         size_t gen_id,
                         size_t starting_block,
@@ -54,35 +51,26 @@ namespace Orly {
 
         TKind Kind;
 
-        /* TODO */
         size_t GenId;
 
-        /* TODO */
         size_t StartingBlockId;
 
-        /* TODO */
         size_t StartingBlockOffset;
 
-        /* TODO */
         size_t FileSize;
 
-        /* TODO */
         size_t NumKeys;
 
-        /* TODO */
         TSequenceNumber LowestSeq;
 
-        /* TODO */
         TSequenceNumber HighestSeq;
 
       };  // TFileObj
 
-      /* TODO */
       class TFileServiceBase {
         NO_COPY(TFileServiceBase);
         public:
 
-        /* TODO */
         virtual bool FindFile(const Base::TUuid &file_uid,
                               size_t gen_id,
                               size_t &starting_block,
@@ -90,7 +78,6 @@ namespace Orly {
                               size_t &file_length,
                               size_t &num_keys) const = 0;
 
-        /* TODO */
         virtual void InsertFile(const Base::TUuid &file_uid,
                                 TFileObj::TKind kind,
                                 size_t gen_id,
@@ -102,24 +89,19 @@ namespace Orly {
                                 TSequenceNumber highest_seq,
                                 TCompletionTrigger &completion_trigger) = 0;
 
-        /* TODO */
         virtual void RemoveFile(const Base::TUuid &file_uid,
                                 size_t gen_id,
                                 TCompletionTrigger &completion_trigger) = 0;
 
-        /* TODO */
         virtual void AppendFileGenSet(const Base::TUuid &file_uid,
                                       std::vector<TFileObj> &out_vec) = 0;
 
-        /* TODO */
         virtual bool ForEachFile(const std::function<bool (const Base::TUuid &file_uid, const TFileObj &)> &cb) = 0;
 
-        /* TODO */
         virtual ~TFileServiceBase() {}
 
         protected:
 
-        /* TODO */
         TFileServiceBase() {}
 
       };  // TFileServiceBase

--- a/orly/indy/disk/in_file.h
+++ b/orly/indy/disk/in_file.h
@@ -53,16 +53,12 @@ namespace Orly {
            Kept in sync with THistoryKeyItem in read_file.h via static_assert there. */
         static const size_t KeyHistorySize = sizeof(TSequenceNumber) + sizeof(Atom::TCore) + sizeof(Atom::TCore) + sizeof(uint64_t);
 
-        /* TODO */
         static const size_t HashEntrySize = sizeof(Atom::TCore) + sizeof(size_t);
 
-        /* TODO */
         static const size_t UpdateEntrySize = sizeof(TSequenceNumber) + sizeof(Atom::TCore) + sizeof(Atom::TCore) + sizeof(size_t) + sizeof(size_t);
 
-        /* TODO */
         static const size_t UpdateKeyPtrSize = sizeof(size_t);
 
-        /* TODO */
         static const size_t NumMetaFields = 10U;
         /*
            1.  # of blocks
@@ -78,7 +74,6 @@ namespace Orly {
 
         */
 
-        /* TODO */
         static const size_t NumIndexMetaFields = 8U;
         /*
            Offset of Arena
@@ -93,13 +88,10 @@ namespace Orly {
            (n) (size_t) -> (size_t) hash index offset -> num hash fields pairings
         */
 
-        /* TODO */
         static const uint8_t NullCore[sizeof(Atom::TCore)];
 
-        /* TODO */
         static const Atom::TCore TombstoneCore;
 
-        /* TODO */
         static Atom::TCore GetTombstoneCore() {
           void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
           Atom::TSuprena suprena;
@@ -108,49 +100,38 @@ namespace Orly {
 
       };  // TData
 
-      /* TODO */
       class TInFile {
         NO_COPY(TInFile);
         public:
 
-        /* TODO */
         virtual size_t GetFileLength() const = 0;
 
-        /* TODO */
         virtual size_t GetStartingBlock() const = 0;
 
-        /* TODO */
         virtual void ReadMeta(size_t offset, size_t &out) const = 0;
 
-        /* TODO */
         virtual size_t FindPageIdOfByte(size_t offset) const = 0;
 
         protected:
 
-        /* TODO */
         TInFile() {}
 
-        /* TODO */
         virtual ~TInFile() {}
 
       };  // TInFile
 
-      /* TODO */
       template <size_t CachePageSize, size_t BlockSize, size_t PhysicalBlockSize, Util::TBufKind BufKind, size_t MaxLocalCacheSize, bool ScanAheadAllowed = true>
       class TStream {
         NO_COPY(TStream);
         public:
 
-        /* TODO */
         static constexpr size_t DataChunkSize = Util::GetLogicalDataChunkSize<BufKind>();
         static constexpr size_t PhysicalDataChunkSize = Util::GetPhysicalDataChunkSize<BufKind>();
         static constexpr size_t PhysicalCachePageSize = PhysicalBlockSize / (BlockSize / CachePageSize);
 
-        /* TODO */
         TStream(const Base::TCodeLocation &code_location /* DEBUG */, uint8_t util_src, DiskPriority priority, const TInFile *file, Util::TCache<PhysicalCachePageSize> *cache, size_t byte_offset/*, bool scan_ahead_allowed = true*/)
             : TStream(code_location, util_src, priority, file->GetFileLength(), file, cache, byte_offset/*, scan_ahead_allowed*/) {}
 
-        /* TODO */
         TStream(const Base::TCodeLocation &code_location /* DEBUG */, uint8_t util_src, DiskPriority priority, size_t end_of_stream, const TInFile *file, Util::TCache<PhysicalCachePageSize> *cache, size_t byte_offset/*, bool scan_ahead_allowed = true*/)
             : File(file),
               Cache(cache),
@@ -181,7 +162,6 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         virtual ~TStream() {
           AsyncTrigger.Wait();
           if (MaxLocalCacheSize > 0) {
@@ -191,7 +171,6 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         void Read(size_t &out) {
           assert(ByteOffset + sizeof(size_t) <= EndOfStream);
           //if (OffsetInPage <= (CachePageSize - sizeof(size_t))) {
@@ -208,7 +187,6 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         void Read(int64_t &out) {
           assert(ByteOffset + sizeof(int64_t) <= EndOfStream);
           //if (OffsetInPage <= (CachePageSize - sizeof(int64_t))) {
@@ -225,7 +203,6 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         void Read(uint8_t &out) {
           assert(ByteOffset + sizeof(uint8_t) <= EndOfStream);
           //if (OffsetInPage <= (CachePageSize - sizeof(uint8_t))) {
@@ -242,7 +219,6 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         void Read(uint16_t &out) {
           assert(ByteOffset + sizeof(uint16_t) <= EndOfStream);
           //if (OffsetInPage <= (CachePageSize - sizeof(uint16_t))) {
@@ -259,7 +235,6 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         void Read(uint32_t &out) {
           assert(ByteOffset + sizeof(uint32_t) <= EndOfStream);
           //if (OffsetInPage <= (CachePageSize - sizeof(uint32_t))) {
@@ -276,7 +251,6 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         void Read(bool &out) {
           assert(ByteOffset + sizeof(bool) <= EndOfStream);
           //if (OffsetInPage <= (CachePageSize - sizeof(bool))) {
@@ -293,7 +267,6 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         void Read(Base::TUuid &out) {
           assert(ByteOffset + sizeof(uuid_t) <= EndOfStream);
           //if (OffsetInPage <= (CachePageSize - sizeof(uuid_t))) {
@@ -314,7 +287,6 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         void Read(void *buf, size_t len) {
           assert(ByteOffset + len <= EndOfStream);
           size_t left = len;
@@ -334,7 +306,6 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         inline void Skip(size_t num_bytes) {
           assert(ByteOffset + num_bytes <= EndOfStream);
           ByteOffset += num_bytes;
@@ -344,7 +315,6 @@ namespace Orly {
           OffsetInChunk = OffsetInPage % DataChunkSize;
         }
 
-        /* TODO */
         inline void GoTo(size_t offset) {
           assert(offset <= EndOfStream);
           assert(offset < EndOfStream);
@@ -355,28 +325,23 @@ namespace Orly {
           OffsetInChunk = OffsetInPage % DataChunkSize;
         }
 
-        /* TODO */
         inline operator bool() const {
           return ByteOffset < EndOfStream;
         }
 
-        /* TODO */
         inline size_t GetOffset() const {
           return ByteOffset;
         }
 
-        /* TODO */
         size_t GetLoadedPageId() const {
           return LoadedPageId;
         }
 
-        /* TODO */
         Util::TPageCache::TSlot *GetLoadedMainSlot() const {
           assert(MainSlot);
           return MainSlot;
         }
 
-        /* TODO */
         Util::TPageCache::TSlot *GetLoadedDataSlot() const {
           assert(DataSlot);
           return DataSlot;
@@ -389,23 +354,19 @@ namespace Orly {
           return ChunkInPage;
         }
 
-        /* TODO */
         size_t GetFetchCount() const {
           return FetchCount;
         }
 
-        /* TODO */
         inline size_t FindPageIdOfByte(size_t offset) const {
           return File->FindPageIdOfByte(offset);
         }
 
-        /* TODO */
         const char *GetData() const {
           //return (BufData + OffsetInPage);
           return (BufData + (ChunkInPage * PhysicalDataChunkSize) + OffsetInChunk);
         }
 
-        /* TODO */
         void ReleaseBuf() {
           ByteOffset = -1;
           if (MainSlot) {
@@ -417,7 +378,6 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         void PrefetchNextPage(size_t offset) {
           ++NumSequentialFetch;
           size_t num_keep_prefetched = 0UL;
@@ -468,7 +428,6 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         inline void FetchBuf(size_t page_id, size_t offset) {
           const size_t prev_loaded_page_id = LoadedPageId;
           LoadedPageId = page_id;
@@ -524,7 +483,6 @@ namespace Orly {
           LastFetched = offset / CachePageSize;
         }
 
-        /* TODO */
         inline void CheckBuf() {
           if ((ByteOffset >= LoadedByteEnd || ByteOffset < LoadedByteStart) && ByteOffset < EndOfStream) {
             size_t page_id_of_byte_index = FindPageIdOfByte(ByteOffset);
@@ -533,36 +491,27 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         const TInFile *File;
 
-        /* TODO */
         Util::TCache<PhysicalCachePageSize> *Cache;
 
-        /* TODO */
         const size_t EndOfStream;
 
-        /* TODO */
         size_t LoadedPageId;
 
-        /* TODO */
         size_t LoadedByteStart;
         size_t LoadedByteEnd;
 
-        /* TODO */
         size_t ByteOffset;
 
-        /* TODO */
         size_t OffsetInPage;
         size_t OffsetInChunk;
         size_t ChunkInPage;
 
-        /* TODO */
         typename Util::TCache<PhysicalCachePageSize>::TSlot *MainSlot;
         typename Util::TCache<PhysicalCachePageSize>::TSlot *DataSlot;
         const char *BufData;
 
-        /* TODO */
         struct TSlotStruct {
           TSlotStruct(size_t page_id,
                       Util::TCache<PhysicalCachePageSize> *cache,
@@ -582,30 +531,22 @@ namespace Orly {
         };
         Base::TMiniCache<MaxLocalCacheSize, size_t, TSlotStruct> LocalBufCache;
 
-        /* TODO */
         size_t FetchCount;
 
-        /* TODO */
         size_t NumSequentialFetch;
 
-        /* TODO */
         size_t PrefetchedTo;
 
-        /* TODO */
         size_t LastFetched;
 
-        /* TODO */
         TCompletionTrigger SyncTrigger;
         TCompletionTrigger AsyncTrigger;
 
-        /* TODO */
         DiskPriority Priority;
 
-        /* TODO */
         TDiskResult DiskResult;
         const char *DiskErrStr;
 
-        /* TODO */
         const Base::TCodeLocation CodeLocation;
         const uint8_t UtilSrc;
 

--- a/orly/indy/disk/indy_util_reporter.h
+++ b/orly/indy/disk/indy_util_reporter.h
@@ -36,7 +36,6 @@ namespace Orly {
 
     namespace Disk {
 
-      /* TODO */
       enum Source : uint8_t {
         BlockService,
         DataFileArena,
@@ -84,35 +83,26 @@ namespace Orly {
         UpdateWalk,
       };
 
-      /* TODO */
       class TIndyUtilReporter : public TUtilizationReporter {
         NO_COPY(TIndyUtilReporter);
         public:
 
-        /* TODO */
         TIndyUtilReporter() = default;
 
-        /* TODO */
         virtual ~TIndyUtilReporter() {}
 
-        /* TODO */
         virtual void Push(uint8_t /*source*/, TUtilizationReporter::TKind /*kind*/, size_t /*num_bytes*/, DiskPriority /*priority*/);
 
-        /* TODO */
         virtual void Report(std::stringstream &ss);
 
         private:
 
-        /* TODO */
         const char *GetName(uint8_t) const;
 
-        /* TODO */
         Base::TTimer ReportTimer;
 
-        /* TODO */
         static const size_t NumFields = UpdateWalk + 1;
 
-        /* TODO */
         std::atomic<size_t> SyncReadNumByte[NumFields];
         std::atomic<size_t> AsyncReadNumByte[NumFields];
         std::atomic<size_t> WriteNumByte[NumFields];

--- a/orly/indy/disk/merge_data_file.cc
+++ b/orly/indy/disk/merge_data_file.cc
@@ -32,7 +32,6 @@ using namespace Orly::Indy::Disk;
 using namespace Orly::Indy::Disk::Util;
 using namespace Orly::Indy::Util;
 
-/* TODO */
 template <bool CanTail, bool CanTailTombstones>
 class TMergeDataFileImpl {
   NO_COPY(TMergeDataFileImpl);
@@ -43,7 +42,6 @@ class TMergeDataFileImpl {
 
   using TDataOutStream = TDataFile::TDataOutStream;
 
-  /* TODO */
   TMergeDataFileImpl(TEngine *engine,
                      Disk::Util::TVolume::TDesc::TStorageSpeed storage_speed,
                      const Base::TUuid &file_uuid,
@@ -836,63 +834,48 @@ class TMergeDataFileImpl {
     #endif
   }
 
-  /* TODO */
   class TUpdateObj {
     public:
 
-    /* TODO */
     TUpdateObj(TSequenceNumber seq_num, size_t offset, bool is_current, const Base::TUuid &index_id)
         : SequenceNumber(seq_num),
           Offset(offset),
           IsCurrent(is_current),
           IndexId(index_id) {}
 
-    /* TODO */
     bool operator<(const TUpdateObj &that) const {
       return SequenceNumber < that.SequenceNumber;
     }
 
-    /* TODO */
     TSequenceNumber SequenceNumber;
 
-    /* TODO */
     Atom::TCore Metadata;
 
-    /* TODO */
     Atom::TCore Id;
 
-    /* TODO */
     size_t Offset;
 
-    /* TODO */
     bool IsCurrent;
 
-    /* TODO */
     Base::TUuid IndexId;
 
   };  // TUpdateObj
 
-  /* TODO */
   typedef Disk::Util::TIndexManager<TUpdateObj, Disk::Util::SortBufSize, Disk::Util::SortBufMinParallelSize> TUpdateCollector;
   using TTypeBoundaryOffsetVec = TDataFile::TTypeBoundaryOffsetVec;
 
-  /* TODO */
   typedef Indy::Util::TBlockVec TBlockVec;
   typedef std::unordered_set<TRemapObj> TRemapIndex;
 
-  /* TODO */
   class TL0MergeNote {
     public:
 
-    /* TODO */
     TL0MergeNote()
         : Arena(nullptr), Offset(0UL), Note(nullptr) {}
 
-    /* TODO */
     TL0MergeNote(Atom::TCore::TArena *arena, Atom::TCore::TOffset offset, const Atom::TCore::TNote *note)
         : Arena(arena), Offset(offset), Note(note) {}
 
-    /* TODO */
     bool operator<(const TL0MergeNote &that) const {
       assert(Arena);
       assert(that.Arena);
@@ -913,7 +896,6 @@ class TMergeDataFileImpl {
       return Atom::IsLt(Sabot::CompareStates(*lhs, *rhs, lhs_type_alloc, rhs_type_alloc));
     }
 
-    /* TODO */
     bool operator==(const TL0MergeNote &that) const {
       assert(Arena);
       assert(that.Arena);
@@ -932,7 +914,6 @@ class TMergeDataFileImpl {
       return Atom::IsEq(Sabot::CompareStates(*lhs, *rhs, lhs_type_alloc, rhs_type_alloc));
     }
 
-    /* TODO */
     bool operator!=(const TL0MergeNote &that) const {
       assert(Arena);
       assert(that.Arena);
@@ -951,52 +932,41 @@ class TMergeDataFileImpl {
       return Atom::IsNe(Sabot::CompareStates(*lhs, *rhs, lhs_type_alloc, rhs_type_alloc));
     }
 
-    /* TODO */
     Atom::TCore::TArena *GetArena() const {
       return Arena;
     }
 
-    /* TODO */
     Atom::TCore::TOffset GetOffset() const {
       return Offset;
     }
 
-    /* TODO */
     const Atom::TCore::TNote *GetNote() const {
       return Note;
     }
 
     private:
 
-    /* TODO */
     Atom::TCore::TArena *Arena;
 
-    /* TODO */
     Atom::TCore::TOffset Offset;
 
-    /* TODO */
     const Atom::TCore::TNote *Note;
 
   };  // TL0MergeNote
 
-  /* TODO */
   class TMergeNote {
     public:
 
-    /* TODO */
     TMergeNote()
         : Arena(nullptr), Offset(0UL), Note(nullptr) {}
 
-    /* TODO */
     TMergeNote(Atom::TCore::TArena *arena, Atom::TCore::TOffset offset, const Atom::TCore::TNote *note)
         : Arena(arena), Offset(offset), Note(note) {}
 
-    /* TODO */
     bool operator<(const TMergeNote &/*that*/) const {
       throw std::logic_error("TMergeNote::operator < should not get used.");
     }
 
-    /* TODO */
     bool operator==(const TMergeNote &that) const {
       assert(Arena == that.Arena);
       assert(Note);
@@ -1006,7 +976,6 @@ class TMergeDataFileImpl {
       return lhs_note_size == rhs_note_size && memcmp(Note, that.Note, lhs_note_size) == 0;
     }
 
-    /* TODO */
     bool operator!=(const TMergeNote &that) const {
       assert(Arena == that.Arena);
       assert(Note);
@@ -1016,66 +985,53 @@ class TMergeDataFileImpl {
       return lhs_note_size != rhs_note_size || memcmp(Note, that.Note, lhs_note_size) != 0;
     }
 
-    /* TODO */
     Atom::TCore::TArena *GetArena() const {
       return Arena;
     }
 
-    /* TODO */
     Atom::TCore::TOffset GetOffset() const {
       return Offset;
     }
 
-    /* TODO */
     const Atom::TCore::TNote *GetNote() const {
       return Note;
     }
 
     private:
 
-    /* TODO */
     Atom::TCore::TArena *Arena;
 
-    /* TODO */
     Atom::TCore::TOffset Offset;
 
-    /* TODO */
     const Atom::TCore::TNote *Note;
 
   };  // TMergeNote
 
-  /* TODO */
   class TTypeNote {
     public:
 
-    /* TODO */
     TTypeNote(Atom::TCore::TArena *arena, Atom::TCore::TOffset offset)
         : Arena(arena),
           Offset(offset){}
 
-    /* TODO */
     inline bool operator<(const TTypeNote &that) const {
       return Atom::IsLt(Compare(that));
     }
 
-    /* TODO */
     inline bool operator!=(const TTypeNote &that) const {
       return Atom::IsNe(Compare(that));
     }
 
-    /* TODO */
     inline Atom::TCore::TArena *GetArena() const {
       return Arena;
     }
 
-    /* TODO */
     inline Atom::TCore::TOffset GetOffset() const {
       return Offset;
     }
 
     private:
 
-    /* TODO */
     inline Atom::TComparison Compare(const TTypeNote &that) const {
       void *lhs_pin_alloc = alloca(sizeof(Atom::TCore::TArena::TFinalPin) * 2);
       void *rhs_pin_alloc = reinterpret_cast<uint8_t *>(lhs_pin_alloc) + sizeof(Atom::TCore::TArena::TFinalPin);
@@ -1100,10 +1056,8 @@ class TMergeDataFileImpl {
       return ret;
     }
 
-    /* TODO */
     Atom::TCore::TArena *Arena;
 
-    /* TODO */
     Atom::TCore::TOffset Offset;
 
   };  // TTypeNote
@@ -1162,101 +1116,77 @@ class TMergeDataFileImpl {
 
   };
 
-  /* TODO */
   class TNewRemapObj {
     public:
 
-    /* TODO */
     TNewRemapObj(Atom::TCore::TOffset old_key, Atom::TCore::TOffset new_key) : OldKey(old_key), NewKey(new_key) {}
 
-    /* TODO */
     bool operator<(const TNewRemapObj &that) const {
       return OldKey < that.OldKey;
     }
 
-    /* TODO */
     Atom::TCore::TOffset OldKey;
 
-    /* TODO */
     Atom::TCore::TOffset NewKey;
 
   };  // TNewRemapObj
 
-  /* TODO */
   typedef TIndexManager<TNewRemapObj, Disk::Util::NewRemapBufSize, Disk::Util::SortBufMinParallelSize> TRemapSorter;
 
-  /* TODO */
   template <typename TKey>
   class TAccessObj {
     public:
 
-    /* TODO */
     TAccessObj(size_t idx, TKey key) : Idx(idx), Key(key) {}
 
-    /* TODO */
     bool operator<(const TAccessObj &that) const {
       return Key < that.Key;
     }
 
-    /* TODO */
     size_t Idx;
 
-    /* TODO */
     TKey Key;
 
   };  // TAccessObj
 
-  /* TODO */
   template <typename TOldKey, typename TNewKey>
   class TResolvedObj {
     public:
 
-    /* TODO */
     TResolvedObj(size_t idx, TOldKey old_key, TNewKey new_key) : Idx(idx), OldKey(old_key), NewKey(new_key) {}
 
-    /* TODO */
     bool operator<(const TResolvedObj &that) const {
       return Idx < that.Idx;
     }
 
-    /* TODO */
     size_t Idx;
 
-    /* TODO */
     TOldKey OldKey;
 
-    /* TODO */
     TNewKey NewKey;
 
   };  // TResolvedObj
 
-  /* TODO */
   template <typename TKey>
   using TAccessSorter = TIndexManager<TAccessObj<TKey>, Disk::Util::AccessBufSize, Disk::Util::SortBufMinParallelSize>;
 
-  /* TODO */
   template <typename TOldKey, typename TNewKey>
   using TResolvedSorter = TIndexManager<TResolvedObj<TOldKey, TNewKey>, Disk::Util::AccessBufSize, Disk::Util::SortBufMinParallelSize>;
 
-  /* TODO */
   typedef TIndexManager<TSequenceNumber, Disk::Util::SeqKeeperBufSize, Disk::Util::SortBufMinParallelSize> TSeqKeeperSorter;
 
-  /* TODO */
   typedef TIndexManager<Atom::TCore::TOffset, Disk::Util::ArenaKeeperBufSize, Disk::Util::SortBufMinParallelSize> TArenaKeeperSorter;
 
-  /* TODO */
   typedef TAccessObj<Atom::TCore::TOffset> TRemapAccessObj;
   typedef TAccessSorter<Atom::TCore::TOffset> TRemapAccessSorter;
   typedef TResolvedObj<Atom::TCore::TOffset, Atom::TCore::TOffset> TRemapResolvedObj;
   typedef TResolvedSorter<Atom::TCore::TOffset, Atom::TCore::TOffset> TRemapResolvedSorter;
 
-  /* TODO */
   typedef TAccessObj<TSequenceNumber> TSeqAccessObj;
   typedef TAccessSorter<TSequenceNumber> TSeqAccessSorter;
   typedef TResolvedObj<TSequenceNumber, bool> TSeqResolvedObj;
   typedef TResolvedSorter<TSequenceNumber, bool> TSeqResolvedSorter;
 
-  /* TODO */
   static void ResolveRemap(size_t max_block_cache_read_slots_allowed,
                            TRemapAccessSorter &access_sorter,
                            TRemapSorter &remap_sorter,
@@ -1279,7 +1209,6 @@ class TMergeDataFileImpl {
     }
   }
 
-  /* TODO */
   static void ResolveSeqFilter(size_t max_block_cache_read_slots_allowed,
                            TSeqAccessSorter &access_sorter,
                            TSeqKeeperSorter &keep_filter_sorter,
@@ -1960,7 +1889,6 @@ class TMergeDataFileImpl {
     }
   }
 
-  /* TODO */
   inline size_t GetNumKeys() const {
     return NumKeys;
   }
@@ -1972,26 +1900,21 @@ class TMergeDataFileImpl {
     return NumNonAssignEntries;
   }
 
-  /* TODO */
   inline TSequenceNumber GetLowestSequence() const {
     return LowestSeq;
   }
 
-  /* TODO */
   inline TSequenceNumber GetHighestSequence() const {
     return HighestSeq;
   }
 
   private:
 
-  /* TODO */
   class TSortedKey {
     public:
 
-    /* TODO */
     TSortedKey() : Arena(nullptr), SeqNum(0UL) {}
 
-    /* TODO */
     inline bool operator<(const TSortedKey &that) const {
       Atom::TComparison comp;
       if (Arena && that.Arena && Core.TryQuickOrderComparison(Arena, that.Core, that.Arena, comp)) {
@@ -2004,14 +1927,12 @@ class TMergeDataFileImpl {
       return Atom::IsLt(comp) || (Atom::IsEq(comp) && SeqNum >= that.SeqNum);
     }
 
-    /* TODO */
     Atom::TCore Core;
     Atom::TCore::TArena *Arena;
     TSequenceNumber SeqNum;
 
   };  // TSortedKey
 
-  /* TODO */
   class TReader
       : public TReadFile<LogicalBlockSize, LogicalBlockSize, PhysicalBlockSize, PageCheckedBlock, true> {
     NO_COPY(TReader);
@@ -2021,21 +1942,17 @@ class TMergeDataFileImpl {
 
     using TArena = TDiskArena<LogicalBlockSize, LogicalBlockSize, PhysicalBlockSize, PageCheckedBlock, 128, true>;
 
-    /* TODO */
     TReader(const Base::TCodeLocation &code_location /* DEBUG */, uint8_t util_src, TEngine *engine, const Base::TUuid &file_id, size_t gen_id)
         : TReadFile(code_location, util_src, engine, file_id, Low, gen_id) {
       Arena = std::make_unique<TArena>(this, engine->GetCache<PhysicalCachePageSize>(), Low);
     }
 
-    /* TODO */
     virtual ~TReader() {
       Arena.reset();
     }
 
-    /* TODO */
     using TReadFile::TIndexFile;
 
-    /* TODO */
     using TReadFile::GetNumBytesOfArena;
     using TReadFile::GetNumUpdates;
     using TReadFile::GetNumArenaNotes;
@@ -2043,7 +1960,6 @@ class TMergeDataFileImpl {
     using TReadFile::GetTypeBoundaryOffsetVec;
     using TReadFile::ForEachIndex;
 
-    /* TODO */
     inline const std::unique_ptr<TArena> &GetArena() const {
       assert(Arena);
       return Arena;
@@ -2051,7 +1967,6 @@ class TMergeDataFileImpl {
 
     private:
 
-    /* TODO */
     std::unique_ptr<TArena> Arena;
 
   };  // TReader
@@ -2673,60 +2588,45 @@ class TMergeDataFileImpl {
 
   };
 
-  /* TODO */
   TEngine *Engine;
 
-  /* TODO */
   Disk::Util::TVolume::TDesc::TStorageSpeed StorageSpeed;
   Disk::Util::TVolume::TDesc::TStorageSpeed UpdateIndexStorageSpeed;
   Disk::Util::TVolume::TDesc::TStorageSpeed SorterStorageSpeed;
 
-  /* TODO */
   DiskPriority Priority;
 
-  /* TODO */
   size_t MaxBlockCacheReadSlotsAllowed;
 
-  /* TODO */
   TBlockVec BlockVec;
 
-  /* TODO */
   size_t MainArenaByteOffset;
   TRemapIndex MainArenaRemapIndex;
   TTypeBoundaryOffsetVec MainArenaTypeBoundaryOffsetVec;
 
-  /* TODO */
   size_t NumUpdates;
 
-  /* TODO */
   size_t NumKeys;
   size_t NumNonAssignEntries = 0UL;
   TSequenceNumber LowestSeq;
   TSequenceNumber HighestSeq;
 
-  /* TODO */
   size_t StartingBlockId;
 
-  /* TODO */
   size_t StartingBlockOffset;
 
-  /* TODO */
   size_t FileLength;
 
   size_t TempFileConsolThresh;
 
-  /* TODO */
   std::vector<std::unique_ptr<TReader>> ReadFileVec;
 
-  /* TODO */
   TUpdateCollector UpdateCollector;
 
-  /* TODO */
   #ifndef NDEBUG
   std::unordered_set<size_t> WrittenBlockSet;
   #endif
 
-  /* TODO */
   friend class TMergeIndexFile;
 
 };  // TMergeDataFileImpl

--- a/orly/indy/disk/merge_data_file.h
+++ b/orly/indy/disk/merge_data_file.h
@@ -38,16 +38,13 @@ namespace Orly {
 
     namespace Disk {
 
-      /* TODO */
       template <bool ScanAheadAllowed>
       using TDataDiskArena = TDiskArena<Util::LogicalBlockSize, Util::LogicalBlockSize, Util::PhysicalBlockSize, Util::PageCheckedBlock, DiskArenaMaxCacheSize, ScanAheadAllowed>;
 
-      /* TODO */
       class TMergeDataFile {
         NO_COPY(TMergeDataFile);
         public:
 
-        /* TODO */
         TMergeDataFile(Util::TEngine *engine,
                        Disk::Util::TVolume::TDesc::TStorageSpeed storage_speed,
                        const Base::TUuid &file_uuid,
@@ -61,7 +58,6 @@ namespace Orly {
                        bool can_tail,
                        bool can_tail_tombstone);
 
-        /* TODO */
         inline size_t GetNumKeys() const {
           return NumKeys;
         }
@@ -73,12 +69,10 @@ namespace Orly {
           return NumNonAssignEntries;
         }
 
-        /* TODO */
         inline TSequenceNumber GetLowestSequence() const {
           return LowestSeq;
         }
 
-        /* TODO */
         inline TSequenceNumber GetHighestSequence() const {
           return HighestSeq;
         }

--- a/orly/indy/disk/meta_rewriter.h
+++ b/orly/indy/disk/meta_rewriter.h
@@ -32,16 +32,13 @@ namespace Orly {
 
     namespace Disk {
 
-      /* TODO */
       class TMetaRewriter {
         NO_CONSTRUCTION(TMetaRewriter);
         public:
 
-        /* TODO */
         typedef TStream<Util::LogicalPageSize, Util::LogicalBlockSize, Util::PhysicalBlockSize, Util::CheckedPage, 0UL> TInStream;
         typedef TOutStream<Util::LogicalPageSize, Util::LogicalBlockSize, Util::PhysicalBlockSize, Util::CheckedPage> TDataOutStream;
 
-        /* TODO */
         static std::pair<size_t, size_t> RewriteMetaData(Util::TEngine *engine, const Indy::Util::TBlockVec &block_vec, size_t starting_block_offset);
 
       };  // TMetaRewriter

--- a/orly/indy/disk/out_stream.h
+++ b/orly/indy/disk/out_stream.h
@@ -40,7 +40,6 @@ namespace Orly {
 
     namespace Disk {
 
-      /* TODO */
       template <size_t PageSize, size_t BlockSize>
       class TBoundaryChecker {
         NO_CONSTRUCTION(TBoundaryChecker);
@@ -49,7 +48,6 @@ namespace Orly {
         static constexpr size_t PagesInBlock = BlockSize / PageSize;
         static_assert(PagesInBlock > 1, "TBoundaryChecker requires template specialization for PagesInBlock == 1");
 
-        /* TODO */
         static inline bool IsNewPage(const size_t byte_index, size_t &page_in_buf, const TBufBlock *buf) {
           size_t page = (byte_index / PageSize) % PagesInBlock;
           if (page != page_in_buf || !buf) {
@@ -61,19 +59,16 @@ namespace Orly {
 
       };  // TBoundaryChecker
 
-      /* TODO */
       template <size_t SameSize>
       class TBoundaryChecker<SameSize, SameSize> {
         NO_CONSTRUCTION(TBoundaryChecker);
         public:
 
-        /* TODO */
         static inline bool IsNewPage(const size_t /*byte_index*/, size_t &/*page_in_buf*/, const TBufBlock */*buf*/) {
           return true;
         }
       };  // TBoundaryChecker<SameSize, SameSize>
 
-      /* TODO */
       template <size_t PageSize, size_t BlockSize, size_t PhysicalBlockSize, Util::TBufKind BufKind>
         class TOutStream
             : public TWriteGroup {
@@ -83,7 +78,6 @@ namespace Orly {
           static constexpr size_t PagesInBlock = BlockSize / PageSize;
           static constexpr size_t PhysicalPageSize = PhysicalBlockSize / PagesInBlock;
 
-          /* TODO */
           TOutStream(const Base::TCodeLocation &code_location /* DEBUG */,
                      uint8_t util_src,
                      Util::TVolumeManager *vol_man,
@@ -117,7 +111,6 @@ namespace Orly {
                 UtilSrc(util_src) {
           }
 
-          /* TODO */
           virtual ~TOutStream() {
             if (!CurBlockIsCollision && Buf) {
             //if (!CurBlockIsCollision && Buf && ((ByteIndex % TService::BlockSize) != 0)) {
@@ -133,12 +126,10 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           inline size_t GetOffset() const {
             return ByteIndex;
           }
 
-          /* TODO */
           inline virtual void Write(size_t out) {
             size_t offset = ByteIndex % PageSize;
             if (PageSize - offset >= sizeof(size_t)) {
@@ -150,7 +141,6 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           inline virtual void Write(int64_t out) {
             size_t offset = ByteIndex % PageSize;
             if (PageSize - offset >= sizeof(int64_t)) {
@@ -162,7 +152,6 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           inline virtual void Write(uint8_t out) {
             size_t offset = ByteIndex % PageSize;
             if (PageSize - offset >= sizeof(uint8_t)) {
@@ -174,7 +163,6 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           inline virtual void Write(uint16_t out) {
             size_t offset = ByteIndex % PageSize;
             if (PageSize - offset >= sizeof(uint16_t)) {
@@ -186,7 +174,6 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           inline virtual void Write(uint32_t out) {
             size_t offset = ByteIndex % PageSize;
             if (PageSize - offset >= sizeof(uint32_t)) {
@@ -198,7 +185,6 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           inline virtual void Write(bool out) {
             size_t offset = ByteIndex % PageSize;
             if (PageSize - offset >= sizeof(bool)) {
@@ -210,12 +196,10 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           inline virtual void Write(const Base::TUuid &out) {
             Write(out.GetRaw(), sizeof(uuid_t));
           }
 
-          /* TODO */
           inline virtual void Write(const void *buf, size_t len) {
             size_t left = len;
             const char *ptr = reinterpret_cast<const char *>(buf);
@@ -230,7 +214,6 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           void MakeCurBlockCollisionBlock() {
             if (!CurBlockIsCollision && Buf /* && (ByteIndex % TService::BlockSize) != 0*/) {
               CurBlockIsCollision = true;
@@ -244,7 +227,6 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           void Sync() {
             if (!CurBlockIsCollision && Buf) {
               while (BlockVec.Size() < BlockInBuf + 1) {
@@ -265,7 +247,6 @@ namespace Orly {
 
           private:
 
-          /* TODO */
           inline void CheckBuf() {
             if (TBoundaryChecker<PageSize, BlockSize>::IsNewPage(ByteIndex, PageInBuf, Buf)) {
               size_t block = ByteIndex / BlockSize;
@@ -275,7 +256,6 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           inline void FetchBlock(size_t block) {
             if (!CurBlockIsCollision && Buf) {
               while (BlockVec.Size() < BlockInBuf + 1) {
@@ -296,7 +276,6 @@ namespace Orly {
             BlockInBuf = block;
           }
 
-          /* TODO */
           void Flush() {
             TCompletionTrigger *completion_trigger = &CompletionTrigger;
             /* TODO: implement write groups with new volume manager. */
@@ -313,45 +292,33 @@ namespace Orly {
             TWriteGroup::Flush();
           }
 
-          /* TODO */
           virtual size_t GetLogicalBlockSize() const override {
             return Util::LogicalBlockSize;
           }
 
-          /* TODO */
           virtual size_t GetPhysicalBlockSize() const override {
             return Util::PhysicalBlockSize;
           }
 
-          /* TODO */
           Util::TVolumeManager *VolMan;
 
-          /* TODO */
           bool DoCache;
 
-          /* TODO */
           size_t ByteIndex;
 
-          /* TODO */
           std::unordered_map<size_t, std::shared_ptr<const TBufBlock>> &BlockCollisionMap;
 
-          /* TODO */
           Indy::Util::TBlockVec &BlockVec;
 
-          /* TODO */
           const TBufBlock *Buf;
 
-          /* TODO */
           size_t BlockInBuf;
           size_t PageInBuf;
 
-          /* TODO */
           bool CurBlockIsCollision;
 
-          /* TODO */
           TCompletionTrigger &CompletionTrigger;
 
-          /* TODO */
           const std::function<size_t (Disk::Util::TVolumeManager *)> NewBlockCb;
 
           #ifndef NDEBUG
@@ -359,13 +326,11 @@ namespace Orly {
           std::unordered_set<size_t> &WrittenToSet;
           #endif
 
-          /* TODO */
           DiskPriority Priority;
 
           /* DEBUG */
           const Base::TCodeLocation CodeLocation;
 
-          /* TODO */
           uint8_t UtilSrc;
 
         };  // TOutStream

--- a/orly/indy/disk/present_walk_file.h
+++ b/orly/indy/disk/present_walk_file.h
@@ -37,36 +37,27 @@ namespace Orly {
 
     namespace Disk {
 
-      /* TODO */
       class TWalkerKey {
         public:
 
-        /* TODO */
         TWalkerKey(const Base::TUuid &file_id, size_t gen_id, const Base::TUuid &index_id) : FileId(file_id), GenId(gen_id), IndexId(index_id) {}
 
-        /* TODO */
         TWalkerKey(Base::TUuid &&file_id, size_t gen_id, Base::TUuid &&index_id) : FileId(std::move(file_id)), GenId(gen_id), IndexId(std::move(index_id)) {}
 
-        /* TODO */
         Base::TUuid FileId;
 
-        /* TODO */
         size_t GenId;
 
-        /* TODO */
         Base::TUuid IndexId;
 
-        /* TODO */
         inline size_t GetHash() const {
           return GenId ^ FileId.GetHash()^ IndexId.GetHash();
         }
 
-        /* TODO */
         inline bool operator==(const TWalkerKey &that) const {
           return FileId == that.FileId && GenId == that.GenId && IndexId == that.IndexId;
         }
 
-        /* TODO */
         inline bool operator!=(const TWalkerKey &that) const {
           return FileId != that.FileId || GenId != that.GenId || IndexId != that.IndexId;
         }
@@ -99,30 +90,24 @@ namespace Orly {
 
     namespace Disk {
 
-      /* TODO */
       class TLocalWalkerCache {
         NO_COPY(TLocalWalkerCache);
         public:
 
-        /* TODO */
         TLocalWalkerCache() : LoaderCollection(this) {}
 
         /* Forward Declaration */
         class TLoaderObj;
 
-        /* TODO */
         class TPresentWalkFile
             : public TPresentWalker {
           NO_COPY(TPresentWalkFile);
           public:
 
-          /* TODO */
           static constexpr size_t PhysicalCachePageSize = Util::PhysicalBlockSize / (Util::LogicalBlockSize / Util::LogicalPageSize);
 
-          /* TODO */
           using TArena = TDiskArena<Util::LogicalPageSize, Util::LogicalBlockSize, Util::PhysicalBlockSize, Util::CheckedPage, DiskArenaMaxCacheSize, true>;
 
-          /* TODO */
           using TInStream = TStream<Util::LogicalPageSize, Util::LogicalBlockSize, Util::PhysicalBlockSize, Util::CheckedPage, 0UL>;
           using TMyReadFile = Orly::Indy::Disk::TReadFile<Util::LogicalPageSize, Util::LogicalBlockSize, Util::PhysicalBlockSize, Util::CheckedPage>;
 
@@ -151,10 +136,8 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           struct TDeleter {
 
-            /* TODO */
             void operator ()(TPresentWalkFile *p) const {
               p->LoaderObj->Free(p);
             };
@@ -207,7 +190,6 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           virtual ~TPresentWalkFile() {}
 
           /* True iff. we have an item. */
@@ -234,7 +216,6 @@ namespace Orly {
 
           private:
 
-          /* TODO */
           void Refresh() const {
             assert (!Cached);
             assert(Valid);
@@ -338,41 +319,29 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           Base::TUuid IndexId;
 
-          /* TODO */
           TMyReadFile *MyReadFile;
 
-          /* TODO */
           typename TMyReadFile::TIndexFile *IndexFile;
 
-          /* TODO */
           TArena MainArena;
           std::unique_ptr<TArena> IndexArena;
 
-          /* TODO */
           TKey From;
 
-          /* TODO */
           TKey To;
 
-          /* TODO */
           mutable TInStream Stream;
 
-          /* TODO */
           mutable TInStream IndexStream;
 
-          /* TODO */
           mutable bool Valid;
 
-          /* TODO */
           mutable bool Cached;
 
-          /* TODO */
           mutable TItem Item;
 
-          /* TODO */
           mutable size_t Offset;
 
           /* #227 / #49: when the current key just yielded is a deferred
@@ -386,10 +355,8 @@ namespace Orly {
           mutable std::unique_ptr<typename TMyReadFile::TIndexFile::THistoryKeyCursor> HistCursor;
           mutable size_t HistRemaining = 0UL;
 
-          /* TODO */
           TLoaderObj *LoaderObj;
 
-          /* TODO */
           TPresentWalkFile *NextWalker;
 
           friend class TLoaderObj;
@@ -397,7 +364,6 @@ namespace Orly {
 
         };  // TPresentWalkFile
 
-        /* TODO */
         TPresentWalkFile *Get(Util::TEngine *engine,
                               const Base::TUuid &file_id,
                               size_t gen_id,
@@ -409,29 +375,23 @@ namespace Orly {
           return loader->GetNewFile(engine, file_id, gen_id, index_id);
         }
 
-        /* TODO */
         void Clear(const Base::TUuid &file_id, size_t gen_id, const Base::TUuid &index_id) {
           TLoaderObj *loader = LoaderCollection.TryGetFirstMember(TWalkerKey(file_id, gen_id, index_id));
           delete loader;
         }
 
-        /* TODO */
         static __thread TLocalWalkerCache *Cache;
 
-        /* TODO */
         class TLoaderObj {
           NO_COPY(TLoaderObj);
           public:
 
-          /* TODO */
           typedef InvCon::UnorderedMultimap::TMembership<TLoaderObj, TLocalWalkerCache, TWalkerKey> TCacheMembership;
 
-          /* TODO */
           TLoaderObj(TLocalWalkerCache *cache, const Base::TUuid &file_id, size_t gen_id, const Base::TUuid &index_id)
               : FreeQueue(nullptr),
                 CacheMembership(this, TWalkerKey(file_id, gen_id, index_id), &cache->LoaderCollection) {}
 
-          /* TODO */
           ~TLoaderObj() {
             for (TPresentWalkFile *file = FreeQueue; file;) {
               TPresentWalkFile *to_delete = file;
@@ -440,7 +400,6 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           TPresentWalkFile *GetNewFile(Util::TEngine *engine, const Base::TUuid &file_id, size_t gen_id, const Base::TUuid &index_id) {
             if (!FreeQueue) {
               return new TPresentWalkFile(engine, file_id, gen_id, index_id, this);
@@ -451,7 +410,6 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           void Free(TPresentWalkFile *walker) {
             walker->NextWalker = FreeQueue;
             FreeQueue = walker;
@@ -459,31 +417,25 @@ namespace Orly {
 
           private:
 
-          /* TODO */
           TPresentWalkFile *FreeQueue;
 
-          /* TODO */
           typename TCacheMembership::TImpl CacheMembership;
 
         };  // TLoaderObj
 
         private:
 
-        /* TODO */
         typedef InvCon::UnorderedMultimap::TCollection<TLocalWalkerCache, TLoaderObj, TWalkerKey> TLoaderCollection;
 
-        /* TODO */
         mutable typename TLoaderCollection::TImpl LoaderCollection;
 
       };  // TLocalWalkerCache
 
-      /* TODO */
       class TPresentWalkFileWrapper
           : public TPresentWalker {
         NO_COPY(TPresentWalkFileWrapper);
         public:
 
-        /* TODO */
         TPresentWalkFileWrapper(Util::TEngine *engine,
                                 const Base::TUuid &file_id,
                                 size_t gen_id,
@@ -495,7 +447,6 @@ namespace Orly {
           File->Init(from, to);
         }
 
-        /* TODO */
         TPresentWalkFileWrapper(Util::TEngine *engine,
                                 const Base::TUuid &file_id,
                                 size_t gen_id,
@@ -506,7 +457,6 @@ namespace Orly {
           File->Init(key);
         }
 
-        /* TODO */
         virtual ~TPresentWalkFileWrapper() {
           assert(File);
           assert(File->LoaderObj);
@@ -531,7 +481,6 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         TLocalWalkerCache::TPresentWalkFile *File;
 
       };  // TPresentWalkFileWrapper

--- a/orly/indy/disk/priority.h
+++ b/orly/indy/disk/priority.h
@@ -27,7 +27,6 @@ namespace Orly {
 
     namespace Disk {
 
-      /* TODO */
       enum DiskPriority {
         RealTime,
         Medium,

--- a/orly/indy/disk/read_file.h
+++ b/orly/indy/disk/read_file.h
@@ -45,33 +45,25 @@ namespace Orly {
 
     namespace Disk {
 
-      /* TODO */
       class TFileKey {
         public:
 
-        /* TODO */
         TFileKey(const Base::TUuid &file_id, size_t gen_id) : FileId(file_id), GenId(gen_id) {}
 
-        /* TODO */
         TFileKey(Base::TUuid &&file_id, size_t gen_id) : FileId(std::move(file_id)), GenId(gen_id) {}
 
-        /* TODO */
         Base::TUuid FileId;
 
-        /* TODO */
         size_t GenId;
 
-        /* TODO */
         inline size_t GetHash() const {
           return GenId ^ FileId.GetHash();
         }
 
-        /* TODO */
         inline bool operator==(const TFileKey &that) const {
           return FileId == that.FileId && GenId == that.GenId;
         }
 
-        /* TODO */
         inline bool operator!=(const TFileKey &that) const {
           return FileId != that.FileId || GenId != that.GenId;
         }
@@ -104,35 +96,27 @@ namespace Orly {
 
     namespace Disk {
 
-      /* TODO */
       class TArenaInFile
           : public TInFile {
         NO_COPY(TArenaInFile);
         public:
 
-        /* TODO */
         virtual size_t GetByteOffsetOfArena() const = 0;
 
-        /* TODO */
         virtual size_t GetNumArenaNotes() const = 0;
 
-        /* TODO */
         virtual Atom::TCore::TOffset GetNumBytesOfArena() const = 0;
 
         protected:
 
-        /* TODO */
         TArenaInFile() {}
 
-        /* TODO */
         virtual ~TArenaInFile() {}
 
       };
 
-      /* TODO */
       static constexpr size_t DiskArenaMaxCacheSize = 128;
 
-      /* TODO */
       template <size_t CachePageSize, size_t BlockSize, size_t PhysicalBlockSize, Util::TBufKind BufKind, size_t StreamLocalCacheSize, bool ScanAheadAllowed>
       class TDiskArena
           : public Atom::TCore::TArena {
@@ -141,17 +125,14 @@ namespace Orly {
 
         public:
 
-        /* TODO */
         static constexpr size_t DataChunkSize = Util::GetLogicalDataChunkSize<BufKind>();
         static constexpr size_t PhysicalDataChunkSize = Util::GetPhysicalDataChunkSize<BufKind>();
         static constexpr size_t PhysicalCachePageSize = PhysicalBlockSize / (BlockSize / CachePageSize);
 
-        /* TODO */
         class TCursor {
           NO_COPY(TCursor);
           public:
 
-          /* TODO */
           TCursor(TDiskArena *context, Atom::TCore::TOffset start_offset, Atom::TCore::TOffset end_offset)
               : Arena(context),
                 Pin(nullptr),
@@ -175,7 +156,6 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           ~TCursor() {
             if (Pin) {
               Pin->TPin::~TPin();
@@ -183,44 +163,37 @@ namespace Orly {
             free(PinAlloc);
           }
 
-          /* TODO */
           operator bool() const {
             return Pin != nullptr;
           }
 
-          /* TODO */
           const Atom::TCore::TNote *operator*() const {
             assert(Pin);
             assert(Pin->GetNote());
             return Pin->GetNote();
           }
 
-          /* TODO */
           const Atom::TCore::TNote *operator->() const {
             assert(Pin);
             assert(Pin->GetNote());
             return Pin->GetNote();
           }
 
-          /* TODO */
           TCursor &operator++() {
             Refresh();
             return *this;
           }
 
-          /* TODO */
           Atom::TCore::TOffset GetOffset() const {
             return Offset;
           }
 
-          /* TODO */
           inline TDiskArena *GetArena() const {
             return Arena;
           }
 
           private:
 
-          /* TODO */
           void Refresh() {
             if (Pin) {
               Offset += sizeof(Atom::TCore::TNote) + Pin->GetNote()->GetRawSize();
@@ -233,24 +206,18 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           TDiskArena *Arena;
 
-          /* TODO */
           TDiskArena::TFinalPin *Pin;
 
-          /* TODO */
           TDiskArena::TFinalPin *PinAlloc;
 
-          /* TODO */
           Atom::TCore::TOffset Offset;
 
-          /* TODO */
           Atom::TCore::TOffset EndOffset;
 
         };  // TCursor
 
-        /* TODO */
         TDiskArena(TArenaInFile *file, Util::TCache<PhysicalCachePageSize> *cache, DiskPriority priority)
             : TArena(true),
               File(file),
@@ -262,76 +229,58 @@ namespace Orly {
           assert(file);
         }
 
-        /* TODO */
         virtual ~TDiskArena() {
         }
 
-        /* TODO */
         inline virtual void ReleaseNote(const Atom::TCore::TNote *note, Atom::TCore::TOffset offset, void *data1, void *data2, void *data3);
 
-        /* TODO */
         inline virtual const Atom::TCore::TNote *TryAcquireNote(Atom::TCore::TOffset offset, void *&data1, void *&data2, void *&data3);
 
-        /* TODO */
         inline virtual const Atom::TCore::TNote *TryAcquireNote(Atom::TCore::TOffset offset, size_t known_size, void *&data1, void *&data2, void *&data3);
 
-        /* TODO */
         Atom::TCore::TOffset GetNumBytesOfArena() const {
           return File->GetNumBytesOfArena();
         }
 
         private:
 
-        /* TODO */
         TArenaInFile *File;
 
-        /* TODO */
         DiskPriority Priority;
 
-        /* TODO */
         Util::TCache<PhysicalCachePageSize> *Cache;
 
-        /* TODO */
         TCompletionTrigger SyncTrigger;
 
-        /* TODO */
         size_t StartOffset;
 
-        /* TODO */
         TStream<CachePageSize, BlockSize, PhysicalBlockSize, BufKind, StreamLocalCacheSize, ScanAheadAllowed> Stream;
 
-        /* TODO */
         size_t NumNotes;
 
       };  // TDiskArena
 
-      /* TODO */
       template <size_t CachePageSize, size_t BlockSize, size_t PhysicalBlockSize, Util::TBufKind BufKind, bool ScanAheadAllowed = true>
       class TReadFile
           : public TArenaInFile {
         NO_COPY(TReadFile);
         public:
 
-        /* TODO */
         static constexpr size_t PagesInBlock = BlockSize / CachePageSize;
         static constexpr size_t PhysicalCachePageSize = PhysicalBlockSize / (BlockSize / CachePageSize);
 
-        /* TODO */
         inline virtual size_t GetFileLength() const {
           return FileLength;
         }
 
-        /* TODO */
         inline virtual size_t GetStartingBlock() const {
           return StartingBlockId;
         }
 
-        /* TODO */
         virtual void ReadMeta(size_t , size_t &) const {
           throw std::logic_error("Deprecated");
         }
 
-        /* TODO */
         inline virtual size_t FindPageIdOfByte(size_t offset) const {
           assert(offset < FileLength);
           size_t num_blocks_into_file = offset / BlockSize;
@@ -345,12 +294,10 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         static __thread size_t HashHitCount;
 
         protected:
 
-        /* TODO */
         TReadFile(const Base::TCodeLocation &code_location,
                   uint8_t util_src,
                   Util::TCache<PhysicalCachePageSize> *cache,
@@ -371,7 +318,6 @@ namespace Orly {
           Init();
         }
 
-        /* TODO */
         TReadFile(const Base::TCodeLocation &code_location,
                   uint8_t util_src,
                   Util::TEngine *engine,
@@ -395,7 +341,6 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         void Init() {
           assert(StartingBlockOffset * BlockSize < FileLength);
           TStream<CachePageSize, BlockSize, PhysicalBlockSize, BufKind, MaxMetaCacheSize> in_stream(CodeLocation, UtilSrc, Priority, this, Cache, StartingBlockOffset * BlockSize);
@@ -459,72 +404,58 @@ namespace Orly {
 
         protected:
 
-        /* TODO */
         virtual ~TReadFile() {}
 
-        /* TODO */
         inline size_t GetNumBlocks() const {
           return NumBlocks;
         }
 
-        /* TODO */
         inline size_t GetStartingBlockOffset() const {
           return StartingBlockOffset;
         }
 
-        /* TODO */
         inline size_t GetNumMetaBlocks() const {
           return NumMetaBlocks;
         }
 
-        /* TODO */
         inline size_t GetNumSequentialBlockPairings() const {
           return NumSequentialBlockPairings;
         }
 
-        /* TODO */
         inline size_t GetByteOffsetOfArena() const {
           return ByteOffsetOfMainArena;
         }
 
-        /* TODO */
         inline size_t GetNumArenaNotes() const {
           return NumMainArenaNotes;
         }
 
-        /* TODO */
         inline size_t GetNumBytesOfArena() const {
           return NumMainArenaBytes;
         }
 
-        /* TODO */
         inline const std::vector<size_t> &GetTypeBoundaryOffsetVec() const {
           return MainArenaTypeBoundaryOffsetVec;
         }
 
-        /* TODO */
         inline size_t GetNumUpdates() const {
           return NumUpdates;
         }
 
-        /* TODO */
         inline size_t GetGenId() const {
           return GenId;
         }
 
-        /* TODO */
         inline size_t GetByteOffsetOfUpdateIndex() const {
           return ByteOffsetOfUpdateIndex;
         }
 
-        /* TODO */
         void ForEachIndex(const std::function<void (const Base::TUuid &, size_t)> &cb) const {
           for (const auto &idx : IndexOffsetById) {
             cb(idx.first, idx.second);
           }
         }
 
-        /* TODO */
         bool FindInHash(const Base::TUuid &index_id, const TKey &key, size_t &out_offset) const {
           auto ret = IndexById.find(index_id);
           if (ret != IndexById.end()) {
@@ -535,16 +466,13 @@ namespace Orly {
 
         public:
 
-        /* TODO */
         class TIndexFile
             : public TArenaInFile {
           NO_COPY(TIndexFile);
           public:
 
-          /* TODO */
           using TArena = TDiskArena<CachePageSize, BlockSize, PhysicalBlockSize, BufKind, DiskArenaMaxCacheSize, ScanAheadAllowed>;
 
-          /* TODO */
           using TInStream = TStream<CachePageSize, BlockSize, PhysicalBlockSize, BufKind, 0UL /* local cache size */>;
 
           /* On-disk current-key entry. Read/written verbatim via
@@ -555,7 +483,6 @@ namespace Orly {
           class TKeyItem {
             public:
 
-            /* TODO */
             TSequenceNumber SeqNum;
             Atom::TCore Key;
             Atom::TCore Value;
@@ -572,7 +499,6 @@ namespace Orly {
           class THistoryKeyItem {
             public:
 
-            /* TODO */
             TSequenceNumber SeqNum;
             Atom::TCore Key;
             Atom::TCore Value;
@@ -581,12 +507,10 @@ namespace Orly {
 
           };  // THistoryKeyItem
 
-          /* TODO */
           class TKeyCursor {
             NO_COPY(TKeyCursor);
             public:
 
-            /* TODO */
             TKeyCursor(TIndexFile *idx_file, size_t start_num = 0UL)
                 : Cur(start_num),
                   Limit(idx_file->NumCurKeys),
@@ -620,27 +544,21 @@ namespace Orly {
 
             private:
 
-            /* TODO */
             TKeyItem Item;
             static_assert(sizeof(TKeyItem) == TData::KeyEntrySize, "TKeyItem is not the same size as a current key entry in a data file");
 
-            /* TODO */
             size_t Cur;
 
-            /* TODO */
             size_t Limit;
 
-            /* TODO */
             TStream<CachePageSize, BlockSize, PhysicalBlockSize, BufKind, 0UL /* local cache size */> InStream;
 
           };  // TKeyCursor
 
-          /* TODO */
           class THistoryKeyCursor {
             NO_COPY(THistoryKeyCursor);
             public:
 
-            /* TODO */
             THistoryKeyCursor(TIndexFile *idx_file, size_t start_num = 0UL)
                 : Cur(start_num),
                   Limit(idx_file->NumHistKeys),
@@ -679,17 +597,13 @@ namespace Orly {
 
             private:
 
-            /* TODO */
             THistoryKeyItem Item;
             static_assert(sizeof(THistoryKeyItem) == TData::KeyHistorySize, "THistoryKeyItem is not the same size as a history key entry in a data file");
 
-            /* TODO */
             size_t Cur;
 
-            /* TODO */
             size_t Limit;
 
-            /* TODO */
             TStream<CachePageSize, BlockSize, PhysicalBlockSize, BufKind, 0UL /* local cache size */> InStream;
 
           };  // THistoryKeyCursor
@@ -697,7 +611,6 @@ namespace Orly {
           TIndexFile(const TReadFile *file, const Base::TUuid &index_id, DiskPriority priority)
               : TIndexFile(file, index_id, file->IndexOffsetById.find(index_id)->second , priority) {}
 
-          /* TODO */
           TIndexFile(const TReadFile *file, const Base::TUuid &index_id, size_t index_meta_offset, DiskPriority /*priority*/)
               : File(file),
                 IndexId(index_id) {
@@ -725,7 +638,6 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           bool FindInHash(const TKey &key, size_t &out_offset, TInStream &in_stream, TArena *file_arena) const {
             assert(key.GetCore().IsTuple());
             const Atom::TCore &core = key.GetCore();
@@ -805,7 +717,6 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           bool BinaryLowerBoundOnKey(const TKey &key, size_t &out_offset, TInStream &in_stream, TArena *file_arena) const {
             assert(NumCurKeys > 0);
             size_t first = 0U;
@@ -831,7 +742,6 @@ namespace Orly {
             return first < NumCurKeys;
           }
 
-          /* TODO */
           Indy::TKey GetKey(size_t n, TInStream &in_stream, TArena *file_arena) const {
             assert(n < NumCurKeys);
             Atom::TCore core;
@@ -840,94 +750,76 @@ namespace Orly {
             return Indy::TKey(core, file_arena);
           }
 
-          /* TODO */
           inline const Base::TUuid &GetIndexId() const {
             return IndexId;
           }
 
-          /* TODO */
           inline virtual Atom::TCore::TOffset GetNumBytesOfArena() const override {
             return NumArenaBytes;
           }
 
-          /* TODO */
           inline const std::vector<size_t> &GetTypeBoundaryOffsetVec() const {
             return ArenaTypeBoundaryByOffset;
           }
 
-          /* TODO */
           inline size_t GetNumCurKeys() const {
             return NumCurKeys;
           }
 
-          /* TODO */
           inline size_t GetNumHistKeys() const {
             return NumHistKeys;
           }
 
-          /* TODO */
           inline size_t GetGenId() const {
             return File->GenId;
           }
 
-          /* TODO */
           inline size_t GetByteOffsetOfKeyIndex() const {
             return ByteOffsetOfKeyIndex;
           }
 
-          /* TODO */
           inline size_t GetByteOffsetOfHistoryIndex() const {
             return ByteOffsetOfKeyIndex + (NumCurKeys * TData::KeyEntrySize);
           }
 
-          /* TODO */
           inline const std::vector<std::pair<size_t, size_t>> &GetNumHashFieldsByOffset() const {
             return NumHashFieldsByOffset;
           }
 
           private:
 
-          /* TODO */
           inline virtual size_t GetByteOffsetOfArena() const override {
             return ArenaByteOffset;
           }
 
-          /* TODO */
           inline virtual size_t GetNumArenaNotes() const override {
             return NumArenaNotes;
           }
 
-          /* TODO */
           inline virtual size_t GetFileLength() const override {
             assert(File);
             return File->GetFileLength();
           }
 
-          /* TODO */
           inline virtual size_t GetStartingBlock() const override {
             assert(File);
             return File->GetStartingBlock();
           }
 
-          /* TODO */
           inline virtual void ReadMeta(size_t offset, size_t &out) const override {
             assert(File);
             return File->ReadMeta(offset, out);
           }
 
-          /* TODO */
           inline virtual size_t FindPageIdOfByte(size_t offset) const override {
             assert(File);
             return File->FindPageIdOfByte(offset);
           }
 
-          /* TODO */
           const TReadFile *File;
 
-          /* TODO */
           Base::TUuid IndexId;
 
-          /* TODO */
           size_t ArenaByteOffset;
           size_t NumArenaNotes;
           size_t NumArenaBytes;
@@ -937,35 +829,27 @@ namespace Orly {
           size_t ByteOffsetOfKeyIndex;
           size_t NumHashTables;
 
-          /* TODO */
           std::vector<std::pair<size_t, size_t>> NumHashFieldsByOffset;
 
-          /* TODO */
           std::vector<size_t> ArenaTypeBoundaryByOffset;
 
         };  // TIndexFile
 
-        /* TODO */
         inline const std::unordered_map<Base::TUuid, std::unique_ptr<TIndexFile>> &GetIndexByIdMap() {
           return IndexById;
         }
 
         protected:
 
-        /* TODO */
         //Util::TPageCache *PageCache;
         Util::TCache<PhysicalCachePageSize> *Cache;
 
-        /* TODO */
         size_t StartingBlockId;
 
-        /* TODO */
         size_t StartingBlockOffset;
 
-        /* TODO */
         size_t FileLength;
 
-        /* TODO */
         size_t NumBlocks;
         size_t NumMetaBlocks;
         size_t NumSequentialBlockPairings;
@@ -977,49 +861,37 @@ namespace Orly {
         size_t ByteOffsetOfMainArena;
         size_t ByteOffsetOfUpdateIndex;
 
-        /* TODO */
         static constexpr size_t MaxMetaCacheSize = 64;
 
-        /* TODO */
         std::map<size_t, size_t> OffsetBlockByBlockId;
 
-        /* TODO */
         std::unordered_map<Base::TUuid, size_t> IndexOffsetById;
 
-        /* TODO */
         std::unordered_map<Base::TUuid, std::unique_ptr<TIndexFile>> IndexById;
 
-        /* TODO */
         std::map<size_t, TIndexFile *> IndexByOffset;
 
-        /* TODO */
         std::vector<size_t> MainArenaTypeBoundaryOffsetVec;
 
-        /* TODO */
         DiskPriority Priority;
 
-        /* TODO */
         size_t GenId;
 
-        /* TODO */
         const Base::TCodeLocation CodeLocation;
         const uint8_t UtilSrc;
 
       };  // TReadFile
 
-      /* TODO */
       template <size_t CachePageSize, size_t BlockSize, size_t PhysicalBlockSize, Util::TBufKind BufKind, bool ScanAheadAllowed = true>
       class TLocalReadFileCache {
         NO_COPY(TLocalReadFileCache);
         public:
 
-        /* TODO */
         class TLocalReadFile
             : public TReadFile<CachePageSize, BlockSize, PhysicalBlockSize, BufKind, ScanAheadAllowed> {
           NO_COPY(TLocalReadFile);
           public:
 
-          /* TODO */
           TLocalReadFile(Util::TEngine *engine,
                          const Base::TUuid &file_id,
                          size_t gen_id)
@@ -1030,16 +902,13 @@ namespace Orly {
                                                                                                   RealTime,
                                                                                                   gen_id) {}
 
-          /* TODO */
           virtual ~TLocalReadFile() {}
 
 
         };  // TLocalReadFile
 
-        /* TODO */
         TLocalReadFileCache() : LoaderCollection(this) {}
 
-        /* TODO */
         TLocalReadFile *Get(Util::TEngine *engine,
                             const Base::TUuid &file_id,
                             size_t gen_id) {
@@ -1050,26 +919,21 @@ namespace Orly {
           return loader->GetFile();
         }
 
-        /* TODO */
         void Clear(const Base::TUuid &file_id, size_t gen_id) {
           TLoaderObj *loader = LoaderCollection.TryGetFirstMember(TFileKey(file_id, gen_id));
           delete loader;
         }
 
-        /* TODO */
         static __thread TLocalReadFileCache *Cache;
 
         private:
 
-        /* TODO */
         class TLoaderObj {
           NO_COPY(TLoaderObj);
           public:
 
-          /* TODO */
           typedef InvCon::UnorderedMultimap::TMembership<TLoaderObj, TLocalReadFileCache, TFileKey> TCacheMembership;
 
-          /* TODO */
           TLoaderObj(TLocalReadFileCache *cache, Util::TEngine *engine, const Base::TUuid &file_id, size_t gen_id) : CacheMembership(this, TFileKey(file_id, gen_id), &cache->LoaderCollection) {
             File = std::make_unique<TLocalReadFile>(engine, file_id, gen_id);
             /* if frames have joined the waiting queue, schedule them */
@@ -1079,7 +943,6 @@ namespace Orly {
             FrameWaitingVec.clear();
           }
 
-          /* TODO */
           TLocalReadFile *GetFile() {
             if (!File) {
               FrameWaitingVec.emplace_back(Fiber::TFrame::LocalFrame);
@@ -1090,21 +953,16 @@ namespace Orly {
 
           private:
 
-          /* TODO */
           std::unique_ptr<TLocalReadFile> File;
 
-          /* TODO */
           std::vector<Fiber::TFrame *> FrameWaitingVec;
 
-          /* TODO */
           typename TCacheMembership::TImpl CacheMembership;
 
         };  // TLoaderObj
 
-        /* TODO */
         typedef InvCon::UnorderedMultimap::TCollection<TLocalReadFileCache, TLoaderObj, TFileKey> TLoaderCollection;
 
-        /* TODO */
         mutable typename TLoaderCollection::TImpl LoaderCollection;
 
       };  // TLocalReadFileCache

--- a/orly/indy/disk/result.h
+++ b/orly/indy/disk/result.h
@@ -86,7 +86,6 @@ namespace Orly {
 
       };  // TResult
 
-      /* TODO */
       template <typename TVal>
       static void WaitForDiskSpin(TVal &trigger, TVal wait_for_this, std::condition_variable &cond, std::unique_lock<std::mutex> &lock, TDiskResult &result, const char *err_str) {
         while (trigger != wait_for_this) {
@@ -111,48 +110,35 @@ namespace Orly {
         }
       }
 
-      /* TODO */
       class TCompletionTrigger {
         NO_COPY(TCompletionTrigger);
         public:
 
-        /* TODO */
         inline TCompletionTrigger();
 
-        /* TODO */
         inline ~TCompletionTrigger();
 
-        /* TODO */
         inline void WaitForMore(size_t num);
 
-        /* TODO */
         inline void WaitForOneMore();
 
-        /* TODO */
         inline void Callback(TDiskResult disk_result, const char *err_str);
 
-        /* TODO */
         inline void Wait(bool come_back_right_away = false);
 
         private:
 
-        /* TODO */
         std::atomic<size_t> WaitFor;
 
-        /* TODO */
         std::atomic<size_t> NumFinished;
 
-        /* TODO */
         Fiber::TFrame *FrameWaiting;
         Fiber::TRunner *RunnerToReactivateOn;
 
-        /* TODO */
         Base::TSpinLock SpinLock;
 
-        /* TODO */
         TDiskResult Result;
 
-        /* TODO */
         const char *ErrStr;
 
       };  // TCompletionTrigger

--- a/orly/indy/disk/sim/mem_engine.h
+++ b/orly/indy/disk/sim/mem_engine.h
@@ -34,12 +34,10 @@ namespace Orly {
 
       namespace Sim {
 
-        /* TODO */
         class TMemEngine {
           NO_COPY(TMemEngine);
           public:
 
-          /* TODO */
           TMemEngine(Base::TScheduler *scheduler, size_t num_mb, size_t num_slow_mb, size_t page_cache_size, size_t num_page_lru, size_t block_cache_size, size_t num_block_lru) {
             const size_t logical_block_size = 512;
             const size_t physical_block_size = 512;
@@ -160,22 +158,18 @@ namespace Orly {
             Engine = std::make_unique<Util::TEngine>(VolMan.get(), PageCache.get(), BlockCache.get(), &TestFileService, false);
           }
 
-          /* TODO */
           Util::TEngine *GetEngine() const {
             return Engine.get();
           }
 
-          /* TODO */
           Util::TPageCache *GetPageCache() const {
             return PageCache.get();
           }
 
-          /* TODO */
           Util::TBlockCache *GetBlockCache() const {
             return BlockCache.get();
           }
 
-          /* TODO */
           Util::TVolumeManager *GetVolMan() const {
             return VolMan.get();
           }
@@ -186,22 +180,18 @@ namespace Orly {
 
           static constexpr size_t NumSlowMemDevice = 1UL;
 
-          /* TODO */
           TTestFileService TestFileService;
 
-          /* TODO */
           std::unique_ptr<Util::TMemoryDevice> FastMemDeviceArray[NumFastMemDevice];
           std::unique_ptr<Util::TMemoryDevice> SlowMemDeviceArray[NumSlowMemDevice];
           std::unique_ptr<Util::TVolume> FastVolume;
           std::unique_ptr<Util::TVolume> SlowVolume;
           std::unique_ptr<Util::TVolumeManager> VolMan;
 
-          /* TODO */
           std::unique_ptr<Util::TPageCache> PageCache;
           std::unique_ptr<Util::TBlockCache> BlockCache;
           std::unique_ptr<Util::TEngine> Engine;
 
-          /* TODO */
           Util::TCacheCb CacheCb;
 
         };

--- a/orly/indy/disk/test_file_service.h
+++ b/orly/indy/disk/test_file_service.h
@@ -30,13 +30,11 @@ namespace Orly {
 
     namespace Disk {
 
-      /* TODO */
       class TTestFileService
           : public TFileServiceBase {
         NO_COPY(TTestFileService);
         public:
 
-        /* TODO */
         virtual bool FindFile(const Base::TUuid &file_uid,
                               size_t gen_id,
                               size_t &out_block_id,
@@ -44,7 +42,6 @@ namespace Orly {
                               size_t &out_file_size,
                               size_t &out_num_keys) const override;
 
-        /* TODO */
         virtual void InsertFile(const Base::TUuid &file_uid,
                                 TFileObj::TKind file_kind,
                                 size_t gen_id,
@@ -56,30 +53,23 @@ namespace Orly {
                                 TSequenceNumber highest_seq,
                                 TCompletionTrigger &completion_trigger) override;
 
-        /* TODO */
         virtual void RemoveFile(const Base::TUuid &file_uid,
                                 size_t gen_id,
                                 TCompletionTrigger &completion_trigger) override;
 
-        /* TODO */
         virtual void AppendFileGenSet(const Base::TUuid &file_uid,
                                       std::vector<TFileObj> &out_vec) override;
 
-        /* TODO */
         virtual bool ForEachFile(const std::function<bool (const Base::TUuid &file_uid, const TFileObj &)> &cb) override;
 
-        /* TODO */
         TTestFileService() {}
 
-        /* TODO */
         virtual ~TTestFileService() {}
 
         private:
 
-        /* TODO */
         typedef std::unordered_map<Base::TUuid, std::unordered_map<size_t, TFileObj>> TFileMap;
 
-        /* TODO */
         static void AddToMap(TFileMap &file_map,
                              const Base::TUuid &file_uid,
                              TFileObj::TKind file_kind,
@@ -91,15 +81,12 @@ namespace Orly {
                              TSequenceNumber lowest_seq,
                              TSequenceNumber highest_seq);
 
-        /* TODO */
         static void RemoveFromMap(TFileMap &file_map,
                                   const Base::TUuid &file_uid,
                                   size_t file_gen);
 
-        /* TODO */
         mutable std::mutex Mutex;
 
-        /* TODO */
         TFileMap FileMap;
 
       };  // TFileServiceBase

--- a/orly/indy/disk/update_walk_file.h
+++ b/orly/indy/disk/update_walk_file.h
@@ -37,10 +37,8 @@ namespace Orly {
 
     namespace Disk {
 
-      /* TODO */
       static constexpr size_t UpdateWalkerLocalCacheSize = 64;
 
-      /* TODO */
       class TUpdateWalkFile
           : public TReadFile<Util::LogicalPageSize, Util::LogicalBlockSize, Util::PhysicalBlockSize, Util::CheckedPage>,
             public TUpdateWalker {
@@ -49,11 +47,9 @@ namespace Orly {
 
         using TArena = TDiskArena<Util::LogicalPageSize, Util::LogicalBlockSize, Util::PhysicalBlockSize, Util::CheckedPage, DiskArenaMaxCacheSize, true>;
 
-        /* TODO */
         typedef TStream<Util::LogicalPageSize, Util::LogicalBlockSize, Util::PhysicalBlockSize, Util::CheckedPage, UpdateWalkerLocalCacheSize> TInStream;
         typedef Orly::Indy::Disk::TReadFile<Util::LogicalPageSize, Util::LogicalBlockSize, Util::PhysicalBlockSize, Util::CheckedPage> TMyReadFile;
 
-        /* TODO */
         TUpdateWalkFile(Util::TEngine *engine,
                         const Base::TUuid &file_id,
                         size_t gen_id,
@@ -72,7 +68,6 @@ namespace Orly {
           Refresh();
         }
 
-        /* TODO */
         virtual ~TUpdateWalkFile() {}
 
         /* True iff. we have an item. */
@@ -97,7 +92,6 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         void Refresh() const {
           if (Valid && !Cached) {
             if (NumScanned < GetNumUpdates()) {
@@ -159,32 +153,23 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         mutable TArena MainArena;
         std::unordered_map<Base::TUuid, std::unique_ptr<TArena>> ArenaByIndexId;
 
-        /* TODO */
         TSequenceNumber From;
 
-        /* TODO */
         mutable size_t NumScanned;
 
-        /* TODO */
         mutable TInStream IndexStream;
 
-        /* TODO */
         mutable TInStream BucketStream;
 
-        /* TODO */
         mutable TInStream EntryStream;
 
-        /* TODO */
         mutable bool Valid;
 
-        /* TODO */
         mutable bool Cached;
 
-        /* TODO */
         mutable TItem Item;
 
       };  // TUpdateWalkFile

--- a/orly/indy/disk/util/cache.h
+++ b/orly/indy/disk/util/cache.h
@@ -48,13 +48,11 @@ namespace Orly {
 
       namespace Util {
 
-        /* TODO */
         template <size_t PageSize>
         class TCache {
           NO_COPY(TCache);
           private:
 
-          /* TODO */
           class TLRU;
 
           public:
@@ -68,17 +66,14 @@ namespace Orly {
           static constexpr size_t SecondHighestBit = 1UL << 62;
           static constexpr size_t ThirdHighestBit = 1UL << 61;
 
-          /* TODO */
           static constexpr size_t LockedSlot = -1;
           static constexpr size_t EmptySlot = -2;
           static constexpr size_t DummyStartSlot = -3;
 
-          /* TODO */
           struct TSlot {
 
             typedef InvCon::AtomicUnorderedList::TMembership<TSlot, TLRU> TLRUMembership;
 
-            /* TODO */
             TSlot()
                 : PageId(EmptySlot), RefCount(0UL), BufAddr(0UL), LRUMembership(this), NextSlot(nullptr), MainSlot(nullptr) {}
 
@@ -91,7 +86,6 @@ namespace Orly {
               return cache->PageData.get() + (page_offset * PageSize);
             }
 
-            /* TODO */
             inline void AsyncGetData(const Base::TCodeLocation &code_location,
                                      DiskPriority priority,
                                      TCache *cache,
@@ -155,7 +149,6 @@ namespace Orly {
               }
             }
 
-            /* TODO */
             inline const char *SyncGetData(const Base::TCodeLocation &code_location,
                                            DiskPriority priority,
                                            TCache *cache,
@@ -214,7 +207,6 @@ namespace Orly {
 
             private:
 
-            /* TODO */
             mutable std::atomic<size_t> PageId;
             size_t RefCount;
             /* BufAddr represents the offset of the page from the start of the cache's in a multiple of the page size:
@@ -227,12 +219,10 @@ namespace Orly {
             TSlot *NextSlot;
             TSlot *MainSlot;
 
-            /* TODO */
             friend class TCache;
 
           };  // TSlot
 
-          /* TODO */
           TCache(TVolumeManager *volume_manager,
                  size_t max_cache_size,
                  size_t num_lru)
@@ -285,7 +275,6 @@ namespace Orly {
           }
           #endif
 
-          /* TODO */
           inline void PreGet(size_t page_id) {
             const size_t slot_num = page_id % NumSlots;
             TSlot *const my_slot = &SlotArray[slot_num];
@@ -512,7 +501,6 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           inline void Clear(size_t page_id) {
             const size_t slot_num = page_id % NumSlots;
             TSlot &slot = SlotArray[slot_num];
@@ -584,7 +572,6 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           inline void Replace(size_t page_id, void *buf) {
             TSlot *data_slot;
             TSlot *main_slot = Get(page_id, data_slot);
@@ -602,7 +589,6 @@ namespace Orly {
             Release(main_slot, page_id);
           }
 
-          /* TODO */
           inline bool AssertNoRefCount(size_t page_id) {
             TSlot *data_slot;
             TSlot *main_slot = Get(page_id, data_slot);
@@ -614,7 +600,6 @@ namespace Orly {
             return ret;
           }
 
-          /* TODO */
           inline void AsyncMultiGet(const Base::TCodeLocation &code_location,
                                     DiskPriority priority,
                                     TCache *cache,
@@ -753,21 +738,18 @@ namespace Orly {
 
           private:
 
-          /* TODO */
           class alignas(64) TLRU {
             NO_COPY(TLRU);
             public:
 
             typedef InvCon::AtomicUnorderedList::TCollection<TLRU, TSlot> TSlotCollection;
 
-            /* TODO */
             TLRU() : SlotCollection(this)
             #ifdef PERF_STATS
             , NumBufInLRU(0UL)
             #endif
             {}
 
-            /* TODO */
             mutable typename TSlotCollection::TImpl SlotCollection;
 
             /* Stats */
@@ -777,7 +759,6 @@ namespace Orly {
 
           };  // TLRU
 
-          /* TODO */
           inline size_t NewPageBuf() {
             int lru_start = sched_getcpu() % NumLRU;
             size_t stop_lru = NumLRU;
@@ -819,7 +800,6 @@ namespace Orly {
             throw std::runtime_error("Ran out of cache pages");
           }
 
-          /* TODO */
           bool TryRemoveSlot(const TSlot &slot, TSlot *&slot_to_remove, size_t &out_reclaimed_page_buf, size_t &main_slot_page_id) {
             /* there are 2 cases:
                - this slot is in the main (pre-allocated) array ... common case
@@ -891,38 +871,28 @@ namespace Orly {
             return true;
           }
 
-          /* TODO */
           inline TSlot *NewSlot() {
             return new TSlot();
           }
 
-          /* TODO */
           inline void DeleteSlot(TSlot *slot) {
             delete slot;
           }
 
-          /* TODO */
           TVolumeManager *const VolumeManager;
 
-          /* TODO */
           const size_t MaxCacheSize;
 
-          /* TODO */
           const size_t NumSlots;
 
-          /* TODO */
           const size_t NumLRU;
 
-          /* TODO */
           std::unique_ptr<TSlot[]> SlotArray;
 
-          /* TODO */
           std::unique_ptr<TLRU[]> LRUArray;
 
-          /* TODO */
           std::unique_ptr<char> PageData;
 
-          /* TODO */
           std::function<bool (const TSlot &, TSlot *&, size_t &, size_t &)> TryRemoveSlotFunc;
 
         };  // TCache

--- a/orly/indy/disk/util/corruption_detector.h
+++ b/orly/indy/disk/util/corruption_detector.h
@@ -40,23 +40,19 @@ namespace Orly {
 
       namespace Util {
 
-        /* TODO */
         class TCorruptionDetector {
           NO_CONSTRUCTION(TCorruptionDetector);
           public:
 
-          /* TODO */
           static void inline WriteMurmur(size_t *buf, size_t buf_size, size_t key) {
             *reinterpret_cast<uint64_t *>(reinterpret_cast<uint8_t *>(buf) + buf_size - sizeof(size_t)) = Base::Murmur(buf, (buf_size / sizeof(size_t) - 1), key);
           }
 
-          /* TODO */
           static bool inline TryReadMurmur(size_t *buf, size_t buf_size, size_t key) {
             uint64_t hash = *reinterpret_cast<uint64_t *>(reinterpret_cast<uint8_t *>(buf) + buf_size - sizeof(size_t));
             return hash == Base::Murmur(buf, (buf_size / sizeof(size_t) - 1), key);
           }
 
-          /* TODO */
           static void inline ReadMurmur(size_t *buf, size_t buf_size, size_t key) {
             if (!TryReadMurmur(buf, buf_size, key)) {
               throw std::runtime_error("Caught Disk Corruption");

--- a/orly/indy/disk/util/device_util.h
+++ b/orly/indy/disk/util/device_util.h
@@ -37,7 +37,6 @@ namespace Orly {
 
         static constexpr size_t MaxInstanceNameSize = 24UL;
 
-        /* TODO */
         struct TVolumeId {
           size_t Id;
           char InstanceName[MaxInstanceNameSize];
@@ -82,7 +81,6 @@ namespace Orly {
 
       namespace Util {
 
-        /* TODO */
         class TDeviceUtil {
           NO_CONSTRUCTION(TDeviceUtil);
           public:
@@ -123,16 +121,12 @@ namespace Orly {
             uint64_t MinDiscardBlocks;
           };
 
-          /* TODO */
           static bool ProbeDevice(const char *path, TOrlyDevice &out_device);
 
-          /* TODO */
           static void ModifyDevice(const char *path, TOrlyDevice &new_device_info);
 
-          /* TODO */
           static void ZeroSuperBlock(const char *path);
 
-          /* TODO */
           static bool ForEachDevice(const std::function<bool (const char *)> &cb);
 
           static bool IsHardDrive(const std::string &dev_path);

--- a/orly/indy/disk/util/disk_engine.h
+++ b/orly/indy/disk/util/disk_engine.h
@@ -29,12 +29,10 @@ namespace Orly {
 
       namespace Util {
 
-        /* TODO */
         class TDiskEngine {
           NO_COPY(TDiskEngine);
           public:
 
-          /* TODO */
           TDiskEngine(Base::TScheduler *scheduler,
                       Fiber::TRunner::TRunnerCons &runner_cons,
                       Base::TThreadLocalGlobalPoolManager<Indy::Fiber::TFrame, size_t, Indy::Fiber::TRunner *> *frame_pool_manager,
@@ -281,44 +279,36 @@ namespace Orly {
                 std::make_unique<Util::TEngine>(VolMan, PageCache.get(), BlockCache.get(), FileService.get(), true);
           }
 
-          /* TODO */
           Util::TEngine *GetEngine() const {
             return Engine.get();
           }
 
-          /* TODO */
           Util::TPageCache *GetPageCache() const {
             return PageCache.get();
           }
 
-          /* TODO */
           Util::TBlockCache *GetBlockCache() const {
             return BlockCache.get();
           }
 
-          /* TODO */
           Util::TVolumeManager *GetVolMan() const {
             return VolMan;
           }
 
-          /* TODO */
           void Report(std::stringstream &ss, double elapsed_time) const {
             DiskController->Report(ss, elapsed_time);
           }
 
           private:
 
-          /* TODO */
           class TDataFileReader
               : public TReadFile<LogicalPageSize, LogicalBlockSize, PhysicalBlockSize, CheckedPage> {
             NO_COPY(TDataFileReader);
             public:
 
-            /* TODO */
             typedef TStream<Disk::Util::LogicalPageSize, Disk::Util::LogicalBlockSize, Disk::Util::PhysicalBlockSize, Disk::Util::CheckedPage, 0UL> TInStream;
             typedef Orly::Indy::Disk::TReadFile<Disk::Util::LogicalPageSize, Disk::Util::LogicalBlockSize, Disk::Util::PhysicalBlockSize, Disk::Util::CheckedPage> TMyReadFile;
 
-            /* TODO */
             TDataFileReader(Disk::Util::TPageCache *page_cache,
                             const Base::TUuid &file_id,
                             DiskPriority priority,
@@ -336,10 +326,8 @@ namespace Orly {
                               starting_block_offset,
                               file_length) {}
 
-            /* TODO */
             virtual ~TDataFileReader() {}
 
-            /* TODO */
             using TReadFile::GetStartingBlockOffset;
             using TReadFile::GetNumBlocks;
             using TReadFile::GetNumMetaBlocks;
@@ -350,34 +338,26 @@ namespace Orly {
 
           };  // TDataFileReader
 
-          /* TODO */
           Base::TScheduler *Scheduler;
 
-          /* TODO */
           std::unique_ptr<TDiskController> DiskController;
 
-          /* TODO */
           std::unique_ptr<TDiskUtil> DiskUtil;
 
-          /* TODO */
           size_t SystemBlockId;
 
-          /* TODO */
           std::unique_ptr<TFileService> FileService;
           size_t FileAppendLogBlocks;
           size_t Image1BlockId;
           size_t Image2BlockId;
           std::vector<size_t> AppendLogBlockVec;
 
-          /* TODO */
           Util::TVolumeManager *VolMan;
 
-          /* TODO */
           std::unique_ptr<Util::TPageCache> PageCache;
           std::unique_ptr<Util::TBlockCache> BlockCache;
           std::unique_ptr<Util::TEngine> Engine;
 
-          /* TODO */
           Util::TCacheCb CacheCb;
 
         };  // TDiskEngine

--- a/orly/indy/disk/util/disk_util.h
+++ b/orly/indy/disk/util/disk_util.h
@@ -30,12 +30,10 @@ namespace Orly {
 
       namespace Util {
 
-        /* TODO */
         class TDiskUtil {
           NO_COPY(TDiskUtil);
           public:
 
-          /* TODO */
           TDiskUtil(Base::TScheduler *scheduler,
                     TDiskController *controller,
                     const std::optional<std::string> &instance_filter,
@@ -43,10 +41,8 @@ namespace Orly {
                     const TCacheCb &cache_cb,
                     bool do_corruption_check = true);
 
-          /* TODO */
           void List(std::stringstream &ss) const;
 
-          /* TODO */
           void CreateVolume(const std::string &instance_name,
                             size_t num_devices,
                             const std::set<std::string> &device_set,
@@ -56,36 +52,27 @@ namespace Orly {
                             const TVolume::TDesc::TStorageSpeed storage_speed,
                             bool do_fsync);
 
-          /* TODO */
           TVolumeManager *GetVolumeManager(const std::string &instance_name) const;
 
-          /* TODO */
           inline const std::unordered_set<std::unique_ptr<TDevice>> &GetPersistentDeviceSet() const {
             return PersistentDeviceSet;
           }
 
           private:
 
-          /* TODO */
           Base::TScheduler *Scheduler;
 
-          /* TODO */
           TDiskController *Controller;
 
-          /* TODO */
           std::unordered_map<std::string, std::unique_ptr<TVolumeManager>> VolumeManagerByInstance;
 
-          /* TODO */
           std::unordered_map<TVolumeId, std::unique_ptr<TVolume>> VolumeById;
           std::unordered_set<std::unique_ptr<TDevice>> PersistentDeviceSet;
 
-          /* TODO */
           std::unordered_set<std::string> AllDeviceSet;
 
-          /* TODO */
           std::unordered_map<std::string, TDeviceUtil::TOrlyDevice> OrlyDeviceMap;
 
-          /* TODO */
           const TCacheCb &CacheCb;
 
         };  // TDiskUtil

--- a/orly/indy/disk/util/engine.h
+++ b/orly/indy/disk/util/engine.h
@@ -38,16 +38,13 @@ namespace Orly {
 
       namespace Util {
 
-        /* TODO */
         typedef TCache<PhysicalPageSize> TPageCache;
         typedef TCache<PhysicalBlockSize> TBlockCache;
 
-        /* TODO */
         class TEngine {
           NO_COPY(TEngine);
           public:
 
-          /* TODO */
           TEngine(TVolumeManager *vol_man,
                   TPageCache *page_cache,
                   TBlockCache *block_cache,
@@ -59,15 +56,12 @@ namespace Orly {
                 FileService(file_service),
                 IsDiskBasedEngine(is_disk_engine) {}
 
-          /* TODO */
           ~TEngine() {}
 
-          /* TODO */
           bool FindFile(const Base::TUuid &file_uid, size_t gen_id, size_t &starting_block, size_t &starting_block_offset, size_t &file_length, size_t &num_keys) {
             return FileService->FindFile(file_uid, gen_id, starting_block, starting_block_offset, file_length, num_keys);
           }
 
-          /* TODO */
           void InsertFile(const Base::TUuid &file_uid,
                           TFileObj::TKind file_kind,
                           size_t gen_id,
@@ -81,22 +75,18 @@ namespace Orly {
             FileService->InsertFile(file_uid, file_kind, gen_id, starting_block_id, starting_block_offset, file_size, num_keys, lowest_seq, highest_seq, completion_trigger);
           }
 
-          /* TODO */
           void RemoveFile(const Base::TUuid &file_uid, size_t gen_id, TCompletionTrigger &completion_trigger) {
             FileService->RemoveFile(file_uid, gen_id, completion_trigger);
           }
 
-          /* TODO */
           void AppendFileGenSet(const Base::TUuid &file_uid, std::vector<TFileObj> &out_vec) {
             return FileService->AppendFileGenSet(file_uid, out_vec);
           }
 
-          /* TODO */
           bool ForEachFile(const std::function<bool (const Base::TUuid &file_uid, const TFileObj &)> &cb) {
             return FileService->ForEachFile(cb);
           }
 
-          /* TODO */
           size_t ReserveBlock(TVolume::TDesc::TStorageSpeed storage_speed) {
             TBlockRange range;
             VolMan->TryAllocateSequentialBlocks(storage_speed, 1UL, [&](const TBlockRange &block_range) {
@@ -106,7 +96,6 @@ namespace Orly {
             return range.first;
           }
 
-          /* TODO */
           /* TODO: can we get rid of this version? */
           void AppendReserveBlocks(TVolume::TDesc::TStorageSpeed storage_speed, size_t num_blocks, std::vector<size_t> &append_vec) {
             assert(num_blocks > 0);
@@ -128,7 +117,6 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           void AppendReserveBlocks(TVolume::TDesc::TStorageSpeed storage_speed, size_t num_blocks, Indy::Util::TBlockVec &append_vec) {
             assert(num_blocks > 0);
             size_t left = num_blocks;
@@ -146,70 +134,56 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           void FreeBlock(size_t block_id) {
             VolMan->FreeSequentialBlocks(TBlockRange(block_id, 1UL));
           }
 
-          /* TODO */
           void FreeSeqBlocks(size_t block_id, size_t num_blocks) {
             VolMan->FreeSequentialBlocks(TBlockRange(block_id, num_blocks));
           }
 
-          /* TODO */
           inline TVolumeManager *GetVolMan() const {
             return VolMan;
           }
 
-          /* TODO */
           template <size_t PhysicalCacheSize>
           inline Util::TCache<PhysicalCacheSize> *GetCache() const {
             return TCacheGetter<PhysicalCacheSize>::Get(this);
           }
 
-          /* TODO */
           inline TPageCache *GetPageCache() const {
             return PageCache;
           }
 
-          /* TODO */
           inline TBlockCache *GetBlockCache() const {
             return BlockCache;
           }
 
-          /* TODO */
           inline bool IsDiskBased() const {
             return IsDiskBasedEngine;
           }
 
           private:
 
-          /* TODO */
           template <size_t PhysicalCacheSize>
           class TCacheGetter {
             NO_CONSTRUCTION(TCacheGetter);
             public:
 
-            /* TODO */
             static Util::TCache<PhysicalCacheSize> *Get(TEngine *) {
               //static_assert(false, "TCacheGetter not specialized on the cache size you are trying to get");
             }
 
           };  // TCacheGetter
 
-          /* TODO */
           TVolumeManager *VolMan;
 
-          /* TODO */
           TPageCache *PageCache;
 
-          /* TODO */
           TBlockCache *BlockCache;
 
-          /* TODO */
           TFileServiceBase *FileService;
 
-          /* TODO */
           bool IsDiskBasedEngine;
 
         };  // TEngine

--- a/orly/indy/disk/util/hash_util.cc
+++ b/orly/indy/disk/util/hash_util.cc
@@ -45,7 +45,6 @@ const set<size_t> Orly::Indy::Disk::Util::GenSizeSet {64,
                                                      549755813888,
                                                      2199023255552};
 
-/* TODO */
 const set<size_t> Orly::Indy::Disk::Util::HashSizeSet {97UL,
                                                       193UL,
                                                       389UL,

--- a/orly/indy/disk/util/hash_util.h
+++ b/orly/indy/disk/util/hash_util.h
@@ -28,22 +28,16 @@ namespace Orly {
 
       namespace Util {
 
-        /* TODO */
         extern const std::set<size_t> GenSizeSet;
 
-        /* TODO */
         constexpr size_t HighestPrecalculatedHashSize = 1111976UL;
 
-        /* TODO */
         extern const std::set<size_t> HashSizeSet;
 
-        /* TODO */
         constexpr double MaximumLoadFactor = 0.8;
 
-        /* TODO */
         size_t SuggestHashSize(size_t num_keys);
 
-        /* TODO */
         size_t SuggestGeneration(size_t num_keys);
 
       }  // Util

--- a/orly/indy/disk/util/index_manager.h
+++ b/orly/indy/disk/util/index_manager.h
@@ -40,23 +40,19 @@ namespace Orly {
 
       namespace Util {
 
-        /* TODO */
         template <typename TVal, size_t MemSize, size_t MinParallelSortThreshold, class TComparator = std::less<TVal>>
         class TIndexManager {
           NO_COPY(TIndexManager);
           public:
 
-          /* TODO */
           typedef TIndexManager<TVal, MemSize, MinParallelSortThreshold, TComparator> TMe;
           typedef TIndexSortFile<TIndexManager, TVal, MemSize, TComparator> TSortFile;
           typedef InvCon::OrderedList::TCollection<TIndexManager, TSortFile, size_t> TSortFileCollection;
 
-          /* TODO */
           class TCursor {
             NO_COPY(TCursor);
             public:
 
-            /* TODO */
             TCursor(TIndexManager *manager, size_t total_read_ahead_slots)
                 : Manager(manager) {
               Manager->SortMem();
@@ -76,16 +72,13 @@ namespace Orly {
               }
             }
 
-            /* TODO */
             ~TCursor() {
             }
 
-            /* TODO */
             operator bool() const {
               return static_cast<bool>(*MinHeap);
             }
 
-            /* TODO */
             const TVal &operator*() const {
               #ifndef NDEBUG
               if (!static_cast<bool>(*MinHeap)) {
@@ -97,7 +90,6 @@ namespace Orly {
               return MinHeap->Peek(dummy);
             }
 
-            /* TODO */
             const TVal *operator->() const {
               #ifndef NDEBUG
               if (!static_cast<bool>(*MinHeap)) {
@@ -109,7 +101,6 @@ namespace Orly {
               return &(MinHeap->Peek(dummy));
             }
 
-            /* TODO */
             TCursor &operator++() {
               size_t pos = 0U;
               MinHeap->Pop(pos);
@@ -124,18 +115,14 @@ namespace Orly {
 
             private:
 
-            /* TODO */
             TIndexManager *Manager;
 
-            /* TODO */
             std::vector<std::unique_ptr<typename Indy::Util::TSorter<TVal, MemSize>::TCursor>> CsrVec;
 
-            /* TODO */
             std::unique_ptr<Indy::Util::TMinHeap<TVal, size_t, TComparator>> MinHeap;
 
           };  // TCursor
 
-          /* TODO */
           TIndexManager(const Base::TCodeLocation &code_location /* DEBUG */,
                         uint8_t util_src,
                         size_t consolidation_threshold,
@@ -158,12 +145,10 @@ namespace Orly {
             assert(consolidation_threshold > 0UL);
           }
 
-          /* TODO */
           ~TIndexManager() {
             SortFileCollection.DeleteEachMember();
           }
 
-          /* TODO */
           template <class... Args>
           void Emplace(Args &&... args) {
             if (MemSorter.IsFull()) {
@@ -197,7 +182,6 @@ namespace Orly {
             ++Size;
           }
 
-          /* TODO */
           void Clear() {
             MemSorter.Clear();
             MemSorted = false;
@@ -205,14 +189,12 @@ namespace Orly {
             Size = 0UL;
           }
 
-          /* TODO */
           inline size_t GetSize() const {
             return Size;
           }
 
           private:
 
-          /* TODO */
           void SortMem() {
             if (!MemSorted) {
               if (Size >= MinParallelSortThreshold) {
@@ -225,48 +207,35 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           void ConsolidateGeneration(size_t gen, size_t num) {
             new TSortFile(CodeLocation, UtilSrc, StorageSpeed, Engine, VolMan, BlockCache, gen, num, SortFileCollection, 10UL, Comp, CacheInstr);
           }
 
-          /* TODO */
           TVolume::TDesc::TStorageSpeed StorageSpeed;
 
-          /* TODO */
           TEngine *Engine;
 
-          /* TODO */
           TVolumeManager *VolMan;
 
-          /* TODO */
           TBlockCache *BlockCache;
 
-          /* TODO */
           TCacheInstr CacheInstr;
 
-          /* TODO */
           size_t Size;
 
-          /* TODO */
           Indy::Util::TSorter<TVal, MemSize> MemSorter;
 
-          /* TODO */
           mutable typename TSortFileCollection::TImpl SortFileCollection;
 
-          /* TODO */
           bool MemSorted;
 
-          /* TODO */
           TComparator Comp;
 
           /* DEBUG */
           const Base::TCodeLocation CodeLocation;
 
-          /* TODO */
           const uint8_t UtilSrc;
 
-          /* TODO */
           size_t ConsolidationThreshold;
 
         };  // TIndexManager

--- a/orly/indy/disk/util/index_sort_file.h
+++ b/orly/indy/disk/util/index_sort_file.h
@@ -42,35 +42,28 @@ namespace Orly {
 
       namespace Util {
 
-        /* TODO */
         template <typename TOwner, typename TVal, size_t MemSize, class TComparator>
         class TIndexSortFile
             : public TInFile {
           NO_COPY(TIndexSortFile);
           public:
 
-          /* TODO */
           typedef Util::TIndexSortFile<TOwner, TVal, MemSize, TComparator> TMe;
 
-          /* TODO */
           typedef InvCon::OrderedList::TCollection<TOwner, TMe, size_t> TOwnerCollection;
 
-          /* TODO */
           typedef InvCon::OrderedList::TMembership<TIndexSortFile, TOwner, size_t> TOwnerMembership;
 
-          /* TODO */
           typedef Snappy::TBlockSink<Disk::Util::LogicalCheckedBlockSize, Disk::Util::LogicalCheckedBlockSize, Disk::Util::PhysicalBlockSize, Disk::Util::CheckedBlock> TMyBlockSink;
           typedef Snappy::TStreamSource<Disk::Util::LogicalCheckedBlockSize, Disk::Util::LogicalCheckedBlockSize, Disk::Util::PhysicalBlockSize, Disk::Util::CheckedBlock> TMyStreamSource;
 
           class TCursor;
 
-          /* TODO */
           class TCursor
               : public Orly::Indy::Util::TSorter<TVal, MemSize>::TCursor {
             NO_COPY(TCursor);
             public:
 
-            /* TODO */
             TCursor(TIndexSortFile *file, size_t read_ahead_amt = IndexCursorScanAhead)
                 : File(file),
                   MetaStream(HERE, File->UtilSrc, Low, File, File->BlockCache, 0UL),
@@ -87,22 +80,18 @@ namespace Orly {
               Refresh();
             }
 
-            /* TODO */
             ~TCursor() {
             }
 
-            /* TODO */
             inline virtual operator bool() const {
               return NumIntoPage != NumInCurPage || DataStream.GetOffset() < File->FileLength;
             }
 
-            /* TODO */
             inline virtual const TVal &operator*() const {
               assert(BufData);
               return *(reinterpret_cast<const TVal *>(BufData) + NumIntoPage);
             }
 
-            /* TODO */
             inline virtual TCursor &operator++() {
               assert(static_cast<bool>(*this));
               ++NumIntoPage;
@@ -115,7 +104,6 @@ namespace Orly {
 
             private:
 
-            /* TODO */
             inline void Refresh() const {
               size_t compressed_size = 0UL;
               MetaStream.Read(NumInCurPage);
@@ -129,29 +117,22 @@ namespace Orly {
               assert(DataStream.GetOffset() - start_val == compressed_size);
             }
 
-            /* TODO */
             TIndexSortFile *File;
 
-            /* TODO */
             mutable TMyStreamSource::TDataInStream MetaStream;
             mutable TMyStreamSource::TDataInStream DataStream;
 
-            /* TODO */
             size_t NumIntoPage;
             mutable size_t NumInCurPage;
 
-            /* TODO */
             mutable std::unique_ptr<TBufBlock> BufBlock;
 
-            /* TODO */
             mutable const char *BufData;
 
-            /* TODO */
             static constexpr size_t IndexCursorScanAhead = 16;
 
           };  // TCursor
 
-          /* TODO */
           TIndexSortFile(const Base::TCodeLocation &code_location /* DEBUG */,
                          uint8_t util_src,
                          TVolume::TDesc::TStorageSpeed storage_speed,
@@ -255,7 +236,6 @@ namespace Orly {
             CompletionTrigger.Wait();
           }
 
-          /* TODO */
           TIndexSortFile(const Base::TCodeLocation &code_location /* DEBUG */,
                          uint8_t util_src,
                          TVolume::TDesc::TStorageSpeed storage_speed,
@@ -408,100 +388,78 @@ namespace Orly {
             OwnerMembership.Insert(&collection);
           }
 
-          /* TODO */
           ~TIndexSortFile() {
             for (const auto &iter : BlockVec.GetSeqBlockMap()) {
               Engine->FreeSeqBlocks(iter.second.first, iter.second.second);
             }
           }
 
-          /* TODO */
           virtual size_t GetFileLength() const override {
             return FileLength;
           }
 
-          /* TODO */
           virtual size_t GetStartingBlock() const override {
             assert(BlockVec.Size());
             return BlockVec.Front();
           }
 
-          /* TODO */
           virtual void ReadMeta(size_t /*offset*/, size_t &/*out*/) const override {
             throw std::logic_error("ReadMeta is not required");
           }
 
-          /* TODO */
           virtual size_t FindPageIdOfByte(size_t offset) const override {
             assert(offset <= GetFileLength());
             return BlockVec[offset / Disk::Util::LogicalCheckedBlockSize];
           }
 
 
-          /* TODO */
           virtual size_t GetLogicalBlockSize() const {
             return LogicalCheckedBlockSize;
           }
 
-          /* TODO */
           virtual size_t GetPhysicalBlockSize() const {
             return PhysicalBlockSize;
           }
 
-          /* TODO */
           inline TEngine *GetEngine() const {
             return Engine;
           }
 
-          /* TODO */
           inline TBlockCache *GetBlockCache() const {
             return BlockCache;
           }
 
-          /* TODO */
           inline size_t GetSize() const {
             return Size;
           }
 
           private:
 
-          /* TODO */
           TVolume::TDesc::TStorageSpeed StorageSpeed;
 
-          /* TODO */
           TEngine *Engine;
 
-          /* TODO */
           TVolumeManager *VolMan;
 
-          /* TODO */
           TBlockCache *BlockCache;
 
-          /* TODO */
           TCacheInstr CacheInstr;
 
-          /* TODO */
           typename TOwnerMembership::TImpl OwnerMembership;
 
-          /* TODO */
           Indy::Util::TBlockVec BlockVec;
 
-          /* TODO */
           size_t NumMetaBytes;
 
-          /* TODO */
           size_t FileLength;
 
-          /* TODO */
           size_t Size;
 
-          /* TODO */
           TCompletionTrigger CompletionTrigger;
 
           /* DEBUG */
           const Base::TCodeLocation CodeLocation;
 
-          /* TODO */
           uint8_t UtilSrc;
 
         };  // TIndexSortFile

--- a/orly/indy/disk/util/snappy.h
+++ b/orly/indy/disk/util/snappy.h
@@ -46,33 +46,25 @@ namespace Orly {
 
         namespace Snappy {
 
-          /* TODO */
           class TBlockSource
               : public snappy::Source {
             NO_COPY(TBlockSource);
             public:
 
-            /* TODO */
             TBlockSource(const std::unique_ptr<TBufBlock> &buf);
 
-            /* TODO */
             virtual ~TBlockSource();
 
-            /* TODO */
             virtual size_t Available() const override;
 
-            /* TODO */
             virtual const char* Peek(size_t *len) override;
 
-            /* TODO */
             virtual void Skip(size_t n) override;
 
             private:
 
-            /* TODO */
             const std::unique_ptr<TBufBlock> &Buf;
 
-            /* TODO */
             size_t BytesRead;
 
           };  // TBlockSource
@@ -85,27 +77,22 @@ namespace Orly {
 
             typedef TStream<CachePageSize, BlockSize, PhysicalBlockSize, BufKind, 0UL /*local cache */> TDataInStream;
 
-            /* TODO */
             TStreamSource(TDataInStream &in_stream, size_t avail_bytes)
               : InStream(in_stream), AvailBytes(avail_bytes) {
             }
 
-            /* TODO */
             virtual ~TStreamSource() {}
 
-            /* TODO */
             inline virtual size_t Available() const override {
               return AvailBytes;
             }
 
-            /* TODO */
             inline virtual const char* Peek(size_t *len) override {
               size_t offset_in_chunk = InStream.GetOffsetInChunk();
               *len = std::min(TDataInStream::DataChunkSize - offset_in_chunk, AvailBytes);
               return InStream.GetData();
             }
 
-            /* TODO */
             inline virtual void Skip(size_t n) override {
               assert(AvailBytes >= n);
               AvailBytes -= n;
@@ -114,68 +101,54 @@ namespace Orly {
 
             private:
 
-            /* TODO */
             TDataInStream &InStream;
 
-            /* TODO */
             size_t AvailBytes;
 
           };  // TStreamSource
 
-          /* TODO */
           template <size_t PageSize, size_t BlockSize, size_t PhysicalBlockSize, Util::TBufKind BufKind>
           class TBlockSink
               : public snappy::Sink {
             NO_COPY(TBlockSink);
             public:
 
-            /* TODO */
             typedef TOutStream<PageSize, BlockSize, PhysicalBlockSize, BufKind> TDataOutStream;
 
-            /* TODO */
             TBlockSink(TDataOutStream &out_stream)
               : OutStream(out_stream) {}
 
-            /* TODO */
             virtual ~TBlockSink() {}
 
-            /* TODO */
             inline virtual void Append(const char *bytes, size_t n) override {
               OutStream.Write(bytes, n);
             }
 
             private:
 
-            /* TODO */
             TDataOutStream &OutStream;
 
           };  // TBlockSink
 
-          /* TODO */
           class TIoStreamSource
               : public snappy::Source {
             NO_COPY(TIoStreamSource);
             public:
 
-            /* TODO */
             TIoStreamSource(Io::TBinaryInputStream &stream, size_t avail_bytes)
               : InStream(stream), AvailBytes(avail_bytes) {}
 
-            /* TODO */
             virtual ~TIoStreamSource() {}
 
-            /* TODO */
             inline virtual size_t Available() const override {
               return AvailBytes;
             }
 
-            /* TODO */
             inline virtual const char* Peek(size_t *len) override {
               *len = std::min(InStream.GetPeekSize(), AvailBytes);
               return InStream.Peek();
             }
 
-            /* TODO */
             inline virtual void Skip(size_t n) override {
               assert(AvailBytes >= n);
               AvailBytes -= n;
@@ -184,53 +157,42 @@ namespace Orly {
 
             private:
 
-            /* TODO */
             Io::TBinaryInputStream &InStream;
 
-            /* TODO */
             size_t AvailBytes;
 
           };  // TIoStreamSource
 
-          /* TODO */
           class TIoStreamSink
               : public snappy::Sink {
             NO_COPY(TIoStreamSink);
             public:
 
-            /* TODO */
             TIoStreamSink(Io::TBinaryOutputStream &stream)
               : OutStream(stream) {}
 
-            /* TODO */
             virtual ~TIoStreamSink() {}
 
-            /* TODO */
             inline virtual void Append(const char *bytes, size_t n) override {
               OutStream.WriteExactly(bytes, n);
             }
 
             private:
 
-            /* TODO */
             Io::TBinaryOutputStream &OutStream;
 
           };  // TIoStreamSink
 
-          /* TODO */
           class TRawSink
               : public snappy::Sink {
             NO_COPY(TRawSink);
             public:
 
-            /* TODO */
             TRawSink(char *buf, size_t max_size)
               : Buf(buf), BytesIn(0UL), MaxBytes(max_size) {}
 
-            /* TODO */
             virtual ~TRawSink() {}
 
-            /* TODO */
             inline virtual void Append(const char *bytes, size_t n) override {
               assert(BytesIn + n <= MaxBytes);
               memcpy(&Buf[BytesIn], bytes, n);
@@ -240,7 +202,6 @@ namespace Orly {
 
             private:
 
-            /* TODO */
             char *Buf;
             size_t BytesIn;
             size_t MaxBytes;

--- a/orly/indy/disk/util/volume_manager.cc
+++ b/orly/indy/disk/util/volume_manager.cc
@@ -52,12 +52,10 @@ namespace Orly {
           /* this is where we can report any controller or device specific metrics */
         }
 
-        /* TODO */
         class TGroupRequest {
           NO_COPY(TGroupRequest);
           public:
 
-          /* TODO */
           TGroupRequest(size_t total_num_request,
                         const TIOCallback &cb)
               : NumFinished(0UL),
@@ -66,7 +64,6 @@ namespace Orly {
                 Result(Success),
                 ErrStr(nullptr) {}
 
-          /* TODO */
           inline void Callback(TDiskResult disk_result, const char *err_str) {
             size_t prev = std::atomic_fetch_add(&NumFinished, 1UL);
             switch (Result) {
@@ -104,19 +101,14 @@ namespace Orly {
 
           private:
 
-          /* TODO */
           std::atomic<size_t> NumFinished;
 
-          /* TODO */
           size_t NumRequest;
 
-          /* TODO */
           const TIOCallback Cb;
 
-          /* TODO */
           TDiskResult Result;
 
-          /* TODO */
           const char *ErrStr;
 
         };  // TGroupRequest
@@ -766,23 +758,19 @@ namespace Orly {
 
       namespace Util {
 
-        /* TODO */
         class TVolume::TStrategy {
           NO_COPY(TStrategy);
           public:
 
-          /* TODO */
           typedef size_t TLogicalExtentStart;
 
           /* An object that gets filled in to represent all the sequential IO to be performed to a device. The kind of IO (R/W) must be the same. */
           class TDeviceRequest {
             public:
 
-            /* TODO */
             TDeviceRequest()
                 : NumReq(0UL), PhysicalOffsetStart(0UL), TotalBytes(0UL) {}
 
-            /* TODO */
             void AddRequest(void *buf, size_t physical_offset_on_device, size_t num_bytes, size_t max_segments_per_io, size_t max_sector_kb_per_io) {
               const size_t op_pos = std::max(NumReq / max_segments_per_io, TotalBytes / (max_sector_kb_per_io * 1024));
               if (NumReq > 0) {
@@ -803,41 +791,33 @@ namespace Orly {
 
             }
 
-            /* TODO */
             inline size_t GetNumRequest() const {
               return NumReq;
             }
 
-            /* TODO */
             inline size_t GetTotalNumBytes() const {
               return TotalBytes;
             }
 
-            /* TODO */
             inline size_t GetNumIops() const {
               return VecPerOp.size();
             }
 
             private:
 
-            /* TODO */
             size_t NumReq;
 
-            /* TODO */
             size_t PhysicalOffsetStart;
 
-            /* TODO */
             size_t TotalBytes;
 
             /* TODO : more efficient */
             std::vector<std::vector<void *>> VecPerOp;
 
-            /* TODO */
             friend class TStrategy;
 
           };  // TDeviceRequest
 
-          /* TODO */
           virtual ~TStrategy() {
             /* acquire discard lock */ {
               std::lock_guard<std::mutex> lock(DiscardMapLock);
@@ -849,22 +829,17 @@ namespace Orly {
             }  // release block lock
           }
 
-          /* TODO */
           virtual void DelegateWrite(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf, const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error, TCompletionTrigger &trigger) = 0;
           virtual void DelegateWrite(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf, const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error, TCompletionTrigger &trigger, const TIOCallback &cb) = 0;
 
-          /* TODO */
           virtual void DelegateRead(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf, const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error, TCompletionTrigger &trigger) = 0;
           virtual void DelegateRead(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf, const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error, TCompletionTrigger &trigger, const TIOCallback &cb) = 0;
 
-          /* TODO */
           virtual void DelegateReadV(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void **buf_array, size_t num_buf, const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error, TCompletionTrigger &trigger) = 0;
           virtual void DelegateReadV(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void **buf_array, size_t num_buf, const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error, TCompletionTrigger &trigger, const TIOCallback &cb) = 0;
 
-          /* TODO */
           virtual void DelegateAppendTouchedDevicesToSet(TDeviceSet &device_set, const TBlockRange &block_range) const = 0;
 
-          /* TODO */
           void DiscardAll() {
             for (const auto &device_set : DeviceVec) {
               for (TDevice *device : device_set) {
@@ -873,29 +848,22 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           std::pair<size_t, size_t> AppendUsage(std::stringstream &ss) const;
 
-          /* TODO */
           inline void TryAllocateSequentialBlocks(size_t num_blocks, const std::function<void (const TBlockRange &block_range)> &cb);
 
-          /* TODO */
           void FreeSequentialBlocks(const TBlockRange &block_range);
 
-          /* TODO */
           void MarkBlockRangeUsed(const TBlockRange &block_range);
 
-          /* TODO */
           bool Init(const TExtentSet &extent_set);
 
-          /* TODO */
           inline const std::vector<TLogicalExtent> &GetLogicalExtentVec() const {
             return ExtentVec;
           }
 
           protected:
 
-          /* TODO */
           TStrategy(TVolume *volume, Base::TScheduler *scheduler)
               : Volume(volume),
                 Scheduler(scheduler),
@@ -932,58 +900,45 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           template <typename... TArgs>
           TGroupRequest *NewGroupRequest(size_t total_num_request, TArgs &...args);
 
-          /* TODO */
           template <typename... TArgs>
           void Write(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf, size_t device_num,
                      const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error, const TOffset logical_start_offset,
                      TArgs &...args);
 
-          /* TODO */
           template <typename... TArgs>
           void Read(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf, size_t device_num,
                     const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error, TArgs &...args);
 
-          /* TODO */
           template <typename... TArgs>
           void SubmitRequest(size_t device_num, const TDeviceRequest &device_request, TGroupRequest *group_request,
                              const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src,
                              DiskPriority priority, bool abort_on_error, TArgs &...args);
 
-          /* TODO */
           void AppendTouchedDevicesToSet(TDeviceSet &device_set, size_t device_num) const;
 
           /* Used for debugging. Verify that we have this block reserved. */
           inline bool CheckBufBlock(size_t block_id) const;
           inline bool CheckDiscardBuf(size_t block_id) const;
 
-          /* TODO */
           TVolume *Volume;
 
-          /* TODO */
           std::vector<TLogicalExtent> ExtentVec;
 
-          /* TODO */
           std::vector<TDeviceSet> DeviceVec;
 
           //private:
 
-          /* TODO */
           inline size_t GetBlock();
 
-          /* TODO */
           size_t TryGetSeqBlocks(const size_t num, size_t &start_out);
 
-          /* TODO */
           inline void PutBack(size_t block_id);
 
-          /* TODO */
           inline size_t ReserveBlock(std::unique_lock<std::mutex> &lock);
 
-          /* TODO */
           inline size_t TryReserveSeqBlocks(std::unique_lock<std::mutex> &lock, const size_t num_blocks, size_t &out_start);
 
           /* Set an individual bit to (on / off) */
@@ -995,26 +950,20 @@ namespace Orly {
           /* Set a range of bits to (on / off) */
           inline void SetBlockBufRange(size_t block_id, const size_t num_blocks, const bool on);
 
-          /* TODO */
           inline void SetDiscardRange(const size_t block_id, const size_t num_blocks, const bool on);
 
-          /* TODO */
           inline void SetDiscardBuf(size_t block_id, bool on);
 
-          /* TODO */
           virtual size_t GetBlockMapBytesPerDiscardRange() const = 0;
 
-          /* TODO */
           virtual void DoDiscard(const TBlockRange &block_range) const = 0;
 
-          /* TODO */
           inline void CheckRange(const TOffset start_offset, long long nbytes, const TDevice *device) {
             if (unlikely(start_offset + SuperBytes + nbytes > device->Desc.Capacity)) {
               throw std::logic_error("Accessing range on device past capacity");
             }
           }
 
-          /* TODO */
           void DiscardRunner();
 
           /* Signal the background DiscardRunner job to exit and block until it
@@ -1026,20 +975,17 @@ namespace Orly {
 
           Base::TScheduler *Scheduler;
 
-          /* TODO */
           std::unique_ptr<size_t> BlockMapBuf;
           std::mutex BlockMapLock;
           size_t CachedStart;
           std::unique_ptr<size_t> DiscardMapBuf;
           std::mutex DiscardMapLock;
 
-          /* TODO */
           size_t BlocksUsed;
 
           /* The number of blocks waiting to be discarded */
           size_t DiscardBlockWaiting;
 
-          /* TODO */
           Base::TFd DiscardEpollFd;
           Base::TEventSemaphore DiscardSem;
           epoll_event DiscardEvent;
@@ -1062,10 +1008,8 @@ namespace Orly {
           bool DiscardRunnerExited;
           std::condition_variable DiscardRunnerDoneCond;
 
-          /* TODO */
           const size_t SuperBytes;
 
-          /* TODO */
           const size_t NumBlocks;
           const size_t NumBlocksPerExtent;
           const size_t BlockMapByteSize;
@@ -1073,20 +1017,17 @@ namespace Orly {
 
         };
 
-        /* TODO */
         template <typename... TArgs>
         TGroupRequest *TVolume::TStrategy::NewGroupRequest(size_t /*total_num_request*/, TArgs &.../*args*/) {
           throw std::logic_error("Should not be reached");
         }
 
-        /* TODO */
         template <>
         TGroupRequest *TVolume::TStrategy::NewGroupRequest<Orly::Indy::Disk::TCompletionTrigger>(size_t /*total_num_request*/,
                                                                                                  TCompletionTrigger &/*trigger*/) {
           return nullptr;
         }
 
-        /* TODO */
         template <>
         TGroupRequest *TVolume::TStrategy::NewGroupRequest<Orly::Indy::Disk::TCompletionTrigger, const TIOCallback>(size_t total_num_request,
                                                                                                                     TCompletionTrigger &trigger,
@@ -1570,13 +1511,11 @@ inline bool TVolume::TStrategy::CheckDiscardBuf(size_t block_id) const {
   return (*offset & mask) == mask;
 }
 
-/* TODO */
 class TVolume::TStripedStrategy
     : public TVolume::TStrategy {
   NO_COPY(TStripedStrategy);
   public:
 
-  /* TODO */
   TStripedStrategy(TVolume *volume, Base::TScheduler *scheduler)
       : TStrategy(volume, scheduler) {
     PostCtor();
@@ -1588,7 +1527,6 @@ class TVolume::TStripedStrategy
     StopDiscardRunner();
   }
 
-  /* TODO */
   virtual void DelegateWrite(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                              const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error,
                              TCompletionTrigger &trigger) override;
@@ -1596,7 +1534,6 @@ class TVolume::TStripedStrategy
                              const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error, TCompletionTrigger &trigger,
                              const TIOCallback &cb) override;
 
-  /* TODO */
   virtual void DelegateRead(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                             const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error,
                             TCompletionTrigger &trigger) override;
@@ -1604,7 +1541,6 @@ class TVolume::TStripedStrategy
                             const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error, TCompletionTrigger &trigger,
                             const TIOCallback &cb) override;
 
-  /* TODO */
   virtual void DelegateReadV(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void **buf_array,
                              size_t num_buf, const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error,
                              TCompletionTrigger &trigger) override;
@@ -1612,39 +1548,31 @@ class TVolume::TStripedStrategy
                              size_t num_buf, const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error,
                              TCompletionTrigger &trigger, const TIOCallback &cb) override;
 
-  /* TODO */
   virtual void DelegateAppendTouchedDevicesToSet(TDeviceSet &device_set, const TBlockRange &block_range) const override;
 
-  /* TODO */
   virtual size_t GetBlockMapBytesPerDiscardRange() const override;
 
-  /* TODO */
   virtual void DoDiscard(const TBlockRange &block_range) const override;
 
   private:
 
-  /* TODO */
   enum TOp {R, W};
 
-  /* TODO */
   template <typename... TArgs>
   void DoStripe(TOp op, const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                 const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error, TArgs &...args);
 
-  /* TODO */
   template <typename... TArgs>
   void DoStripeV(TOp op, const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void **buf_array, size_t num_buf,
                  const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error, TArgs &...args);
 
 };  // TStripedStrategy
 
-/* TODO */
 class TVolume::TChainedStrategy
     : public TVolume::TStrategy {
   NO_COPY(TChainedStrategy);
   public:
 
-  /* TODO */
   TChainedStrategy(TVolume *volume, Base::TScheduler *scheduler)
       : TStrategy(volume, scheduler) {
     PostCtor();
@@ -1656,7 +1584,6 @@ class TVolume::TChainedStrategy
     StopDiscardRunner();
   }
 
-  /* TODO */
   virtual void DelegateWrite(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                              const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error,
                              TCompletionTrigger &trigger) override;
@@ -1664,7 +1591,6 @@ class TVolume::TChainedStrategy
                              const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error, TCompletionTrigger &trigger,
                              const TIOCallback &cb) override;
 
-  /* TODO */
   virtual void DelegateRead(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                             const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error,
                             TCompletionTrigger &trigger) override;
@@ -1672,7 +1598,6 @@ class TVolume::TChainedStrategy
                             const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error, TCompletionTrigger &trigger,
                             const TIOCallback &cb) override;
 
-  /* TODO */
   virtual void DelegateReadV(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void **buf_array,
                              size_t num_buf, const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error,
                              TCompletionTrigger &trigger) override;
@@ -1680,21 +1605,16 @@ class TVolume::TChainedStrategy
                              size_t num_buf, const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error,
                              TCompletionTrigger &trigger, const TIOCallback &cb) override;
 
-  /* TODO */
   virtual void DelegateAppendTouchedDevicesToSet(TDeviceSet &device_set, const TBlockRange &block_range) const override;
 
-  /* TODO */
   virtual size_t GetBlockMapBytesPerDiscardRange() const override;
 
-  /* TODO */
   virtual void DoDiscard(const TBlockRange &block_range) const override;
 
   private:
 
-  /* TODO */
   enum TOp {R, W};
 
-  /* TODO */
   template <typename... TArgs>
   void DoChain(TOp op, const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error, TArgs &...args);

--- a/orly/indy/disk/util/volume_manager.h
+++ b/orly/indy/disk/util/volume_manager.h
@@ -65,7 +65,6 @@ namespace Orly {
 
       namespace Util {
 
-        /* TODO */
         struct TLogicalExtent {
           const size_t Start;
           const size_t Span;
@@ -114,14 +113,11 @@ namespace Orly {
         class TVolume;
         class TVolumeManager;
 
-        /* TODO */
         typedef uint64_t TOffset;
 
-        /* TODO */
         typedef std::set<TLogicalExtent> TExtentSet;
         typedef std::pair<size_t, size_t> TBlockRange;
 
-        /* TODO */
         enum TBufKind {
           SectorCheckedBlock,
           PageCheckedBlock,
@@ -133,7 +129,6 @@ namespace Orly {
           FullBlock
         };
 
-        /* TODO */
         enum TCacheInstr {
           CacheAll,
           CachePageOnly,
@@ -144,22 +139,16 @@ namespace Orly {
           NoCache
         };
 
-        /* TODO */
         constexpr size_t CorruptionDetectionSize = sizeof(uint64_t);
 
-        /* TODO */
         constexpr size_t PhysicalSectorSize = 512UL;
 
-        /* TODO */
         constexpr size_t PhysicalPageSize = 4096UL;
 
-        /* TODO */
         constexpr size_t PhysicalBlockSize = PhysicalPageSize * 16UL;
 
-        /* TODO */
         constexpr size_t SectorsPerBlock = PhysicalBlockSize / PhysicalSectorSize;
 
-        /* TODO */
         constexpr size_t PagesPerBlock = PhysicalBlockSize / PhysicalPageSize;
 
         /* This is a 512 byte sector with only 1 uint64_t check value at the end. */
@@ -177,38 +166,27 @@ namespace Orly {
         /* This is how many blocks a write group represents */
         constexpr size_t MaxOutBlockGroupSize = 16UL;
 
-        /* TODO */
         constexpr size_t SortBufSize = 524288;
         constexpr size_t SortBufMinParallelSize = 32768;
 
-        /* TODO */
         constexpr size_t MaxMemHashSize = 524288;
 
-        /* TODO */
         constexpr size_t MaxMergeDiskKeyCache = 262144;
 
-        /* TODO */
         constexpr size_t RemapBufSize = 100000;
 
-        /* TODO */
         constexpr size_t NewRemapBufSize = 100000;
 
-        /* TODO */
         constexpr size_t AccessBufSize = 100000;
 
-        /* TODO */
         constexpr size_t SeqKeeperBufSize = 100000;
 
-        /* TODO */
         constexpr size_t ArenaKeeperBufSize = 100000;
 
-        /* TODO */
         constexpr size_t ScanAhead = 128;
 
-        /* TODO */
         constexpr size_t MaxSegmentsPerIO = 1UL;
 
-        /* TODO */
         static inline size_t GetPhysicalSize(TBufKind buf_kind) {
           switch (buf_kind) {
             case SectorCheckedBlock: {
@@ -239,7 +217,6 @@ namespace Orly {
           return 0UL;
         }
 
-        /* TODO */
         template <size_t BufKind>
         class TDataChunkSizeGetter {
           NO_CONSTRUCTION(TDataChunkSizeGetter);
@@ -312,46 +289,37 @@ namespace Orly {
           static constexpr size_t GetPhysicalDataChunkSize() { return PhysicalBlockSize; }
         };  // TDataChunkSizeGetter
 
-        /* TODO */
         template <size_t BufKind>
         constexpr size_t GetLogicalDataChunkSize() {
           return TDataChunkSizeGetter<BufKind>::GetLogicalDataChunkSize();
         }
 
-        /* TODO */
         template <size_t BufKind>
         constexpr size_t GetPhysicalDataChunkSize() {
           return TDataChunkSizeGetter<BufKind>::GetPhysicalDataChunkSize();
         }
 
-        /* TODO */
         typedef std::function<void (Orly::Indy::Disk::TDiskResult, const char *err_str)> TIOCallback;
 
-        /* TODO */
         typedef std::function<void (TCacheInstr cache_instr, const TOffset logical_start_offset, void *buf, size_t count)> TCacheCb;
 
         /* Forward Declarations */
         class TPersistentDevice;
         class TGroupRequest;
 
-        /* TODO */
         class TDiskController {
           NO_COPY(TDiskController);
           public:
 
-          /* TODO */
           typedef InvCon::UnorderedList::TCollection<TDiskController, TPersistentDevice> TDeviceCollection;
 
-          /* TODO */
           class TEvent
               : public Base::TThreadLocalGlobalPoolManager<TEvent>::TObjBase {
             NO_COPY(TEvent);
             public:
 
-            /* TODO */
             typedef InvCon::UnorderedList::TMembership<TEvent, TPersistentDevice> TDeviceMembership;
 
-            /* TODO */
             enum TKind {
               TriggeredRead,
               TriggeredReadV,
@@ -361,10 +329,8 @@ namespace Orly {
               CallbackWrite
             };
 
-            /* TODO */
             TEvent() : Device(nullptr), NextEvent(nullptr), DeviceMembership(this), EventPool(nullptr) {}
 
-            /* TODO */
             ~TEvent();
 
             /* TriggeredOp */
@@ -423,7 +389,6 @@ namespace Orly {
                       long long nbytes,
                       bool abort_on_error);
 
-            /* TODO */
             void Reset(bool back_to_pool);
 
             #ifndef NDEBUG
@@ -444,13 +409,11 @@ namespace Orly {
               DiskEventPoolManager.reset();
             }
 
-            /* TODO */
             static std::unique_ptr<Base::TThreadLocalGlobalPoolManager<Indy::Disk::Util::TDiskController::TEvent>> DiskEventPoolManager;
             static __thread Base::TThreadLocalGlobalPoolManager<TEvent>::TThreadLocalPool *LocalEventPool;
 
             private:
 
-            /* TODO */
             inline void CommonInit(DiskPriority priority) {
               switch (priority) {
                 case RealTime: {
@@ -469,33 +432,24 @@ namespace Orly {
               Iocb.data = this;
             }
 
-            /* TODO */
             TPersistentDevice *Device;
 
-            /* TODO */
             TEvent *NextEvent;
             TDeviceMembership::TImpl DeviceMembership;
 
-            /* TODO */
             Base::TThreadLocalGlobalPoolManager<TEvent>::TThreadLocalPool *EventPool;
 
-            /* TODO */
             TKind Kind;
 
-            /* TODO */
             struct iocb Iocb;
 
-            /* TODO */
             TBufKind BufKind;
 
-            /* TODO */
             TOffset LogicalStartOffset;
 
-            /* TODO */
             bool AbortOnError;
 
             #ifndef NDEBUG
-            /* TODO */
             size_t RequestId;
             #endif
 
@@ -517,41 +471,32 @@ namespace Orly {
               } CallbackVOp;
             };
 
-            /* TODO */
             friend class TDiskController;
             friend class TPersistentDevice;
 
           };  // TEvent
 
-          /* TODO */
           TDiskController();
 
-          /* TODO */
           ~TDiskController();
 
-          /* TODO */
           inline TDeviceCollection *GetDeviceCollection() const {
             return &DeviceCollection;
           }
 
-          /* TODO */
           void QueueRunner(std::vector<TPersistentDevice *> device_vec, bool no_realtime, size_t core);
 
-          /* TODO */
           void Report(std::stringstream &ss, double elapsed_time) const;
 
           private:
 
-          /* TODO */
           static constexpr int RealTimePriority = -2;
           static constexpr int MediumPriority = 2;
           static constexpr int LowPriority = 4;
 
-          /* TODO */
           mutable TDeviceCollection::TImpl DeviceCollection;
 
           #ifndef NDEBUG
-          /* TODO */
           std::unordered_set<size_t> OutstandingIdSet;
           size_t NextId;
           std::mutex OutstandingIdMutex;
@@ -559,12 +504,10 @@ namespace Orly {
 
         };  // TDiskController
 
-        /* TODO */
         class TDevice {
           NO_COPY(TDevice);
           public:
 
-          /* TODO */
           struct TDesc {
             const enum TKind {SSD, HDD, FlashSAN, HDDSAN, Mem} Kind;
             const size_t LogicalBlockSize;
@@ -580,98 +523,75 @@ namespace Orly {
             }
           };
 
-          /* TODO */
           typedef InvCon::OrderedList::TMembership<TDevice, TVolume, size_t> TVolumeMembership;
 
-          /* TODO */
           virtual ~TDevice() {}
 
-          /* TODO */
           inline const TDesc &GetDesc() const {
             return Desc;
           }
 
-          /* TODO */
           TVolumeMembership *GetVolumeMembership() {
             return &VolumeMembership;
           }
 
-          /* TODO */
           virtual void Write(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                              const TOffset offset, long long nbytes, DiskPriority priority, bool abort_on_error, const TOffset logical_start_offset,
                              TCompletionTrigger &trigger) = 0;
 
-          /* TODO */
           virtual void Write(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                              const TOffset offset, long long nbytes, DiskPriority priority, bool abort_on_error, const TOffset logical_start_offset,
                              const TIOCallback &cb) = 0;
 
-          /* TODO */
           virtual void Read(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                             const TOffset offset, long long nbytes, DiskPriority priority, bool abort_on_error, TCompletionTrigger &trigger) = 0;
 
-          /* TODO */
           virtual void Read(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                             const TOffset offset, long long nbytes, DiskPriority priority, bool abort_on_error, const TIOCallback &cb) = 0;
 
-          /* TODO */
           virtual void ReadV(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src,
                              const std::vector<void *> &buf_vec, const TOffset offset, long long nbytes, DiskPriority priority, bool abort_on_error,
                              TCompletionTrigger &trigger) = 0;
 
-          /* TODO */
           virtual void ReadV(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src,
                              const std::vector<void *> &buf_vec, const TOffset offset, long long nbytes, DiskPriority priority, bool abort_on_error,
                              TGroupRequest *group_request) = 0;
 
-          /* TODO */
           virtual void AsyncSyncFlush(std::mutex &mut, std::condition_variable &cond, size_t &num_finished, size_t &num_err) = 0;
 
-          /* TODO */
           virtual void Sync() = 0;
 
-          /* TODO */
           virtual size_t GetMaxSegments() const = 0;
 
-          /* TODO */
           virtual size_t GetMaxSectorsKb() const = 0;
 
-          /* TODO */
           virtual void DiscardAll() = 0;
 
-          /* TODO */
           virtual void DiscardRange(uint64_t from, uint64_t num_bytes) = 0;
 
           protected:
 
-          /* TODO */
           inline TDevice(TDesc desc, bool fsync_on, bool do_corruption_check)
               : VolumeMembership(this, 0UL),
                 Desc(desc),
                 FsyncOn(fsync_on),
                 DoCorruptionCheck(do_corruption_check) {}
 
-          /* TODO */
           void SetPos(size_t pos) {
             VolumeMembership.SetKey(pos);
           }
 
-          /* TODO */
           void ApplyCorruptionCheck(TBufKind buf_kind, void *buf, const TOffset offset, long long nbytes) const;
 
-          /* TODO */
           bool CheckCorruptCheck(TBufKind buf_kind, void *buf, const TOffset offset, long long nbytes) const;
 
-          /* TODO */
           TVolumeMembership::TImpl VolumeMembership;
 
-          /* TODO */
           TDesc Desc;
 
           /* Controls whether this device actually fsyncs when requested. */
           bool FsyncOn;
 
-          /* TODO */
           const bool DoCorruptionCheck;
 
           /* TODo */
@@ -679,16 +599,13 @@ namespace Orly {
 
         };  // TDevice
 
-        /* TODO */
         typedef std::unordered_set<TDevice *> TDeviceSet;
 
-        /* TODO */
         class TMemoryDevice
             : public TDevice {
           NO_COPY(TMemoryDevice);
           public:
 
-          /* TODO */
           TMemoryDevice(size_t logical_block_size, size_t physical_block_size, size_t num_logical_block, bool fsync_on, bool do_corruption_check)
               : TDevice(TDesc{TDesc::Mem, logical_block_size, physical_block_size, num_logical_block, logical_block_size * num_logical_block}, fsync_on, do_corruption_check),
                 Data(Base::MemAlignedAllocZeroInitialized<char>(getpagesize(), PhysicalBlockSize /* super block */ + Desc.Capacity)) {
@@ -696,51 +613,40 @@ namespace Orly {
             Base::MlockRaw(Data.get(), PhysicalBlockSize + Desc.Capacity);
           }
 
-          /* TODO */
           virtual void Write(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                              const TOffset offset, long long nbytes, DiskPriority priority, bool abort_on_error, const TOffset logical_start_offset,
                              TCompletionTrigger &trigger) override;
 
-          /* TODO */
           virtual void Write(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                              const TOffset offset, long long nbytes, DiskPriority priority, bool abort_on_error, const TOffset logical_start_offset,
                              const TIOCallback &cb) override;
 
-          /* TODO */
           virtual void Read(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                             const TOffset offset, long long nbytes, DiskPriority priority, bool abort_on_error, TCompletionTrigger &trigger) override;
 
-          /* TODO */
           virtual void Read(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                             const TOffset offset, long long nbytes, DiskPriority priority, bool abort_on_error, const TIOCallback &cb) override;
 
-          /* TODO */
           virtual void ReadV(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src,
                              const std::vector<void *> &buf_vec, const TOffset offset, long long nbytes, DiskPriority priority,
                              bool abort_on_error, TCompletionTrigger &trigger) override;
 
-          /* TODO */
           virtual void ReadV(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src,
                              const std::vector<void *> &buf_vec, const TOffset offset, long long nbytes, DiskPriority priority, bool abort_on_error,
                              TGroupRequest *group_request) override;
 
-          /* TODO */
           virtual void AsyncSyncFlush(std::mutex &mut, std::condition_variable &cond, size_t &num_finished, size_t &num_err) override;
 
-          /* TODO */
           virtual void Sync() override;
 
-          /* TODO */
           virtual size_t GetMaxSegments() const override {
             return MaxSegmentsPerIO;
           }
 
-          /* TODO */
           virtual size_t GetMaxSectorsKb() const override {
             return 64UL;
           }
 
-          /* TODO */
           virtual void DiscardAll() override {
             #ifndef NDEBUG
             memset(Data.get() + PhysicalBlockSize /* super block */, 0, Desc.Capacity);
@@ -748,7 +654,6 @@ namespace Orly {
             /* do nothing */
           }
 
-          /* TODO */
           virtual void DiscardRange(uint64_t from, uint64_t num_bytes) override {
             #ifndef NDEBUG
             memset(Data.get() + from, 0, num_bytes);
@@ -757,30 +662,24 @@ namespace Orly {
 
           private:
 
-          /* TODO */
           void WriteImpl(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf, const TOffset offset,
                          long long nbytes, DiskPriority priority, bool abort_on_error);
 
-          /* TODO */
           bool ReadImpl(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf, const TOffset offset,
                         long long nbytes, DiskPriority priority, bool abort_on_error);
 
-          /* TODO */
           std::unique_ptr<char> Data;
 
         };  // TMemoryDevice
 
-        /* TODO */
         class TPersistentDevice
             : public TDevice {
           NO_COPY(TPersistentDevice);
           public:
 
-          /* TODO */
           typedef InvCon::UnorderedList::TMembership<TPersistentDevice, TDiskController> TControllerMembership;
           typedef InvCon::UnorderedList::TCollection<TPersistentDevice, TDiskController::TEvent> TEventQueue;
 
-          /* TODO */
           TPersistentDevice(TDiskController *controller, const char *device_path, const char *device_name, size_t logical_block_size, size_t physical_block_size, size_t num_logical_block, bool fsync_on, bool do_corruption_check)
               : TDevice(TDesc{TDesc::SSD, logical_block_size, physical_block_size, num_logical_block, logical_block_size * num_logical_block}, fsync_on, do_corruption_check),
                 ControllerMembership(this, controller->GetDeviceCollection()),
@@ -816,25 +715,20 @@ namespace Orly {
             MaxSectorsKb = std::min(64UL, MaxSectorsKb);
           }
 
-          /* TODO */
           virtual ~TPersistentDevice() {}
 
-          /* TODO */
           inline const char *GetDevicePath() const {
             return DevicePath.c_str();
           }
 
-          /* TODO */
           const Base::TFd &GetDiskFd() const {
             return DiskFd;
           }
 
-          /* TODO */
           inline virtual size_t GetMaxSegments() const override {
             return MaxSegmentsPerIO;
           }
 
-          /* TODO */
           inline virtual size_t GetMaxSectorsKb() const override {
             return MaxSectorsKb;
           }
@@ -844,7 +738,6 @@ namespace Orly {
             DiscardRange(PhysicalBlockSize /* skip super block */, Desc.Capacity - PhysicalBlockSize);
           }
 
-          /* TODO */
           virtual void DiscardRange(uint64_t from, uint64_t num_bytes) override {
             if (DiscardSupport) {
               uint64_t range[2];
@@ -859,40 +752,32 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           virtual void Write(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind /*buf_kind*/, uint8_t /*util_src*/, void */*buf*/,
                              const TOffset /*offset*/, long long /*nbytes*/, DiskPriority /*priority*/, bool abort_on_error,
                              const TOffset /*logical_start_offset*/, TCompletionTrigger &/*trigger*/) override;
 
-          /* TODO */
           virtual void Write(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind /*buf_kind*/, uint8_t /*util_src*/, void */*buf*/,
                              const TOffset /*offset*/, long long /*nbytes*/, DiskPriority /*priority*/, bool abort_on_error,
                              const TOffset /*logical_start_offset*/, const TIOCallback &/*cb*/) override;
 
-          /* TODO */
           virtual void Read(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind /*buf_kind*/, uint8_t /*util_src*/, void */*buf*/,
                             const TOffset /*offset*/, long long /*nbytes*/, DiskPriority /*priority*/, bool abort_on_error,
                             TCompletionTrigger &/*trigger*/) override;
 
-          /* TODO */
           virtual void Read(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind /*buf_kind*/, uint8_t /*util_src*/, void */*buf*/,
                             const TOffset /*offset*/, long long /*nbytes*/, DiskPriority /*priority*/, bool abort_on_error,
                             const TIOCallback &/*cb*/) override;
 
-          /* TODO */
           virtual void ReadV(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src,
                              const std::vector<void *> &buf_vec, const TOffset offset, long long nbytes, DiskPriority priority, bool abort_on_error,
                              TCompletionTrigger &trigger) override;
 
-          /* TODO */
           virtual void ReadV(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src,
                              const std::vector<void *> &buf_vec, const TOffset offset, long long nbytes, DiskPriority priority, bool abort_on_error,
                              TGroupRequest *group_request) override;
 
-          /* TODO */
           virtual void AsyncSyncFlush(std::mutex &/*mut*/, std::condition_variable &/*cond*/, size_t &/*num_finished*/, size_t &/*num_err*/) override;
 
-          /* TODO */
           virtual void Sync() override;
 
           private:
@@ -909,45 +794,34 @@ namespace Orly {
             assert(inbound_event->NextEvent != reinterpret_cast<void *>(0xbfffe0000));
           }
 
-          /* TODO */
           TControllerMembership::TImpl ControllerMembership;
 
-          /* TODO */
           TDiskController::TEvent *IncomingEventQueue;
           Base::TEventSemaphore EventQueueSem;
           std::mutex EventQueueMutex;
 
-          /* TODO */
           TEventQueue::TImpl RealTimePrioEventQueue;
           TEventQueue::TImpl MediumPrioEventQueue;
           TEventQueue::TImpl LowPrioEventQueue;
 
-          /* TODO */
           std::string DevicePath;
 
-          /* TODO */
           Base::TFd DiskFd;
 
-          /* TODO */
           size_t MaxSegments;
 
-          /* TODO */
           size_t MaxSectorsKb;
 
-          /* TODO */
           bool DiscardSupport;
           size_t DiscardMaxBytes;
           size_t DiscardGranularity;
 
-          /* TODO */
           std::atomic<size_t> Inflight;
 
-          /* TODO */
           friend class TDiskController;
 
         };  // TPersistentDevice
 
-        /* TODO */
         class TVolume {
           NO_COPY(TVolume);
           public:
@@ -963,17 +837,13 @@ namespace Orly {
             const double HighUtilizationThreshold;
           };
 
-          /* TODO */
           typedef InvCon::OrderedList::TCollection<TVolume, TDevice, size_t> TDeviceCollection;
           typedef InvCon::UnorderedList::TMembership<TVolume, TVolumeManager> TManagerMembership;
 
-          /* TODO */
           TVolume(TDesc desc, const TCacheCb &cache_cb, Base::TScheduler *scheduler);
 
-          /* TODO */
           virtual ~TVolume();
 
-          /* TODO */
           void AddDevice(TDevice *device, size_t pos) {
             assert(device);
             device->SetPos(pos);
@@ -988,72 +858,56 @@ namespace Orly {
             DeviceCollection.Insert(device->GetVolumeMembership());
           }
 
-          /* TODO */
           inline size_t GetVolumeId() const {
             return VolumeId;
           }
 
-          /* TODO */
           inline const TDesc &GetDesc() const {
             return Desc;
           }
 
-          /* TODO */
           TDeviceCollection *GetDeviceCollection() const {
             return &DeviceCollection;
           }
 
-          /* TODO */
           size_t GetNumDevices() const {
             size_t count = 0UL;
             for (TDeviceCollection::TCursor csr(&DeviceCollection); csr; ++csr, ++count) {}
             return count;
           }
 
-          /* TODO */
           const std::vector<TLogicalExtent> &GetLogicalExtentVec() const;
 
-          /* TODO */
           TManagerMembership *GetManagerMembership() {
             return &ManagerMembership;
           }
 
-          /* TODO */
           template <typename... TArgs>
           void Write(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf, const TOffset start_offset,
                      long long nbytes, DiskPriority priority, bool abort_on_error, TCacheInstr cache_instr, TArgs &...args);
 
-          /* TODO */
           template <typename... TArgs>
           void Read(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf, const TOffset start_offset,
                     long long nbytes, DiskPriority priority, bool abort_on_error, TArgs &...args);
 
-          /* TODO */
           template <typename... TArgs>
           void ReadV(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void **buf_array, size_t num_buf,
                      const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error, TArgs &...args);
 
-          /* TODO */
           void TryAllocateSequentialBlocks(size_t num_blocks, const std::function<void (const TBlockRange &block_range)> &cb);
 
-          /* TODO */
           void FreeSequentialBlocks(const TBlockRange &block_range);
 
-          /* TODO */
           void MarkBlockRangeUsed(const TBlockRange &block_range);
 
-          /* TODO */
           void AppendTouchedDevicesToSet(TDeviceSet &device_set, const TBlockRange &block_range) const;
 
-          /* TODO */
           std::pair<size_t, size_t> AppendUsage(std::stringstream &ss) const;
 
-          /* TODO */
           void DiscardAll();
 
           private:
 
-          /* TODO */
           inline void DoCache(TCacheInstr cache_instr, const TOffset start_offset, void *buf, long long nbytes);
 
           /* Forward declaration of PIMPL */
@@ -1061,126 +915,94 @@ namespace Orly {
           class TStripedStrategy;
           class TChainedStrategy;
 
-          /* TODO */
           bool Init(const TExtentSet &extent_set);
 
-          /* TODO */
           inline void SetVolumeId(size_t vol_id) {
             VolumeId = vol_id;
           }
 
-          /* TODO */
           mutable TDeviceCollection::TImpl DeviceCollection;
 
-          /* TODO */
           TManagerMembership::TImpl ManagerMembership;
 
-          /* TODO */
           size_t VolumeId;
 
-          /* TODO */
           const TDesc Desc;
 
-          /* TODO */
           TStrategy *Strategy;
 
-          /* TODO */
           Base::TScheduler *Scheduler;
 
-          /* TODO */
           const TCacheCb CacheCb;
 
-          /* TODO */
           friend class TDiskUtil;
           friend class TVolumeManager;
 
         };  // TVolume
 
-        /* TODO */
         class TVolumeManager {
           NO_COPY(TVolumeManager);
           public:
 
-          /* TODO */
           typedef InvCon::UnorderedList::TCollection<TVolumeManager, TVolume> TVolumeCollection;
 
-          /* TODO */
           TVolumeManager(Base::TScheduler *scheduler);
 
-          /* TODO */
           ~TVolumeManager();
 
-          /* TODO */
           bool AddNewVolume(TVolume *volume);
 
-          /* TODO */
           void AddExistingVolume(TVolume *volume, size_t volume_id);
 
-          /* TODO */
           inline void Write(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                             const TOffset start_offset, long long nbytes, DiskPriority priority, TCacheInstr cache_instr, TCompletionTrigger &trigger,
                             bool abort_on_error = true);
 
-          /* TODO */
           inline void Write(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                             const TOffset start_offset, long long nbytes, DiskPriority priority, TCacheInstr cache_instr, TCompletionTrigger &trigger,
                             const TIOCallback &cb, bool abort_on_error = true);
 
-          /* TODO */
           inline void WriteAndFlush(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                                     const TOffset start_offset, long long nbytes, DiskPriority priority, TCacheInstr cache_instr,
                                     TCompletionTrigger &trigger, bool abort_on_error = true);
 
-          /* TODO */
           inline void WriteBlock(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                                  size_t block_id, DiskPriority priority, TCacheInstr cache_instr, TCompletionTrigger &trigger,
                                  bool abort_on_error = true);
 
-          /* TODO */
           inline void WriteBlock(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                                  size_t block_id, DiskPriority priority, TCacheInstr cache_instr, TCompletionTrigger &trigger, const TIOCallback &cb,
                                  bool abort_on_error = true);
 
-          /* TODO */
           inline void Read(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                            const TOffset start_offset, long long nbytes, DiskPriority priority, TCompletionTrigger &trigger,
                            bool abort_on_error = true);
 
-          /* TODO */
           inline void Read(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                            const TOffset start_offset, long long nbytes, DiskPriority priority, TCompletionTrigger &trigger, const TIOCallback &cb,
                            bool abort_on_error = true);
 
-          /* TODO */
           inline void ReadV(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void **buf_array,
                             size_t num_buf, const TOffset start_offset, long long nbytes, DiskPriority priority, TCompletionTrigger &trigger,
                             const TIOCallback &cb, bool abort_on_error = true);
 
-          /* TODO */
           inline void ReadBlock(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf, size_t block_id,
                                 DiskPriority priority, TCompletionTrigger &trigger, bool abort_on_error = true);
 
-          /* TODO */
           void TryAllocateSequentialBlocks(TVolume::TDesc::TStorageSpeed storage_speed, size_t num_blocks, const std::function<void (const TBlockRange &block_range)> &cb);
 
-          /* TODO */
           void MarkBlockRangeUsed(const TBlockRange &block_range);
 
-          /* TODO */
           void FreeSequentialBlocks(const TBlockRange &block_range);
 
-          /* TODO */
           void SyncToDisk(const std::vector<TBlockRange> &block_range_vec);
 
-          /* TODO */
           void AppendVolumeUsageReport(std::stringstream &ss) const;
 
-          /* TODO */
           void DiscardAllDevices();
 
           private:
 
-          /* TODO */
           size_t RequestNewVolumeId() const {
             size_t max_id = 0UL;
             for (TVolumeCollection::TCursor csr(&VolumeCollection); csr; ++csr) {
@@ -1189,41 +1011,31 @@ namespace Orly {
             return max_id + 1;
           }
 
-          /* TODO */
           template <typename ...TArgs>
           void WriteImpl(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                          const TOffset start_offset, long long nbytes, DiskPriority priority, TCacheInstr cache_instr, bool abort_on_error,
                          TArgs &...args);
 
-          /* TODO */
           template <typename ...TArgs>
           void ReadImpl(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf,
                         const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error, TArgs &...args);
 
-          /* TODO */
           template <typename ...TArgs>
           void ReadVImpl(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void **buf_array, size_t num_buf,
                          const TOffset start_offset, long long nbytes, DiskPriority priority, bool abort_on_error, TArgs &...args);
 
-          /* TODO */
           void AllocateLogicalExtents(TExtentSet &logical_extent_set, size_t num_extent, size_t extent_size, TVolume *volume);
 
-          /* TODO */
           mutable TVolumeCollection::TImpl VolumeCollection;
 
-          /* TODO */
           Base::TScheduler *Scheduler;
 
-          /* TODO */
           std::vector<bool> AllocatedExtentBlocks;
 
-          /* TODO */
           std::unordered_map<size_t, TVolume *> LogicalExtentStartToVolumeMap;
 
-          /* TODO */
           static constexpr size_t ExtentAllocationBlockSize = 16UL * 1024UL * 1024UL * 1024UL * 1024UL; /* 16 TB */
 
-          /* TODO */
           friend class TDiskUtil;
 
         };  // TVolumeManager

--- a/orly/indy/disk/utilization_reporter.h
+++ b/orly/indy/disk/utilization_reporter.h
@@ -32,7 +32,6 @@ namespace Orly {
 
     namespace Disk {
 
-      /* TODO */
       class TUtilizationReporter {
         NO_COPY(TUtilizationReporter);
         public:
@@ -43,18 +42,14 @@ namespace Orly {
           Write
         };
 
-        /* TODO */
         virtual void Push(uint8_t source, TKind kind, size_t num_bytes, DiskPriority priority) = 0;
 
-        /* TODO */
         virtual void Report(std::stringstream &ss) = 0;
 
         protected:
 
-        /* TODO */
         TUtilizationReporter() {}
 
-        /* TODO */
         virtual ~TUtilizationReporter() {}
 
       };  // TUtilizationReporter

--- a/orly/indy/disk/write_group.h
+++ b/orly/indy/disk/write_group.h
@@ -48,7 +48,6 @@ namespace Orly {
         class TIndexSortFile;
       }  // Util
 
-      /* TODO */
       class TWriteGroup {
         NO_COPY(TWriteGroup);
         protected:
@@ -56,79 +55,61 @@ namespace Orly {
         /* Forward Declarations. */
         class TBufferedWrite;
 
-        /* TODO */
         typedef InvCon::UnorderedList::TCollection<TWriteGroup, TBufferedWrite> TWriteCollection;
 
-        /* TODO */
         class TBufferedWrite {
           NO_COPY(TBufferedWrite);
           public:
 
-          /* TODO */
           typedef InvCon::UnorderedList::TMembership<TBufferedWrite, TWriteGroup> TMembership;
 
-          /* TODO */
           TBufferedWrite(TWriteGroup *write_group, size_t block_id, const TBufBlock *buf)
               : Membership(this, &write_group->WriteCollection),
                 BlockId(block_id),
                 Buf(buf) {}
 
-          /* TODO */
           ~TBufferedWrite() {}
 
-          /* TODO */
           const TBufBlock *GetBuf() const {
             return Buf;
           }
 
-          /* TODO */
           size_t GetBlockId() const {
             return BlockId;
           }
 
           private:
 
-          /* TODO */
           TMembership::TImpl Membership;
 
-          /* TODO */
           size_t BlockId;
 
-          /* TODO */
           const TBufBlock *Buf;
 
-          /* TODO */
           friend class TWriteGroup;
 
         };  // TBufferedWrite
 
-        /* TODO */
         TWriteGroup(size_t max_group_size)
             : WriteCollection(this),
               QueueSize(0UL),
               MaxGroupSize(max_group_size) {}
 
-        /* TODO */
         virtual ~TWriteGroup() {}
 
-        /* TODO */
         virtual void Flush() {
           WriteCollection.DeleteEachMember();
           QueueSize = 0UL;
         }
 
-        /* TODO */
         virtual size_t GetLogicalBlockSize() const = 0;
 
-        /* TODO */
         virtual size_t GetPhysicalBlockSize() const = 0;
 
-        /* TODO */
         size_t GetSize() const {
           return QueueSize;
         }
 
-        /* TODO */
         void Append(size_t cur_block_id, const TBufBlock *buf) {
           auto handle = WriteCollection.TryGetLastMember();
           if (!handle) {
@@ -156,16 +137,12 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         mutable TWriteCollection::TImpl WriteCollection;
 
-        /* TODO */
         size_t QueueSize;
 
-        /* TODO */
         size_t MaxGroupSize;
 
-        /* TODO */
         friend class TController;
         friend class TService;
         template <size_t PageSize, size_t BlockSize, size_t PhysicalBlockSize, Util::TBufKind BufKind>

--- a/orly/indy/disk_layer.h
+++ b/orly/indy/disk_layer.h
@@ -27,13 +27,11 @@ namespace Orly {
 
   namespace Indy {
 
-    /* TODO */
     class TDiskLayer
         : public L0::TManager::TRepo::TDataLayer {
       NO_COPY(TDiskLayer);
       public:
 
-      /* TODO */
       TDiskLayer(L0::TManager *manager,
                  L0::TManager::TRepo *repo,
                  size_t gen_id,
@@ -41,10 +39,8 @@ namespace Orly {
                  TSequenceNumber lowest_seq,
                  TSequenceNumber highest_seq);
 
-      /* TODO */
       virtual ~TDiskLayer();
 
-      /* TODO */
       virtual std::unique_ptr<Indy::TPresentWalker> NewPresentWalker(const TIndexKey &from,
                                                                      const TIndexKey &to) const override;
 
@@ -52,69 +48,52 @@ namespace Orly {
          (hashed), so there is no head-scan to avoid (#257). */
       virtual std::unique_ptr<Indy::TPresentWalker> NewPresentWalker(const TIndexKey &key, bool exact_point = false) const override;
 
-      /* TODO */
       virtual std::unique_ptr<Indy::TUpdateWalker> NewUpdateWalker(TSequenceNumber from) const override;
 
-      /* TODO */
       inline virtual TKind GetKind() const override;
 
-      /* TODO */
       inline size_t GetGenId() const;
 
-      /* TODO */
       inline size_t GetNumKeys() const;
 
-      /* TODO */
       inline virtual size_t GetSize() const override;
 
-      /* TODO */
       inline virtual TSequenceNumber GetLowestSeq() const override;
 
-      /* TODO */
       inline virtual TSequenceNumber GetHighestSeq() const override;
 
       private:
 
-      /* TODO */
       L0::TManager::TRepo *Repo;
 
-      /* TODO */
       size_t GenId;
 
-      /* TODO */
       size_t NumKeys;
 
-      /* TODO */
       TSequenceNumber LowestSeq, HighestSeq;
 
     };  // TDiskLayer
 
-    /* TODO */
     inline L0::TManager::TRepo::TDataLayer::TKind TDiskLayer::GetKind() const {
       return L0::TManager::TRepo::TDataLayer::Disk;
     }
 
-    /* TODO */
     inline size_t TDiskLayer::GetGenId() const {
       return GenId;
     }
 
-    /* TODO */
     inline size_t TDiskLayer::GetNumKeys() const {
       return NumKeys;
     }
 
-    /* TODO */
     inline size_t TDiskLayer::GetSize() const {
       return NumKeys;
     }
 
-    /* TODO */
     inline TSequenceNumber TDiskLayer::GetLowestSeq() const {
       return LowestSeq;
     }
 
-    /* TODO */
     inline TSequenceNumber TDiskLayer::GetHighestSeq() const {
       return HighestSeq;
     }

--- a/orly/indy/failover.h
+++ b/orly/indy/failover.h
@@ -44,7 +44,6 @@ namespace Orly {
 
     };
 
-    /* TODO */
     class TConnectionFailed
         : public std::runtime_error {
       public:
@@ -54,91 +53,69 @@ namespace Orly {
 
     };  // TConnectionFailed
 
-    /* TODO */
     class TCommonContext
         : public Rpc::TContext {
       NO_COPY(TCommonContext);
       public:
 
-      /* TODO */
       static const Rpc::TEntryId PingId = 3001;
 
-      /* TODO */
       virtual ~TCommonContext();
 
-      /* TODO */
       void Shutdown();
 
-      /* TODO */
       virtual bool Queue();
 
-      /* TODO */
       virtual bool Work();
 
-      /* TODO */
       virtual void Join();
 
       protected:
 
-      /* TODO */
       class TProtocol
           : public Rpc::TProtocol {
         NO_COPY(TProtocol);
         protected:
 
-        /* TODO */
         TProtocol() {
           Register<TCommonContext, void>(PingId, &TCommonContext::Ping);
         }
 
       };  // TProtocol
 
-      /* TODO */
       TCommonContext(const Rpc::TProtocol &protocol, const Base::TFd &fd);
 
-      /* TODO */
       std::mutex Mutex;
 
-      /* TODO */
       Base::TEventSemaphore Sem;
 
-      /* TODO */
       std::queue<std::shared_ptr<const Rpc::TAnyRequest>> RequestQueue;
 
       private:
 
-      /* TODO */
       enum TReaderState {Connected, NotConnected};
 
-      /* TODO */
       enum TWorkerState {Running, Exited, ExitedOnWriteFailure};
 
-      /* TODO */
       virtual void Ping() = 0;
 
-      /* TODO */
       Base::TFd Fd;
 
-      /* TODO */
       std::shared_ptr<Io::TDevice> Device;
 
-      /* TODO */
       TReaderState ReaderState;
 
-      /* TODO */
       TWorkerState WorkerState;
       std::mutex WorkerMutex;
       Base::TEventSemaphore WorkerStateChanged;
 
     };  // TCommonContext
 
-    /* TODO */
     class TMasterContext
         : public TCommonContext {
       NO_COPY(TMasterContext);
       public:
 
-      /* TODO */
       static const Rpc::TEntryId FetchUpdatesId = 3500;
       static const Rpc::TEntryId NotifyFinishSyncInventoryId = 3501;
       static const Rpc::TEntryId GetViewId = 3502;
@@ -150,18 +127,15 @@ namespace Orly {
 
       protected:
 
-      /* TODO */
       class TProtocol
           : public TCommonContext::TProtocol {
         NO_COPY(TProtocol);
         public:
 
-        /* TODO */
         static const TProtocol Protocol;
 
         private:
 
-        /* TODO */
         TProtocol() {
           Register<TMasterContext, Util::TContextInputStreamer, Base::TUuid, TSequenceNumber, TSequenceNumber>(FetchUpdatesId, &TMasterContext::FetchUpdates);
           Register<TMasterContext, void>(NotifyFinishSyncInventoryId, &TMasterContext::NotifyFinishSyncInventory);
@@ -171,33 +145,25 @@ namespace Orly {
 
       };  // TProtocol
 
-      /* TODO */
       TMasterContext(const Base::TFd &fd);
 
-      /* TODO */
       virtual ~TMasterContext();
 
-      /* TODO */
       virtual Util::TContextInputStreamer FetchUpdates(const Base::TUuid &repo_id, TSequenceNumber lowest, TSequenceNumber highest) = 0;
 
-      /* TODO */
       virtual void NotifyFinishSyncInventory() = 0;
 
-      /* TODO */
       virtual TViewDef GetView(const Base::TUuid &repo_id) = 0;
 
-      /* TODO */
       virtual TFileSync SyncFile(const Base::TUuid &file_id, size_t gen_id, size_t context) = 0;
 
     };  // TMasterContext
 
-    /* TODO */
     class TSlaveContext
         : public TCommonContext {
       NO_COPY(TSlaveContext);
       public:
 
-      /* TODO */
       static const Rpc::TEntryId InventoryId = 3100;
       static const Rpc::TEntryId PushNotificationsId = 3101;
       static const Rpc::TEntryId TransitionToSlaveId = 3102;
@@ -206,18 +172,15 @@ namespace Orly {
 
       protected:
 
-      /* TODO */
       class TProtocol
           : public TCommonContext::TProtocol {
         NO_COPY(TProtocol);
         public:
 
-        /* TODO */
         static const TProtocol Protocol;
 
         private:
 
-        /* TODO */
         TProtocol() {
           Register<TSlaveContext, void,
             Base::TUuid,
@@ -235,13 +198,10 @@ namespace Orly {
 
       };  // TProtocol
 
-      /* TODO */
       TSlaveContext(const Base::TFd &fd);
 
-      /* TODO */
       virtual ~TSlaveContext();
 
-      /* TODO */
       virtual void Inventory(const Base::TUuid &repo_id,
                              size_t ttl,
                              const std::optional<Base::TUuid> &parent_repo_id,
@@ -250,16 +210,12 @@ namespace Orly {
                              const std::optional<TSequenceNumber> &highest,
                              TSequenceNumber) = 0;
 
-      /* TODO */
       virtual void Index(const TIndexMapReplica &index_map_replica) = 0;
 
-      /* TODO */
       virtual void PushNotifications(const TReplicationStreamer &replication_streamer) = 0;
 
-      /* TODO */
       virtual void TransitionToSlave() = 0;
 
-      /* TODO */
       virtual void ScheduleSyncInventory() = 0;
 
     };  // TSlaveContext

--- a/orly/indy/fiber/algorithm.h
+++ b/orly/indy/fiber/algorithm.h
@@ -29,7 +29,6 @@ namespace Orly {
 
     namespace Fiber {
 
-      /* TODO */
       template <
           typename TRandomAccessIterator,
           typename TVal = typename Util::ForIter<TRandomAccessIterator>::TVal,
@@ -39,7 +38,6 @@ namespace Orly {
         NO_COPY(TSubSortRunnable);
         public:
 
-        /* TODO */
         TSubSortRunnable(TRunnerPool &work_pool,
                          const TRandomAccessIterator &begin,
                          const TRandomAccessIterator &end,
@@ -51,12 +49,10 @@ namespace Orly {
           work_pool.Schedule(Frame, this, static_cast<TRunnable::TFunc>(&TSubSortRunnable::DoSort));
         }
 
-        /* TODO */
         ~TSubSortRunnable() {
           TFrame::LocalFramePool->Free(Frame);
         }
 
-        /* TODO */
         void DoSort() {
           std::sort(Begin, End, Comp);
           SafeSync.Complete();
@@ -66,7 +62,6 @@ namespace Orly {
 
         TFrame *Frame;
 
-        /* TODO */
         const TRandomAccessIterator Begin;
         const TRandomAccessIterator End;
         TSafeSync &SafeSync;
@@ -74,7 +69,6 @@ namespace Orly {
 
       };  // TSubSortRunnable
 
-      /* TODO */
       template <
           typename TRandomAccessIterator,
           typename TVal = typename Util::ForIter<TRandomAccessIterator>::TVal,
@@ -84,7 +78,6 @@ namespace Orly {
         NO_COPY(TInplaceMergeRunnable);
         public:
 
-        /* TODO */
         TInplaceMergeRunnable(TRunnerPool &work_pool,
                          const TRandomAccessIterator &begin,
                          const TRandomAccessIterator &middle,
@@ -98,12 +91,10 @@ namespace Orly {
           work_pool.Schedule(Frame, this, static_cast<TRunnable::TFunc>(&TInplaceMergeRunnable::DoMerge));
         }
 
-        /* TODO */
         ~TInplaceMergeRunnable() {
           TFrame::LocalFramePool->Free(Frame);
         }
 
-        /* TODO */
         void DoMerge() {
           WaitOnSafeSync.Sync();
           std::inplace_merge(Begin, Middle, End, Comp);
@@ -114,7 +105,6 @@ namespace Orly {
 
         TFrame *Frame;
 
-        /* TODO */
         const TRandomAccessIterator Begin;
         const TRandomAccessIterator Middle;
         const TRandomAccessIterator End;
@@ -124,7 +114,6 @@ namespace Orly {
 
       };  // TInplaceMergeRunnable
 
-      /* TODO */
       template <
           size_t ParallelThreshold,
           typename TRandomAccessIterator,

--- a/orly/indy/fiber/algorithm.test.cc
+++ b/orly/indy/fiber/algorithm.test.cc
@@ -149,23 +149,18 @@ void TestSort(const std::vector<TVal> &input_data, const size_t num_workers) {
 class TSortedObj {
     public:
 
-    /* TODO */
     TSortedObj(size_t old_key, size_t new_key) : OldKey(old_key), NewKey(new_key) {}
 
-    /* TODO */
     bool operator<(const TSortedObj &that) const {
       return OldKey < that.OldKey;
     }
 
-    /* TODO */
     bool operator==(const TSortedObj &that) const {
       return OldKey == that.OldKey && NewKey == that.NewKey;
     }
 
-    /* TODO */
     size_t OldKey;
 
-    /* TODO */
     size_t NewKey;
 
   };  // TSortedObj

--- a/orly/indy/fiber/extern_fiber.h
+++ b/orly/indy/fiber/extern_fiber.h
@@ -43,34 +43,26 @@ namespace Orly {
         NO_COPY(TSync);
         public:
 
-        /* TODO */
         TSync(size_t waiting_for = 0UL);
 
-        /* TODO */
         ~TSync();
 
-        /* TODO */
         void Sync(bool come_back_right_away = true);
 
-        /* TODO */
         void Complete();
 
-        /* TODO */
         void WaitForMore(size_t num);
 
         private:
 
-        /* TODO */
         inline Fiber::TSync *GetImpl() {
           return reinterpret_cast<Fiber::TSync *>(&SyncSpace[0]);
         }
 
-        /* TODO */
         char SyncSpace[SyncImplSize];
 
       };  // TSync
 
-      /* TODO */
       void SchedTaskLocally(const std::function<void ()> &func);
 
     }  // Fiber

--- a/orly/indy/fiber/fiber.h
+++ b/orly/indy/fiber/fiber.h
@@ -168,14 +168,12 @@ namespace Orly {
          mask save/restore). ucontext is used only once, to bootstrap each
          fiber's jmp_buf. This is the only path compiled in normal builds. */
 
-      /* TODO */
       struct fiber_t {
         ucontext_t fib;
         jmp_buf jmp;
         uint8_t *start_of_stack;
       };
 
-      /* TODO */
       struct fiber_ctx_t {
         void (*fnc)(void *);
         void *ctx;
@@ -183,7 +181,6 @@ namespace Orly {
         ucontext_t *prv;
       };
 
-      /* TODO */
       static void fiber_start_fnc(void *p) {
         fiber_ctx_t *ctx = reinterpret_cast<fiber_ctx_t *>(p);
         void (*ufnc)(void *) = ctx->fnc;
@@ -195,7 +192,6 @@ namespace Orly {
         ufnc(uctx);
       }
 
-      /* TODO */
       inline void create_fiber(fiber_t &fib, void(*ufnc)(void *), void *uctx, size_t stack_size) {
         getcontext(&fib.fib);
         fib.start_of_stack = reinterpret_cast<uint8_t *>(malloc(stack_size));
@@ -223,18 +219,15 @@ namespace Orly {
         swapcontext(&tmp, &fib.fib);
       }
 
-      /* TODO */
       inline size_t get_stack_size(fiber_t &fib) {
         return fib.fib.uc_stack.ss_size;
       }
 
-      /* TODO */
       inline void free_fiber(fiber_t &fib) {
         assert(fib.start_of_stack);
         free(fib.start_of_stack);
       }
 
-      /* TODO */
       inline void switch_to_fiber(fiber_t &fib, fiber_t &prv) {
         if (_setjmp(prv.jmp) == 0) {
           _longjmp(fib.jmp, 1);
@@ -262,7 +255,6 @@ namespace Orly {
          This path is ONLY compiled under -fsanitize=thread; it never affects
          production builds, which use the setjmp/longjmp path above. */
 
-      /* TODO */
       struct fiber_t {
         ucontext_t fib;
         jmp_buf jmp;  // unused under TSan; kept so layout/_mm_prefetch sites compile.
@@ -277,13 +269,11 @@ namespace Orly {
         void *entry_ctx = nullptr;
       };
 
-      /* TODO */
       static void fiber_start_fnc(void *p) {
         fiber_t *fib = reinterpret_cast<fiber_t *>(p);
         fib->entry_fnc(fib->entry_ctx);
       }
 
-      /* TODO */
       inline void create_fiber(fiber_t &fib, void(*ufnc)(void *), void *uctx, size_t stack_size) {
         getcontext(&fib.fib);
         fib.start_of_stack = reinterpret_cast<uint8_t *>(malloc(stack_size));
@@ -308,12 +298,10 @@ namespace Orly {
         makecontext(&fib.fib, reinterpret_cast<void(*)()>(fiber_start_fnc), 1, &fib);
       }
 
-      /* TODO */
       inline size_t get_stack_size(fiber_t &fib) {
         return fib.fib.uc_stack.ss_size;
       }
 
-      /* TODO */
       inline void free_fiber(fiber_t &fib) {
         assert(fib.start_of_stack);
         if (fib.tsan_fiber) {
@@ -323,7 +311,6 @@ namespace Orly {
         free(fib.start_of_stack);
       }
 
-      /* TODO */
       inline void switch_to_fiber(fiber_t &fib, fiber_t &prv) {
         /* Announce the switch to TSan, then swapcontext (which saves our
            resume point into prv.fib and resumes fib.fib). */
@@ -335,10 +322,8 @@ namespace Orly {
 
       #else
 
-      /* TODO */
       typedef ucontext_t fiber_t;
 
-      /* TODO */
       inline void create_fiber(fiber_t &fib, void(*ufnc)(void *), void *uctx, size_t stack_size) {
         static_assert(false, "swapcontext based fibers need fiber local support");
         getcontext(&fib);
@@ -348,18 +333,15 @@ namespace Orly {
         makecontext(&fib, reinterpret_cast<void (*)()>(ufnc), 1, uctx);
       }
 
-      /* TODO */
       inline size_t get_stack_size(fiber_t &fib) {
         return fib.uc_stack.ss_size;
       }
 
-      /* TODO */
       inline void free_fiber(fiber_t &fib) {
         assert(fib.uc_stack.ss_sp);
         free(fib.uc_stack.ss_sp);
       }
 
-      /* TODO */
       inline void switch_to_fiber(fiber_t &fib, fiber_t &prev) {
         swapcontext(&prev, &fib);
       }
@@ -368,20 +350,16 @@ namespace Orly {
       /* Forward Declaration */
       class TFrame;
 
-      /* TODO */
       class alignas(64) TRunner {
         NO_COPY(TRunner);
         public:
 
-        /* TODO */
         //typedef InvCon::UnorderedList::TCollection<TRunner, TFrame> TFrameQueue;
 
-        /* TODO */
         class TRunnerCons {
           NO_COPY(TRunnerCons);
           public:
 
-          /* TODO */
           TRunnerCons(size_t num_runners)
               : NumRunners(num_runners), NextId(0UL) {
             syslog(LOG_INFO, "TRunnerCons [%ld]", num_runners);
@@ -393,14 +371,12 @@ namespace Orly {
             syslog(LOG_INFO, "TRunnerCons [%ld] B", num_runners);
           }
 
-          /* TODO */
           ~TRunnerCons() {
             delete[] RunnerArray;
           }
 
           private:
 
-          /* TODO */
           size_t GetNewId() {
             syslog(LOG_INFO, "TRunnerCons [%ld] GetNewId()", NextId);
             size_t ret = NextId;
@@ -412,10 +388,8 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           const size_t NumRunners;
 
-          /* TODO */
           size_t NextId;
 
           /* Per-runner publication slots. A TRunner publishes itself into its
@@ -435,7 +409,6 @@ namespace Orly {
           runner_cons.RunnerArray[RunnerId].store(this, std::memory_order_release);
         }
 
-        /* TODO */
         TRunner(size_t total_num_runners, size_t runner_id, std::atomic<TRunner *> *runner_array)
             : FreeFrame(nullptr),
               FreeFramePool(nullptr),
@@ -461,42 +434,33 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         ~TRunner() {
           RunnerArray[RunnerId].store(nullptr, std::memory_order_release);
           delete[] QueueArray;
         }
 
-        /* TODO */
         void Run();
 
-        /* TODO */
         void ShutDown() {
           KeepRunning.store(false);
         }
 
-        /* TODO */
         static inline void Yield(fiber_t &fiber) {
           assert(LocalRunner);
           switch_to_fiber(LocalRunner->MainFiber, fiber);
         }
 
-        /* TODO */
         static inline void Schedule(TFrame *frame) {
           assert(LocalRunner);
           LocalRunner->ScheduleFrame(frame);
         }
 
-        /* TODO */
         inline void ScheduleFrame(TFrame *frame);
 
-        /* TODO */
         fiber_t MainFiber;
 
-        /* TODO */
         static __thread TRunner *LocalRunner;
 
-        /* TODO */
         TFrame *FreeFrame;
         Base::TThreadLocalGlobalPoolManager<Indy::Fiber::TFrame, size_t, Indy::Fiber::TRunner *>::TThreadLocalPool *FreeFramePool;
 
@@ -512,12 +476,10 @@ namespace Orly {
         /* Push 'frame' onto a Treiber-stack queue head (see definition). */
         static inline void PushFrameOntoQueue(std::atomic<TFrame *> &head, TFrame *frame);
 
-        /* TODO */
         //mutable TFrameQueue::TImpl MyFrameQueue;
         TFrame *ReadyToRunQueue;
         TFrame *NewReadyToRunQueue;
 
-        /* TODO */
         std::atomic<bool> KeepRunning;
 
         /* Treiber-stack head for frames scheduled onto this runner from a
@@ -532,11 +494,9 @@ namespace Orly {
         };
         TOutboundQueue *QueueArray;
 
-        /* TODO */
         TRunner *ForeignRunnerToMoveFrameTo;
         TFrame *FrameToMoveToForeignRunner;
 
-        /* TODO */
         size_t TotalNumRunners alignas(64);
         size_t RunnerId alignas(64);
         size_t blank_buf[7];
@@ -549,27 +509,22 @@ namespace Orly {
 
       };  // TRunner
 
-      /* TODO */
       class TRunnable {
         NO_COPY(TRunnable);
         public:
 
-        /* TODO */
         typedef void (TRunnable::*TFunc)();
 
         protected:
 
-        /* TODO */
         TRunnable() {}
 
       };  // TRunnable
 
-      /* TODO */
       class alignas(64) TRunnerPool {
         NO_COPY(TRunnerPool);
         public:
 
-        /* TODO */
         TRunnerPool(TRunner::TRunnerCons &runner_cons,
                     size_t num_worker)
             : WorkerCount(num_worker), AssignPos(0UL) {
@@ -581,7 +536,6 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         ~TRunnerPool() {
           for (auto &runner : RunnerVec) {
             runner->ShutDown();
@@ -591,17 +545,14 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         inline size_t GetWorkerCount() const {
           return WorkerCount;
         }
 
-        /* TODO */
         inline void Schedule(TFrame *frame, TRunnable *runnable, const TRunnable::TFunc &func);
 
         private:
 
-        /* TODO */
         const size_t WorkerCount;
 
         /* TODO: use better data structure */
@@ -615,13 +566,11 @@ namespace Orly {
 
       static void StartFrame(void *void_frame);
 
-      /* TODO */
       class TFrame
           : public Base::TThreadLocalGlobalPoolManager<TFrame, size_t, TRunner *>::TObjBase {
         NO_COPY(TFrame);
         public:
 
-        /* TODO */
         TFrame(size_t stack_size, TRunner */*runner*/)
             :
               #ifndef NDEBUG
@@ -652,7 +601,6 @@ namespace Orly {
           free_fiber(MyFiber);
         }
 
-        /* TODO */
         inline void Latch(TRunner *runner, TRunnable *runnable, TRunnable::TFunc runnable_func) {
           //printf("TFrame [%p] Latch runnable [%p]\n", this, runnable);
           CheckFrameUnwound();
@@ -663,7 +611,6 @@ namespace Orly {
           runner->ScheduleFrame(this);
         }
 
-        /* TODO */
         inline void Latch(TRunnable *runnable, TRunnable::TFunc runnable_func) {
           //printf("TFrame [%p] Latch runnable [%p]\n", this, runnable);
           CheckFrameUnwound();
@@ -674,34 +621,29 @@ namespace Orly {
           TRunner::Schedule(this);
         }
 
-        /* TODO */
         inline void Yield() {
           ComeBackRightAway = false;
           TRunner::Schedule(this);
           TRunner::Yield(MyFiber);
         }
 
-        /* TODO */
         inline void YieldSlow() {
           ComeBackRightAway = false;
           TRunner::LocalRunner->ScheduleFrameSlow(this);
           TRunner::Yield(MyFiber);
         }
 
-        /* TODO */
         inline void Wait(bool come_back_right_away) {
           ComeBackRightAway = come_back_right_away;
           TRunner::Yield(MyFiber);
         }
 
-        /* TODO */
         inline void SwitchTo(TRunner *runner) {
           ComeBackRightAway = false;
           runner->ScheduleFrame(this);
           TRunner::Yield(MyFiber);
         }
 
-        /* TODO */
         void Run() {
           //printf("TFrame [%p] Run()\n", this);
           /* wait to get scheduled (after a Latch). */
@@ -751,19 +693,16 @@ namespace Orly {
         }
         #endif
 
-        /* TODO */
         inline fiber_t &GetFiber() {
           return MyFiber;
         }
 
-        /* TODO */
         static __thread TFrame *LocalFrame;
 
         static __thread Base::TThreadLocalGlobalPoolManager<Fiber::TFrame, size_t, Fiber::TRunner *>::TThreadLocalPool *LocalFramePool;
 
         private:
 
-        /* TODO */
         inline void CheckFrameUnwound() {
           /* this is where we make sure that our frame's stack unwound properly... */
           #ifndef NDEBUG
@@ -779,22 +718,16 @@ namespace Orly {
         std::atomic<bool> DebugIsRunning;
         #endif
 
-        /* TODO */
         fiber_t MyFiber;
 
-        /* TODO */
         TRunnable::TFunc RunnableFunc;
 
-        /* TODO */
         TRunnable *Runnable;
 
-        /* TODO */
         //TQueueMembership::TImpl QueueMembership;
 
-        /* TODO */
         TFrame *InboundQueueNextFrame;
 
-        /* TODO */
         bool ComeBackRightAway;
 
         /* MyFiber */
@@ -806,7 +739,6 @@ namespace Orly {
 
       };  // TFrame
 
-      /* TODO */
       static void StartFrame(void *void_frame) {
         TFrame *frame = reinterpret_cast<TFrame*>(void_frame);
         assert(frame);
@@ -814,7 +746,6 @@ namespace Orly {
         TRunner::Yield(frame->GetFiber());
       }
 
-      /* TODO */
       template <typename TVal, typename TArgs>
       class TFiberLocal : public FiberLocal::TFiberLocal {
         NO_COPY(TFiberLocal);
@@ -892,21 +823,16 @@ namespace Orly {
           #endif
         }
 
-        /* TODO */
         inline void Sync(bool come_back_right_away = true);
 
-        /* TODO */
         inline void Complete();
 
-        /* TODO */
         inline void WaitForMore(size_t num);
 
         private:
 
-        /* TODO */
         TFrame *Frame;
 
-        /* TODO */
         size_t WaitingFor;
         size_t Finished;
 
@@ -929,50 +855,38 @@ namespace Orly {
               FrameWaiting(nullptr),
               RunnerToReactivateOn(nullptr) {}
 
-        /* TODO */
         inline void Sync(bool come_back_right_away = true);
 
-        /* TODO */
         inline void Complete();
 
-        /* TODO */
         inline void WaitForMore(size_t num);
 
         private:
 
-        /* TODO */
         std::atomic<size_t> WaitingFor;
         std::atomic<size_t> Finished;
 
-        /* TODO */
         Fiber::TFrame *FrameWaiting;
         Fiber::TRunner *RunnerToReactivateOn;
 
-        /* TODO */
         Base::TSpinLock SpinLock;
 
       };  // TSafeSync
 
-      /* TODO */
       class TSingleSem {
         NO_COPY(TSingleSem);
         public:
 
-        /* TODO */
         TSingleSem() : FlagOn(false), FrameWaiting(nullptr), RunnerToReactivateOn(nullptr) {}
 
-        /* TODO */
         ~TSingleSem() {}
 
-        /* TODO */
         inline void Push();
 
-        /* TODO */
         inline void Pop();
 
         private:
 
-        /* TODO */
         Base::TSpinLock SpinLock;
         bool FlagOn;
 
@@ -981,26 +895,20 @@ namespace Orly {
 
       };  // TSingleSem
 
-      /* TODO */
       class TSem {
         NO_COPY(TSem);
         public:
 
-        /* TODO */
         TSem() : Count(0UL), FrameWaiting(nullptr), RunnerToReactivateOn(nullptr) {}
 
-        /* TODO */
         ~TSem() {}
 
-        /* TODO */
         inline void Push();
 
-        /* TODO */
         inline void Pop();
 
         private:
 
-        /* TODO */
         Base::TSpinLock SpinLock;
         size_t Count;
 
@@ -1017,16 +925,13 @@ namespace Orly {
         NO_COPY(TFiberLock);
         public:
 
-        /* TODO */
         inline TFiberLock()
             : Taken(false), RootLock(nullptr) {}
 
-        /* TODO */
         class alignas(64) TLock {
           NO_COPY(TLock);
           public:
 
-          /* TODO */
           inline TLock(TFiberLock &lock)
               : Lock(lock) {
             #ifndef NDEBUG
@@ -1051,7 +956,6 @@ namespace Orly {
             assert(lock.Taken);
           }
 
-          /* TODO */
           inline ~TLock() {
             /* Grab the spin lock to release control, and enqueue anyone who is waiting. */ {
               Base::TSpinLock::TLock lock(Lock.SpinLock);
@@ -1070,13 +974,10 @@ namespace Orly {
 
           private:
 
-          /* TODO */
           TFiberLock &Lock;
 
-          /* TODO */
           TLock *NextLock;
 
-          /* TODO */
           TRunner *Runner;
           TFrame *Frame;
 
@@ -1088,13 +989,10 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         Base::TSpinLock SpinLock;
 
-        /* TODO */
         bool Taken;
 
-        /* TODO */
         TLock *RootLock;
 
       };  // TFiberLock
@@ -1109,16 +1007,13 @@ namespace Orly {
         NO_COPY(TLockedQueue);
         public:
 
-        /* TODO */
         inline TLockedQueue(TRunner *runner)
             : Runner(runner) {}
 
-        /* TODO */
         class alignas(64) TLock {
           NO_COPY(TLock);
           public:
 
-          /* TODO */
           inline TLock(TLockedQueue &lock)
               : Lock(lock) {
             assert(TRunner::LocalRunner);
@@ -1129,7 +1024,6 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           inline ~TLock() {
             if (Runner != Lock.Runner) {
               TFrame::LocalFrame->SwitchTo(Runner);
@@ -1138,17 +1032,14 @@ namespace Orly {
 
           private:
 
-          /* TODO */
           TLockedQueue &Lock;
 
-          /* TODO */
           TRunner *Runner;
 
         };  // TLock
 
         private:
 
-        /* TODO */
         TRunner *Runner;
 
       };  // TLockedQueue
@@ -1191,19 +1082,16 @@ namespace Orly {
         TRunner::LocalRunner->FreeFramePool = pool;
       }
 
-      /* TODO */
       class TSwitchToRunner {
         NO_COPY(TSwitchToRunner);
         public:
 
-        /* TODO */
         TSwitchToRunner(TRunner *runner_to_switch_to)
             : ComeFromRunner(Base::AssertTrue(TRunner::LocalRunner)) {
           assert(runner_to_switch_to);
           SwitchTo(runner_to_switch_to);
         }
 
-        /* TODO */
         ~TSwitchToRunner() {
           assert(ComeFromRunner);
           SwitchTo(ComeFromRunner);
@@ -1211,7 +1099,6 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         TRunner *ComeFromRunner;
 
       };  // TSwitchToRunner

--- a/orly/indy/fiber/fiber_test_runner.h
+++ b/orly/indy/fiber/fiber_test_runner.h
@@ -25,7 +25,6 @@ namespace Orly {
 
     namespace Fiber {
 
-      /* TODO */
       class TFiberTestRunner
           : public Indy::Fiber::TRunnable {
         NO_COPY(TFiberTestRunner);

--- a/orly/indy/file_sync.h
+++ b/orly/indy/file_sync.h
@@ -26,44 +26,35 @@ namespace Orly {
 
   namespace Indy {
 
-    /* TODO */
     class TFileSync {
       public:
 
       /* This constructor is used on the read end. We default construct before we call read. */
       TFileSync() : Type(Destination), Engine(nullptr), StartingBlockId(0UL), StartingBlockOffset(0UL), Context(0UL) {}
 
-      /* TODO */
       TFileSync(Disk::Util::TEngine *engine, const Base::TUuid &file_id, size_t gen_id, size_t context)
           : Type(Source), Engine(engine), FileId(file_id), GenId(gen_id), StartingBlockId(0UL), StartingBlockOffset(0UL), Context(context) {}
 
-      /* TODO */
       ~TFileSync() {}
 
-      /* TODO */
       void Write(Io::TBinaryOutputStream &stream) const;
 
-      /* TODO */
       void Read(Io::TBinaryInputStream &stream);
 
-      /* TODO */
       inline size_t GetStartingBlockId() const {
         return StartingBlockId;
       }
 
-      /* TODO */
       inline size_t GetStartingBlockOffset() const {
         return StartingBlockOffset;
       }
 
-      /* TODO */
       inline size_t GetFileLength() const {
         return BlockVec.Size() * Disk::Util::LogicalBlockSize;
       }
 
       private:
 
-      /* TODO */
       enum TType {
         Source,
         Destination
@@ -72,26 +63,19 @@ namespace Orly {
       /* This represents whether we are a Source (We will be written, should not be read), or a Destination (We will be read, should not be written) */
       TType Type;
 
-      /* TODO */
       Disk::Util::TEngine *Engine;
 
-      /* TODO */
       Base::TUuid FileId;
 
-      /* TODO */
       size_t GenId;
 
-      /* TODO */
       size_t StartingBlockId;
       size_t StartingBlockOffset;
 
-      /* TODO */
       Indy::Util::TBlockVec BlockVec;
 
-      /* TODO */
       size_t Context;
 
-      /* TODO */
       static const size_t CopyBufSize;
 
     };  // TFileSync

--- a/orly/indy/key.h
+++ b/orly/indy/key.h
@@ -25,23 +25,17 @@ namespace Orly {
 
   namespace Indy {
 
-    /* TODO */
     class TKey {
       public:
 
-      /* TODO */
       explicit inline TKey(Atom::TCore::TArena *arena = nullptr);
 
-      /* TODO */
       explicit inline TKey(const Atom::TCore &core, Atom::TCore::TArena *arena = nullptr);
 
-      /* TODO */
       inline TKey(const TKey &that);
 
-      /* TODO */
       inline TKey(TKey &&that);
 
-      /* TODO */
       template <typename TVal>
       inline TKey(const TVal &val, Atom::TCore::TExtensibleArena *fast_arena, void *state_alloc);
 
@@ -54,113 +48,82 @@ namespace Orly {
       /* Concat tuples */
       inline TKey(Atom::TCore::TExtensibleArena *fast_arena, const Sabot::State::TAny *lhs, const Sabot::State::TAny *rhs);
 
-      /* TODO */
       inline TKey &operator=(TKey &&that);
 
-      /* TODO */
       inline TKey &operator=(const TKey &that);
 
-      /* TODO */
       inline bool operator==(const TKey &that) const;
 
-      /* TODO */
       inline bool operator!=(const TKey &that) const;
 
-      /* TODO */
       inline bool operator<(const TKey &that) const;
 
-      /* TODO */
       inline bool operator<=(const TKey &that) const;
 
-      /* TODO */
       inline bool operator>(const TKey &that) const;
 
-      /* TODO */
       inline bool operator>=(const TKey &that) const;
 
-      /* TODO */
       inline Atom::TComparison Compare(const TKey &that) const;
 
-      /* TODO */
       inline void Dump(std::ostream &strm) const;
 
-      /* TODO */
       inline Atom::TCore::TArena *GetArena() const;
 
-      /* TODO */
       inline const Atom::TCore &GetCore() const;
 
-      /* TODO */
       inline Atom::TCore &GetCore();
 
-      /* TODO */
       inline Sabot::State::TAny *GetState(void *state_alloc) const;
 
-      /* TODO */
       inline size_t GetHash() const;
 
-      /* TODO */
       static inline bool EqEq(const Atom::TCore &lhs, Atom::TCore::TArena *lhs_arena, const Atom::TCore &rhs, Atom::TCore::TArena *rhs_arena);
 
-      /* TODO */
       static inline bool TupleEqEq(const Atom::TCore &lhs, Atom::TCore::TArena *lhs_arena, const Atom::TCore &rhs, Atom::TCore::TArena *rhs_arena);
 
-      /* TODO */
       static inline bool NeEq(const Atom::TCore &lhs, Atom::TCore::TArena *lhs_arena, const Atom::TCore &rhs, Atom::TCore::TArena *rhs_arena);
 
-      /* TODO */
       static inline bool TupleNeEq(const Atom::TCore &lhs, Atom::TCore::TArena *lhs_arena, const Atom::TCore &rhs, Atom::TCore::TArena *rhs_arena);
 
-      /* TODO */
       static inline Atom::TComparison Compare(const Atom::TCore &lhs, Atom::TCore::TArena *lhs_arena, const Atom::TCore &rhs, Atom::TCore::TArena *rhs_arena);
 
       private:
 
-      /* TODO */
       Atom::TCore::TArena *Arena;
 
-      /* TODO */
       Atom::TCore Core;
 
-      /* TODO */
       mutable bool HashIsCached;
       mutable size_t CachedHash;
 
     };  // TKey
 
-    /* TODO */
     class TIndexKey {
       public:
 
-      /* TODO */
       TIndexKey() {}
 
-      /* TODO */
       TIndexKey(const Base::TUuid &index_id, const TKey &key)
           : IndexId(index_id),
             Key(key) {}
 
-      /* TODO */
       inline const Base::TUuid &GetIndexId() const {
         return IndexId;
       }
 
-      /* TODO */
       inline const TKey &GetKey() const {
         return Key;
       }
 
-      /* TODO */
       inline TKey &GetKey() {
         return Key;
       }
 
-      /* TODO */
       inline size_t GetHash() const {
         return IndexId.GetHash() ^ Key.GetHash();
       }
 
-      /* TODO */
       bool operator<(const TIndexKey &that) const {
         Atom::TComparison comp = Atom::CompareOrdered(IndexId, that.IndexId);
         switch (comp) {
@@ -180,22 +143,18 @@ namespace Orly {
         throw;
       }
 
-      /* TODO */
       bool operator==(const TIndexKey &that) const {
         return IndexId == that.IndexId && Key == that.Key;
       }
 
-      /* TODO */
       bool operator!=(const TIndexKey &that) const {
         return IndexId != that.IndexId || Key != that.Key;
       }
 
       private:
 
-      /* TODO */
       Base::TUuid IndexId;
 
-      /* TODO */
       TKey Key;
 
     };  // TIndexKey

--- a/orly/indy/manager.h
+++ b/orly/indy/manager.h
@@ -40,13 +40,11 @@ namespace Orly {
     /* The index id of the system repo space used to store index namespace mappings */
     const Base::TUuid SystemIDNSIndexId("9154D7AE-FA10-42D5-9A10-AC68664B0092");
 
-    /* TODO */
     class TManager
         : public L1::TManager, public DurableManager::TManager {
       NO_COPY(TManager);
       public:
 
-      /* TODO */
       enum TState {
         Solo,
         Master,
@@ -58,7 +56,6 @@ namespace Orly {
           void(const Base::TUuid &idx_id, const std::string &pkg_key, const Indy::TKey &val)>;
       using TForEachIndexIdCb = std::function<void(const TIndexCb &)>;
 
-      /* TODO */
       TManager(Disk::Util::TEngine *engine,
                size_t replication_sync_slave_buf_size_mb,
                std::chrono::milliseconds merge_mem_delay,
@@ -85,65 +82,50 @@ namespace Orly {
                const std::vector<size_t> &merge_disk_cores,
                bool create_new);
 
-      /* TODO */
       virtual ~TManager();
 
-      /* TODO */
       inline TManager::TPtr<Indy::TRepo> NewSafeRepo(const Base::TUuid &repo_id,
                                                      const std::optional<TTtl> &ttl);
 
-      /* TODO */
       inline TManager::TPtr<Indy::TRepo> NewSafeRepo(const Base::TUuid &repo_id,
                                                       const std::optional<TTtl> &ttl,
                                                       const TManager::TPtr<Indy::TRepo> &parent_repo);
 
-      /* TODO */
       TManager::TPtr<Indy::TRepo> NewSafeRepo(const Base::TUuid &repo_id,
                                               const std::optional<TTtl> &ttl,
                                               const std::optional<TManager::TPtr<L0::TManager::TRepo>> &parent_repo);
 
-      /* TODO */
       inline TManager::TPtr<Indy::TRepo> NewFastRepo(const Base::TUuid &repo_id,
                                                      const std::optional<TTtl> &ttl);
 
-      /* TODO */
       inline TManager::TPtr<Indy::TRepo> NewFastRepo(const Base::TUuid &repo_id,
                                                      const std::optional<TTtl> &ttl,
                                                      const TManager::TPtr<Indy::TRepo> &parent_repo);
 
-      /* TODO */
       TManager::TPtr<Indy::TRepo> NewFastRepo(const Base::TUuid &repo_id,
                                               const std::optional<TTtl> &ttl,
                                               const std::optional<TManager::TPtr<L0::TManager::TRepo>> &parent_repo);
 
-      /* TODO */
       inline TManager::TPtr<Indy::TRepo> GetRepo(const Base::TUuid &repo_id,
                                                  const std::optional<TTtl> &deadline,
                                                  const std::optional<TManager::TPtr<TRepo>> &parent_repo,
                                                  bool is_safe,
                                                  bool create = true);
 
-      /* TODO */
       inline TManager::TPtr<Indy::TRepo> ForceGetRepo(const Base::TUuid &repo_id);
 
-      /* TODO */
       inline TManager::TPtr<Indy::TRepo> GetSystemRepo() const;
 
-      /* TODO */
       virtual void RunReplicationQueue() override;
 
-      /* TODO */
       virtual void RunReplicationWork() override;
 
-      /* TODO */
       virtual void RunReplicateTransaction() override;
 
-      /* TODO */
       inline void SetDurableManager(const std::shared_ptr<Durable::TManager> &durable_manager) {
         DurableManager = durable_manager;
       }
 
-      /* TODO */
       static const Base::TUuid MinId;
       static const Base::TUuid MaxId;
       static const Base::TUuid SystemRepoId;
@@ -159,27 +141,21 @@ namespace Orly {
       /* Prepended to sync repo entries. */
       typedef std::tuple<int, Base::TUuid, Base::TUuid, TSequenceNumber, int> TSyncPrepend;
 
-      /* TODO */
       typedef std::tuple<int, Base::TUuid> TSavedRepoKey;
       static const int SavedRepoMagicNumber;
 
-      /* TODO */
       class TSavedRepoObj {
         public:
 
-        /* TODO */
         typedef std::vector<Base::TUuid> TRootPath;
         typedef std::optional<TSequenceNumber> TOptSeq;
 
-        /* TODO */
         static const int Normal = 0;
         static const int Paused = 1;
         static const int Failed = 2;
 
-        /* TODO */
         TSavedRepoObj() {}
 
-        /* TODO */
         TSavedRepoObj(bool is_safe,
                       const TRootPath &root_path,
                       const TOptSeq &lowest_seq,
@@ -197,7 +173,6 @@ namespace Orly {
           assert(State == Normal || State == Paused || State == Failed);
         }
 
-        /* TODO */
         bool operator==(const TSavedRepoObj &that) const {
           return IsSafe == that.IsSafe &&
             RootPath == that.RootPath &&
@@ -208,88 +183,64 @@ namespace Orly {
             State == that.State;
         }
 
-        /* TODO */
         bool IsSafe;
 
-        /* TODO */
         TRootPath RootPath;
 
-        /* TODO */
         TOptSeq LowestSequenceNumber;
 
-        /* TODO */
         TOptSeq HighestSequenceNumber;
 
-        /* TODO */
         TSequenceNumber NextUpdate;
 
-        /* TODO */
         TSequenceNumber ReleasedUpTo;
 
-        /* TODO */
         int State;
 
       };
 
-      /* TODO */
       class TMaster
           : public TMasterContext {
         NO_COPY(TMaster);
         public:
 
-        /* TODO */
         TMaster(TManager *manager, const Base::TFd &fd);
 
-        /* TODO */
         virtual ~TMaster();
 
-        /* TODO */
         virtual bool Queue();
 
-        /* TODO */
         virtual bool Work();
 
-        /* TODO */
         virtual Util::TContextInputStreamer FetchUpdates(const Base::TUuid &repo_id, TSequenceNumber lowest, TSequenceNumber highest);
 
-        /* TODO */
         virtual void NotifyFinishSyncInventory();
 
-        /* TODO */
         virtual TViewDef GetView(const Base::TUuid &repo_id);
 
-        /* TODO */
         virtual TFileSync SyncFile(const Base::TUuid &file_id, size_t gen_id, size_t context);
 
-        /* TODO */
         virtual void Ping();
 
         private:
 
-        /* TODO */
         TManager *Manager;
 
       };  // TMaster
 
-      /* TODO */
       class TSlave
           : public TSlaveContext, Indy::Fiber::TRunnable {
         NO_COPY(TSlave);
         public:
 
-        /* TODO */
         TSlave(TManager *manager, const Base::TFd &fd);
 
-        /* TODO */
         virtual ~TSlave();
 
-        /* TODO */
         virtual bool Queue() override;
 
-        /* TODO */
         virtual bool Work() override;
 
-        /* TODO */
         virtual void Inventory(const Base::TUuid &repo_id,
                                size_t ttl,
                                const std::optional<Base::TUuid> &parent_repo_id,
@@ -298,33 +249,24 @@ namespace Orly {
                                const std::optional<TSequenceNumber> &highest,
                                TSequenceNumber next_id) override;
 
-        /* TODO */
         virtual void Index(const TIndexMapReplica &index_map_replica) override;
 
-        /* TODO */
         virtual void PushNotifications(const TReplicationStreamer &replication_streamer) override;
 
-        /* TODO */
         size_t ApplyCoreVectorTransactions(const std::vector<Atom::TCore> &core_vec, Atom::TCore::TArena *arena);
 
-        /* TODO */
         virtual void TransitionToSlave() override;
 
-        /* TODO */
         virtual void Ping();
 
-        /* TODO */
         virtual void ScheduleSyncInventory() override;
 
         private:
 
-        /* TODO */
         void SyncInventory();
 
-        /* TODO */
         void PullUpdateRange(const Base::TUuid &repo_id, TManager::TPtr<Indy::TRepo> &repo, TSequenceNumber from, TSequenceNumber to);
 
-        /* TODO */
         class TFlusher
             : public Io::TOutputConsumer,
               public Io::TInputProducer,
@@ -332,11 +274,9 @@ namespace Orly {
           NO_COPY(TFlusher);
           public:
 
-          /* TODO */
           typedef Disk::TStream<Disk::Util::LogicalPageSize, Disk::Util::LogicalBlockSize, Disk::Util::PhysicalBlockSize, Disk::Util::CheckedPage, 0UL /*local cache size */> TDataInStream;
           typedef Disk::TOutStream<Disk::Util::LogicalPageSize, Disk::Util::LogicalBlockSize, Disk::Util::PhysicalBlockSize, Disk::Util::PageCheckedBlock> TDataOutStream;
 
-          /* TODO */
           TFlusher(Disk::Util::TEngine *engine)
               : Engine(engine),
                 OutStream(new TDataOutStream(HERE,
@@ -354,7 +294,6 @@ namespace Orly {
                                              std::bind(&TFlusher::NewBlockCb, this, std::placeholders::_1))),
                 Pool(std::make_shared<Io::TPool>(Io::TPool::TArgs())) {}
 
-          /* TODO */
           virtual ~TFlusher() {
             InStream.reset();
             for (const auto &iter : BlockVec.GetSeqBlockMap()) {
@@ -362,87 +301,67 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           virtual void ConsumeOutput(const std::shared_ptr<const Io::TChunk> &chunk) override;
 
-          /* TODO */
           virtual std::shared_ptr<const Io::TChunk> TryProduceInput() override;
 
-          /* TODO */
           const std::vector<size_t> &GetOffsetVec() const {
             return OffsetVec;
           }
 
-          /* TODO */
           void SetStoredOffset() {
             OffsetVec.push_back(OutStream->GetOffset());
           }
 
-          /* TODO */
           void Flush();
 
           private:
 
-          /* TODO */
           virtual size_t GetFileLength() const override {
             return BlockVec.Size() * Disk::Util::LogicalBlockSize;
           }
 
-          /* TODO */
           virtual size_t GetStartingBlock() const override {
             assert(BlockVec.Size() > 0);
             return BlockVec.Front();
           }
 
-          /* TODO */
           virtual void ReadMeta(size_t /*offset*/, size_t &/*out*/) const override {
             throw std::logic_error("Manager::Flusher::ReadMeta should not be used.");
           }
 
-          /* TODO */
           virtual size_t FindPageIdOfByte(size_t offset) const override {
             assert(offset <= GetFileLength());
             return ((BlockVec[offset / Disk::Util::LogicalBlockSize]) * Disk::Util::PagesPerBlock) + ((offset % Disk::Util::LogicalBlockSize) / Disk::Util::LogicalPageSize);
           }
 
-          /* TODO */
           size_t NewBlockCb(Disk::Util::TVolumeManager */*vol_man*/);
 
-          /* TODO */
           Disk::Util::TEngine *Engine;
 
-          /* TODO */
           Util::TBlockVec BlockVec;
 
-          /* TODO */
           std::unordered_map<size_t, std::shared_ptr<const Disk::TBufBlock>> CollisionMap;
 
-          /* TODO */
           Disk::TCompletionTrigger Trigger;
 
           #ifndef NDEBUG
           std::unordered_set<size_t> WrittenBlockSet;
           #endif
 
-          /* TODO */
           std::unique_ptr<TDataOutStream> OutStream;
 
-          /* TODO */
           std::vector<size_t> OffsetVec;
 
-          /* TODO */
           std::shared_ptr<Io::TPool> Pool;
 
-          /* TODO */
           std::unique_ptr<TDataInStream> InStream;
 
         };  // TFlusher
 
-        /* TODO */
         class TToSync {
           public:
 
-          /* TODO */
           TToSync(const Base::TUuid &repo_id,
                   size_t ttl,
                   const std::optional<Base::TUuid> &parent_repo_id,
@@ -460,7 +379,6 @@ namespace Orly {
 
           private:
 
-          /* TODO */
           Base::TUuid RepoId;
           size_t Ttl;
           std::optional<Base::TUuid> ParentRepoId;
@@ -473,7 +391,6 @@ namespace Orly {
 
         };  // TToSync
 
-        /* TODO */
         TManager *Manager;
 
         /* queue of repos to synchronize */
@@ -482,22 +399,18 @@ namespace Orly {
         /* A core-vec slush buffer representing the updates we've accumulated */
         std::unique_ptr<Orly::Atom::TCoreVectorBuilder> SlushCoreVec;
 
-        /* TODO */
         std::shared_ptr<TFlusher> Flusher;
 
       };  // TSlave
 
-      /* TODO */
       virtual TRepo *ConstructRepo(const Base::TUuid &repo_id,
                                    const std::optional<TTtl> &ttl,
                                    const std::optional<TManager::TPtr<TRepo>> &parent_repo,
                                    bool is_safe,
                                    bool create) override;
 
-      /* TODO */
       TRepo *ReconstructRepo(const Base::TUuid &repo_id) override;
 
-      /* TODO */
       virtual bool CanLoad(const L0::TId &id) override;
 
       /* The L0 manager's load/save/delete of durable objects by id. Not wired up: the call sites
@@ -518,71 +431,51 @@ namespace Orly {
         throw std::logic_error("TManager::TryLoad not implemented: durable on-disk object load was never ported (#173).");
       }
 
-      /* TODO */
       virtual void SaveRepo(TRepo *base_repo) override;
 
-      /* TODO */
       void SaveIndexNamespaceMapping(const Base::TUuid &index_id, const std::string &namespace_name);
 
-      /* TODO */
       std::unordered_map<Base::TUuid, std::string> GetIndexNamespaceMapping();
 
-      /* TODO */
       void OnSlaveJoin(const Base::TFd &fd);
 
-      /* TODO */
       inline virtual std::mutex &GetReplicationQueueLock() NO_THROW {
         return ReplicationLock;
       }
 
-      /* TODO */
       virtual void Enqueue(TTransactionReplication *transaction_replication, L1::TTransaction::TReplica &&replica) NO_THROW;
 
-      /* TODO */
       virtual void Enqueue(TRepoReplication *repo_replication) NO_THROW;
 
-      /* TODO */
       void Enqueue(TIndexIdReplication *index_replication) NO_THROW;
 
-      /* TODO */
       virtual TTransactionReplication *NewTransactionReplication();
 
-      /* TODO */
       virtual void DeleteTransactionReplication(TTransactionReplication *transaction_replication) NO_THROW override;
 
-      /* TODO */
       virtual void EnqueueDurable(TDurableReplication *durable_replication) NO_THROW override;
 
       /* TOOD */
       virtual TDurableReplication *NewDurableReplication(const Base::TUuid &id, const TTtl &ttl, const std::string &serialized_form) const override;
 
-      /* TODO */
       virtual void DeleteDurableReplication(TDurableReplication *durable_replication) NO_THROW override;
 
-      /* TODO */
       void Demote();
 
-      /* TODO */
       void PromoteSolo(const Base::TFd &fd);
 
-      /* TODO */
       void PromoteSlave();
 
-      /* TODO */
       void AugmentViewMapWithDiskLayers(TMaster::TViewDef &view_def, const std::unique_ptr<Indy::TRepo::TView> &view) const;
 
-      /* TODO */
       virtual void ForEachScheduler(const std::function<bool (Fiber::TRunner *)> &cb) const {
         ForEachSchedulerCb(cb);
       }
 
-      /* TODO */
       TManager::TPtr<Indy::TRepo> SystemRepo;
 
-      /* TODO */
       TState State;
 
-      /* TODO */
       std::shared_ptr<TCommonContext> Context;
       std::mutex ContextLock;
 
@@ -590,63 +483,48 @@ namespace Orly {
       std::mutex SlaveNotifyLock;
       std::condition_variable SlaveNotifyCond;
 
-      /* TODO */
       std::function<void (const std::shared_ptr<std::function<void (const Base::TFd &)>> &)> WaitForSlave;
 
-      /* TODO */
       std::function<void (TState)> StateChangeCb;
 
-      /* TODO */
       bool ReplicationRead, ReplicationWork;
 
-      /* TODO */
       TReplicationQueue ReplicationQueue;
       std::mutex ReplicationLock;
 
-      /* TODO */
       Base::TFd ReplicationQueueEpollFd;
       std::mutex ReplicationQueueEpollLock;
       epoll_event ReplicationQueueEvent;
       Base::TEventSemaphore ReplicationQueueSem;
 
-      /* TODO */
       Base::TFd ReplicationWorkEpollFd;
       std::mutex ReplicationWorkEpollLock;
       epoll_event ReplicationWorkEvent;
       Base::TEventSemaphore ReplicationWorkSem;
 
-      /* TODO */
       Base::TFd ReplicationEpollFd;
       std::mutex ReplicationEpollLock;
       epoll_event ReplicationEvent;
       Base::TEventSemaphore ReplicationSem;
       std::chrono::steady_clock::time_point ReplicationNextTime;
 
-      /* TODO */
       std::chrono::milliseconds ReplicationDelay;
 
-      /* TODO */
       std::function<void (const Base::TUuid &, const Base::TUuid &, const Base::TUuid &)> UpdateReplicationNotificationCb;
 
       TIndexCb OnReplicateIndexIdCb;
       TForEachIndexIdCb ForEachIndexIdCb;
 
-      /* TODO */
       std::function<void (const std::function<bool (Fiber::TRunner *)> &)> ForEachSchedulerCb;
 
-      /* TODO */
       std::shared_ptr<Durable::TManager> DurableManager;
 
-      /* TODO */
       Indy::Fiber::TRunner *BGFastRunner;
 
-      /* TODO */
       size_t ReplicationSyncSlaveBufSizeBytes;
 
-      /* TODO */
       bool AllowFileSync;
 
-      /* TODO */
       std::unordered_map<Base::TUuid, std::unique_ptr<Indy::TRepo::TView>> SlaveSyncViewMap;
 
       friend class Orly::Server::TServer;
@@ -655,7 +533,6 @@ namespace Orly {
 
     namespace L0 {
 
-      /* TODO */
       template<>
       template<>
       inline TManager::TPtr<Indy::TRepo>::TPtr(const TPtr<L0::TManager::TRepo> &that) {

--- a/orly/indy/manager_base.h
+++ b/orly/indy/manager_base.h
@@ -80,7 +80,6 @@ namespace Orly {
       DEFINE_ERROR(TDoesntExist, std::runtime_error, "durable object doesn't exist");
       DEFINE_ERROR(TWrongType, std::runtime_error, "durable object of wrong type");
 
-      /* TODO */
       class TManager
           : public Fiber::TRunnable {
         NO_COPY(TManager);
@@ -334,34 +333,26 @@ namespace Orly {
 
         };  // TObj
 
-        /* TODO */
         class TRepo
             : public TManager::TObj {
           NO_COPY(TRepo);
           public:
 
-          /* TODO */
           typedef std::optional<TManager::TPtr<L0::TManager::TRepo>> TParentRepo;
 
           /* Forward Declarations. */
           class TDataLayer;
 
-          /* TODO */
           typedef InvCon::OrderedList::TMembership<TRepo, TManager, std::chrono::steady_clock::time_point> TQueueMembership;
 
-          /* TODO */
           virtual ~TRepo();
 
-          /* TODO */
           const Base::TUuid &GetId() const;
 
-          /* TODO */
           inline TStatus GetStatus() const;
 
-          /* TODO */
           virtual bool IsSafeRepo() const = 0;
 
-          /* TODO */
           inline bool IsTailingAllowed() const;
 
           protected:
@@ -369,10 +360,8 @@ namespace Orly {
           /* Forward Declarations. */
           class TMapping;
 
-          /* TODO */
           typedef InvCon::UnorderedList::TCollection<TRepo, TMapping> TMappingCollection;
 
-          /* TODO */
           class TMapping {
             NO_COPY(TMapping);
             public:
@@ -380,108 +369,79 @@ namespace Orly {
             /* Forward Declarations. */
             class TEntry;
 
-            /* TODO */
             typedef InvCon::UnorderedList::TMembership<TMapping, TRepo> TRepoMembership;
 
-            /* TODO */
             typedef InvCon::OrderedList::TCollection<TMapping, TEntry, TSequenceNumber> TEntryCollection;
 
-            /* TODO */
             class TEntry {
               NO_COPY(TEntry);
               public:
 
-              /* TODO */
               typedef InvCon::OrderedList::TMembership<TEntry, TMapping, TSequenceNumber> TMappingMembership;
 
-              /* TODO */
               TEntry(TMapping *mapping, TDataLayer *layer);
 
-              /* TODO */
               ~TEntry();
 
-              /* TODO */
               TDataLayer *GetLayer() const;
 
-              /* TODO */
               TEntry *TryGetNextMember() const;
 
-              /* TODO */
               TEntry *TryGetPrevMember() const;
 
-              /* TODO */
               static void *operator new(size_t size) {
                 return Pool.Alloc(size);
               }
 
-              /* TODO */
               static void operator delete(void *ptr, size_t) {
                 Pool.Free(ptr);
               }
 
               private:
 
-              /* TODO */
               TMappingMembership::TImpl MappingMembership;
 
-              /* TODO */
               TDataLayer *Layer;
 
-              /* TODO */
               static Util::TPool Pool;
 
-              /* TODO */
               friend class TManager;
               friend class Server::TIndyReporter;
 
             };  // TEntry
 
-            /* TODO */
             TMapping(TRepo *repo);
 
-            /* TODO */
             ~TMapping();
 
-            /* TODO */
             inline void Incr();
 
-            /* TODO */
             inline void Decr();
 
-            /* TODO */
             inline size_t GetRefCount() const;
 
-            /* TODO */
             TEntryCollection *GetEntryCollection() const;
 
-            /* TODO */
             static void *operator new(size_t size) {
               return Pool.Alloc(size);
             }
 
-            /* TODO */
             static void operator delete(void *ptr, size_t) {
               Pool.Free(ptr);
             }
 
             private:
 
-            /* TODO */
             TRepoMembership::TImpl RepoMembership;
 
-            /* TODO */
             mutable TEntryCollection::TImpl EntryCollection;
 
-            /* TODO */
             size_t RefCount;
 
-            /* TODO */
             bool MarkedForDelete;
 
-            /* TODO */
             static Util::TPool Pool;
 
-            /* TODO */
             friend class TManager;
             friend class Server::TIndyReporter;
 
@@ -489,7 +449,6 @@ namespace Orly {
 
           public:
 
-          /* TODO */
           class TDataLayer {
             NO_COPY(TDataLayer);
             public:
@@ -499,22 +458,16 @@ namespace Orly {
               Disk
             };
 
-            /* TODO */
             typedef InvCon::UnorderedList::TMembership<TDataLayer, TManager> TRemovalMembership;
 
-            /* TODO */
             virtual ~TDataLayer();
 
-            /* TODO */
             inline void RemoveFromCollection();
 
-            /* TODO */
             void Incr();
 
-            /* TODO */
             void Decr();
 
-            /* TODO */
             virtual std::unique_ptr<TPresentWalker> NewPresentWalker(const TIndexKey &from,
                                                                      const TIndexKey &to) const = 0;
 
@@ -523,89 +476,65 @@ namespace Orly {
                Defaults false so prefix/cursor callers keep the scan. */
             virtual std::unique_ptr<TPresentWalker> NewPresentWalker(const TIndexKey &key, bool exact_point = false) const = 0;
 
-            /* TODO */
             virtual std::unique_ptr<TUpdateWalker> NewUpdateWalker(TSequenceNumber from) const = 0;
 
-            /* TODO */
             virtual TKind GetKind() const = 0;
 
-            /* TODO */
             inline bool GetMarkedTaken() const;
 
-            /* TODO */
             inline void MarkTaken();
 
-            /* TODO */
             inline void UnmarkTaken();
 
-            /* TODO */
             inline bool GetMarkedForDelete() const;
 
-            /* TODO */
             inline void MarkForDelete();
 
-            /* TODO */
             virtual size_t GetSize() const = 0;
 
-            /* TODO */
             virtual TSequenceNumber GetLowestSeq() const = 0;
 
-            /* TODO */
             virtual TSequenceNumber GetHighestSeq() const = 0;
 
-            /* TODO */
             static void *operator new(size_t size) {
               return Pool.Alloc(size);
             }
 
-            /* TODO */
             static void operator delete(void *ptr, size_t) {
               Pool.Free(ptr);
             }
 
             protected:
 
-            /* TODO */
             TDataLayer(TManager *manager);
 
             private:
 
-            /* TODO */
             TManager *Manager;
 
-            /* TODO */
             TRemovalMembership::TImpl RemovalMembership;
 
-            /* TODO */
             size_t RefCount;
 
-            /* TODO */
             bool MarkedForDelete;
 
-            /* TODO */
             bool MarkedTaken;
 
-            /* TODO */
             static Util::TPool Pool;
 
-            /* TODO */
             friend class TManager;
             friend class Server::TIndyReporter;
 
           };  // TDataLayer
 
-          /* TODO */
           virtual const TParentRepo &GetParentRepo() const = 0;
 
           protected:
 
-          /* TODO */
           TRepo(TManager *manager, const Base::TUuid &repo_id, const TTtl &ttl, TStatus status);
 
-          /* TODO */
           void PreDtor();
 
-          /* TODO */
           virtual size_t MergeFiles(const std::vector<size_t> &gen_id_vec,
                                     Disk::Util::TVolume::TDesc::TStorageSpeed storage_speed,
                                     size_t max_block_cache_read_slots_allowed,
@@ -617,10 +546,8 @@ namespace Orly {
                                     bool can_tail,
                                     bool can_tail_tombstone);
 
-          /* TODO */
           virtual void RemoveFile(size_t gen_id);
 
-          /* TODO */
           virtual size_t WriteFile(TMemoryLayer *memory_layer,
                                    Disk::Util::TVolume::TDesc::TStorageSpeed storage_speed,
                                    TSequenceNumber &out_saved_low_seq,
@@ -628,74 +555,54 @@ namespace Orly {
                                    size_t &out_num_keys,
                                    TSequenceNumber release_up_to);
 
-          /* TODO */
           virtual std::unique_ptr<Indy::TPresentWalker> NewPresentWalkerFile(size_t gen_id,
                                                                              const TIndexKey &from,
                                                                              const TIndexKey &to) const;
 
-          /* TODO */
           virtual std::unique_ptr<Indy::TPresentWalker> NewPresentWalkerFile(size_t gen_id,
                                                                              const TIndexKey &key) const;
 
-          /* TODO */
           virtual std::unique_ptr<Indy::TUpdateWalker> NewUpdateWalkerFile(size_t gen_id, TSequenceNumber from) const;
 
-          /* TODO */
           inline void EnqueueMergeMem();
 
-          /* TODO */
           inline void EnqueueMergeDisk();
 
-          /* TODO */
           virtual void StepMergeMem() = 0;
 
-          /* TODO */
           virtual void StepMergeDisk(size_t block_slots_available) = 0;
 
-          /* TODO */
           virtual void StepTail(size_t block_slots_available) = 0;
 
-          /* TODO */
           void MakeDirty();
 
-          /* TODO */
           void RemoveFromDirty();
 
-          /* TODO */
           inline void RemoveFromClosedBuffer();
 
-          /* TODO */
           mutable TMappingCollection::TImpl MappingCollection;
 
-          /* TODO */
           std::mutex MappingLock;
 
-          /* TODO */
           TManager *Manager;
 
-          /* TODO */
           TStatus Status;
 
           private:
 
-          /* TODO */
           inline const std::chrono::steady_clock::time_point &GetTimeOfNextMergeMem() const;
           inline const std::chrono::steady_clock::time_point &GetTimeOfNextMergeDisk() const;
 
-          /* TODO */
           inline void SetTimeOfNextMergeMem(const std::chrono::steady_clock::time_point &time);
           inline void SetTimeOfNextMergeDisk(const std::chrono::steady_clock::time_point &time);
 
           TPtr<TRepo> DirtyPtr;
 
-          /* TODO */
           Base::TUuid Id;
 
-          /* TODO */
           TQueueMembership::TImpl MergeMemMembership;
           TQueueMembership::TImpl MergeDiskMembership;
 
-          /* TODO */
           friend class TManager;
           friend class Orly::Indy::TManager;
           friend class Orly::Indy::TMemoryLayer;
@@ -705,68 +612,50 @@ namespace Orly {
 
         };  // TRepo
 
-        /* TODO */
         typedef InvCon::UnorderedList::TCollection<TManager, TRepo::TDataLayer> TRemovalCollection;
 
-        /* TODO */
         inline Disk::Util::TEngine *GetEngine() const;
 
-        /* TODO */
         inline size_t GetTempFileConsolThresh() const;
 
-        /* TODO */
         void CompactOpemMap();
 
-        /* TODO */
         void RunLayerCleaner();
 
-        /* TODO */
         void RunMergeMem();
 
-        /* TODO */
         void RunMergeDisk();
 
-        /* TODO */
         void GetFileGenSet(const Base::TUuid &repo_id, std::vector<Disk::TFileObj> &file_vec);
 
-        /* TODO */
         Server::TTetrisManager *GetTetrisManager() const;
 
-        /* TODO */
         void SetTetrisManager(Server::TTetrisManager *tetris_manager);
 
-        /* TODO */
         void ReportMergeCPUTime(std::chrono::nanoseconds &out_merge_mem, std::chrono::nanoseconds &out_merge_disk);
 
-        /* TODO */
         virtual void ForEachScheduler(const std::function<bool (Fiber::TRunner *)> &cb) const = 0;
 
-        /* TODO */
         static void InitMappingPool(size_t num_obj) {
           TRepo::TMapping::Pool.Init(num_obj);
         }
 
-        /* TODO */
         static constexpr size_t GetMappingSize() {
           return sizeof(TRepo::TMapping);
         }
 
-        /* TODO */
         static void InitMappingEntryPool(size_t num_obj) {
           TRepo::TMapping::TEntry::Pool.Init(num_obj);
         }
 
-        /* TODO */
         static constexpr size_t GetMappingEntrySize() {
           return sizeof(TRepo::TMapping::TEntry);
         }
 
-        /* TODO */
         static void InitDataLayerPool(size_t num_obj) {
           TRepo::TDataLayer::Pool.Init(num_obj);
         }
 
-        /* TODO */
         static constexpr size_t GetDataLayerSize() {
           return sizeof(TRepo::TDataLayer);
         }
@@ -779,21 +668,17 @@ namespace Orly {
 
         protected:
 
-        /* TODO */
         template <typename... TArgs>
         TPtr<TRepo> New(const TId &id, const TTtl &ttl, TArgs &&... args);
 
-        /* TODO */
         template <typename TSomeObj>
         TPtr<TSomeObj> Open(const TId &id);
 
-        /* TODO */
         TManager::TPtr<TRepo> OpenOrCreate(const TId &id,
                                            const std::optional<TTtl> &ttl,
                                            const std::optional<TPtr<TRepo>> &parent_repo,
                                            bool is_safe);
 
-        /* TODO */
         std::mutex DurableMutex;
         std::condition_variable DurableCond;
 
@@ -847,10 +732,8 @@ namespace Orly {
 
         protected:
 
-        /* TODO */
         typedef InvCon::OrderedList::TCollection<TManager, TRepo, std::chrono::steady_clock::time_point> TRepoQueue;
 
-        /* TODO */
         TManager(Disk::Util::TEngine *engine,
                  std::chrono::milliseconds merge_mem_delay,
                  std::chrono::milliseconds merge_disk_delay,
@@ -865,106 +748,77 @@ namespace Orly {
                  const std::vector<size_t> &merge_disk_cores,
                  bool create_new);
 
-        /* TODO */
         virtual ~TManager();
 
-        /* TODO */
         void CloseAllUnreferencedObjects();
 
-        /* TODO */
         bool PreDtor();
 
-        /* TODO */
         inline TManager::TPtr<TRepo> ForceOpenRepo(const Base::TUuid &repo_id);
 
-        /* TODO */
         virtual TRepo *ConstructRepo(const Base::TUuid &repo_id,
                                      const std::optional<TTtl> &ttl,
                                      const std::optional<TManager::TPtr<TRepo>> &parent_repo,
                                      bool is_safe,
                                      bool create) = 0;
 
-        /* TODO */
         virtual TRepo *ReconstructRepo(const Base::TUuid &repo_id) = 0;
 
-        /* TODO */
         virtual void SaveRepo(TRepo *repo) = 0;
 
-        /* TODO */
         virtual void RunReplicationQueue() = 0;
 
-        /* TODO */
         virtual void RunReplicationWork() = 0;
 
-        /* TODO */
         virtual void RunReplicateTransaction() = 0;
 
-        /* TODO */
         Base::TScheduler *Scheduler;
 
         private:
 
-        /* TODO */
         void OnClose(TRepo *repo);
 
-        /* TODO */
         void EnqueueMergeMem(TRepo *repo);
 
-        /* TODO */
         void EnqueueMergeDisk(TRepo *repo);
 
-        /* TODO */
         void RemoveLayersFromQueue();
 
-        /* TODO */
         bool ShuttingDown;
 
-        /* TODO */
         bool AllowTailing;
 
-        /* TODO */
         mutable TRemovalCollection::TImpl RemovalCollection;
         std::mutex RemovalLock;
         Base::TTimerFd LayerCleanerTimer;
 
-        /* TODO */
         mutable TRepoQueue::TImpl MergeMemQueue;
         std::mutex MergeMemLock;
         std::mutex MergeMemEpollLock;
         Fiber::TSingleSem MergeMemSem;
 
-        /* TODO */
         mutable TRepoQueue::TImpl MergeDiskQueue;
         Fiber::TFiberLock MergeDiskLock;
         Fiber::TFiberLock MergeDiskEpollLock;
         Fiber::TSingleSem MergeDiskSem;
 
-        /* TODO */
         std::chrono::milliseconds MergeMemDelay;
         std::chrono::milliseconds MergeDiskDelay;
 
-        /* TODO */
         size_t BlockSlotsAvailablePerMerger;
 
-        /* TODO */
         size_t MaxCacheSize;
 
-        /* TODO */
         Disk::Util::TEngine *Engine;
 
-        /* TODO */
         size_t TempFileConsolThresh;
 
-        /* TODO */
         const std::vector<size_t> &MergeMemCores;
 
-        /* TODO */
         const std::vector<size_t> &MergeDiskCores;
 
-        /* TODO */
         Server::TTetrisManager *TetrisManager;
 
-        /* TODO */
         std::function<void (TRepo *)> OnCloseCb;
 
         /* Merge CPU Timer Information */
@@ -972,7 +826,6 @@ namespace Orly {
         std::unordered_map<pthread_t, Base::thread_clock::time_point> MergeDiskThreadCPUMap;
         std::mutex MergeThreadCPUMutex;
 
-        /* TODO */
         friend class Orly::Server::TServer;
 
       };  // TManager

--- a/orly/indy/memory_layer.h
+++ b/orly/indy/memory_layer.h
@@ -40,29 +40,22 @@ namespace Orly {
     class TRepo;
     class TManager;
 
-    /* TODO */
     class TMemoryLayer
         : public L0::TManager::TRepo::TDataLayer {
       NO_COPY(TMemoryLayer);
       public:
 
-      /* TODO */
       typedef InvCon::OrderedList::TCollection<TMemoryLayer, TUpdate, TSequenceNumber> TUpdateCollection;
       typedef InvCon::OrderedList::TCollection<TMemoryLayer, TUpdate::TEntry, TUpdate::TEntry::TEntryKey> TEntryCollection;
 
-      /* TODO */
       TMemoryLayer(L0::TManager *manager);
 
-      /* TODO */
       virtual ~TMemoryLayer();
 
-      /* TODO */
       void Insert(TUpdate *update) NO_THROW;
 
-      /* TODO */
       void ReverseInsert(TUpdate *update) NO_THROW;
 
-      /* TODO */
       inline TEntryCollection *GetEntryCollection() const;
 
       /* Link a freshly-inserted entry into the skip-list accelerator (#257).
@@ -85,43 +78,34 @@ namespace Orly {
          TMatchPresentWalker's exact-point guard). */
       TEntryCollection::TCursor SeekRun(const TIndexKey &key) const;
 
-      /* TODO */
       inline TUpdateCollection *GetUpdateCollection() const;
 
       inline bool IsEmpty() const;
 
-      /* TODO */
       virtual std::unique_ptr<Indy::TPresentWalker> NewPresentWalker(const TIndexKey &from,
                                                                      const TIndexKey &to) const override;
 
       virtual std::unique_ptr<Indy::TPresentWalker> NewPresentWalker(const TIndexKey &key, bool exact_point = false) const override;
 
-      /* TODO */
       virtual std::unique_ptr<Indy::TUpdateWalker> NewUpdateWalker(TSequenceNumber from) const override;
 
-      /* TODO */
       inline virtual size_t GetSize() const override;
 
-      /* TODO */
       inline virtual TSequenceNumber GetLowestSeq() const override;
 
-      /* TODO */
       inline virtual TSequenceNumber GetHighestSeq() const override;
 
       private:
 
-      /* TODO */
       class TMatchPresentWalker
           : public Indy::TPresentWalker {
         NO_COPY(TMatchPresentWalker);
         public:
 
-        /* TODO */
         TMatchPresentWalker(const TMemoryLayer *layer,
                        const TIndexKey &key,
                        bool exact_point);
 
-        /* TODO */
         virtual ~TMatchPresentWalker();
 
         /* True iff. we have an item. */
@@ -135,25 +119,18 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         void Refresh() const;
 
-        /* TODO */
         const TMemoryLayer *const Layer;
 
-        /* TODO */
         const TIndexKey &Key;
 
-        /* TODO */
         mutable TMemoryLayer::TEntryCollection::TCursor Csr;
 
-        /* TODO */
         mutable bool Valid;
 
-        /* TODO */
         mutable bool Cached;
 
-        /* TODO */
         mutable bool PassedMatch;
 
         /* When true, the search key is a fully-bound point read (from
@@ -161,23 +138,19 @@ namespace Orly {
            instead of scanning the ordered list from the head (#257). */
         const bool ExactPoint;
 
-        /* TODO */
         mutable TItem Item;
 
       };  // TMatchPresentWalker
 
-      /* TODO */
       class TRangePresentWalker
           : public Indy::TPresentWalker {
         NO_COPY(TRangePresentWalker);
         public:
 
-        /* TODO */
         TRangePresentWalker(const TMemoryLayer *layer,
                        const TIndexKey &from,
                        const TIndexKey &to);
 
-        /* TODO */
         virtual ~TRangePresentWalker();
 
         /* True iff. we have an item. */
@@ -191,45 +164,33 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         void Refresh() const;
 
-        /* TODO */
         const TMemoryLayer *const Layer;
 
-        /* TODO */
         const TIndexKey &From;
 
-        /* TODO */
         const TIndexKey &To;
 
-        /* TODO */
         mutable TMemoryLayer::TEntryCollection::TCursor Csr;
 
-        /* TODO */
         mutable bool Valid;
 
-        /* TODO */
         mutable bool Cached;
 
-        /* TODO */
         mutable bool PassedMatch;
 
-        /* TODO */
         mutable TItem Item;
 
       };  // TRangePresentWalker
 
-      /* TODO */
       class TUpdateWalker
           : public Indy::TUpdateWalker {
         NO_COPY(TUpdateWalker);
         public:
 
-        /* TODO */
         TUpdateWalker(const TMemoryLayer *layer, TSequenceNumber from);
 
-        /* TODO */
         virtual ~TUpdateWalker();
 
         /* True iff. we have an item. */
@@ -243,39 +204,28 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         void Refresh();
 
-        /* TODO */
         const TMemoryLayer *const Layer;
 
-        /* TODO */
         TSequenceNumber From;
 
-        /* TODO */
         TMemoryLayer::TUpdateCollection::TCursor Csr;
 
-        /* TODO */
         bool Valid;
 
-        /* TODO */
         mutable TItem Item;
 
       };  // TUpdateWalker
 
-      /* TODO */
       inline virtual TKind GetKind() const;
 
-      /* TODO */
       void ImporterAppendUpdate(TUpdate *update);
 
-      /* TODO */
       void ImporterAppendEntry(TUpdate::TEntry *entry);
 
-      /* TODO */
       mutable TUpdateCollection::TImpl UpdateCollection;
 
-      /* TODO */
       mutable TEntryCollection::TImpl EntryCollection;
 
       /* Per-level head pointers for the skip-list accelerator over
@@ -286,7 +236,6 @@ namespace Orly {
       std::atomic<TUpdate::TEntry *> SkipHead[TUpdate::TEntry::SkipMaxLevel];
       std::atomic<size_t> SkipListLevel;
 
-      /* TODO */
       size_t Size;
 
       friend class Orly::Server::TServer;
@@ -295,38 +244,31 @@ namespace Orly {
 
     };  // TMemoryLayer
 
-    /* TODO */
     inline TMemoryLayer::TEntryCollection *TMemoryLayer::GetEntryCollection() const {
       return &EntryCollection;
     }
 
-    /* TODO */
     inline TMemoryLayer::TUpdateCollection *TMemoryLayer::GetUpdateCollection() const {
       return &UpdateCollection;
     }
 
-    /* TODO */
     inline bool TMemoryLayer::IsEmpty() const {
       return UpdateCollection.TryGetFirstMember() == nullptr;
     }
 
-    /* TODO */
     inline L0::TManager::TRepo::TDataLayer::TKind TMemoryLayer::GetKind() const {
       return L0::TManager::TRepo::TDataLayer::Mem;
     }
 
-    /* TODO */
     inline size_t TMemoryLayer::GetSize() const {
       return Size;
     }
 
-    /* TODO */
     inline TSequenceNumber TMemoryLayer::GetLowestSeq() const {
       assert(Size);
       return UpdateCollection.TryGetFirstMember()->GetSequenceNumber();
     }
 
-    /* TODO */
     inline TSequenceNumber TMemoryLayer::GetHighestSeq() const {
       assert(Size);
       return UpdateCollection.TryGetLastMember()->GetSequenceNumber();

--- a/orly/indy/present_walker.h
+++ b/orly/indy/present_walker.h
@@ -45,7 +45,6 @@ namespace Orly {
         /* Do-little. */
         TItem() : SequenceNumber(0UL), KeyArena(nullptr), OpArena(nullptr), Mutator(TMutator::Assign), UpdateId() {}
 
-        /* TODO */
         bool operator<(const TItem &that) const {
           Atom::TComparison comp;
           if (KeyArena && that.KeyArena && Key.TryQuickOrderComparison(KeyArena, that.Key, that.KeyArena, comp)) {
@@ -104,7 +103,6 @@ namespace Orly {
       /* Walk to the next item, if any. */
       virtual TPresentWalker &operator++() = 0;
 
-      /* TODO */
       virtual ~TPresentWalker() {}
 
       protected:
@@ -117,7 +115,6 @@ namespace Orly {
       /* Prepare to walk. */
       TPresentWalker(TSearchKind search_kind) : SearchKind(search_kind) {}
 
-      /* TODO */
       TSearchKind SearchKind;
 
     };  // TPresentWalker

--- a/orly/indy/replication.h
+++ b/orly/indy/replication.h
@@ -27,14 +27,11 @@ namespace Orly {
 
   namespace Indy {
 
-    /* TODO */
     class TIndexMapReplica {
       public:
 
-      /* TODO */
       TIndexMapReplica() {}
 
-      /* TODO */
       void Push(const Base::TUuid &index_id, const std::string &pkg_key, const Indy::TKey &val) {
         void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
         CoreVecBuilder.Push(index_id);
@@ -42,18 +39,15 @@ namespace Orly {
         CoreVecBuilder.PushState(val.GetState(state_alloc));
       }
 
-      /* TODO */
       void Write(Io::TBinaryOutputStream &stream) const {
         CoreVecBuilder.Write(stream);
       }
 
-      /* TODO */
       void Read(Io::TBinaryInputStream &stream) {
         assert(!CoreVec);
         CoreVec = std::make_unique<Atom::TCoreVector>(stream);
       }
 
-      /* TODO */
       const Atom::TCoreVector &GetCoreVec() const {
         assert(CoreVec);
         return *CoreVec;
@@ -74,7 +68,6 @@ namespace Orly {
       UnPause
     };
 
-    /* TODO */
     class TReplicationQueue {
       NO_COPY(TReplicationQueue);
       public:
@@ -82,18 +75,14 @@ namespace Orly {
       /* Forward Declarations. */
       class TReplicationItem;
 
-      /* TODO */
       typedef InvCon::UnorderedList::TCollection<TReplicationQueue, TReplicationItem> TItemCollection;
 
-      /* TODO */
       class TReplicationItem {
         NO_COPY(TReplicationItem);
         public:
 
-        /* TODO */
         typedef InvCon::UnorderedList::TMembership<TReplicationItem, TReplicationQueue> TQueueMembership;
 
-        /* TODO */
         enum TKind {
           Repo,
           Durable,
@@ -101,295 +90,214 @@ namespace Orly {
           IndexId
         };
 
-        /* TODO */
         virtual ~TReplicationItem();
 
-        /* TODO */
         virtual TKind GetKind() const = 0;
 
         protected:
 
-        /* TODO */
         TReplicationItem();
 
         private:
 
-        /* TODO */
         TQueueMembership::TImpl QueueMembership;
 
-        /* TODO */
         friend class TReplicationQueue;
 
       };  // TReplicationItem
 
-      /* TODO */
       TReplicationQueue();
 
-      /* TODO */
       ~TReplicationQueue();
 
-      /* TODO */
       void Insert(TReplicationItem *item) NO_THROW;
 
-      /* TODO */
       void Swap(TReplicationQueue &that);
 
-      /* TODO */
       inline void Clear();
 
-      /* TODO */
       TItemCollection *GetItemCollection() const;
 
-      /* TODO */
       inline bool IsEmpty() const;
 
       private:
 
-      /* TODO */
       mutable TItemCollection::TImpl ItemCollection;
 
     };  // TReplicationQueue
 
-    /* TODO */
     class TRepoReplication
         : public TReplicationQueue::TReplicationItem {
       NO_COPY(TRepoReplication);
       public:
 
-      /* TODO */
       class TReplica {
         public:
 
-        /* TODO */
         inline TReplica(const Base::TUuid &id, bool is_safe, const TTtl &ttl, const std::optional<Base::TUuid> &parent_id);
 
-        /* TODO */
         inline TReplica(const TRepoReplication &replication_obj);
 
-        /* TODO */
         inline TReplica(const TReplica &that);
 
-        /* TODO */
         inline TReplica(TReplica &&that);
 
-        /* TODO */
         inline const TTtl &GetTtl() const;
 
-        /* TODO */
         inline const Base::TUuid &GetId() const;
 
-        /* TODO */
         inline bool GetIsSafe() const;
 
-        /* TODO */
         inline const std::optional<Base::TUuid> &GetOptParentId() const;
 
         private:
 
-        /* TODO */
         const TTtl Ttl;
 
-        /* TODO */
         const Base::TUuid Id;
 
-        /* TODO */
         const bool IsSafe;
 
-        /* TODO */
         const std::optional<Base::TUuid> OptParentId;
 
       };  // TReplica
 
-      /* TODO */
       TRepoReplication(const Base::TUuid &repo_id, bool is_safe, const TTtl &ttl, const std::optional<Base::TUuid> &opt_parent_repo_id);
 
-      /* TODO */
       virtual ~TRepoReplication();
 
-      /* TODO */
       inline virtual TKind GetKind() const;
 
-      /* TODO */
       inline const Base::TUuid &GetId() const;
 
-      /* TODO */
       inline const TTtl &GetTtl() const;
 
-      /* TODO */
       inline bool GetIsSafe() const;
 
-      /* TODO */
       inline const std::optional<Base::TUuid> &GetOptParentRepoId() const;
 
       private:
 
-      /* TODO */
       const TTtl Ttl;
 
-      /* TODO */
       const Base::TUuid RepoId;
 
-      /* TODO */
       const bool IsSafe;
 
-      /* TODO */
       const std::optional<Base::TUuid> OptParentRepoId;
 
     };  // TRepoReplication
 
-    /* TODO */
     class TDurableReplication
         : public TReplicationQueue::TReplicationItem {
       NO_COPY(TDurableReplication);
       public:
 
-      /* TODO */
       class TReplica {
         public:
 
-        /* TODO */
         inline TReplica(const Base::TUuid &id, const TTtl &ttl, const std::string &serialized_obj);
 
-        /* TODO */
         inline TReplica(const TDurableReplication &replication_obj);
 
-        /* TODO */
         inline TReplica(const TReplica &that);
 
-        /* TODO */
         inline TReplica(TReplica &&that);
 
-        /* TODO */
         inline const TTtl &GetTtl() const;
 
-        /* TODO */
         inline const Base::TUuid &GetId() const;
 
-        /* TODO */
         inline const std::string &GetSerializedObj() const;
 
         private:
 
-        /* TODO */
         const TTtl Ttl;
 
-        /* TODO */
         const Base::TUuid Id;
 
-        /* TODO */
         const std::string SerializedObj;
 
       };  // TReplica
 
-      /* TODO */
       TDurableReplication(const Base::TUuid &durable_id, const TTtl &ttl, const std::string &serialized_obj);
 
-      /* TODO */
       virtual ~TDurableReplication();
 
-      /* TODO */
       inline virtual TKind GetKind() const;
 
-      /* TODO */
       inline const Base::TUuid &GetId() const;
 
-      /* TODO */
       inline const TTtl &GetTtl() const;
 
-      /* TODO */
       inline const std::string &GetSerializedObj() const;
 
       private:
 
-      /* TODO */
       const TTtl DurableTtl;
 
-      /* TODO */
       const Base::TUuid DurableId;
 
-      /* TODO */
       const std::string SerializedObj;
 
     };  // TDurableReplication
 
-    /* TODO */
     class TIndexIdReplication
         : public TReplicationQueue::TReplicationItem {
       NO_COPY(TIndexIdReplication);
       public:
 
-      /* TODO */
       class TReplica {
         public:
 
-        /* TODO */
         inline TReplica(const Base::TUuid &id, const std::string &pkg_key, const Indy::TKey &val);
 
-        /* TODO */
         inline TReplica(const TIndexIdReplication &replication_obj);
 
-        /* TODO */
         inline TReplica(const TReplica &that);
 
-        /* TODO */
         inline TReplica(TReplica &&that);
 
-        /* TODO */
         inline const Base::TUuid &GetId() const;
 
-        /* TODO */
         inline const std::string &GetPkgKey() const;
 
-        /* TODO */
         inline const Indy::TKey &GetVal() const;
 
         private:
 
-        /* TODO */
         const Base::TUuid Id;
 
-        /* TODO */
         std::string PkgKey;
         Indy::TKey Val;
 
-        /* TODO */
         Atom::TSuprena Suprena;
 
       };  // TReplica
 
-      /* TODO */
       TIndexIdReplication(const Base::TUuid &id, const std::string &pkg_key, const Indy::TKey &val);
 
-      /* TODO */
       virtual ~TIndexIdReplication();
 
-      /* TODO */
       inline virtual TKind GetKind() const;
 
-      /* TODO */
       inline const Base::TUuid &GetId() const;
 
-      /* TODO */
       inline const std::string &GetPkgKey() const;
 
-      /* TODO */
       inline const Indy::TKey &GetVal() const;
 
       private:
 
-      /* TODO */
       const Base::TUuid Id;
 
-      /* TODO */
       Atom::TSuprena Suprena;
 
-      /* TODO */
       const std::string PkgKey;
       Indy::TKey Val;
 
     };  // TIndexIdReplication
 
-    /* TODO */
     class TTransactionReplication
           : public TReplicationQueue::TReplicationItem {
       NO_COPY(TTransactionReplication);
@@ -397,24 +305,18 @@ namespace Orly {
 
       TTransactionReplication();
 
-      /* TODO */
       TTransactionReplication(L1::TTransaction::TReplica &&replica);
 
-      /* TODO */
       virtual ~TTransactionReplication();
 
-      /* TODO */
       inline void SwapReplica(L1::TTransaction::TReplica &&replica);
 
-      /* TODO */
       inline virtual TKind GetKind() const;
 
-      /* TODO */
       inline const L1::TTransaction::TReplica &GetReplica() const;
 
       private:
 
-      /* TODO */
       L1::TTransaction::TReplica Replica;
 
     };  // TTransactionReplication
@@ -422,83 +324,62 @@ namespace Orly {
     class TReplicationStreamer {
       public:
 
-      /* TODO */
       TReplicationStreamer();
 
-      /* TODO */
       ~TReplicationStreamer();
 
-      /* TODO */
       void Write(Io::TBinaryOutputStream &stream) const;
 
-      /* TODO */
       void Read(Io::TBinaryInputStream &stream);
 
-      /* TODO */
       void PushIndexId(const TIndexIdReplication &index_replica);
 
-      /* TODO */
       void PushTransaction(const L1::TTransaction::TReplica &replica);
 
-      /* TODO */
       void PushDurable(const TDurableReplication &durable_replica);
 
-      /* TODO */
       void PushRepo(const TRepoReplication &repo_replica);
 
-      /* TODO */
       inline const Atom::TCoreVector &GetIndexIdVec() const {
         assert(IndexIdVector);
         return *IndexIdVector;
       }
 
-      /* TODO */
       inline const Atom::TCoreVector &GetRepoVec() const {
         assert(RepoVector);
         return *RepoVector;
       }
 
-      /* TODO */
       inline const Atom::TCoreVector &GetDurableVec() const {
         assert(DurableVector);
         return *DurableVector;
       }
 
-      /* TODO */
       inline const Atom::TCoreVector &GetTransactionVec() const {
         assert(TransactionVector);
         return *TransactionVector;
       }
 
-      /* TODO */
       inline bool IsEmpty() const {
         return IndexIdBuilder.GetCores().empty() && RepoBuilder.GetCores().empty() && DurableBuilder.GetCores().empty() && TransactionBuilder.GetCores().empty();
       }
 
       private:
 
-      /* TODO */
       Atom::TCoreVectorBuilder IndexIdBuilder;
 
-      /* TODO */
       Atom::TCoreVectorBuilder RepoBuilder;
 
-      /* TODO */
       Atom::TCoreVectorBuilder DurableBuilder;
 
-      /* TODO */
       Atom::TCoreVectorBuilder TransactionBuilder;
 
-      /* TODO */
       std::unique_ptr<Atom::TCoreVector> IndexIdVector;
 
-      /* TODO */
       std::unique_ptr<Atom::TCoreVector> RepoVector;
 
-      /* TODO */
       std::unique_ptr<Atom::TCoreVector> DurableVector;
 
-      /* TODO */
       std::unique_ptr<Atom::TCoreVector> TransactionVector;
 
     };  // TReplicationStreamer

--- a/orly/indy/repo.cc
+++ b/orly/indy/repo.cc
@@ -38,7 +38,6 @@ class TReader
   NO_COPY(TReader);
   public:
 
-  /* TODO */
   typedef TStream<Disk::Util::LogicalPageSize, Disk::Util::LogicalBlockSize, Disk::Util::PhysicalBlockSize, Disk::Util::CheckedPage, 0UL> TInStream;
   typedef Orly::Indy::Disk::TReadFile<Disk::Util::LogicalPageSize, Disk::Util::LogicalBlockSize, Disk::Util::PhysicalBlockSize, Disk::Util::CheckedPage> TMyReadFile;
 
@@ -464,10 +463,8 @@ std::optional<TSequenceNumber> TRepo::ChangeStatus(TStatus status, TSequenceNumb
 class TUpdateSortComparator {
   public:
 
-  /* TODO */
   TUpdateSortComparator() {}
 
-  /* TODO */
   bool operator()(const TUpdate *lhs, const TUpdate *rhs) const {
     assert(lhs);
     assert(rhs);

--- a/orly/indy/transaction_base.cc
+++ b/orly/indy/transaction_base.cc
@@ -350,7 +350,6 @@ TTransaction::TTransactionCompletion::~TTransactionCompletion() {
   }  // release TransactionCompletion lock
 }
 
-/* TODO */
 void TTransaction::TTransactionCompletion::SetWaitFor(size_t wait_for) {
   WaitFor = wait_for;
   if (WaitFor == 0) {

--- a/orly/indy/transaction_base.h
+++ b/orly/indy/transaction_base.h
@@ -35,39 +35,30 @@ namespace Orly {
       /* Forward Delcarations. */
       class TManager;
 
-      /* TODO */
       class TTransaction {
         NO_COPY(TTransaction);
         public:
 
-        /* TODO */
         typedef InvCon::UnorderedList::TMembership<TTransaction, TManager> TManagerMembership;
 
-        /* TODO */
         bool Push(const L0::TManager::TPtr<TRepo> &repo,
                   const std::shared_ptr<TUpdate> &update,
                   const std::optional<TSequenceNumber> &ensure_or_discard = std::optional<TSequenceNumber>());
 
-        /* TODO */
         bool Pop(const L0::TManager::TPtr<TRepo> &repo,
                  const std::optional<TSequenceNumber> &ensure_or_discard = std::optional<TSequenceNumber>());
 
-        /* TODO */
         bool Fail(const L0::TManager::TPtr<TRepo> &repo,
                   const std::optional<TSequenceNumber> &follow_or_discard = std::optional<TSequenceNumber>());
 
-        /* TODO */
         bool Pause(const L0::TManager::TPtr<TRepo> &repo,
                    const std::optional<TSequenceNumber> &follow_or_discard = std::optional<TSequenceNumber>());
 
-        /* TODO */
         bool UnPause(const L0::TManager::TPtr<TRepo> &repo,
                      const std::optional<TSequenceNumber> &follow_or_discard = std::optional<TSequenceNumber>());
 
-        /* TODO */
         const std::shared_ptr<TUpdate> &Peek(const L0::TManager::TPtr<TRepo> &repo);
 
-        /* TODO */
         void Prepare();
 
         /* Mark the prepared action to be committed.  The commitment will occur when this object destructs.
@@ -87,7 +78,6 @@ namespace Orly {
            on the commit path. See orly/indy/transaction_base.cc. */
         static std::function<void ()> OnCommitBetweenPushAndPopForTest;
 
-        /* TODO */
         class TTransactionCompletion {
           NO_COPY(TTransactionCompletion);
           public:
@@ -97,55 +87,41 @@ namespace Orly {
             Failed
           };
 
-          /* TODO */
           typedef InvCon::UnorderedList::TMembership<TTransactionCompletion, TManager> TManagerMembership;
 
-          /* TODO */
           TTransactionCompletion(TManager *manager);
 
-          /* TODO */
           ~TTransactionCompletion();
 
-          /* TODO */
           void RegisterCompletion();
 
-          /* TODO */
           void RegisterFailure();
 
-          /* TODO */
           void SetWaitFor(size_t wait_for);
 
-          /* TODO */
           inline void SetCb(const std::shared_ptr<std::function<void (TTransactionResult)>> &cb);
 
           private:
 
-          /* TODO */
           size_t WaitFor;
 
-          /* TODO */
           size_t NumCompleted;
           std::mutex Mutex;
 
-          /* TODO */
           std::shared_ptr<std::function<void (TTransactionResult)>> Cb;
 
-          /* TODO */
           TManagerMembership::TImpl ManagerMembership;
 
         };  // TTransactionCompletion
 
-        /* TODO */
         class TReplica {
           public:
 
           /* Forward Declarations. */
           class TMutation;
 
-          /* TODO */
           typedef std::list<TMutation> TMutationList;
 
-          /* TODO */
           class TMutation {
             public:
 
@@ -157,217 +133,154 @@ namespace Orly {
               UnPauser
             };
 
-            /* TODO */
             class TUpdate {
               public:
 
-              /* TODO */
               typedef std::vector<std::pair<TIndexKey, Atom::TCore>> TOpByKey;
 
-              /* TODO */
               TUpdate();
 
-              /* TODO */
               TUpdate(TUpdate &&update);
 
-              /* TODO */
               TUpdate(const TUpdate &update);
 
-              /* TODO */
               TUpdate(const Orly::Indy::TUpdate *update);
 
-              /* TODO */
               ~TUpdate();
 
-              /* TODO */
               TUpdate &operator=(TUpdate &&that);
 
-              /* TODO */
               TUpdate &operator=(const TUpdate &that);
 
-              /* TODO */
               inline const Atom::TCore &GetMetadata() const;
 
-              /* TODO */
               inline const Atom::TCore &GetId() const;
 
-              /* TODO */
               inline const TOpByKey &GetOpByKey() const;
 
-              /* TODO */
               inline const std::shared_ptr<Atom::TSuprena> &GetSuprena() const;
 
-              /* TODO */
               inline void SetArena(const std::shared_ptr<Atom::TSuprena> &suprena);
 
-              /* TODO */
               void Write(Io::TBinaryOutputStream &strm, const Atom::TCore::TRemap &remap) const;
 
-              /* TODO */
               void Read(Io::TBinaryInputStream &strm, const Atom::TCore::TRemap &remap);
 
               private:
 
-              /* TODO */
               std::shared_ptr<Atom::TSuprena> Suprena;
 
-              /* TODO */
               Atom::TCore Metadata;
 
-              /* TODO */
               Atom::TCore Id;
 
-              /* TODO */
               TOpByKey OpByKey;
 
-              /* TODO */
               friend class Orly::Indy::TReplicationStreamer;
 
             };  // TUpdate
 
-            /* TODO */
             TMutation(TMutation &&mutation);
 
-            /* TODO */
             TMutation(const TMutation &mutation);
 
-            /* TODO */
             TMutation(TKind kind, const Base::TUuid &repo_id, const std::optional<TSequenceNumber> &seq_num);
 
-            /* TODO */
             TMutation(TKind kind, const Base::TUuid &repo_id, const Orly::Indy::TUpdate *update, const std::optional<TSequenceNumber> &seq_num);
 
-            /* TODO */
             TMutation(TKind kind, const Base::TUuid &repo_id, TUpdate &&update, const std::optional<TSequenceNumber> &seq_num);
 
-            /* TODO */
             virtual ~TMutation();
 
-            /* TODO */
             TMutation &operator=(TMutation &&that);
 
-            /* TODO */
             TMutation &operator=(const TMutation &that);
 
-            /* TODO */
             inline TKind GetKind() const;
 
-            /* TODO */
             inline const Base::TUuid &GetRepoId() const;
 
-            /* TODO */
             inline const std::optional<TSequenceNumber> &GetSequenceNumber() const;
 
-            /* TODO */
             inline const TUpdate &GetUpdate() const;
 
-            /* TODO */
             inline TUpdate &GetUpdate();
 
-            /* TODO */
             inline void SetSequenceNumber(std::optional<TSequenceNumber> seq_num) NO_THROW;
 
-            /* TODO */
             inline TSequenceNumber &GetNextUpdate() NO_THROW;
 
             private:
 
-            /* TODO */
             TKind Kind;
 
-            /* TODO */
             Base::TUuid RepoId;
 
-            /* TODO */
             TUpdate Update;
 
-            /* TODO */
             std::optional<TSequenceNumber> SequenceNumber;
 
-            /* TODO */
             TSequenceNumber NextUpdate;
 
           };  // TMutation
 
-          /* TODO */
           TReplica(TReplica &&replica);
 
-          /* TODO */
           TReplica(const TReplica &replica);
 
-          /* TODO */
           TReplica();
 
-          /* TODO */
           ~TReplica();
 
-          /* TODO */
           TReplica &operator=(TReplica &&that);
 
-          /* TODO */
           TReplica &operator=(const TReplica &that);
 
-          /* TODO */
           TMutation *Push(const Base::TUuid &repo_id, const TUpdate *update);
 
-          /* TODO */
           TMutation *Pop(const Base::TUuid &repo_id, const std::optional<TSequenceNumber> &seq_num);
 
-          /* TODO */
           TMutation *Fail(const Base::TUuid &repo_id, const std::optional<TSequenceNumber> &seq_num);
 
-          /* TODO */
           TMutation *Pause(const Base::TUuid &repo_id, const std::optional<TSequenceNumber> &seq_num);
 
-          /* TODO */
           TMutation *UnPause(const Base::TUuid &repo_id, const std::optional<TSequenceNumber> &seq_num);
 
-          /* TODO */
           void Reset();
 
-          /* TODO */
           inline TMutationList &GetMutationList() const;
 
-          /* TODO */
           inline size_t GetSize() const;
 
           private:
 
-          /* TODO */
           mutable TMutationList MutationList;
 
-          /* TODO */
           friend class TManager;
           friend class Orly::Indy::TReplicationStreamer;
 
         };  // TReplica
 
-        /* TODO */
         static void *operator new(size_t size) {
           return Pool.Alloc(size);
         }
 
-        /* TODO */
         static void operator delete(void *ptr, size_t) {
           Pool.Free(ptr);
         }
 
-        /* TODO */
         static void InitTransactionPool(size_t num_obj) {
           Pool.Init(num_obj);
         }
 
-        /* TODO */
         static constexpr size_t GetTransactionSize() {
           return sizeof(TTransaction);
         }
 
-        /* TODO */
         static void InitTransactionMutationPool(size_t num_obj) {
           TMutation::Pool.Init(num_obj);
         }
 
-        /* TODO */
         static constexpr size_t GetTransactionMutationSize() {
           return sizeof(TMutation);
         }
@@ -377,16 +290,12 @@ namespace Orly {
         /* Forward Declarations. */
         class TMutation;
 
-        /* TODO */
         typedef InvCon::UnorderedMultimap::TCollection<TTransaction, TMutation, Base::TUuid> TMutationCollection;
 
-        /* TODO */
         TTransaction(TManager *manager, bool should_replicate);
 
-        /* TODO */
         ~TTransaction() NO_THROW;
 
-        /* TODO */
         class TMutation {
           NO_COPY(TMutation);
           public:
@@ -397,214 +306,159 @@ namespace Orly {
             StatusChanger
           };
 
-          /* TODO */
           typedef InvCon::UnorderedMultimap::TMembership<TMutation, TTransaction, Base::TUuid> TTransactionMembership;
 
-          /* TODO */
           virtual ~TMutation() NO_THROW;
 
-          /* TODO */
           virtual TKind GetKind() const = 0;
 
-          /* TODO */
           inline const Base::TUuid &GetRepoId() const;
 
-          /* TODO */
           TMutation *TryGetNextMember() const {
             return TransactionMembership.TryGetNextMember();
           }
 
-          /* TODO */
           static void *operator new(size_t size) {
             return Pool.Alloc(size);
           }
 
-          /* TODO */
           static void operator delete(void *ptr, size_t) {
             Pool.Free(ptr);
           }
 
           protected:
 
-          /* TODO */
           TMutation(TTransaction *transaction, const L0::TManager::TPtr<TRepo> &repo);
 
-          /* TODO */
           TTransactionMembership::TImpl TransactionMembership;
 
-          /* TODO */
           L0::TManager::TPtr<TRepo> Repo;
 
-          /* TODO */
           mutable TReplica::TMutation *MyMutation;
 
-          /* TODO */
           static Util::TPool Pool;
 
-          /* TODO */
           friend class Server::TIndyReporter;
           friend class TTransaction;
 
         };  // TMutation
 
-        /* TODO */
         class TPusher
             : public TMutation {
           NO_COPY(TPusher);
           public:
 
-          /* TODO */
           TPusher(TTransaction *transaction, const L0::TManager::TPtr<TRepo> &repo, const std::shared_ptr<TUpdate> &update);
 
-          /* TODO */
           virtual ~TPusher() NO_THROW;
 
-          /* TODO */
           virtual TKind GetKind() const;
 
           private:
 
-          /* TODO */
           TUpdate *Update;
 
-          /* TODO */
           friend class TTransaction;
 
         };  // TPusher
 
-        /* TODO */
         class TPopper
             : public TMutation {
           NO_COPY(TPopper);
           public:
 
-          /* TODO */
           enum TState {
             Peek,
             Pop,
             Fail
           };
 
-          /* TODO */
           TPopper(TTransaction *transaction, const L0::TManager::TPtr<TRepo> &repo, TState state);
 
-          /* TODO */
           virtual ~TPopper() NO_THROW;
 
-          /* TODO */
           virtual TKind GetKind() const;
 
-          /* TODO */
           TState GetState() const;
 
-          /* TODO */
           void DoPeek() const;
 
-          /* TODO */
           void SetState(TState state);
 
-          /* TODO */
           inline const std::shared_ptr<TUpdate> &GetUpdate() const;
 
           private:
 
-          /* TODO */
           TState State;
 
-          /* TODO */
           mutable std::shared_ptr<TRepo::TView> View;
 
-          /* TODO */
           mutable std::shared_ptr<TUpdate> Update;
 
-          /* TODO */
           friend class TTransaction;
 
         };  // TPopper
 
-        /* TODO */
         class TStatusChanger
             : public TMutation {
           NO_COPY(TStatusChanger);
           public:
 
-          /* TODO */
           TStatusChanger(TTransaction *transaction, const L0::TManager::TPtr<TRepo> &repo, TStatus status);
 
-          /* TODO */
           virtual ~TStatusChanger() NO_THROW;
 
-          /* TODO */
           virtual TKind GetKind() const;
 
           private:
 
-          /* TODO */
           TStatus Status;
 
-          /* TODO */
           friend class TTransaction;
 
         };  // TStatusChanger
 
-        /* TODO */
         bool GetCommitFlag() const;
 
-        /* TODO */
         TManager *Manager;
 
-        /* TODO */
         TManagerMembership::TImpl ManagerMembership;
 
-        /* TODO */
         mutable TMutationCollection::TImpl MutationCollection;
 
-        /* TODO */
         bool CommitFlag;
 
-        /* TODO */
         bool ShouldReplicate;
 
-        /* TODO */
         bool Prepared;
 
-        /* TODO */
         bool EnsureOrDiscard;
 
-        /* TODO */
         TReplica Replica;
 
-        /* TODO */
         TTransactionReplication *TransactionReplication;
 
-        /* TODO */
         TTransactionCompletion *TransactionCompletion;
 
-        /* TODO */
         static Util::TPool Pool;
 
-        /* TODO */
         friend class TManager;
         friend class Server::TIndyReporter;
 
       };  // TTransaction
 
-      /* TODO */
       class TManager
           : public L0::TManager {
         NO_COPY(TManager);
         public:
 
-        /* TODO */
         typedef InvCon::UnorderedList::TCollection<TManager, TTransaction> TTransactionCollection;
         typedef InvCon::UnorderedList::TCollection<TManager, TTransaction::TTransactionCompletion> TTransactionCompletionCollection;
 
-        /* TODO */
         std::unique_ptr<TTransaction, std::function<void (TTransaction *)>> NewTransaction(bool should_replicate = true);
 
         protected:
 
-        /* TODO */
         TManager(Disk::Util::TEngine *engine,
                  std::chrono::milliseconds merge_mem_delay,
                  std::chrono::milliseconds merge_disk_delay,
@@ -619,35 +473,26 @@ namespace Orly {
                  const std::vector<size_t> &merge_disk_cores,
                  bool create_new);
 
-        /* TODO */
         virtual ~TManager();
 
-        /* TODO */
         virtual std::mutex &GetReplicationQueueLock() NO_THROW = 0;
 
-        /* TODO */
         virtual void Enqueue(TTransactionReplication *transaction_replication, TTransaction::TReplica &&replica) NO_THROW = 0;
 
-        /* TODO */
         virtual TTransactionReplication *NewTransactionReplication() = 0;
 
-        /* TODO */
         virtual void DeleteTransactionReplication(TTransactionReplication *transaction_replication) NO_THROW = 0;
 
         private:
 
-        /* TODO */
         void OnCloseTransaction(TTransaction *transaction);
 
-        /* TODO */
         mutable TTransactionCollection::TImpl TransactionCollection;
         std::mutex TransactionLock;
 
-        /* TODO */
         mutable TTransactionCompletionCollection::TImpl TransactionCompletionCollection;
         std::mutex TransactionCompletionLock;
 
-        /* TODO */
         std::function<void (TTransaction *)> OnCloseTransactionCb;
 
         /* access to Enqueue */
@@ -655,131 +500,106 @@ namespace Orly {
 
       };  // TManager
 
-      /* TODO */
       inline void TTransaction::CommitAction() NO_THROW {
         CommitFlag = true;
       }
 
-      /* TODO */
       inline void TTransaction::DiscardAction() NO_THROW {
         CommitFlag = false;
       }
 
-      /* TODO */
       inline const Atom::TCore &TTransaction::TReplica::TMutation::TUpdate::GetMetadata() const {
         return Metadata;
       }
 
-      /* TODO */
       inline const Atom::TCore &TTransaction::TReplica::TMutation::TUpdate::GetId() const {
         return Id;
       }
 
-      /* TODO */
       inline const TTransaction::TReplica::TMutation::TUpdate::TOpByKey &TTransaction::TReplica::TMutation::TUpdate::GetOpByKey() const {
         return OpByKey;
       }
 
-      /* TODO */
       inline const std::shared_ptr<Atom::TSuprena> &TTransaction::TReplica::TMutation::TUpdate::GetSuprena() const {
         return Suprena;
       }
 
-      /* TODO */
       inline void TTransaction::TReplica::TMutation::TUpdate::SetArena(const std::shared_ptr<Atom::TSuprena> &suprena) {
         Suprena = suprena;
       }
 
-      /* TODO */
       inline TTransaction::TReplica::TMutation::TKind TTransaction::TReplica::TMutation::GetKind() const {
         return Kind;
       }
 
-      /* TODO */
       inline const Base::TUuid &TTransaction::TReplica::TMutation::GetRepoId() const {
         return RepoId;
       }
 
-      /* TODO */
       inline const std::optional<TSequenceNumber> &TTransaction::TReplica::TMutation::GetSequenceNumber() const {
         return SequenceNumber;
       }
 
-      /* TODO */
       inline const TTransaction::TReplica::TMutation::TUpdate &TTransaction::TReplica::TMutation::GetUpdate() const {
         assert(Kind == Pusher);
         return Update;
       }
 
-      /* TODO */
       inline TTransaction::TReplica::TMutation::TUpdate &TTransaction::TReplica::TMutation::GetUpdate() {
         assert(Kind == Pusher);
         return Update;
       }
 
-      /* TODO */
       inline void TTransaction::TReplica::TMutation::SetSequenceNumber(std::optional<TSequenceNumber> seq_num) NO_THROW {
         SequenceNumber = seq_num;
       }
 
-      /* TODO */
       inline TSequenceNumber &TTransaction::TReplica::TMutation::GetNextUpdate() NO_THROW {
         return NextUpdate;
       }
 
-      /* TODO */
       inline TTransaction::TReplica::TMutationList &TTransaction::TReplica::GetMutationList() const {
         return MutationList;
       }
 
-      /* TODO */
       inline size_t TTransaction::TReplica::GetSize() const {
         size_t count = 0U;
         for (auto iter = MutationList.begin(); iter != MutationList.end(); ++iter, ++count);
         return count;
       }
 
-      /* TODO */
       inline const Base::TUuid &TTransaction::TMutation::GetRepoId() const {
         return Repo->GetId();
       }
 
-      /* TODO */
       inline TTransaction::TMutation::TKind TTransaction::TPusher::GetKind() const {
         return TMutation::Pusher;
       }
 
-      /* TODO */
       inline TTransaction::TMutation::TKind TTransaction::TPopper::GetKind() const {
         return TMutation::Popper;
       }
 
-      /* TODO */
       inline TTransaction::TPopper::TState TTransaction::TPopper::GetState() const {
         return State;
       }
 
-      /* TODO */
       inline const std::shared_ptr<TUpdate> &TTransaction::TPopper::GetUpdate() const {
         return Update;
       }
 
-      /* TODO */
       inline void TTransaction::TPopper::SetState(TState state) {
         State = state;
       }
 
-      /* TODO */
       inline TTransaction::TMutation::TKind TTransaction::TStatusChanger::GetKind() const {
         return TMutation::StatusChanger;
       }
 
-      /* TODO */
       inline bool TTransaction::GetCommitFlag() const {
         return CommitFlag;
       }
 
-      /* TODO */
       inline void TTransaction::TTransactionCompletion::SetCb(const std::shared_ptr<std::function<void (TTransactionResult)>> &cb) {
         Cb = cb;
       }

--- a/orly/indy/update.h
+++ b/orly/indy/update.h
@@ -52,7 +52,6 @@ namespace Orly {
 
     }  // L1
 
-    /* TODO */
     class TUpdate {
       NO_COPY(TUpdate);
       public:
@@ -60,16 +59,12 @@ namespace Orly {
       /* Forward Declarations. */
       class TEntry;
 
-      /* TODO */
       typedef std::map<TIndexKey, TKey> TOpByKey;
 
-      /* TODO */
       typedef InvCon::OrderedList::TCollection<TUpdate, TEntry, TKey> TEntryCollection;
 
-      /* TODO */
       ~TUpdate();
 
-      /* TODO */
       class TPersistenceNotification {
         NO_COPY(TPersistenceNotification);
         public:
@@ -79,23 +74,18 @@ namespace Orly {
           Failed
         };
 
-        /* TODO */
         TPersistenceNotification(const std::function<void (TResult)> &cb);
 
-        /* TODO */
         ~TPersistenceNotification();
 
-        /* TODO */
         inline void Call(TUpdate::TPersistenceNotification::TResult result);
 
         private:
 
-        /* TODO */
         std::function<void (TResult)> Cb;
 
       };  // TPersistenceNotification
 
-      /* TODO */
       class TEntry {
         NO_COPY(TEntry);
         public:
@@ -107,13 +97,10 @@ namespace Orly {
            TMemoryLayer::SkipInsert / SeekRun. */
         static constexpr size_t SkipMaxLevel = 16;
 
-        /* TODO */
         inline const TKey &GetKey() const;
 
-        /* TODO */
         inline const TIndexKey &GetIndexKey() const;
 
-        /* TODO */
         inline const Atom::TCore &GetOp() const;
 
         /* The mutator used to produce Op. For assignments (the historical
@@ -129,60 +116,45 @@ namespace Orly {
            unchanged until phase 2 (session.cc emits the real mutator). */
         inline TMutator GetMutator() const;
 
-        /* TODO */
         inline TSequenceNumber GetSequenceNumber() const;
 
-        /* TODO */
         inline const Atom::TCore &GetMetadata() const;
 
-        /* TODO */
         inline const Atom::TCore &GetId() const;
 
-        /* TODO */
         inline Atom::TSuprena &GetSuprena() const;
 
-        /* TODO */
         inline const TUpdate *GetUpdate() const;
 
-        /* TODO */
         static void *operator new(size_t size) {
           return Pool.Alloc(size);
         }
 
-        /* TODO */
         static void operator delete(void *ptr, size_t) {
           Pool.Free(ptr);
         }
 
         private:
 
-        /* TODO */
         class TEntryKey {
           public:
 
-          /* TODO */
           TEntryKey(const TEntry *entry);
 
-          /* TODO */
           bool operator==(const TEntryKey &that) const;
 
-          /* TODO */
           bool operator!=(const TEntryKey &that) const;
 
-          /* TODO */
           bool operator<=(const TEntryKey &that) const;
 
-          /* TODO */
           bool operator>(const TEntryKey &that) const;
 
           private:
 
-          /* TODO */
           const TEntry *Entry;
 
         };  // TKey
 
-        /* TODO */
         typedef InvCon::OrderedList::TMembership<TEntry, TUpdate, TKey> TUpdateMembership;
         typedef InvCon::OrderedList::TMembership<TEntry, TMemoryLayer, TEntryKey> TMemoryLayerMembership;
 
@@ -193,16 +165,12 @@ namespace Orly {
         TEntry(TUpdate *update, const TIndexKey &key, const TKey &op, void *state_alloc,
                TMutator mutator = TMutator::Assign);
 
-        /* TODO */
         inline const TEntryKey &GetEntryKey() const;
 
-        /* TODO */
         TIndexKey IndexKey;
 
-        /* TODO */
         TUpdateMembership::TImpl UpdateMembership;
 
-        /* TODO */
         TMemoryLayerMembership::TImpl MemoryLayerMembership;
 
         /* Express-lane forward pointers for the layer's skip-list seek
@@ -215,17 +183,14 @@ namespace Orly {
            more of level 0, never a wrong result. */
         std::atomic<TEntry *> SkipFwd[SkipMaxLevel];
 
-        /* TODO */
         Atom::TCore Op;
 
         /* See GetMutator(). Defaults to TMutator::Assign for every
            in-tree write path until phase 2 of #49 lands. */
         TMutator Mutator;
 
-        /* TODO */
         static Util::TPool Pool;
 
-        /* TODO */
         friend class TMemoryLayer;
         friend class TManager;
         friend class TUpdate;
@@ -234,37 +199,26 @@ namespace Orly {
 
       };  // TEntry
 
-      /* TODO */
       inline TSequenceNumber GetSequenceNumber() const;
 
-      /* TODO */
       inline const Atom::TCore &GetId() const;
 
-      /* TODO */
       inline const Atom::TCore &GetMetadata() const;
 
-      /* TODO */
       inline Atom::TSuprena &GetSuprena() const;
 
-      /* TODO */
       inline TEntryCollection *GetEntryCollection() const;
 
-      /* TODO */
       inline const std::shared_ptr<TPersistenceNotification> &GetPersistenceNotification() const;
 
-      /* TODO */
       inline void SetSequenceNumber(TSequenceNumber seq_num);
 
-      /* TODO */
       inline void SetMetadata(const TKey &metadata);
 
-      /* TODO */
       inline void SetId(const TKey &id);
 
-      /* TODO */
       inline void SetPersistenceNotification(const std::function<void (TPersistenceNotification::TResult)> &cb);
 
-      /* TODO */
       inline TEntry *AddEntry(const TIndexKey &key, const TKey &op);
 
       /* Add an entry that carries a mutator. The default-mutator
@@ -272,89 +226,67 @@ namespace Orly {
          existing call sites stay behaviorally identical. */
       inline TEntry *AddEntry(const TIndexKey &key, const TKey &op, TMutator mutator);
 
-      /* TODO */
       static std::shared_ptr<TUpdate> NewUpdate(const TOpByKey &op_by_key, const TKey &metadata, const TKey &id);
 
-      /* TODO */
       static std::shared_ptr<TUpdate> ReconstructUpdate(TSequenceNumber seq_num);
 
-      /* TODO */
       static TUpdate *CopyUpdate(TUpdate *that, void *state_alloc);
 
-      /* TODO */
       static TUpdate *ShallowCopy(TUpdate *that, void *state_alloc);
 
-      /* TODO */
       static inline void *operator new(size_t size) {
         return Pool.Alloc(size);
       }
 
-      /* TODO */
       static inline void operator delete(void *ptr, size_t) {
         Pool.Free(ptr);
       }
 
-      /* TODO */
       static void InitUpdatePool(size_t num_obj) {
         Pool.Init(num_obj);
       }
 
-      /* TODO */
       static void InitEntryPool(size_t num_obj) {
         TEntry::Pool.Init(num_obj);
       }
 
-      /* TODO */
       static inline double GetUpdatePoolUsedPct() {
         return static_cast<double>(Pool.GetNumBlocksUsed()) / Pool.GetMaxBlocks();
       }
 
-      /* TODO */
       static inline double GetUpdateEntryPoolUsedPct() {
         return static_cast<double>(TEntry::Pool.GetNumBlocksUsed()) / TEntry::Pool.GetMaxBlocks();
       }
 
       protected:
 
-      /* TODO */
       TUpdate(const TOpByKey &op_by_key, const TKey &metadata, const TKey &id, void *state_alloc);
 
-      /* TODO */
       explicit TUpdate(const TUpdate *that, void *state_alloc);
 
       /* Shallow Copy! */
       explicit TUpdate(void *state_alloc, const TUpdate *that);
 
-      /* TODO */
       explicit TUpdate(TSequenceNumber);
 
       private:
 
-      /* TODO */
       typedef InvCon::OrderedList::TMembership<TUpdate, TMemoryLayer, TSequenceNumber> TMemoryLayerMembership;
 
-      /* TODO */
       mutable Atom::TSuprena Suprena;
 
-      /* TODO */
       mutable TEntryCollection::TImpl EntryCollection;
 
-      /* TODO */
       TMemoryLayerMembership::TImpl MemoryLayerMembership;
 
-      /* TODO */
       Atom::TCore Metadata;
 
-      /* TODO */
       Atom::TCore Id;
 
-      /* TODO */
       std::shared_ptr<TPersistenceNotification> PersistenceNotification;
 
-      /* TODO */
       static Util::TPool Pool;
 
-      /* TODO */
       friend class TMemoryLayer;
       friend class TManager;
       friend class L1::TTransaction;
@@ -363,54 +295,44 @@ namespace Orly {
 
     };  // TUpdate
 
-    /* TODO */
     inline void TUpdate::TPersistenceNotification::Call(TUpdate::TPersistenceNotification::TResult result) {
       Cb(result);
     }
 
-    /* TODO */
     inline TSequenceNumber TUpdate::GetSequenceNumber() const {
       return MemoryLayerMembership.GetKey();
     }
 
-    /* TODO */
     inline const Atom::TCore &TUpdate::GetId() const {
       return Id;
     }
 
-    /* TODO */
     inline const Atom::TCore &TUpdate::GetMetadata() const {
       return Metadata;
     }
 
-    /* TODO */
     inline Atom::TSuprena &TUpdate::GetSuprena() const {
       return Suprena;
     }
 
-    /* TODO */
     inline void TUpdate::SetSequenceNumber(TSequenceNumber seq_num) {
       MemoryLayerMembership.SetKey(seq_num);
     }
 
-    /* TODO */
     inline void TUpdate::SetMetadata(const TKey &metadata) {
       void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
       Metadata = Atom::TCore(&Suprena, Sabot::State::TAny::TWrapper(metadata.GetCore().NewState(metadata.GetArena(), state_alloc)));
     }
 
-    /* TODO */
     inline void TUpdate::SetId(const TKey &id) {
       void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
       Id = Atom::TCore(&Suprena, Sabot::State::TAny::TWrapper(id.GetCore().NewState(id.GetArena(), state_alloc)));
     }
 
-    /* TODO */
     inline void TUpdate::SetPersistenceNotification(const std::function<void (TPersistenceNotification::TResult)> &cb) {
       PersistenceNotification = std::make_shared<TPersistenceNotification>(cb);
     }
 
-    /* TODO */
     inline TUpdate::TEntry *TUpdate::AddEntry(const TIndexKey &index_key, const TKey &op) {
       void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
       return new TEntry(this, index_key, op, state_alloc);
@@ -421,17 +343,14 @@ namespace Orly {
       return new TEntry(this, index_key, op, state_alloc, mutator);
     }
 
-    /* TODO */
     inline const TKey &TUpdate::TEntry::GetKey() const {
       return IndexKey.GetKey();
     }
 
-    /* TODO */
     inline const TIndexKey &TUpdate::TEntry::GetIndexKey() const {
       return IndexKey;
     }
 
-    /* TODO */
     inline const Atom::TCore &TUpdate::TEntry::GetOp() const {
       return Op;
     }
@@ -440,31 +359,26 @@ namespace Orly {
       return Mutator;
     }
 
-    /* TODO */
     inline TSequenceNumber TUpdate::TEntry::GetSequenceNumber() const {
       assert(UpdateMembership.TryGetCollector());
       return UpdateMembership.TryGetCollector()->MemoryLayerMembership.GetKey();
     }
 
-    /* TODO */
     inline const Atom::TCore &TUpdate::TEntry::GetMetadata() const {
       assert(UpdateMembership.TryGetCollector());
       return UpdateMembership.TryGetCollector()->Metadata;
     }
 
-    /* TODO */
     inline const Atom::TCore &TUpdate::TEntry::GetId() const {
       assert(UpdateMembership.TryGetCollector());
       return UpdateMembership.TryGetCollector()->Id;
     }
 
-    /* TODO */
     inline Atom::TSuprena &TUpdate::TEntry::GetSuprena() const {
       assert(UpdateMembership.TryGetCollector());
       return UpdateMembership.TryGetCollector()->Suprena;
     }
 
-    /* TODO */
     inline const TUpdate *TUpdate::TEntry::GetUpdate() const {
       assert(UpdateMembership.TryGetCollector());
       return UpdateMembership.TryGetCollector();
@@ -474,12 +388,10 @@ namespace Orly {
       return MemoryLayerMembership.GetKey();
     }
 
-    /* TODO */
     inline TUpdate::TEntryCollection *TUpdate::GetEntryCollection() const {
       return &EntryCollection;
     }
 
-    /* TODO */
     inline const std::shared_ptr<TUpdate::TPersistenceNotification> &TUpdate::GetPersistenceNotification() const {
       return PersistenceNotification;
     }

--- a/orly/indy/update_walker.h
+++ b/orly/indy/update_walker.h
@@ -33,22 +33,17 @@ namespace Orly {
 
   namespace Indy {
 
-    /* TODO */
     class TUpdateWalker {
       NO_COPY(TUpdateWalker);
       public:
 
-      /* TODO */
       class TItem {
         public:
 
-        /* TODO */
         TSequenceNumber SequenceNumber;
 
-        /* TODO */
         Atom::TCore Metadata;
 
-        /* TODO */
         Atom::TCore Id;
 
         /* Per-entry mutator + payload. Mutator defaults to Assign for
@@ -67,7 +62,6 @@ namespace Orly {
         };
         std::vector<TEntry> EntryVec;
 
-        /* TODO */
         Atom::TCore::TArena *MainArena;
 
       };  // TItem
@@ -81,7 +75,6 @@ namespace Orly {
       /* Walk to the next item, if any. */
       virtual TUpdateWalker &operator++() = 0;
 
-      /* TODO */
       virtual ~TUpdateWalker() {}
 
       protected:

--- a/orly/indy/util/block_vec.h
+++ b/orly/indy/util/block_vec.h
@@ -35,44 +35,34 @@ namespace Orly {
 
     namespace Util {
 
-      /* TODO */
       class TBlockVec {
         public:
 
-        /* TODO */
         typedef std::map<size_t, std::pair<size_t, size_t>> TBlockMap;
 
-        /* TODO */
         class TRandomIterator
               : public std::iterator<std::random_access_iterator_tag, size_t> {
           protected:
 
-          /* TODO */
           const TBlockMap *BlockMap;
 
-          /* TODO */
           TBlockMap::const_iterator Iterator;
 
-          /* TODO */
           size_t ElementIndex;
 
           public:
 
-          /* TODO */
           typedef std::random_access_iterator_tag iterator_category;
           typedef typename std::iterator<std::random_access_iterator_tag, size_t>::value_type value_type;
           typedef typename std::iterator<std::random_access_iterator_tag, size_t>::difference_type difference_type;
           typedef typename std::iterator<std::random_access_iterator_tag, size_t>::reference reference;
           typedef typename std::iterator<std::random_access_iterator_tag, size_t>::pointer pointer;
 
-          /* TODO */
           TRandomIterator() : BlockMap(nullptr), ElementIndex(0UL) {}
 
-          /* TODO */
           inline TRandomIterator(const TRandomIterator &r)
               : BlockMap(r.BlockMap), Iterator(r.Iterator), ElementIndex(r.ElementIndex) {}
 
-          /* TODO */
           inline TRandomIterator(const TBlockMap *block_map, const TBlockMap::const_iterator &it, size_t elem_idx)
               : BlockMap(block_map), Iterator(it), ElementIndex(elem_idx) {
             if (Iterator != BlockMap->end()) {
@@ -82,7 +72,6 @@ namespace Orly {
             } /* otherwise it's an empty block vec */
           }
 
-          /* TODO */
           inline TRandomIterator &operator=(const TRandomIterator &r) {
             BlockMap = r.BlockMap;
             Iterator = r.Iterator;
@@ -91,55 +80,46 @@ namespace Orly {
             return *this;
           }
 
-          /* TODO */
           inline TRandomIterator& operator++() {
             ++ElementIndex;
             Refresh();
             return *this;
           }
 
-          /* TODO */
           inline TRandomIterator& operator--() {
             --ElementIndex;
             Refresh();
             return *this;
           }
 
-          /* TODO */
           inline TRandomIterator operator++(int) {
             return TRandomIterator(BlockMap, Iterator, ElementIndex++);
           }
 
-          /* TODO */
           inline TRandomIterator operator--(int) {
             return TRandomIterator(BlockMap, Iterator, ElementIndex--);
           }
 
-          /* TODO */
           inline TRandomIterator operator+(const difference_type& n) const {
             return TRandomIterator(BlockMap, Iterator, ElementIndex + n);
           }
 
-          /* TODO */
           inline TRandomIterator& operator+=(const difference_type& n) {
             ElementIndex += n;
             Refresh();
             return *this;
           }
 
-          /* TODO */
           inline TRandomIterator operator-(const difference_type& n) const {
             return TRandomIterator(BlockMap, Iterator, ElementIndex - n);
           }
 
-          /* TODO */
           inline TRandomIterator& operator-=(const difference_type& n) {
             ElementIndex -= n;
             Refresh();
             return *this;
           }
 
-          /* TODO */
           inline size_t operator*() const {
             assert(BlockMap);
             assert(Iterator != BlockMap->end());
@@ -152,38 +132,28 @@ namespace Orly {
             return Iterator->second.first + pos_from_start_idx;
           }
 
-          /* TODO */
           inline size_t operator->() const {
             return **this;
           }
 
-          /* TODO */
           friend inline bool operator==(const TRandomIterator &r1, const TRandomIterator &r2);
 
-          /* TODO */
           friend inline bool operator!=(const TRandomIterator &r1, const TRandomIterator &r2);
 
-          /* TODO */
           friend inline bool operator<(const TRandomIterator &r1, const TRandomIterator &r2);
 
-          /* TODO */
           friend inline bool operator>(const TRandomIterator &r1, const TRandomIterator &r2);
 
-          /* TODO */
           friend inline bool operator<=(const TRandomIterator &r1, const TRandomIterator &r2);
 
-          /* TODO */
           friend inline bool operator>=(const TRandomIterator &r1, const TRandomIterator &r2);
 
-          /* TODO */
           friend typename TRandomIterator::difference_type operator+(const TRandomIterator &r1, const TRandomIterator &r2);
 
-          /* TODO */
           friend typename TRandomIterator::difference_type operator-(const TRandomIterator &r1, const TRandomIterator &r2);
 
           private:
 
-          /* TODO */
           inline void Refresh() {
             assert(BlockMap);
             assert(Iterator != BlockMap->end());
@@ -205,13 +175,10 @@ namespace Orly {
 
         };  // TRandomIterator
 
-        /* TODO */
         TBlockVec() : VecSize(0UL) {}
 
-        /* TODO */
         ~TBlockVec() {}
 
-        /* TODO */
         inline size_t operator[](size_t pos) const {
           assert(pos < VecSize);
           auto ub = BlockMap.upper_bound(pos);
@@ -223,23 +190,19 @@ namespace Orly {
           return ub->second.first + expected_block_offset;
         }
 
-        /* TODO */
         inline size_t Front() const {
           assert(VecSize > 0UL);
           return BlockMap.begin()->second.first;
         }
 
-        /* TODO */
         inline size_t Size() const {
           return VecSize;
         }
 
-        /* TODO */
         TRandomIterator begin() const {
           return TRandomIterator(&BlockMap, BlockMap.begin(), 0UL);
         }
 
-        /* TODO */
         TRandomIterator end() const {
           return TRandomIterator(&BlockMap, BlockMap.end(), VecSize);
         }
@@ -299,7 +262,6 @@ namespace Orly {
           VecSize -= n;
         }
 
-        /* TODO */
         const TBlockMap &GetSeqBlockMap() const {
           return BlockMap;
         }
@@ -341,37 +303,30 @@ namespace Orly {
         /* A mapping from the starting index in the vector (of a sequential range) to the pair of (block_id -> num sequential blocks)*/
         TBlockMap BlockMap;
 
-        /* TODO */
         size_t VecSize;
 
       };  // TBlockVec
 
-      /* TODO */
       inline bool operator==(const TBlockVec::TRandomIterator &r1, const TBlockVec::TRandomIterator &r2) {
         return r1.ElementIndex == r2.ElementIndex;
       }
 
-      /* TODO */
       inline bool operator!=(const TBlockVec::TRandomIterator &r1, const TBlockVec::TRandomIterator &r2) {
         return r1.ElementIndex != r2.ElementIndex;
       }
 
-      /* TODO */
       inline bool operator<(const TBlockVec::TRandomIterator &r1, const TBlockVec::TRandomIterator &r2) {
         return r1.ElementIndex < r2.ElementIndex;
       }
 
-      /* TODO */
       inline bool operator>(const TBlockVec::TRandomIterator &r1, const TBlockVec::TRandomIterator &r2) {
         return r1.ElementIndex > r2.ElementIndex;
       }
 
-      /* TODO */
       inline bool operator<=(const TBlockVec::TRandomIterator &r1, const TBlockVec::TRandomIterator &r2) {
         return r1.ElementIndex <= r2.ElementIndex;
       }
 
-      /* TODO */
       inline bool operator>=(const TBlockVec::TRandomIterator &r1, const TBlockVec::TRandomIterator &r2) {
         return r1.ElementIndex >= r2.ElementIndex;
       }

--- a/orly/indy/util/context_streamer.h
+++ b/orly/indy/util/context_streamer.h
@@ -39,18 +39,14 @@ namespace Orly {
       /* Forward Declarations. */
       class TContextInputStreamer;
 
-      /* TODO */
       class TContextOutputStreamer {
         NO_COPY(TContextOutputStreamer);
         public:
 
-        /* TODO */
         typedef std::unordered_map<Atom::TCore::TOffset, Atom::TCore::TOffset> TTranslationMap;
 
-        /* TODO */
         TContextOutputStreamer() {}
 
-        /* TODO */
         void AppendUpdate(const Base::TUuid &repo_id, const TUpdateWalker::TItem &item) {
           UpdateVec.push_back(std::move(TUpdate(repo_id, item, Suprena)));
         }
@@ -104,7 +100,6 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         class TUpdate {
           public:
 
@@ -122,10 +117,8 @@ namespace Orly {
             TEntry(const TIndexKey &k, const Atom::TCore &op, TMutator m) : IndexKey(k), Op(op), Mutator(m) {}
           };
 
-          /* TODO */
           TUpdate() {}
 
-          /* TODO */
           TUpdate(const Base::TUuid &repo_id, const TUpdateWalker::TItem &item, Atom::TSuprena &new_arena)
               : RepoId(repo_id),
                 SequenceNumber(item.SequenceNumber) {
@@ -141,47 +134,35 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           Base::TUuid RepoId;
 
-          /* TODO */
           TSequenceNumber SequenceNumber;
 
-          /* TODO */
           Atom::TCore Metadata;
 
-          /* TODO */
           Atom::TCore Id;
 
-          /* TODO */
           std::vector<TEntry> EntryVec;
 
         };  // TUpdate
 
-        /* TODO */
         mutable Atom::TSuprena Suprena;
 
-        /* TODO */
         std::vector<TUpdate> UpdateVec;
 
-        /* TODO */
         friend class TContextInputStreamer;
 
       };  // TContextOutputStreamer
 
-      /* TODO */
       class TContextInputStreamer {
         public:
 
-        /* TODO */
         typedef TContextOutputStreamer::TTranslationMap TTranslationMap;
         typedef TContextOutputStreamer::TUpdate TUpdate;
 
-        /* TODO */
         TContextInputStreamer()
             : Suprena(std::make_shared<Atom::TSuprena>()) {}
 
-        /* TODO */
         void Read(Io::TBinaryInputStream &strm) {
           assert(Suprena);
           TTranslationMap translation_map;
@@ -244,7 +225,6 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         void Write(Io::TBinaryOutputStream &strm) const {
           TTranslationMap translation_map;
           /* Writing out the Intern context first */
@@ -291,15 +271,12 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         void AppendUpdate(const Base::TUuid &repo_id, const TUpdateWalker::TItem &item) {
           UpdateVec.push_back(std::move(TUpdate(repo_id, item, *Suprena)));
         }
 
-        /* TODO */
         std::shared_ptr<Atom::TSuprena> Suprena;
 
-        /* TODO */
         std::vector<TUpdate> UpdateVec;
 
       };  // TContextInputStreamer

--- a/orly/indy/util/growing_pool.h
+++ b/orly/indy/util/growing_pool.h
@@ -37,27 +37,20 @@ namespace Orly {
 
     namespace Util {
 
-      /* TODO */
       class TGrowingPool {
         NO_COPY(TGrowingPool);
         public:
 
-        /* TODO */
         TGrowingPool(size_t block_size, const char *name);
 
-        /* TODO */
         ~TGrowingPool();
 
-        /* TODO */
         inline const char *GetName() const;
 
-        /* TODO */
         inline size_t GetNumBlocksUsed() const;
 
-        /* TODO */
         inline size_t GetMaxBlocks() const;
 
-        /* TODO */
         void *Alloc(size_t size) {
           void *ptr = TryAlloc(size);
           if (!ptr) {
@@ -67,43 +60,32 @@ namespace Orly {
           return ptr;
         }
 
-        /* TODO */
         void Free(void *ptr);
 
-        /* TODO */
         void *TryAlloc(size_t size);
 
         private:
 
-        /* TODO */
         class TBlock {
           NO_COPY(TBlock);
           public:
 
-          /* TODO */
           TBlock *NextBlock;
 
         };  // TBlock
 
-        /* TODO */
         const size_t BlockSize;
 
-        /* TODO */
         void *Blob;
 
-        /* TODO */
         TBlock *FirstBlock;
 
-        /* TODO */
         std::mutex Mutex;
 
-        /* TODO */
         const char *Name;
 
-        /* TODO */
         size_t NumBlocksUsed;
 
-        /* TODO */
         size_t MaxBlocks;
 
       };  // TGrowingPool

--- a/orly/indy/util/lockless_pool.h
+++ b/orly/indy/util/lockless_pool.h
@@ -35,30 +35,22 @@ namespace Orly {
 
     namespace Util {
 
-      /* TODO */
       class TLocklessPool {
         NO_COPY(TLocklessPool);
         public:
 
-        /* TODO */
         TLocklessPool(size_t block_size, const char *name, size_t block_count = 0UL);
 
-        /* TODO */
         ~TLocklessPool();
 
-        /* TODO */
         void Init(size_t block_count);
 
-        /* TODO */
         inline const char *GetName() const;
 
-        /* TODO */
         inline size_t GetNumBlocksUsed() const;
 
-        /* TODO */
         inline size_t GetMaxBlocks() const;
 
-        /* TODO */
         void *Alloc(size_t size) {
           void *ptr = TryAlloc(size);
           if (!ptr) {
@@ -69,40 +61,30 @@ namespace Orly {
           return ptr;
         }
 
-        /* TODO */
         inline void Free(void *ptr);
 
-        /* TODO */
         inline void *TryAlloc(size_t size);
 
         private:
 
-        /* TODO */
         class TBlock {
           NO_COPY(TBlock);
           public:
 
-          /* TODO */
           TBlock *NextBlock;
 
         };  // TBlock
 
-        /* TODO */
         const size_t BlockSize;
 
-        /* TODO */
         void *Blob;
 
-        /* TODO */
         TBlock *FirstBlock;
 
-        /* TODO */
         const char *Name;
 
-        /* TODO */
         size_t NumBlocksUsed;
 
-        /* TODO */
         size_t MaxBlocks;
 
       };  // TLocklessPool

--- a/orly/indy/util/merge_sorter.h
+++ b/orly/indy/util/merge_sorter.h
@@ -34,18 +34,15 @@ namespace Orly {
 
     namespace Util {
 
-      /* TODO */
       template <typename TRef>
       class TKeySorter {
         NO_COPY(TKeySorter);
         public:
 
-          /* TODO */
         class TMergeElement {
           NO_COPY(TMergeElement);
           public:
 
-          /* TODO */
           TMergeElement(TKeySorter *sorter, const TKey &key, TSequenceNumber seq_num, TRef ref)
               : Next(0), Key(key), SeqNum(seq_num), Ref(ref) {
             TMergeElement *first = sorter->First;
@@ -68,32 +65,24 @@ namespace Orly {
             Next = first;
           }
 
-          /* TODO */
           ~TMergeElement() {}
 
           private:
 
-          /* TODO */
           TMergeElement *Next;
 
-          /* TODO */
           const TKey &Key;
 
-          /* TODO */
           TSequenceNumber SeqNum;
 
-          /* TODO */
           TRef Ref;
 
-          /* TODO */
           friend class TKeySorter;
 
         };  // TMergeElement
 
-        /* TODO */
         TKeySorter() : First(0) {}
 
-        /* TODO */
         ~TKeySorter() {
           while (First) {
             TMergeElement *first = First;
@@ -102,7 +91,6 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         TRef Pop() {
           assert(!IsEmpty());
           TRef ref = First->Ref;
@@ -112,30 +100,25 @@ namespace Orly {
           return ref;
         }
 
-        /* TODO */
         bool IsEmpty() const {
           return First == 0;
         }
 
         private:
 
-        /* TODO */
         TMergeElement *First;
 
       };  // TKeySorter
 
-      /* TODO */
       template <typename TRef>
       class TKeyCopySorter {
         NO_COPY(TKeyCopySorter);
         public:
 
-          /* TODO */
         class TMergeElement {
           NO_COPY(TMergeElement);
           public:
 
-          /* TODO */
           TMergeElement(TKeyCopySorter *sorter, const TKey &key, TSequenceNumber seq_num, TRef ref)
               : Next(0), Key(key), SeqNum(seq_num), Ref(ref) {
             TMergeElement *first = sorter->First;
@@ -158,32 +141,24 @@ namespace Orly {
             Next = first;
           }
 
-          /* TODO */
           ~TMergeElement() {}
 
           private:
 
-          /* TODO */
           TMergeElement *Next;
 
-          /* TODO */
           TKey Key;
 
-          /* TODO */
           TSequenceNumber SeqNum;
 
-          /* TODO */
           TRef Ref;
 
-          /* TODO */
           friend class TKeyCopySorter;
 
         };  // TMergeElement
 
-        /* TODO */
         TKeyCopySorter() : First(0) {}
 
-        /* TODO */
         ~TKeyCopySorter() {
           while (First) {
             TMergeElement *first = First;
@@ -192,19 +167,16 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         const TKey &Peek() const {
           assert(!IsEmpty());
           return First->Key;
         }
 
-        /* TODO */
         TKey &Peek() {
           assert(!IsEmpty());
           return First->Key;
         }
 
-        /* TODO */
         TRef Pop(TSequenceNumber &seq_num) {
           assert(!IsEmpty());
           TRef ref = First->Ref;
@@ -215,30 +187,25 @@ namespace Orly {
           return ref;
         }
 
-        /* TODO */
         bool IsEmpty() const {
           return First == 0;
         }
 
         private:
 
-        /* TODO */
         TMergeElement *First;
 
       };  // TKeyCopySorter
 
-      /* TODO */
       template <typename TRef>
       class TCoreSorter {
         NO_COPY(TCoreSorter);
         public:
 
-          /* TODO */
         class TMergeElement {
           NO_COPY(TMergeElement);
           public:
 
-          /* TODO */
           TMergeElement(TCoreSorter *sorter, const Atom::TCore *core, Atom::TCore::TArena *arena, TSequenceNumber seq_num, TRef ref)
               : Next(0), Core(core), Arena(arena), SeqNum(seq_num), Ref(ref) {
             TMergeElement *first = sorter->First;
@@ -267,35 +234,26 @@ namespace Orly {
             Next = first;
           }
 
-          /* TODO */
           ~TMergeElement() {}
 
           private:
 
-          /* TODO */
           TMergeElement *Next;
 
-          /* TODO */
           const Atom::TCore *Core;
 
-          /* TODO */
           Atom::TCore::TArena *Arena;
 
-          /* TODO */
           TSequenceNumber SeqNum;
 
-          /* TODO */
           TRef Ref;
 
-          /* TODO */
           friend class TCoreSorter;
 
         };  // TMergeElement
 
-        /* TODO */
         TCoreSorter() : First(0) {}
 
-        /* TODO */
         ~TCoreSorter() {
           while (First) {
             TMergeElement *first = First;
@@ -304,7 +262,6 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         void Clear() {
           while (First) {
             TMergeElement *first = First;
@@ -313,7 +270,6 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         TRef Pop(TSequenceNumber &seq_num) {
           assert(!IsEmpty());
           TRef ref = First->Ref;
@@ -324,30 +280,25 @@ namespace Orly {
           return ref;
         }
 
-        /* TODO */
         bool IsEmpty() const {
           return First == 0;
         }
 
         private:
 
-        /* TODO */
         TMergeElement *First;
 
       };  // TCoreSorter
 
-      /* TODO */
       template <typename TRef>
       class TDurableSorter {
         NO_COPY(TDurableSorter);
         public:
 
-          /* TODO */
         class TMergeElement {
           NO_COPY(TMergeElement);
           public:
 
-          /* TODO */
           TMergeElement(TDurableSorter *sorter, const uuid_t &id, TSequenceNumber seq_num, TRef ref)
               : Next(0), SeqNum(seq_num), Ref(ref) {
             uuid_copy(Id, id);
@@ -371,32 +322,24 @@ namespace Orly {
             Next = first;
           }
 
-          /* TODO */
           ~TMergeElement() {}
 
           private:
 
-          /* TODO */
           TMergeElement *Next;
 
-          /* TODO */
           uuid_t Id;
 
-          /* TODO */
           const TSequenceNumber SeqNum;
 
-          /* TODO */
           const TRef Ref;
 
-          /* TODO */
           friend class TDurableSorter;
 
         };  // TMergeElement
 
-        /* TODO */
         TDurableSorter() : First(0) {}
 
-        /* TODO */
         ~TDurableSorter() {
           while (First) {
             TMergeElement *first = First;
@@ -405,7 +348,6 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         TRef Pop(TSequenceNumber &seq_num, uuid_t &id) {
           assert(!IsEmpty());
           TRef ref = First->Ref;
@@ -417,30 +359,25 @@ namespace Orly {
           return ref;
         }
 
-        /* TODO */
         bool IsEmpty() const {
           return First == 0;
         }
 
         private:
 
-        /* TODO */
         TMergeElement *First;
 
       };  // TDurableSorter
 
-      /* TODO */
       template <typename TVal, typename TRef, class TComparator = std::less<TVal>>
       class TMergeSorter {
         NO_COPY(TMergeSorter);
         public:
 
-          /* TODO */
         class TMergeElement {
           NO_COPY(TMergeElement);
           public:
 
-          /* TODO */
           TMergeElement(TMergeSorter *sorter, const TVal &val, TRef ref)
               : Next(0), Val(val), Ref(ref) {
             TMergeElement *first = sorter->First;
@@ -462,30 +399,23 @@ namespace Orly {
             Next = first;
           }
 
-          /* TODO */
           ~TMergeElement() {}
 
           private:
 
-          /* TODO */
           TMergeElement *Next;
 
-          /* TODO */
           const TVal &Val;
 
-          /* TODO */
           TRef Ref;
 
-          /* TODO */
           friend class TMergeSorter;
 
         };  // TMergeElement
 
-        /* TODO */
         TMergeSorter(const TComparator &comp = std::less<TVal>())
             : Comp(comp), First(0) {}
 
-        /* TODO */
         ~TMergeSorter() {
           while (First) {
             TMergeElement *first = First;
@@ -494,7 +424,6 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         void Clear() {
           while (First) {
             TMergeElement *first = First;
@@ -503,13 +432,11 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         const TVal &Peek() const {
           assert(!IsEmpty());
           return First->Val;
         }
 
-        /* TODO */
         const TVal &Pop(TRef &ref) {
           assert(!IsEmpty());
           ref = First->Ref;
@@ -520,33 +447,27 @@ namespace Orly {
           return val;
         }
 
-        /* TODO */
         bool IsEmpty() const {
           return First == 0;
         }
 
         private:
 
-        /* TODO */
         TComparator Comp;
 
-        /* TODO */
         TMergeElement *First;
 
       };  // TMergeSorter
 
-      /* TODO */
       template <typename TVal, typename TRef, class TComparator = std::less<TVal>>
       class TCopyMergeSorter {
         NO_COPY(TCopyMergeSorter);
         public:
 
-          /* TODO */
         class TMergeElement {
           NO_COPY(TMergeElement);
           public:
 
-          /* TODO */
           TMergeElement(TCopyMergeSorter *sorter, const TVal &val, TRef ref)
               : Next(0), Val(val), Ref(ref) {
             TMergeElement *first = sorter->First;
@@ -568,30 +489,23 @@ namespace Orly {
             Next = first;
           }
 
-          /* TODO */
           ~TMergeElement() {}
 
           private:
 
-          /* TODO */
           TMergeElement *Next;
 
-          /* TODO */
           const TVal Val;
 
-          /* TODO */
           TRef Ref;
 
-          /* TODO */
           friend class TCopyMergeSorter;
 
         };  // TMergeElement
 
-        /* TODO */
         TCopyMergeSorter(const TComparator &comp = std::less<TVal>())
             : Comp(comp), First(0) {}
 
-        /* TODO */
         ~TCopyMergeSorter() {
           while (First) {
             TMergeElement *first = First;
@@ -600,13 +514,11 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         const TVal &Peek() const {
           assert(!IsEmpty());
           return First->Val;
         }
 
-        /* TODO */
         TVal Pop(TRef &ref) {
           assert(!IsEmpty());
           ref = First->Ref;
@@ -617,17 +529,14 @@ namespace Orly {
           return val;
         }
 
-        /* TODO */
         bool IsEmpty() const {
           return First == 0;
         }
 
         private:
 
-        /* TODO */
         TComparator Comp;
 
-        /* TODO */
         TMergeElement *First;
 
       };  // TCopyMergeSorter

--- a/orly/indy/util/min_heap.h
+++ b/orly/indy/util/min_heap.h
@@ -33,23 +33,18 @@ namespace Orly {
 
     namespace Util {
 
-      /* TODO */
       template <typename TVal, typename TRef, class TComparator = std::less<TVal>>
       class TMinHeap {
         NO_COPY(TMinHeap);
         public:
 
-        /* TODO */
         class TMinHeapElem {
           public:
 
-          /* TODO */
           TMinHeapElem(const TVal &val, TRef ref) : Val(&val), Ref(ref) {}
 
-          /* TODO */
           TMinHeapElem(const TMinHeapElem &&that) : Val(that.Val), Ref(that.Ref) {}
 
-          /* TODO */
           TMinHeapElem &operator=(TMinHeapElem &&that) {
             if (this != &that) {
               std::swap(Val, that.Val);
@@ -60,18 +55,14 @@ namespace Orly {
 
           private:
 
-          /* TODO */
           const TVal *Val;
 
-          /* TODO */
           TRef Ref;
 
-          /* TODO */
           friend class TMinHeap;
 
         };  // TMinHeapElem
 
-        /* TODO */
         TMinHeap(size_t max_elem, const TComparator &comp = std::less<TVal>())
             : MaxElem(max_elem), NumElem(0UL), Data(nullptr), Comp(comp) {
           Data = reinterpret_cast<TMinHeapElem *>(malloc(MaxElem *sizeof(TMinHeapElem)));
@@ -80,7 +71,6 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         ~TMinHeap() {
           for (size_t i = 0; i < NumElem; ++i) {
             Data[i].~TMinHeapElem();
@@ -88,12 +78,10 @@ namespace Orly {
           free(Data);
         }
 
-        /* TODO */
         inline operator bool() const {
           return NumElem > 0;
         }
 
-        /* TODO */
         inline void Insert(const TVal &val, TRef ref) {
           assert(NumElem < MaxElem);
           size_t i = NumElem;
@@ -105,7 +93,6 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         inline const TVal &Peek(TRef &ref) const {
           assert(NumElem > 0);
           const TMinHeapElem &min_val = Data[0];
@@ -113,7 +100,6 @@ namespace Orly {
           return *(min_val.Val);
         }
 
-        /* TODO */
         inline const TVal &Pop(TRef &ref) {
           assert(NumElem > 0);
           const TMinHeapElem &min_val = Data[0];
@@ -144,7 +130,6 @@ namespace Orly {
           return 2 * (i + 1);
         }
 
-        /* TODO */
         void MinHeapify(size_t i) {
           const size_t left = Left(i);
           const size_t right = Right(i);
@@ -163,13 +148,10 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         const size_t MaxElem;
 
-        /* TODO */
         size_t NumElem;
 
-        /* TODO */
         TMinHeapElem *Data;
 
         /* Comparator */
@@ -177,24 +159,19 @@ namespace Orly {
 
       };  // TMinHeap
 
-      /* TODO */
       template <typename TVal, typename TRef, class TComparator = std::less<TVal>>
       class TCopyMinHeap {
         NO_COPY(TCopyMinHeap);
         public:
 
-        /* TODO */
         class TMinHeapElem {
           public:
 
-          /* TODO */
           template <typename... TArgs>
           TMinHeapElem(TRef ref, TArgs &&...args) : Val(args...), Ref(ref) {}
 
-          /* TODO */
           TMinHeapElem(const TMinHeapElem &&that) : Val(that.Val), Ref(that.Ref) {}
 
-          /* TODO */
           TMinHeapElem &operator=(TMinHeapElem &&that) {
             if (this != &that) {
               std::swap(Val, that.Val);
@@ -205,18 +182,14 @@ namespace Orly {
 
           private:
 
-          /* TODO */
           TVal Val;
 
-          /* TODO */
           TRef Ref;
 
-          /* TODO */
           friend class TCopyMinHeap;
 
         };  // TMinHeapElem
 
-        /* TODO */
         TCopyMinHeap(size_t max_elem, const TComparator &comp = std::less<TVal>())
             : MaxElem(max_elem), NumElem(0UL), Data(nullptr), Comp(comp) {
           Data = reinterpret_cast<TMinHeapElem *>(malloc(MaxElem *sizeof(TMinHeapElem)));
@@ -225,7 +198,6 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         ~TCopyMinHeap() {
           for (size_t i = 0; i < NumElem; ++i) {
             Data[i].~TMinHeapElem();
@@ -233,12 +205,10 @@ namespace Orly {
           free(Data);
         }
 
-        /* TODO */
         inline operator bool() const {
           return NumElem > 0;
         }
 
-        /* TODO */
         template <typename... TArgs>
         inline void Emplace(TRef ref, TArgs &&...args) {
           assert(NumElem < MaxElem);
@@ -251,7 +221,6 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         inline const TVal &Peek(TRef &ref) const {
           assert(NumElem > 0);
           const TMinHeapElem &min_val = Data[0];
@@ -259,7 +228,6 @@ namespace Orly {
           return min_val.Val;
         }
 
-        /* TODO */
         inline TRef Pop(TVal &val) {
           assert(NumElem > 0);
           TMinHeapElem &min_val = Data[0];
@@ -290,7 +258,6 @@ namespace Orly {
           return 2 * (i + 1);
         }
 
-        /* TODO */
         void MinHeapify(size_t i) {
           const size_t left = Left(i);
           const size_t right = Right(i);
@@ -309,13 +276,10 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         const size_t MaxElem;
 
-        /* TODO */
         size_t NumElem;
 
-        /* TODO */
         TMinHeapElem *Data;
 
         /* Comparator */

--- a/orly/indy/util/pool.h
+++ b/orly/indy/util/pool.h
@@ -37,30 +37,22 @@ namespace Orly {
 
     namespace Util {
 
-      /* TODO */
       class TPool {
         NO_COPY(TPool);
         public:
 
-        /* TODO */
         TPool(size_t block_size, const char *name, size_t block_count = 0UL);
 
-        /* TODO */
         ~TPool();
 
-        /* TODO */
         void Init(size_t block_count);
 
-        /* TODO */
         inline const char *GetName() const;
 
-        /* TODO */
         inline size_t GetNumBlocksUsed() const;
 
-        /* TODO */
         inline size_t GetMaxBlocks() const;
 
-        /* TODO */
         void *Alloc(size_t size) {
           void *ptr = TryAlloc(size);
           if (!ptr) {
@@ -79,43 +71,32 @@ namespace Orly {
           return ptr;
         }
 
-        /* TODO */
         void Free(void *ptr);
 
-        /* TODO */
         void *TryAlloc(size_t size);
 
         private:
 
-        /* TODO */
         class TBlock {
           NO_COPY(TBlock);
           public:
 
-          /* TODO */
           TBlock *NextBlock;
 
         };  // TBlock
 
-        /* TODO */
         const size_t BlockSize;
 
-        /* TODO */
         void *Blob;
 
-        /* TODO */
         TBlock *FirstBlock;
 
-        /* TODO */
         std::mutex Mutex;
 
-        /* TODO */
         const char *Name;
 
-        /* TODO */
         std::atomic<size_t> NumBlocksUsed;
 
-        /* TODO */
         size_t MaxBlocks;
 
       };  // TPool

--- a/orly/indy/util/sorter.h
+++ b/orly/indy/util/sorter.h
@@ -36,241 +36,194 @@ namespace Orly {
 
     namespace Util {
 
-      /* TODO */
       template<typename TVal>
       class TRandomIterator
             : public std::iterator<std::random_access_iterator_tag, TVal> {
         protected:
 
-        /* TODO */
         TVal *Data;
 
         public:
 
-        /* TODO */
         typedef std::random_access_iterator_tag iterator_category;
         typedef typename std::iterator<std::random_access_iterator_tag, TVal>::value_type value_type;
         typedef typename std::iterator<std::random_access_iterator_tag, TVal>::difference_type difference_type;
         typedef typename std::iterator<std::random_access_iterator_tag, TVal>::reference reference;
         typedef typename std::iterator<std::random_access_iterator_tag, TVal>::pointer pointer;
 
-        /* TODO */
         TRandomIterator()
             : Data(0) {}
 
-        /* TODO */
         template<typename T2>
         TRandomIterator(const TRandomIterator<T2>& r)
             : Data(&(*r)) {}
 
-        /* TODO */
         TRandomIterator(pointer data)
             : Data(data) {}
 
-        /* TODO */
         template<typename T2>
         TRandomIterator& operator=(const TRandomIterator<T2>& r) {
           Data = &(*r);
           return *this;
         }
 
-        /* TODO */
         TRandomIterator& operator++() {
           ++Data;
           return *this;
         }
 
-        /* TODO */
         TRandomIterator& operator--() {
           --Data;
           return *this;
         }
 
-        /* TODO */
         TRandomIterator operator++(int) {
           return TRandomIterator(Data++);
         }
 
-        /* TODO */
         TRandomIterator operator--(int) {
           return TRandomIterator(Data--);
         }
 
-        /* TODO */
         TRandomIterator operator+(const difference_type& n) const {
           return TRandomIterator(Data + n);
         }
 
-        /* TODO */
         TRandomIterator& operator+=(const difference_type& n) {
           Data += n;
           return *this;
         }
 
-        /* TODO */
         TRandomIterator operator-(const difference_type& n) const {
           return TRandomIterator(pointer(Data - n));
         }
 
-        /* TODO */
         TRandomIterator& operator-=(const difference_type& n) {
           Data -= n;
           return *this;
         }
 
-        /* TODO */
         reference operator*() const {
           return *Data;
         }
 
-        /* TODO */
         pointer operator->() const {
           return Data;
         }
 
-        /* TODO */
         reference operator[](const difference_type& n) const {
           return Data[n];
         }
 
-        /* TODO */
         template<typename T>
         friend bool operator==(const TRandomIterator<T>& r1, const TRandomIterator<T>& r2);
 
-        /* TODO */
         template<typename T>
         friend bool operator!=(const TRandomIterator<T>& r1, const TRandomIterator<T>& r2);
 
-        /* TODO */
         template<typename T>
         friend bool operator<(const TRandomIterator<T>& r1, const TRandomIterator<T>& r2);
 
-        /* TODO */
         template<typename T>
         friend bool operator>(const TRandomIterator<T>& r1, const TRandomIterator<T>& r2);
 
-        /* TODO */
         template<typename T>
         friend bool operator<=(const TRandomIterator<T>& r1, const TRandomIterator<T>& r2);
 
-        /* TODO */
         template<typename T>
         friend bool operator>=(const TRandomIterator<T>& r1, const TRandomIterator<T>& r2);
 
-        /* TODO */
         template<typename T>
         friend typename TRandomIterator<T>::difference_type operator+(const TRandomIterator<T>& r1, const TRandomIterator<T>& r2);
 
-        /* TODO */
         template<typename T>
         friend typename TRandomIterator<T>::difference_type operator-(const TRandomIterator<T>& r1, const TRandomIterator<T>& r2);
 
       };  // TRandomIterator
 
-      /* TODO */
       template<typename T>
       bool operator==(const TRandomIterator<T>& r1, const TRandomIterator<T>& r2) {
         return r1.Data == r2.Data;
       }
 
-      /* TODO */
       template<typename T>
       bool operator!=(const TRandomIterator<T>& r1, const TRandomIterator<T>& r2) {
         return r1.Data != r2.Data;
       }
 
-      /* TODO */
       template<typename T>
       bool operator<(const TRandomIterator<T>& r1, const TRandomIterator<T>& r2) {
         return r1.Data < r2.Data;
       }
 
-      /* TODO */
       template<typename T>
       bool operator>(const TRandomIterator<T>& r1, const TRandomIterator<T>& r2) {
         return r1.Data > r2.Data;
       }
 
-      /* TODO */
       template<typename T>
       bool operator<=(const TRandomIterator<T>& r1, const TRandomIterator<T>& r2) {
         return r1.Data <= r2.Data;
       }
 
-      /* TODO */
       template<typename T>
       bool operator>=(const TRandomIterator<T>& r1, const TRandomIterator<T>& r2) {
         return r1.Data >= r2.Data;
       }
 
-      /* TODO */
       template<typename T>
       typename TRandomIterator<T>::difference_type operator+(const TRandomIterator<T>& r1, const TRandomIterator<T>& r2) {
         return TRandomIterator<T>(r1.Data + r2.Data);
       }
 
-      /* TODO */
       template<typename T>
       typename TRandomIterator<T>::difference_type operator-(const TRandomIterator<T>& r1, const TRandomIterator<T>& r2) {
         return r1.Data - r2.Data;
       }
 
-      /* TODO */
       template <typename TVal, size_t MaxSize>
       class TSorter {
         NO_COPY(TSorter);
         public:
 
-        /* TODO */
         class TCursor {
           NO_COPY(TCursor);
           public:
 
-          /* TODO */
           virtual operator bool() const = 0;
 
-          /* TODO */
           virtual const TVal &operator*() const = 0;
 
-          /* TODO */
           virtual TCursor &operator++() = 0;
 
-          /* TODO */
           virtual ~TCursor() {}
 
           protected:
 
-          /* TODO */
           TCursor() {}
 
         };  // TCursor
 
-        /* TODO */
         class TMemCursor
             : public TCursor {
           NO_COPY(TMemCursor);
           public:
 
-          /* TODO */
           TMemCursor(TSorter *sorter)
               : Iter(sorter->begin()),
                 End(sorter->end()) {}
 
-          /* TODO */
           virtual ~TMemCursor() {}
 
-          /* TODO */
           virtual operator bool() const {
             return Iter != End;
           }
 
-          /* TODO */
           virtual const TVal &operator*() const {
             assert(Iter != End);
             return *Iter;
           }
 
-          /* TODO */
           virtual TCursor &operator++() {
             assert(Iter != End);
             ++Iter;
@@ -279,15 +232,12 @@ namespace Orly {
 
           private:
 
-          /* TODO */
           TRandomIterator<TVal> Iter;
 
-          /* TODO */
           TRandomIterator<TVal> End;
 
         };  // TMemCursor
 
-        /* TODO */
         TSorter()
             : Size(0U) {
           Data = reinterpret_cast<TVal *>(malloc(sizeof(TVal) * MaxSize));
@@ -297,18 +247,15 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         virtual ~TSorter() {
           free(Data);
         }
 
-        /* TODO */
         const TVal &operator[](size_t pos) const {
           assert(pos < Size);
           return *(Data + pos);
         }
 
-        /* TODO */
         template <class... Args>
         void Emplace(Args &&... args) {
           assert(Size < MaxSize);
@@ -316,42 +263,34 @@ namespace Orly {
           ++Size;
         }
 
-        /* TODO */
         size_t GetSize() const {
           return Size;
         }
 
-        /* TODO */
         bool IsFull() const {
           return Size == MaxSize;
         }
 
-        /* TODO */
         TRandomIterator<TVal> begin() const {
           return TRandomIterator<TVal>(Data);
         }
 
-        /* TODO */
         TRandomIterator<TVal> end() const {
           return TRandomIterator<TVal>(Data + Size);
         }
 
-        /* TODO */
         void Clear() {
           Size = 0U;
         }
 
-        /* TODO */
         static size_t GetMaxSize() {
           return MaxSize;
         }
 
         private:
 
-        /* TODO */
         size_t Size;
 
-        /* TODO */
         TVal *Data;
 
       };  // TSorter

--- a/orly/key_generator.h
+++ b/orly/key_generator.h
@@ -31,52 +31,40 @@
 
 namespace Orly {
 
-  /* TODO */
   class TKeyCursor {
     NO_COPY(TKeyCursor);
     public:
 
-    /* TODO */
     virtual ~TKeyCursor() {}
 
-    /* TODO */
     virtual operator bool() const = 0;
 
-    /* TODO */
     virtual const Indy::TKey &operator*() const = 0;
 
-    /* TODO */
     virtual const Indy::TKey *operator->() const = 0;
 
-    /* TODO */
     virtual TKeyCursor &operator++() = 0;
 
-    /* TODO */
     inline Atom::TCore::TArena *GetArena() {
       return Arena;
     }
 
     protected:
 
-    /* TODO */
     TKeyCursor(Atom::TCore::TExtensibleArena *arena) : Arena(arena) {}
 
-    /* TODO */
     Atom::TCore::TExtensibleArena *Arena;
 
   };  // TKeyCursor
 
   namespace L0 {
 
-    /* TODO */
     class TPackageContext {
       NO_COPY(TPackageContext);
       public:
 
-      /* TODO */
       virtual ~TPackageContext() {}
 
-      /* TODO */
       virtual TKeyCursor *NewKeyCursor(TContextBase *context, const Indy::TIndexKey &pattern) const = 0;
 
       protected:
@@ -87,7 +75,6 @@ namespace Orly {
 
   }  // L0
 
-  /* TODO */
   template <typename TRet>
   class TKeyGenerator
       : public Rt::TGenerator<TRet>,
@@ -95,7 +82,6 @@ namespace Orly {
     NO_COPY(TKeyGenerator);
     public:
 
-    /* TODO */
     typedef std::shared_ptr<const TKeyGenerator> TPtr;
 
     //TODO: CODY: This cursor needs a rewrite. For now it is roughly copied from what was generated, as that seemed to work.
@@ -103,27 +89,22 @@ namespace Orly {
         : public Base::TIter<const TRet> {
       public:
 
-      /* TODO */
       typedef const TRet TVal;
 
-      /* TODO */
       TCursor(TKeyGenerator::TPtr &ptr)
           : Cached(false), Valid(false), Item(0),
             /*Iter(&ptr->GetContext(), ptr->GetStart()),*/
             Iter(ptr->PackageContext->NewKeyCursor(&ptr->GetContext(), ptr->GetStart())),
             Ptr(ptr) {}
 
-      /* TODO */
       TCursor(const TKeyGenerator::TPtr &ptr)
           : Cached(false), Valid(false), Item(0),
             /* Iter(&ptr->GetContext(), ptr->GetStart()), */
             Iter(ptr->PackageContext->NewKeyCursor(&ptr->GetContext(), ptr->GetStart())),
             Ptr(ptr) {}
 
-      /* TODO */
       TCursor(const TCursor &that) = delete;
 
-      /* TODO */
       TCursor(TCursor &&that)
           : Cached(that.Cached),
             Valid(that.Valid),
@@ -133,19 +114,16 @@ namespace Orly {
         that.Item = 0;
       }
 
-      /* TODO */
       virtual ~TCursor() {
         delete Item;
       }
 
-      /* TODO */
       operator bool() const {
         Refresh();
         assert(Cached);
         return Valid;
       }
 
-      /* TODO */
       TVal &operator*() const {
         Refresh();
         assert(Cached);
@@ -153,7 +131,6 @@ namespace Orly {
         return *Item;
       }
 
-      /* TODO */
       Base::TIter<TVal> &operator++() {
         ++(*Iter);
         Cached = false;
@@ -162,7 +139,6 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       inline void Refresh() const {
         if (!Cached) {
           Cached = true;
@@ -180,47 +156,36 @@ namespace Orly {
         }
       }
 
-      /* TODO */
       mutable bool Cached;
 
-      /* TODO */
       mutable bool Valid;
 
-      /* TODO */
       mutable TRet *Item;
 
-      /* TODO */
       mutable std::unique_ptr<Orly::TKeyCursor> Iter;
 
-      /* TODO */
       const TKeyGenerator::TPtr Ptr;
 
     }; // TCursor<TKeyGenerator<TRet>>
 
-    /* TODO */
     virtual ~TKeyGenerator() {}
 
-    /* TODO */
     TContextBase &GetContext() {
       return Ctx;
     }
 
-    /* TODO */
     TContextBase &GetContext() const {
       return Ctx;
     }
 
-    /* TODO */
     const Indy::TIndexKey &GetStart() const {
       return Start;
     }
 
-    /* TODO */
     virtual Base::TIterHolder<const TRet> NewCursor() const {
       return MakeHolder(new TCursor(this->shared_from_this()));
     }
 
-    /* TODO */
     TKeyGenerator(L0::TPackageContext *package_context, TContextBase &ctx,  const Sabot::State::TAny *start, const Base::TUuid &index_id)
         : PackageContext(package_context),
           Ctx(ctx),
@@ -228,13 +193,10 @@ namespace Orly {
 
     private:
 
-    /* TODO */
     L0::TPackageContext *PackageContext;
 
-    /* TODO */
     TContextBase &Ctx;
 
-    /* TODO */
     const Indy::TIndexKey Start;
 
   };  // TKeyGenerator

--- a/orly/method_request.h
+++ b/orly/method_request.h
@@ -45,16 +45,12 @@ namespace Orly {
     /* We characterize time-to-live in milliseconds. */
     using TTimeToLive = std::chrono::milliseconds;
 
-    /* TODO */
     TMethodRequest() = default;
 
-    /* TODO */
     TMethodRequest(const TId &pov_id, const TPackage &package, const TClosure &closure);
 
-    /* TODO */
     TMethodRequest(const TId &pov_id, const TPackage &package, const TClosure &closure, const TTimeToLive &time_to_live);
 
-    /* TODO */
     TMethodRequest(const TId &pov_id, const TPackage &package, const TClosure &closure, const TId &tracking_id);
 
     /* A method name and set of arguments which the server is to execute. */

--- a/orly/native/point.h
+++ b/orly/native/point.h
@@ -31,12 +31,10 @@ class TPoint {
   TPoint(double x, double y)
       : X(x), Y(y) {}
 
-  /* TODO */
   double GetX() const {
     return X;
   }
 
-  /* TODO */
   double GetY() const {
     return Y;
   }

--- a/orly/native/record.h
+++ b/orly/native/record.h
@@ -114,13 +114,11 @@ namespace Orly {
         /* Override to get the name of the element. */
         virtual const char *GetName() const = 0;
 
-        /* TODO */
         virtual Type::TAny *ConsType(void *type_alloc) const = 0;
 
         /* Override to construct a new state sabot for this emement in the given record. */
         virtual TAnyState *NewStateSabot(const TRec &rec, void *state_alloc) const = 0;
 
-        /* TODO */
         virtual void SetVal(TRec &rec, const TAnyState &state) const = 0;
 
         /* Collect all the elements of the record type into a sorted array.
@@ -170,7 +168,6 @@ namespace Orly {
 
       };  // Record<TRec>::TAnyElem
 
-      /* TODO */
       static const TAnyElem *TryGetElem(const char *name) {
         TAnyElem::CollectElems();
         for (size_t elem_idx = 0; elem_idx < ElemCount; ++elem_idx) {
@@ -288,14 +285,12 @@ namespace Orly {
 
   namespace Sabot {
 
-    /* TODO */
     template <typename TVal>
     class TToNativeVisitor final
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
 
-      /* TODO */
       TToNativeVisitor(TVal &record)
           : Out(record) {}
 

--- a/orly/native/type.h
+++ b/orly/native/type.h
@@ -80,12 +80,10 @@ namespace Orly {
           : public TBase {
         public:
 
-        /* TODO */
         class TPin : public TBase::TPin {
           NO_COPY(TPin);
           public:
 
-          /* TODO */
           TPin() {}
 
           /* Override to construct a new type sabot. */
@@ -95,12 +93,10 @@ namespace Orly {
 
         };  // TPin
 
-        /* TODO */
         virtual typename TBase::TPin *Pin(void *pin_alloc) const {
           return new (pin_alloc) TPin();
         }
 
-        /* TODO */
         virtual TAny *GetType(void *type_alloc) const = 0;
 
         protected:
@@ -133,12 +129,10 @@ namespace Orly {
           : public TBase {
         public:
 
-        /* TODO */
         class TPin : public TBase::TPin {
           NO_COPY(TPin);
           public:
 
-          /* TODO */
           TPin() {}
 
           /* See Sabot::Type::TBinary. */
@@ -153,12 +147,10 @@ namespace Orly {
 
         };  // TPin
 
-        /* TODO */
         virtual typename TBase::TPin *Pin(void *pin_alloc) const {
           return new (pin_alloc) TPin();
         }
 
-        /* TODO */
         virtual TAny *GetType(void *type_alloc) const = 0;
 
         protected:
@@ -185,12 +177,10 @@ namespace Orly {
           : public Sabot::Type::TRecord {
         public:
 
-        /* TODO */
         class TPin : public Sabot::Type::TRecord::TPin {
           NO_COPY(TPin);
           public:
 
-          /* TODO */
           TPin(const TRecord *record) : Sabot::Type::TRecord::TPin(record) {}
 
           /* See Sabot::Type::TRecord. */
@@ -215,12 +205,10 @@ namespace Orly {
           return Record<TVal>::GetElemCount();
         }
 
-        /* TODO */
         virtual Sabot::Type::TRecord::TPin *Pin(void *pin_alloc) const {
           return new (pin_alloc) TPin(this);
         }
 
-        /* TODO */
         virtual TAny *GetType(void *type_alloc) const {
           return new (type_alloc) TRecord();
         }
@@ -230,7 +218,6 @@ namespace Orly {
 
       };  // TRecord<TVal>
 
-      /* TODO */
       template <typename... TElems>
       class TupleUnroller;
 
@@ -240,12 +227,10 @@ namespace Orly {
           : public Sabot::Type::TTuple {
         public:
 
-        /* TODO */
         class TPin : public Sabot::Type::TTuple::TPin {
           NO_COPY(TPin);
           public:
 
-          /* TODO */
           TPin(const TTuple *tuple) : Sabot::Type::TTuple::TPin(tuple) {}
 
           /* See Sabot::Type::TTuple. */
@@ -260,12 +245,10 @@ namespace Orly {
           return std::tuple_size<std::tuple<TElems...>>::value;
         }
 
-        /* TODO */
         virtual Sabot::Type::TTuple::TPin *Pin(void *pin_alloc) const {
           return new (pin_alloc) TPin(this);
         }
 
-        /* TODO */
         virtual TAny *GetType(void *type_alloc) const {
           return new (type_alloc) TTuple();
         }
@@ -280,26 +263,22 @@ namespace Orly {
 
     };  // Type
 
-    /* TODO */
     template <typename TElem, typename... TElems>
     class Type::TupleUnroller<TElem, TElems...> {
       NO_CONSTRUCTION(TupleUnroller);
       public:
 
-      /* TODO */
       static Type::TAny *GetElem(size_t elem_idx, void *type_alloc) {
         return elem_idx ? TupleUnroller<TElems...>::GetElem(elem_idx - 1, type_alloc) : For<TElem>::GetType(type_alloc);
       }
 
     };  // Type::TupleUnroller
 
-    /* TODO */
     template <>
     class Type::TupleUnroller<> {
       NO_CONSTRUCTION(TupleUnroller);
       public:
 
-      /* TODO */
       static Type::TAny *GetElem(size_t /*elem_idx*/, void */*type_alloc*/) {
         throw Sabot::TIdxTooBig();
       }
@@ -319,7 +298,6 @@ namespace Orly {
         return new (type_alloc) TRecord<TVal>();
       }
 
-      /* TODO */
       static Type::TRecord<TVal> *GetRecordType(void *type_alloc) {
         return new (type_alloc) TRecord<TVal>();
       }
@@ -386,7 +364,6 @@ namespace Orly {
         return new (type_alloc) TDesc<TElem>();
       }
 
-      /* TODO */
       static Type::TDesc<TElem> *GetDescType(void *type_alloc) {
         return new (type_alloc) TDesc<TElem>();
       }
@@ -403,7 +380,6 @@ namespace Orly {
         return new (type_alloc) TFree<TElem>();
       }
 
-      /* TODO */
       static Type::TFree<TElem> *GetFreeType(void *type_alloc) {
         return new (type_alloc) TFree<TElem>();
       }
@@ -420,7 +396,6 @@ namespace Orly {
         return new (type_alloc) TOpt<TElem>();
       }
 
-      /* TODO */
       static Type::TOpt<TElem> *GetOptType(void *type_alloc) {
         return new (type_alloc) TOpt<TElem>();
       }
@@ -437,7 +412,6 @@ namespace Orly {
         return new (type_alloc) TSet<TElem>();
       }
 
-      /* TODO */
       static Type::TSet<TElem> *GetSetType(void *type_alloc) {
         return new (type_alloc) TSet<TElem>();
       }
@@ -454,7 +428,6 @@ namespace Orly {
         return new (type_alloc) TSet<TElem>();
       }
 
-      /* TODO */
       static Type::TSet<TElem> *GetSetType(void *type_alloc) {
         return new (type_alloc) TSet<TElem>();
       }
@@ -471,7 +444,6 @@ namespace Orly {
         return new (type_alloc) TVector<TElem>();
       }
 
-      /* TODO */
       static Type::TVector<TElem> *GetVectorType(void *type_alloc) {
         return new (type_alloc) TVector<TElem>();
       }
@@ -488,7 +460,6 @@ namespace Orly {
         return new (type_alloc) TMap<TLhs, TRhs>();
       }
 
-      /* TODO */
       static Type::TMap<TLhs, TRhs> *GetMapType(void *type_alloc) {
         return new (type_alloc) TMap<TLhs, TRhs>();
       }
@@ -505,7 +476,6 @@ namespace Orly {
         return new (type_alloc) TMap<TLhs, TRhs>();
       }
 
-      /* TODO */
       static Type::TMap<TLhs, TRhs> *GetMapType(void *type_alloc) {
         return new (type_alloc) TMap<TLhs, TRhs>();
       }
@@ -517,7 +487,6 @@ namespace Orly {
     class Type::For<std::tuple<TElems...>> final {
       public:
 
-      /* TODO */
       static Sabot::Type::TTuple *GetType(void *type_alloc) {
         return new (type_alloc) TTuple<TElems...>();
       }

--- a/orly/notification/update_progress.h
+++ b/orly/notification/update_progress.h
@@ -32,19 +32,14 @@ namespace Orly {
         : public TNotification {
       public:
 
-      /* TODO */
       enum TResponse {
 
-        /* TODO */
         Accepted,
 
-        /* TODO */
         Replicated,
 
-        /* TODO */
         SemiDurable,
 
-        /* TODO */
         Durable,
 
       };  // TResponse

--- a/orly/package/rt.h
+++ b/orly/package/rt.h
@@ -51,7 +51,6 @@ namespace Orly {
       /* All the results of if statements inside the program. */
       typedef std::vector<bool> TPredicateResults;
 
-      /* TODO */
       virtual ~TContext() {}
 
       /* Add an effect toe the effect map. Will throw if the key has been changed in a way incompatible with the given
@@ -87,12 +86,10 @@ namespace Orly {
         return std::move(Effects);
       }
 
-      /* TODO */
       inline const TEffects &GetEffects() {
         return Effects;
       }
 
-      /* TODO */
       template <typename TRet, typename... TArgs>
       std::shared_ptr<const TKeyGenerator<TRet>> New(TContextBase &ctx, const Base::TUuid &index_id, const std::tuple<TArgs...> &start) {
         void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
@@ -102,10 +99,8 @@ namespace Orly {
       /* Get the FluxCapacitor::TContext. Used by things like KeyGenerators and reading values out of the database. */
       virtual Orly::TContextBase &GetFlux() = 0;
 
-      /* TODO */
       virtual TKeyCursor *NewKeyCursor(TContextBase *context, const Indy::TIndexKey &pattern) const = 0;
 
-      /* TODO */
       virtual TKeyCursor *NewKeyCursor(TContextBase *context, const Indy::TIndexKey &from, const Indy::TIndexKey &to) const = 0;
 
       /* Get the current session id. */
@@ -168,15 +163,12 @@ namespace Orly {
         return OptNow;
       }
 
-      /* TODO */
       inline Atom::TCore::TExtensibleArena *GetArena();
 
-      /* TODO */
       inline Base::TScheduler *GetScheduler() const;
 
       protected:
 
-        /* TODO */
       TContext(const Rt::TOpt<Base::TUuid> &user_id,
         const Base::TUuid &session_id,
         Atom::TCore::TExtensibleArena *arena,
@@ -186,29 +178,22 @@ namespace Orly {
             : Arena(arena), UserId(user_id), SessionId(session_id), Scheduler(scheduler),
               OptNow(now), OptRandomSeed(random_seed) {}
 
-      /* TODO */
       mutable Atom::TCore::TExtensibleArena *Arena;
 
       private:
 
-      /* TODO */
       TEffects Effects;
 
-      /* TODO */
       TPredicateResults PredicateResults;
 
-      /* TODO */
       Rt::TOpt<Base::TUuid> UserId;
 
-      /* TODO */
       Base::TUuid SessionId;
 
-      /* TODO */
       Base::TScheduler *Scheduler;
 
       // Lazily generated members.
       // Ideally we would just get these details from the compiler.
-      /* TODO */
       mutable Rt::TOpt<Base::Chrono::TTimePnt> OptNow;
 
       mutable Rt::TOpt<uint32_t> OptRandomSeed;

--- a/orly/perf/kv_exercise.cc
+++ b/orly/perf/kv_exercise.cc
@@ -117,10 +117,8 @@ class TCmd final
     Parse(argc, argv, TMeta());
   }
 
-  /* TODO  */
   Socket::TAddress Addr;
 
-  /* TODO */
   size_t NumThreads;
   size_t NumReadsPerWrite;
   size_t FlushIntervalMs;

--- a/orly/rt/built_in.h
+++ b/orly/rt/built_in.h
@@ -52,7 +52,6 @@ namespace Orly {
       return out;
     }  // DictCtor
 
-    /* TODO */
     DEFINE_ERROR(TAssertionError, TRuntimeError, "Assertion Error");
 
     inline void Assert(const char *msg, bool result) {

--- a/orly/rt/containers.h
+++ b/orly/rt/containers.h
@@ -49,7 +49,6 @@ namespace Orly {
     template <typename TVal>
     struct TMatch {
 
-      /* TODO */
       bool operator()(const TVal &lhs, const TVal &rhs) const { return Match(lhs, rhs); }
 
     };
@@ -58,17 +57,14 @@ namespace Orly {
     template <typename TVal>
     struct TMatchLess {
 
-      /* TODO */
       bool operator()(const TVal &lhs, const TVal &rhs) const { return MatchLess(lhs, rhs); }
 
     };
 
-    /* TODO */
     template <typename TKey, typename TVal>
     //using TDict = std::unordered_map<TKey, TVal, std::hash<TKey>, TMatch<TKey>>;
     using TDict = std::map<TKey, TVal, TMatchLess<TKey>>;
 
-    /* TODO */
     template <typename TVal>
     //using TSet = std::unordered_set<TVal, std::hash<TVal>, TMatch<TVal>>;
     using TSet = std::set<TVal, TMatchLess<TVal>>;

--- a/orly/rt/desc.h
+++ b/orly/rt/desc.h
@@ -27,13 +27,11 @@ namespace Orly {
 
   namespace Rt {
 
-    /* TODO */
     template <typename TVal>
     TVal UnwrapDesc(const TVal &val) {
       return val;
     }
 
-    /* TODO */
     template <typename TVal>
     TVal UnwrapDesc(const Orly::TDesc<TVal> &val) {
       return *val;

--- a/orly/rt/generator.h
+++ b/orly/rt/generator.h
@@ -297,21 +297,17 @@ namespace Orly {
       /* Convenience. */
       typedef std::shared_ptr<const TMatchGenerator> TPtr;
 
-      /* TODO */
       class TCursor final
         : public Base::TIter<TItem> {
         public:
 
-        /* TODO */
         TCursor(const TPtr &ptr)
             : Ptr(ptr), RegexMatcher(&(ptr->Regex), ptr->Text.c_str()) {}
 
-        /* TODO */
         virtual operator bool() const override {
           return RegexMatcher;
         }
 
-        /* TODO */
         virtual const std::string &operator*() const override {
           return *RegexMatcher;
         }
@@ -328,10 +324,8 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         TPtr Ptr;
 
-        /* TODO */
         TRegexMatcher RegexMatcher;
 
       };  // TMatchGenerator::TCursor
@@ -474,21 +468,17 @@ namespace Orly {
       /* Convenience. */
       typedef std::shared_ptr<const TSplitGenerator> TPtr;
 
-      /* TODO */
       class TCursor final
           : public Base::TIter<TItem> {
         public:
 
-        /* TODO */
         TCursor(const TPtr &ptr)
             : Ptr(ptr), RegexSplitter(&(ptr->Regex), ptr->Text.c_str()), HasData(true) {}
 
-        /* TODO */
         virtual operator bool() const override {
           return HasData;
         }
 
-        /* TODO */
         virtual const TRegexSplitter::TItem &operator*() const override {
           assert(HasData);
           return *RegexSplitter;
@@ -507,13 +497,10 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         TPtr Ptr;
 
-        /* TODO */
         TRegexSplitter RegexSplitter;
 
-        /* TODO */
         bool HasData;
 
       };  // TSplitGenerator::TCursor

--- a/orly/rt/operator.h
+++ b/orly/rt/operator.h
@@ -233,7 +233,6 @@ namespace Orly {
       return IsKnown(lhs) && IsKnown(rhs) ? Xor(GetVal(lhs), GetVal(rhs)) : TOpt<bool>();
     }
 
-    /* TODO */
     template <typename TVal>
     auto IsKnownExpr(const TOpt<TVal> &opt_val, const TVal &val)
         -> decltype(And(IsKnown(opt_val), EqEq(GetVal(opt_val), val))) {
@@ -253,7 +252,6 @@ namespace Orly {
 
     namespace Dict {
 
-      /* TODO */
       template <typename TLhsKey, typename TLhsVal, typename TRhsKey, typename TRhsVal>
       auto Equal(const TDict<TLhsKey, TLhsVal> &lhs, const TDict<TRhsKey, TRhsVal> &rhs, const bool is_eqeq)
               -> decltype(And(EqEq(lhs.begin()->first , rhs.begin()->first),
@@ -301,7 +299,6 @@ namespace Orly {
 
     namespace List {
 
-      /* TODO */
       template <typename TLhs, typename TRhs>
       auto Equal(const std::vector<TLhs> &lhs, const std::vector<TRhs> &rhs, const bool is_eqeq)
             -> decltype(EqEq(*lhs.begin(), *rhs.begin())) {
@@ -323,7 +320,6 @@ namespace Orly {
         return unknown ? decltype(EqEq(*lhs.begin(), *rhs.begin()))() : is_eqeq;
       }
 
-      /* TODO */
       template <typename TLhs, typename TRhs, typename TElemComp, typename TSizeComp>
       auto Compare(
             const std::vector<TLhs> &lhs,
@@ -347,7 +343,6 @@ namespace Orly {
 
     namespace Set {
 
-      /* TODO */
       template <typename TLhs, typename TRhs>
       auto Equal(const TSet<TLhs> &lhs, const TSet<TRhs> &rhs, const bool is_eqeq)
             -> decltype(Contains(rhs, *lhs.begin())) {
@@ -1187,16 +1182,13 @@ namespace Orly {
 
     };  // GtEqStruct<int64_t, size_t>
 
-    /* TODO */
     template <typename TContainer, typename TVal>
     bool Contains(const TContainer &, const TVal &) = delete;
 
-    /* TODO */
     inline bool Contains(const std::string &container, const std::string &val) {
       return container.find(val) != std::string::npos;
     }
 
-    /* TODO */
     template <typename TLhs, typename TRhs>
     auto Contains(const std::vector<TLhs> &container, const TRhs &val)
           -> decltype(EqEq(*container.begin(), val)) {
@@ -1214,7 +1206,6 @@ namespace Orly {
       return unknown ? decltype(EqEq(*iter, val))() : false;
     }
 
-    /* TODO */
     template <typename TLhs, typename TRhs>
     TOpt<bool> Contains(const TSet<TOpt<TLhs>> &container, const TRhs &val) {
       if (container.empty()) {
@@ -1232,7 +1223,6 @@ namespace Orly {
       return TOpt<bool>(false);
     }
 
-    /* TODO */
     template <typename TLhs, typename TRhs>
     auto Contains(const TSet<TLhs> &container, const TRhs &val)
           -> decltype(EqEq(*container.begin(), val)) {
@@ -1245,7 +1235,6 @@ namespace Orly {
       return container.count(GetVal(val));
     }
 
-    /* TODO */
     template <typename TLhsKey, typename TLhsVal, typename TRhsKey>
     TOpt<bool> Contains(const TDict<TOpt<TLhsKey>, TLhsVal> &container, const TRhsKey &key) {
       if (container.empty()) {
@@ -1263,7 +1252,6 @@ namespace Orly {
       return TOpt<bool>(false);
     }
 
-    /* TODO */
     template <typename TLhsKey, typename TLhsVal, typename TRhsKey>
     auto Contains(const TDict<TLhsKey, TLhsVal> &container, const TRhsKey &key)
           -> decltype(EqEq(container.begin()->first, key)) {
@@ -1276,13 +1264,11 @@ namespace Orly {
       return container.count(GetVal(key));
     }
 
-    /* TODO */
     template <typename TContainer, typename TVal>
     TOpt<bool> Contains(const TOpt<TContainer> &container, const TVal &val) {
       return container.IsKnown() ? Contains(container.GetVal(), val) : TOpt<bool>();
     }
 
-    /* TODO */
     template <typename TKey, typename TVal>
     TOpt<bool> Contains(const TOpt<TDict<TKey, TVal>> &container, const TKey &val) {
       return container.IsKnown() ? Contains(container.GetVal(), val) : TOpt<bool>();

--- a/orly/rt/postfix_cast.h
+++ b/orly/rt/postfix_cast.h
@@ -43,58 +43,48 @@ namespace Orly {
 
   namespace Rt {
 
-    /* TODO */
     template <typename TTo, typename TFrom>
     struct CastAs {
       NO_CONSTRUCTION(CastAs);
 
-      /* TODO */
       static TTo Do(const TFrom &val) = delete;
 
     };  // CastAs
 
-    /* TODO */
     template <typename TVal>
     struct CastAs<TVal, TVal> {
       NO_CONSTRUCTION(CastAs);
 
-      /* TODO */
       static const TVal &Do(const TVal &val) {
         return val;
       }
 
     };  // CastAs<TVal, TVal>
 
-    /* TODO */
     template <>
     struct CastAs<double, int64_t> {
       NO_CONSTRUCTION(CastAs);
 
-      /* TODO */
       static double Do(const int64_t &val) {
         return static_cast<double>(val);
       }
 
     };  // CastAs<double, int64_t>
 
-    /* TODO */
     template <>
     struct CastAs<int64_t, double> {
       NO_CONSTRUCTION(CastAs);
 
-      /* TODO */
       static int64_t Do(const double &val) {
         return static_cast<int64_t>(val);
       }
 
     };  // CastAs<int64_t, double>
 
-    /* TODO */
     template <>
     struct CastAs<std::string, int64_t> {
       NO_CONSTRUCTION(CastAs);
 
-      /* TODO */
       static std::string Do(const int64_t &val) {
         std::ostringstream oss;
         oss << val;
@@ -106,12 +96,10 @@ namespace Orly {
 
     };  // CastAs<std::string, int64_t>
 
-    /* TODO */
     template <>
     struct CastAs<int64_t, std::string> {
       NO_CONSTRUCTION(CastAs);
 
-      /* TODO */
       static int64_t Do(const std::string &val) {
         char *endptr = 0;
         int64_t n = strtol(val.c_str(), &endptr, 10);
@@ -126,12 +114,10 @@ namespace Orly {
 
     };  // CastAs<int64_t, std::string>
 
-    /* TODO */
     template <>
     struct CastAs<std::string, double> {
       NO_CONSTRUCTION(CastAs);
 
-      /* TODO */
       static std::string Do(const double &val) {
         std::stringstream oss;
         oss << std::showpoint << val;
@@ -143,12 +129,10 @@ namespace Orly {
 
     };  // CastAs<std::string, double>
 
-    /* TODO */
     template <>
     struct CastAs<double, std::string> {
       NO_CONSTRUCTION(CastAs);
 
-      /* TODO */
       static double Do(const std::string &val) {
         char *endptr = 0;
         double d = strtod(val.c_str(), &endptr);
@@ -167,12 +151,10 @@ namespace Orly {
 
     };  // CastAs<double, std::string>
 
-    /* TODO */
     template <>
     struct CastAs<Base::TUuid, std::string> {
       NO_CONSTRUCTION(CastAs);
 
-      /* TODO */
       static Base::TUuid Do(const std::string &val) {
         return Base::TUuid(val.c_str());
       }
@@ -180,7 +162,6 @@ namespace Orly {
     };  // CastAs<double, int64_t>
 
 
-    /* TODO */
     template <>
     struct CastAs<std::string, Base::TUuid> {
       NO_CONSTRUCTION(CastAs);
@@ -207,12 +188,10 @@ namespace Orly {
       }
     }; // CastAs<RT::TOpt<TVal>, Rt::TOpt<TVal>
 
-    /* TODO */
     template <typename TTo, typename TFrom>
     struct CastAs<Rt::TOpt<TTo>, TFrom> {
       NO_CONSTRUCTION(CastAs);
 
-      /* TODO */
       static Rt::TOpt<TTo> Do(const TFrom &val) {
         return Rt::TOpt<TTo>(CastAs<TTo, TFrom>::Do(val));
       }
@@ -220,36 +199,30 @@ namespace Orly {
     };  // CastAs<Rt::TOpt<TTo>, TFrom>
 
 
-    /* TODO */
     template <typename TTo, typename TFrom>
     struct CastAs<std::vector<TTo>, TFrom> {
       NO_CONSTRUCTION(CastAs);
 
-      /* TODO */
       static std::vector<TTo> Do(const TFrom &val) {
         return {CastAs<TTo, TFrom>::Do(val)};
       }
 
     };  // CastAs<std::vector<TTo>, TFrom>
 
-    /* TODO */
     template <typename TVal>
     struct CastAs<std::vector<TVal>, std::vector<TVal>> {
       NO_CONSTRUCTION(CastAs);
 
-      /* TODO */
       static const std::vector<TVal> &Do(const std::vector<TVal> &val) {
         return val;
       }
 
     };  // CastAs<std::vector<TVal>, std::vector<TVal>>
 
-    /* TODO */
     template <typename TTo, typename TFrom>
     struct CastAs<std::vector<TTo>, std::vector<TFrom>> {
       NO_CONSTRUCTION(CastAs);
 
-      /* TODO */
       static std::vector<TTo> Do(const std::vector<TFrom> &from) {
         std::vector<TTo> to;
         for (auto elem : from) {
@@ -260,12 +233,10 @@ namespace Orly {
 
     };  // CastAs<std::vector<TTo>, std::vector<TFrom>>
 
-    /* TODO */
     template <typename TTo, typename TFrom>
     struct CastAs<std::vector<TTo>, std::shared_ptr<const Rt::TGenerator<TFrom>>> {
       NO_CONSTRUCTION(CastAs);
 
-      /* TODO */
       static std::vector<TTo> Do(const typename Rt::TGenerator<TFrom>::TPtr &val) {
         std::vector<TTo> to;
         for(auto cursor = val->NewCursor(); cursor; ++cursor) {
@@ -276,24 +247,20 @@ namespace Orly {
 
     };  // CastAs<std::vector<TVal>, Rt::TGenerator<TFrom>
 
-    /* TODO */
     template <typename TVal>
     struct CastAs<TSet<TVal>, TSet<TVal>> {
       NO_CONSTRUCTION(CastAs);
 
-      /* TODO */
       static const TSet<TVal> &Do(const TSet<TVal> &val) {
         return val;
       }
 
     };  // CastAs<TSet<TVal>, TSet<TVal>>
 
-    /* TODO */
     template <typename TTo, typename TFrom>
     struct CastAs<TSet<TTo>, TSet<TFrom>> {
       NO_CONSTRUCTION(CastAs);
 
-      /* TODO */
       static TSet<TTo> Do(const TSet<TFrom> &from) {
         TSet<TTo> to;
         for (auto elem : from) {
@@ -304,12 +271,10 @@ namespace Orly {
 
     };  // CastAs<TSet<TTo>, TSet<TFrom>>
 
-    /* TODO */
     template <typename TTo, typename TFrom>
     struct CastAs<TSet<TTo>, std::shared_ptr<const Rt::TGenerator<TFrom>>> {
       NO_CONSTRUCTION(CastAs);
 
-      /* TODO */
       static TSet<TTo> Do(const typename Rt::TGenerator<TFrom>::TPtr &val) {
         TSet<TTo> to;
         for(auto cursor = val->NewCursor(); cursor; ++cursor) {
@@ -320,24 +285,20 @@ namespace Orly {
 
     };  // CastAs<TSet<TVal>, Rt::TGenerator<TFrom>
 
-    /* TODO */
     template <typename TKey, typename TVal>
     struct CastAs<TDict<TKey, TVal>, TDict<TKey, TVal>> {
       NO_CONSTRUCTION(CastAs);
 
-      /* TODO */
       static const TDict<TKey, TVal> &Do(const TDict<TKey, TVal> &val) {
         return val;
       }
 
     };  // CastAs<TDict<TKey, TVal>, TDict<TKey, TVal>>
 
-    /* TODO */
     template <typename TToKey, typename TToVal, typename TFromKey, typename TFromVal>
     struct CastAs<TDict<TToKey, TToVal>, TDict<TFromKey, TFromVal>> {
       NO_CONSTRUCTION(CastAs);
 
-      /* TODO */
       static TDict<TToKey, TToVal> Do(const TDict<TFromKey, TFromVal> &from) {
         TDict<TToKey, TToVal> to;
         for (auto elem : from) {
@@ -349,14 +310,12 @@ namespace Orly {
 
     };  // CastAs<TDict<TToKey, TToVal>, TDict<TFromKey, TFromVal>>
 
-    /* TODO */
     template <typename TToKey, typename TToVal, typename TFromKey, typename TFromVal>
     struct CastAs<TDict<TToKey, TToVal>, std::tuple<TFromKey, TFromVal>> {
       NO_CONSTRUCTION(CastAs);
 
       typedef std::tuple<TFromKey, TFromVal> TFinalTuple;
 
-      /* TODO */
       static TDict<TToKey, TToVal> Do(const TFinalTuple &from) {
         return TDict<TToKey, TToVal>{{CastAs<TToKey, TFromKey>::Do(/*from.template Get<0>()*/std::get<0>(from)),
             CastAs<TToVal, TFromVal>::Do(/*from.template Get<1>()*/std::get<1>(from))}};
@@ -364,7 +323,6 @@ namespace Orly {
 
     };  // CastAs<TDict<TToKey, TToVal>, TDict<TFromKey, TFromVal>>
 
-    /* TODO */
     template <typename TToKey, typename TToVal, typename TFromKey, typename TFromVal>
     struct CastAs<TDict<TToKey, TToVal>,
           std::shared_ptr<const Rt::TGenerator<std::tuple<TFromKey, TFromVal>>>> {
@@ -373,7 +331,6 @@ namespace Orly {
       typedef std::tuple<TFromKey, TFromVal> TFinalTuple;
       typedef std::shared_ptr<const Rt::TGenerator<TFinalTuple>> TTupleGen;
 
-      /* TODO */
       static TDict<TToKey, TToVal> Do(const TTupleGen &from) {
         TDict<TToKey, TToVal> to;
         for(auto it = from->NewCursor(); it; ++it) {

--- a/orly/rt/reverse.h
+++ b/orly/rt/reverse.h
@@ -34,24 +34,20 @@ namespace Orly {
     template <typename TVal>
     TVal Reverse(const TVal &) = delete;
 
-    /* TODO */
     template <typename TVal>
     std::vector<TVal> Reverse(const std::vector<TVal> &val) {
       return std::vector<TVal>(val.rbegin(), val.rend());
     }
 
-    /* TODO */
     template <typename TVal>
     TOpt<std::vector<TVal>> Reverse(const TOpt<std::vector<TVal>> &val) {
       return val.IsKnown() ? TOpt<std::vector<TVal>>(Reverse(val.GetVal())) : TOpt<std::vector<TVal>>();
     }
 
-    /* TODO */
     inline std::string Reverse(const std::string &val) {
       return std::string(val.rbegin(), val.rend());
     }
 
-    /* TODO */
     inline TOpt<std::string> Reverse(const TOpt<std::string> &val) {
       return val.IsKnown() ? TOpt<std::string>(Reverse(val.GetVal())) : TOpt<std::string>();
     }

--- a/orly/rt/shortest_path.h
+++ b/orly/rt/shortest_path.h
@@ -33,7 +33,6 @@ namespace Orly {
 
   namespace Rt {
 
-    /* TODO */
     template <typename TKeyType, typename TSearchType, size_t SrcPos, size_t TargetPos>
     std::vector<std::vector<TKeyType>> BidirShortestPath(Orly::Package::TContext &ctx,
                                                          const size_t num_parallel,

--- a/orly/rt/slice.h
+++ b/orly/rt/slice.h
@@ -31,7 +31,6 @@ namespace Orly {
 
   namespace Rt {
 
-    /* TODO */
     template <typename TVal>
     static TVal SliceSingle(const std::vector<TVal> &container, const int64_t &idx) {
       if (idx < 0 || idx >= static_cast<int64_t>(container.size())) {
@@ -47,7 +46,6 @@ namespace Orly {
       return std::string(container.substr(idx, 1));
     }
 
-    /* TODO */
     template <typename TKey, typename TVal>
     static TVal SliceSingle(const TDict<TKey, TVal> &container, const TKey &idx) {
       auto pos = container.find(idx);
@@ -69,7 +67,6 @@ namespace Orly {
       return RewrapMutable(container, Var::TVar(idx), SliceSingle(container.GetVal(), idx));
     }
 
-    /* TODO */
     template <typename TVal>
     std::vector<TVal> SliceRange(const std::vector<TVal> &container, bool start_range, const int64_t &idx) {
       if (idx < 0 || idx > static_cast<int>(container.size())) {
@@ -79,7 +76,6 @@ namespace Orly {
                          : std::vector<TVal>(container.begin() + idx, container.end());
     }
 
-    /* TODO */
     inline std::string SliceRange(const std::string &container, bool start_range, const int64_t &idx) {
       if (idx < 0 || idx > static_cast<int>(container.size())) {
         throw TSystemError(HERE, "Slice index out of bounds.");
@@ -96,7 +92,6 @@ namespace Orly {
           SliceRange(container.GetVal(), start_range, idx));
     } */
 
-    /* TODO */
     template <typename TVal>
     std::vector<TVal> SliceRangeBoth(const std::vector<TVal> &container, const int64_t &lhs, const int64_t &rhs) {
       if (lhs < 0 || lhs > static_cast<int>(container.size()) ||

--- a/orly/rt/sort.h
+++ b/orly/rt/sort.h
@@ -31,11 +31,9 @@ namespace Orly {
 
   namespace Rt {
 
-    /* TODO */
     template <typename TVal>
     TVal Sort(const TVal &) = delete;
 
-    /* TODO */
     template <typename TVal>
     std::vector<TVal> Sort(const std::vector<TVal> &val,
           const std::function<bool (const TVal &, const TVal &)> &comp) {
@@ -44,7 +42,6 @@ namespace Orly {
       return ret;
     }
 
-    /* TODO */
     template <typename TVal>
     TOpt<std::vector<TVal>> Sort(const TOpt<std::vector<TVal>> &val,
           const std::function<bool (const TVal &, const TVal &)> &comp) {

--- a/orly/rt/unknown.h
+++ b/orly/rt/unknown.h
@@ -29,23 +29,18 @@ namespace Orly {
     class TUnknown {
       public:
 
-      /* TODO */
       virtual size_t GetHash() const {
         return 0;
       }
 
-      /* TODO */
       TUnknown() {}
 
-      /* TODO */
       ~TUnknown() {}
 
-      /* TODO */
       bool operator==(const TUnknown &) const {
         return true;
       }
 
-      /* TODO */
       bool operator!=(const TUnknown &) const {
         return false;
       }

--- a/orly/sabot/all.h
+++ b/orly/sabot/all.h
@@ -37,46 +37,37 @@ namespace Orly {
 
   namespace Sabot {
 
-    /* TODO */
     template <size_t... Sizes>
     class Maxer;
 
-    /* TODO */
     template <size_t Size>
     class Maxer<Size> {
       NO_CONSTRUCTION(Maxer);
       public:
 
-      /* TODO */
       static constexpr size_t Max = Size;
 
     };  // Maxer<Size>
 
-    /* TODO */
     template <size_t Size>
     constexpr size_t Maxer<Size>::Max;
 
-    /* TODO */
     template <size_t Size, size_t... MoreSizes>
     class Maxer<Size, MoreSizes...> {
       NO_CONSTRUCTION(Maxer);
       public:
 
-      /* TODO */
       static constexpr size_t Max = (Size >= Maxer<MoreSizes...>::Max) ? Size : Maxer<MoreSizes...>::Max;
 
     };  // Maxer<Size, MoreSizes...>
 
-    /* TODO */
     template <size_t Size, size_t... MoreSizes>
     constexpr size_t Maxer<Size, MoreSizes...>::Max;
 
-    /* TODO */
     class TSizeChecker {
       NO_CONSTRUCTION(TSizeChecker);
       public:
 
-      /* TODO */
       static constexpr size_t GetMaxTypePinSize() {
         return Maxer<
           sizeof(Native::Type::TDesc<int8_t>::TPin),
@@ -119,7 +110,6 @@ namespace Orly {
         >::Max;
       }
 
-      /* TODO */
       static constexpr size_t GetMaxStatePinSize() {
         return Maxer<
           sizeof(Native::State::TArrayOfScalars<Sabot::State::TBlob>::TPin),

--- a/orly/sabot/assert_tuple.h
+++ b/orly/sabot/assert_tuple.h
@@ -27,7 +27,6 @@ namespace Orly {
 
   namespace Sabot {
 
-    /* TODO */
     const Type::TAny &AssertTuple(const Type::TAny &type);
 
   }  // Sabot

--- a/orly/sabot/compare_states.h
+++ b/orly/sabot/compare_states.h
@@ -33,7 +33,6 @@ namespace Orly {
 
   namespace Sabot {
 
-    /* TODO */
     class TCompareStatesVisitor final
         : public TStateDoubleVisitor {
       public:
@@ -802,41 +801,33 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       template <typename TVal>
       inline void OnScalar(const State::TScalar<TVal> &lhs, const State::TScalar<TVal> &rhs) const;
 
-      /* TODO */
       template <typename TVal>
       inline void OnArrayOfScalars(const State::TArrayOfScalars<TVal> &lhs, const State::TArrayOfScalars<TVal> &rhs) const;
 
-      /* TODO */
       inline void OnArrayOfSingleStates(const State::TArrayOfSingleStates &lhs, const State::TArrayOfSingleStates &rhs) const;
 
-      /* TODO */
       inline void OnArrayOfPairsOfStates(const State::TArrayOfPairsOfStates &lhs, const State::TArrayOfPairsOfStates &rhs) const;
 
       template <typename TVal>
       static inline Atom::TComparison Compare(const TVal &lhs, const TVal &rhs);
 
-      /* TODO */
       Atom::TComparison &Comparison;
 
     };  // TCompareStatesVisitor
 
-    /* TODO */
     template <typename TVal>
     inline Atom::TComparison TCompareStatesVisitor::Compare(const TVal &lhs, const TVal &rhs) {
       return lhs == rhs ? Atom::TComparison::Eq : (lhs < rhs ? Atom::TComparison::Lt : Atom::TComparison::Gt);
     }
 
-    /* TODO */
     template <typename TVal>
     inline void TCompareStatesVisitor::OnScalar(const State::TScalar<TVal> &lhs, const State::TScalar<TVal> &rhs) const {
       Comparison = Compare(lhs.Get(), rhs.Get());
     }
 
-    /* TODO */
     template <typename TVal>
     inline void TCompareStatesVisitor::OnArrayOfScalars(const State::TArrayOfScalars<TVal> &lhs, const State::TArrayOfScalars<TVal> &rhs) const {
       void *lhs_alloc = alloca(State::GetMaxStatePinSize() * 2);
@@ -854,7 +845,6 @@ namespace Orly {
       }
     }
 
-    /* TODO */
     inline void TCompareStatesVisitor::OnArrayOfSingleStates(const State::TArrayOfSingleStates &lhs, const State::TArrayOfSingleStates &rhs) const {
       void *lhs_alloc = alloca(State::GetMaxStatePinSize() * 2);
       void *rhs_alloc = reinterpret_cast<uint8_t *>(lhs_alloc) + State::GetMaxStatePinSize();
@@ -876,7 +866,6 @@ namespace Orly {
       }
     }
 
-    /* TODO */
     inline void TCompareStatesVisitor::OnArrayOfPairsOfStates(const State::TArrayOfPairsOfStates &lhs, const State::TArrayOfPairsOfStates &rhs) const {
       void *lhs_alloc = alloca(State::GetMaxStatePinSize() * 2);
       void *rhs_alloc = reinterpret_cast<uint8_t *>(lhs_alloc) + State::GetMaxStatePinSize();
@@ -907,7 +896,6 @@ namespace Orly {
       }
     }
 
-    /* TODO */
     inline Atom::TComparison CompareStates(const State::TAny &lhs,
                                            const State::TAny &rhs,
                                            void *lhs_type_alloc,

--- a/orly/sabot/compare_types.cc
+++ b/orly/sabot/compare_types.cc
@@ -25,7 +25,6 @@ using namespace Orly;
 using namespace Orly::Atom;
 using namespace Orly::Sabot;
 
-/* TODO */
 class TCompareTypesVisitor final
     : public TTypeDoubleVisitor {
   public:
@@ -797,13 +796,10 @@ class TCompareTypesVisitor final
 
   private:
 
-  /* TODO */
   Atom::TComparison &Comparison;
 
-  /* TODO */
   inline void OnUnary(const Type::TUnary &lhs, const Type::TUnary &rhs) const;
 
-  /* TODO */
   inline void OnBinary(const Type::TBinary &lhs, const Type::TBinary &rhs) const;
 
 };  // TCompareTypesVisitor

--- a/orly/sabot/compare_types.h
+++ b/orly/sabot/compare_types.h
@@ -35,7 +35,6 @@ namespace Orly {
     /* Forward Declaration. */
     Atom::TComparison CompareStates(const State::TAny &lhs, const State::TAny &rhs, void *lhs_type_alloc, void *rhs_type_alloc);
 
-    /* TODO */
     Atom::TComparison CompareTypes(const Type::TAny &lhs, const Type::TAny &rhs);
 
   }  // Sabot

--- a/orly/sabot/get_depth.h
+++ b/orly/sabot/get_depth.h
@@ -28,7 +28,6 @@ namespace Orly {
 
   namespace Sabot {
 
-    /* TODO */
     size_t GetDepth(const Type::TAny &type);
 
   }  // Sabot

--- a/orly/sabot/get_hash.h
+++ b/orly/sabot/get_hash.h
@@ -31,15 +31,12 @@ namespace Orly {
 
   namespace Sabot {
 
-    /* TODO */
     size_t GetHash(const State::TAny &state);
 
-    /* TODO */
     class THashVisitor final
         : public TStateVisitor {
       public:
 
-      /* TODO */
       THashVisitor(size_t &val)
           : Hash(val) {
       }
@@ -75,13 +72,10 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       void OnArrayOfSingle(const State::TArrayOfSingleStates &single) const;
 
-      /* TODO */
       void OnArrayOfPairs(const State::TArrayOfPairsOfStates &that) const;
 
-      /* TODO */
       size_t &Hash;
 
     };  // THashVisitor

--- a/orly/sabot/get_tuple_size.h
+++ b/orly/sabot/get_tuple_size.h
@@ -27,7 +27,6 @@ namespace Orly {
 
   namespace Sabot {
 
-    /* TODO */
     size_t GetTupleSize(const Type::TAny &type);
 
   }  // Sabot

--- a/orly/sabot/match_prefix_state.cc
+++ b/orly/sabot/match_prefix_state.cc
@@ -22,7 +22,6 @@ using namespace std;
 using namespace Orly;
 using namespace Orly::Sabot;
 
-/* TODO */
 class TMatchPrefixStateVisitor final
     : public TStateDoubleVisitor {
   public:
@@ -791,31 +790,23 @@ class TMatchPrefixStateVisitor final
 
   private:
 
-  /* TODO */
   template <typename TVal>
   inline TMatchResult Check(const TVal &lhs, const TVal &rhs) const;
 
-  /* TODO */
   inline void DidNotMatch() const;
 
-  /* TODO */
   inline void DidNotUnify() const;
 
-  /* TODO */
   template <typename TVal>
   inline void OnScalar(const State::TScalar<TVal> &lhs, const State::TScalar<TVal> &rhs) const;
 
-  /* TODO */
   template <typename TVal>
   inline void OnArrayOfScalars(const State::TArrayOfScalars<TVal> &lhs, const State::TArrayOfScalars<TVal> &rhs) const;
 
-  /* TODO */
   inline void OnArrayOfSingleStates(const State::TArrayOfSingleStates &lhs, const State::TArrayOfSingleStates &rhs) const;
 
-  /* TODO */
   inline void OnArrayOfPairsOfStates(const State::TArrayOfPairsOfStates &lhs, const State::TArrayOfPairsOfStates &rhs) const;
 
-  /* TODO */
   TMatchResult &Result;
 
 };  // TMatchPrefixStateVisitor
@@ -874,12 +865,10 @@ inline TMatchResult TMatchPrefixStateVisitor::Check(const TVal &lhs, const TVal 
   return Result;
 }
 
-/* TODO */
 inline void TMatchPrefixStateVisitor::DidNotMatch() const {
   Result = TMatchResult::NoMatch;
 }
 
-/* TODO */
 inline void TMatchPrefixStateVisitor::DidNotUnify() const {
   switch (Result) {
     case TMatchResult::NoMatch: {
@@ -895,13 +884,11 @@ inline void TMatchPrefixStateVisitor::DidNotUnify() const {
   }
 }
 
-/* TODO */
 template <typename TVal>
 inline void TMatchPrefixStateVisitor::OnScalar(const State::TScalar<TVal> &lhs, const State::TScalar<TVal> &rhs) const {
   Check(lhs.Get(), rhs.Get());
 }
 
-/* TODO */
 template <typename TVal>
 inline void TMatchPrefixStateVisitor::OnArrayOfScalars(const State::TArrayOfScalars<TVal> &lhs, const State::TArrayOfScalars<TVal> &rhs) const {
   void *lhs_alloc = alloca(State::GetMaxStatePinSize() * 2);
@@ -915,7 +902,6 @@ inline void TMatchPrefixStateVisitor::OnArrayOfScalars(const State::TArrayOfScal
   Check(comp, 0);
 }
 
-/* TODO */
 inline void TMatchPrefixStateVisitor::OnArrayOfSingleStates(const State::TArrayOfSingleStates &lhs, const State::TArrayOfSingleStates &rhs) const {
   void *lhs_alloc = alloca(State::GetMaxStatePinSize() * 2);
   void *rhs_alloc = reinterpret_cast<uint8_t *>(lhs_alloc) + State::GetMaxStatePinSize();
@@ -937,7 +923,6 @@ inline void TMatchPrefixStateVisitor::OnArrayOfSingleStates(const State::TArrayO
   }
 }
 
-/* TODO */
 inline void TMatchPrefixStateVisitor::OnArrayOfPairsOfStates(const State::TArrayOfPairsOfStates &lhs, const State::TArrayOfPairsOfStates &rhs) const {
   void *lhs_alloc = alloca(State::GetMaxStatePinSize() * 2);
   void *rhs_alloc = reinterpret_cast<uint8_t *>(lhs_alloc) + State::GetMaxStatePinSize();

--- a/orly/sabot/match_prefix_state.h
+++ b/orly/sabot/match_prefix_state.h
@@ -32,7 +32,6 @@ namespace Orly {
 
   namespace Sabot {
 
-    /* TODO */
     TMatchResult MatchPrefixState(const State::TAny &lhs, const State::TAny &rhs);
 
   }  // Sabot

--- a/orly/sabot/match_prefix_type.cc
+++ b/orly/sabot/match_prefix_type.cc
@@ -22,7 +22,6 @@ using namespace std;
 using namespace Orly;
 using namespace Orly::Sabot;
 
-/* TODO */
 class TMatchPrefixTypeVisitor final
     : public TTypeDoubleVisitor {
   public:
@@ -791,22 +790,16 @@ class TMatchPrefixTypeVisitor final
 
   private:
 
-  /* TODO */
   inline void OnUnary(const Type::TUnary &lhs, const Type::TUnary &rhs) const;
 
-  /* TODO */
   inline void OnBinary(const Type::TBinary &lhs, const Type::TBinary &rhs) const;
 
-  /* TODO */
   inline void DidNotMatch() const;
 
-  /* TODO */
   inline void DidNotUnify() const;
 
-  /* TODO */
   inline void OnFree(const Type::TFree &lhs, const Type::TAny &rhs) const;
 
-  /* TODO */
   TMatchResult &Result;
 
 };  // TMatchPrefixTypeVisitor
@@ -842,12 +835,10 @@ inline void TMatchPrefixTypeVisitor::OnBinary(const Type::TBinary &lhs, const Ty
   }
 }
 
-/* TODO */
 inline void TMatchPrefixTypeVisitor::DidNotMatch() const {
   Result = TMatchResult::NoMatch;
 }
 
-/* TODO */
 inline void TMatchPrefixTypeVisitor::DidNotUnify() const {
   switch (Result) {
     case TMatchResult::NoMatch: {
@@ -863,7 +854,6 @@ inline void TMatchPrefixTypeVisitor::DidNotUnify() const {
   }
 }
 
-/* TODO */
 inline void TMatchPrefixTypeVisitor::OnFree(const Type::TFree &lhs, const Type::TAny &rhs) const {
   TMatchResult cur = TMatchResult::Unifies;
   void *lhs_pin_alloc = alloca(Sabot::Type::GetMaxTypePinSize());

--- a/orly/sabot/match_prefix_type.h
+++ b/orly/sabot/match_prefix_type.h
@@ -80,7 +80,6 @@ namespace Orly {
       throw;
     }
 
-    /* TODO */
     TMatchResult MatchPrefixType(const Type::TAny &lhs_any, const Type::TAny &rhs_any);
 
   }  // Sabot

--- a/orly/sabot/order_states.h
+++ b/orly/sabot/order_states.h
@@ -32,7 +32,6 @@ namespace Orly {
 
   namespace Sabot {
 
-    /* TODO */
     class TOrderStatesVisitor final
         : public TStateDoubleVisitor {
       public:
@@ -801,41 +800,33 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       template <typename TVal>
       inline void OnScalar(const State::TScalar<TVal> &lhs, const State::TScalar<TVal> &rhs) const;
 
-      /* TODO */
       template <typename TVal>
       inline void OnArrayOfScalars(const State::TArrayOfScalars<TVal> &lhs, const State::TArrayOfScalars<TVal> &rhs) const;
 
-      /* TODO */
       inline void OnArrayOfSingleStates(const State::TArrayOfSingleStates &lhs, const State::TArrayOfSingleStates &rhs) const;
 
-      /* TODO */
       inline void OnArrayOfPairsOfStates(const State::TArrayOfPairsOfStates &lhs, const State::TArrayOfPairsOfStates &rhs) const;
 
       template <typename TVal>
       static inline Atom::TComparison Compare(const TVal &lhs, const TVal &rhs);
 
-      /* TODO */
       Atom::TComparison &Comparison;
 
     };  // TOrderStatesVisitor
 
-    /* TODO */
     template <typename TVal>
     inline Atom::TComparison TOrderStatesVisitor::Compare(const TVal &lhs, const TVal &rhs) {
       return lhs == rhs ? Atom::TComparison::Eq : (lhs < rhs ? Atom::TComparison::Lt : Atom::TComparison::Gt);
     }
 
-    /* TODO */
     template <typename TVal>
     inline void TOrderStatesVisitor::OnScalar(const State::TScalar<TVal> &lhs, const State::TScalar<TVal> &rhs) const {
       Comparison = Compare(lhs.Get(), rhs.Get());
     }
 
-    /* TODO */
     template <typename TVal>
     inline void TOrderStatesVisitor::OnArrayOfScalars(const State::TArrayOfScalars<TVal> &lhs, const State::TArrayOfScalars<TVal> &rhs) const {
       void *lhs_alloc = alloca(State::GetMaxStatePinSize());
@@ -853,7 +844,6 @@ namespace Orly {
       }
     }
 
-    /* TODO */
     inline void TOrderStatesVisitor::OnArrayOfSingleStates(const State::TArrayOfSingleStates &lhs, const State::TArrayOfSingleStates &rhs) const {
       void *lhs_alloc = alloca(State::GetMaxStatePinSize());
       void *rhs_alloc = alloca(State::GetMaxStatePinSize());
@@ -875,7 +865,6 @@ namespace Orly {
       }
     }
 
-    /* TODO */
     inline void TOrderStatesVisitor::OnArrayOfPairsOfStates(const State::TArrayOfPairsOfStates &lhs, const State::TArrayOfPairsOfStates &rhs) const {
       void *lhs_alloc = alloca(State::GetMaxStatePinSize());
       void *rhs_alloc = alloca(State::GetMaxStatePinSize());
@@ -906,7 +895,6 @@ namespace Orly {
       }
     }
 
-    /* TODO */
     inline Atom::TComparison OrderStates(const State::TAny &lhs, const State::TAny &rhs) {
       void *lhs_type_alloc = alloca(State::GetMaxStatePinSize());
       void *rhs_type_alloc = alloca(State::GetMaxStatePinSize());

--- a/orly/sabot/order_types.cc
+++ b/orly/sabot/order_types.cc
@@ -24,7 +24,6 @@ using namespace Orly;
 using namespace Orly::Atom;
 using namespace Orly::Sabot;
 
-/* TODO */
 class TOrderTypesVisitor final
     : public TTypeDoubleVisitor {
   public:
@@ -796,27 +795,20 @@ class TOrderTypesVisitor final
 
   private:
 
-  /* TODO */
   inline void OnUnary(const Type::TUnary &lhs, const Type::TUnary &rhs) const;
 
-  /* TODO */
   inline void OnBinary(const Type::TBinary &lhs, const Type::TBinary &rhs) const;
 
-  /* TODO */
   void OnWithFree(const Type::TAny &lhs, const Type::TFree &rhs) const;
 
-  /* TODO */
   void OnWithOpt(const Type::TAny &lhs, const Type::TOpt &rhs) const;
 
-  /* TODO */
   static void Reverse(Atom::TComparison &comp);
 
-  /* TODO */
   Atom::TComparison &Comparison;
 
 };  // TOrderTypesVisitor
 
-/* TODO */
 /* See the matching note in compare_types.cc: equal de Bruijn depth => equal
    recursive leaves; a leaf orders before any non-leaf, consistently. */
 void TOrderTypesVisitor::OnSelfRef(const Type::TAny &lhs, const Type::TAny &rhs) const {

--- a/orly/sabot/order_types.h
+++ b/orly/sabot/order_types.h
@@ -32,10 +32,8 @@ namespace Orly {
 
   namespace Sabot {
 
-    /* TODO */
     Atom::TComparison OrderStates(const State::TAny &lhs, const State::TAny &rhs);
 
-    /* TODO */
     Atom::TComparison OrderTypes(const Type::TAny &lhs, const Type::TAny &rhs);
 
   }  // Sabot

--- a/orly/sabot/state.cc
+++ b/orly/sabot/state.cc
@@ -105,17 +105,14 @@ namespace Orly {
 
   namespace Sabot {
 
-    /* TODO */
     template <typename TLhs>
     class TRhsStateVisitor
         : public TStateVisitor {
       public:
 
-      /* TODO */
       TRhsStateVisitor(const TLhs &lhs, const TStateDoubleVisitor &double_visitor)
           : Lhs(lhs), DoubleVisitor(double_visitor) {}
 
-      /* TODO */
       virtual void operator()(const State::TFree &rhs      ) const { DoubleVisitor(Lhs, rhs); }
       virtual void operator()(const State::TTombstone &rhs ) const { DoubleVisitor(Lhs, rhs); }
       virtual void operator()(const State::TVoid &rhs      ) const { DoubleVisitor(Lhs, rhs); }
@@ -146,26 +143,21 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       const TLhs &Lhs;
 
-      /* TODO */
       const TStateDoubleVisitor &DoubleVisitor;
 
     };  // TRhsStateVisitor<TLhs>
 
-    /* TODO */
     class TLhsStateVisitor
         : public TStateVisitor {
       public:
 
-      /* TODO */
       TLhsStateVisitor(const State::TAny &rhs, const TStateDoubleVisitor &double_visitor)
           : Rhs(rhs), DoubleVisitor(double_visitor) {}
 
       virtual ~TLhsStateVisitor() {}
 
-      /* TODO */
       virtual void operator()(const State::TFree &lhs      ) const { Rhs.Accept(TRhsStateVisitor<State::TFree     >(lhs, DoubleVisitor)); }
       virtual void operator()(const State::TTombstone &lhs ) const { Rhs.Accept(TRhsStateVisitor<State::TTombstone>(lhs, DoubleVisitor)); }
       virtual void operator()(const State::TVoid &lhs      ) const { Rhs.Accept(TRhsStateVisitor<State::TVoid     >(lhs, DoubleVisitor)); }
@@ -196,10 +188,8 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       const State::TAny &Rhs;
 
-      /* TODO */
       const TStateDoubleVisitor &DoubleVisitor;
 
     };  // TLhsStateVisitor

--- a/orly/sabot/state.h
+++ b/orly/sabot/state.h
@@ -78,37 +78,30 @@ namespace Orly {
       class TRecord;
       class TTuple;
 
-      /* TODO */
       static constexpr size_t GetMaxStatePinSize() { return 88; }
       static constexpr size_t GetMaxStateSize() { return 48; }
 
-      /* TODO */
       template <typename TVal>
       class TPinWrapper {
         NO_COPY(TPinWrapper);
         public:
 
-        /* TODO */
         TPinWrapper(TVal *pin) : Pin(pin) {}
 
-        /* TODO */
         ~TPinWrapper() {
           Pin->~TVal();
         }
 
-        /* TODO */
         TVal *operator->() const {
           return Pin;
         }
 
-        /* TODO */
         TVal *get() const {
           return Pin;
         }
 
         private:
 
-        /* TODO */
         TVal *Pin;
 
       };  // TPinWrapper
@@ -122,42 +115,34 @@ namespace Orly {
         NO_COPY(TAny);
         public:
 
-        /* TODO */
         class TWrapper {
           NO_COPY(TWrapper);
           public:
 
-          /* TODO */
           TWrapper(TAny *any) : Any(any) {}
 
-          /* TODO */
           ~TWrapper() {
             Any->~TAny();
           }
 
-          /* TODO */
           TAny *operator->() const {
             return Any;
           }
 
-          /* TODO */
           const TAny &operator*() const {
             return *Any;
           }
 
-          /* TODO */
           operator TAny *() const {
             return Any;
           }
 
-          /* TODO */
           TAny *get() const {
             return Any;
           }
 
           private:
 
-          /* TODO */
           TAny *Any;
 
         };  // TWrapper
@@ -165,7 +150,6 @@ namespace Orly {
         /* Do-little. */
         virtual ~TAny() {}
 
-        /* TODO */
         virtual void Accept(const TStateVisitor &visitor) const = 0;
 
         /* Override to return the type object associated with this state. */
@@ -214,7 +198,6 @@ namespace Orly {
           NO_COPY(TPin);
           public:
 
-          /* TODO */
           using TWrapper = TPinWrapper<TPin>;
 
           /* Do-little. */
@@ -275,7 +258,6 @@ namespace Orly {
           NO_COPY(TPin);
           public:
 
-          /* TODO */
           using TWrapper = TPinWrapper<TPin>;
 
           /* Do-little. */
@@ -337,7 +319,6 @@ namespace Orly {
           NO_COPY(TPin);
           public:
 
-          /* TODO */
           using TWrapper = TPinWrapper<TPin>;
 
           /* Do-little. */
@@ -528,12 +509,10 @@ namespace Orly {
 
     };  // State
 
-    /* TODO */
     class TStateVisitor {
       NO_COPY(TStateVisitor);
       public:
 
-      /* TODO */
       virtual ~TStateVisitor() {}
 
       virtual void operator()(const State::TFree &rhs      ) const = 0;
@@ -566,17 +545,14 @@ namespace Orly {
 
       protected:
 
-      /* TODO */
       TStateVisitor() {}
 
     };  // TStateVisitor
 
-    /* TODO */
     class TStateDoubleVisitor {
       NO_COPY(TStateDoubleVisitor);
       public:
 
-      /* TODO */
       virtual ~TStateDoubleVisitor() {}
 
       /* Overrides. */
@@ -1338,7 +1314,6 @@ namespace Orly {
 
       protected:
 
-      /* TODO */
       TStateDoubleVisitor() {}
 
     };  // TStateDoubleVisitor

--- a/orly/sabot/state_dumper.h
+++ b/orly/sabot/state_dumper.h
@@ -71,13 +71,10 @@ namespace Orly {
       /* The stream to which we dump. */
       std::ostream &Strm;
 
-      /* TODO */
       void OnArrayOfPairsOfStates(const char *name, const char *kwd_for_zero_size, const State::TArrayOfPairsOfStates &state) const;
 
-      /* TODO */
       void OnArrayOfSingleStates(const char *name, const char *kwd_for_zero_size, const State::TArrayOfSingleStates &state) const;
 
-      /* TODO */
       void OnContainerOfSingleStates(const char *name, const State::TArrayOfSingleStates &state) const;
 
     };  // TTypeDumper

--- a/orly/sabot/to_native.h
+++ b/orly/sabot/to_native.h
@@ -34,17 +34,14 @@ namespace Orly {
 
     DEFINE_ERROR(TInvalidConversion, std::runtime_error, "Unable to convert sabot to given native type");
 
-    /* TODO */
     template <typename TVal>
     class TToNativeVisitor;
 
-    /* TODO */
     template <typename TVal>
     void ToNative(const Sabot::State::TAny &state, TVal &val) {
       state.Accept(TToNativeVisitor<TVal>(val));
     }
 
-    /* TODO */
     template <typename TVal>
     TVal AsNative(const Sabot::State::TAny &state) {
       TVal val;
@@ -57,7 +54,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(int8_t &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -96,7 +92,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(int16_t &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -135,7 +130,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(int32_t &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -174,7 +168,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(int64_t &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -213,7 +206,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(uint8_t &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -252,7 +244,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(uint16_t &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -291,7 +282,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(uint32_t &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -330,7 +320,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(uint64_t &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -369,7 +358,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(bool &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -408,7 +396,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(char &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -447,7 +434,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(float &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -487,7 +473,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(double &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -526,7 +511,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(Sabot::TStdDuration &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -565,7 +549,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(Sabot::TStdTimePoint &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -604,7 +587,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(Base::TUuid &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -643,7 +625,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(std::string &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -686,7 +667,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(Native::TBlob &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -730,7 +710,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(std::optional<TVal> &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -780,7 +759,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(Rt::TOpt<TVal> &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -830,7 +808,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(Orly::TDesc<TVal> &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -875,7 +852,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(std::vector<TVal> &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -925,7 +901,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(std::vector<bool> &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -975,7 +950,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(std::set<TVal, TCompare> &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }
@@ -1024,7 +998,6 @@ namespace Orly {
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(std::map<TLhs, TRhs, TCompare> &out) : Out(out) {
         out.clear();
       }
@@ -1071,38 +1044,31 @@ namespace Orly {
       std::map<TLhs, TRhs, TCompare> &Out;
     };  // TToNativeVisitor<std::map<TLhs, TRhs, TCompare>>
 
-    /* TODO */
     template <typename TMyTuple, size_t pos, typename... TElems>
     class TTupleExtractor;
 
-    /* TODO */
     template <typename TMyTuple, size_t pos, typename TElem, typename... TElems>
     class TTupleExtractor<TMyTuple, pos, TElem, TElems...> {
       NO_CONSTRUCTION(TTupleExtractor);
       public:
-      /* TODO */
       void static Extract(const State::TTuple::TPin *pin, TMyTuple &out, void *state_alloc) {
         ToNative(*Sabot::State::TAny::TWrapper(pin->NewElem(pos, state_alloc)), std::get<pos>(out));
         TTupleExtractor<TMyTuple, pos + 1, TElems...>::Extract(pin, out, state_alloc);
       }
     };  // TTupleExtractor<TMyTuple, pos, TElem, TElems...>
 
-    /* TODO */
     template <typename TMyTuple, size_t pos>
     class TTupleExtractor<TMyTuple, pos> {
       NO_CONSTRUCTION(TTupleExtractor);
       public:
-      /* TODO */
       void static Extract(const State::TTuple::TPin */*pin*/, TMyTuple &/*out*/, void */*state_alloc*/) {}
     };  // TTupleExtractor<TMyTuple, pos>
 
-    /* TODO */
     template <typename... TElems>
     class TToNativeVisitor<std::tuple<TElems...>> final
         : public TStateVisitor {
       NO_COPY(TToNativeVisitor);
       public:
-      /* TODO */
       TToNativeVisitor(std::tuple<TElems...> &out) : Out(out) {}
       /* Overrides. */
       virtual void operator()(const State::TFree &/*state*/) const override       { THROW_ERROR(TInvalidConversion); }

--- a/orly/sabot/type.cc
+++ b/orly/sabot/type.cc
@@ -100,17 +100,14 @@ namespace Orly {
 
   namespace Sabot {
 
-    /* TODO */
     template <typename TLhs>
     class TRhsTypeVisitor
         : public TTypeVisitor {
       public:
 
-      /* TODO */
       TRhsTypeVisitor(const TLhs &lhs, const TTypeDoubleVisitor &double_visitor)
           : Lhs(lhs), DoubleVisitor(double_visitor) {}
 
-      /* TODO */
       virtual void operator()(const Type::TInt8 &rhs     ) const { DoubleVisitor(Lhs, rhs); }
       virtual void operator()(const Type::TInt16 &rhs    ) const { DoubleVisitor(Lhs, rhs); }
       virtual void operator()(const Type::TInt32 &rhs    ) const { DoubleVisitor(Lhs, rhs); }
@@ -141,26 +138,21 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       const TLhs &Lhs;
 
-      /* TODO */
       const TTypeDoubleVisitor &DoubleVisitor;
 
     };  // TRhsTypeVisitor<TLhs>
 
-    /* TODO */
     class TLhsVisitor
         : public TTypeVisitor {
       public:
 
-      /* TODO */
       TLhsVisitor(const Type::TAny &rhs, const TTypeDoubleVisitor &double_visitor)
           : Rhs(rhs), DoubleVisitor(double_visitor) {}
 
       virtual ~TLhsVisitor() {}
 
-      /* TODO */
       virtual void operator()(const Type::TInt8 &lhs     ) const { Rhs.Accept(TRhsTypeVisitor<Type::TInt8     >(lhs, DoubleVisitor)); }
       virtual void operator()(const Type::TInt16 &lhs    ) const { Rhs.Accept(TRhsTypeVisitor<Type::TInt16    >(lhs, DoubleVisitor)); }
       virtual void operator()(const Type::TInt32 &lhs    ) const { Rhs.Accept(TRhsTypeVisitor<Type::TInt32    >(lhs, DoubleVisitor)); }
@@ -191,10 +183,8 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       const Type::TAny &Rhs;
 
-      /* TODO */
       const TTypeDoubleVisitor &DoubleVisitor;
 
     };  // TLhsVisitor

--- a/orly/sabot/type.h
+++ b/orly/sabot/type.h
@@ -93,47 +93,38 @@ namespace Orly {
       >;  // Sum
       #endif
 
-      /* TODO */
       static constexpr size_t GetMaxTypePinSize() { return 88; }
       static constexpr size_t GetMaxTypeSize() { return 40; }
 
-      /* TODO */
       template <typename TVal>
       class TWrapperBase {
         NO_COPY(TWrapperBase);
         public:
 
-        /* TODO */
         TWrapperBase(TVal *val) : Val(val) {}
 
-        /* TODO */
         ~TWrapperBase() {
           Val->~TVal();
         }
 
-        /* TODO */
         TVal *operator->() const {
           return Val;
         }
 
-        /* TODO */
         const TVal &operator*() const {
           return *Val;
         }
 
-        /* TODO */
         operator TVal *() const {
           return Val;
         }
 
-        /* TODO */
         TVal *get() const {
           return Val;
         }
 
         private:
 
-        /* TODO */
         TVal *Val;
 
       };  // TWrapperBase
@@ -147,13 +138,11 @@ namespace Orly {
         NO_COPY(TAny);
         public:
 
-        /* TODO */
         using TWrapper = TWrapperBase<TAny>;
 
         /* Do-little. */
         virtual ~TAny() {}
 
-        /* TODO */
         virtual void Accept(const TTypeVisitor &vistor) const = 0;
 
         /* True iff this is the recursive back-reference leaf (Type::TSelfRef,
@@ -177,7 +166,6 @@ namespace Orly {
           : public TAny {
         public:
 
-        /* TODO */
         using TWrapper = TWrapperBase<TUnary>;
 
         /* Keeps the array in memory. */
@@ -185,7 +173,6 @@ namespace Orly {
           NO_COPY(TPin);
           public:
 
-          /* TODO */
           using TWrapper = TWrapperBase<TPin>;
 
           /* Do-little. */
@@ -221,7 +208,6 @@ namespace Orly {
           : public TAny {
         public:
 
-        /* TODO */
         using TWrapper = TWrapperBase<TBinary>;
 
         /* Keeps the array in memory. */
@@ -229,7 +215,6 @@ namespace Orly {
           NO_COPY(TPin);
           public:
 
-          /* TODO */
           using TWrapper = TWrapperBase<TPin>;
 
           /* Do-little. */
@@ -268,7 +253,6 @@ namespace Orly {
           : public TAny {
         public:
 
-        /* TODO */
         using TWrapper = TWrapperBase<TNAry>;
 
         /* Override to return the number of elements in the type. */
@@ -384,7 +368,6 @@ namespace Orly {
           : public TNAry {
         public:
 
-        /* TODO */
         using TWrapper = TWrapperBase<TRecord>;
 
         /* See TAny. */
@@ -395,7 +378,6 @@ namespace Orly {
           NO_COPY(TPin);
           public:
 
-          /* TODO */
           using TWrapper = TWrapperBase<TPin>;
 
           /* Do-little. */
@@ -445,7 +427,6 @@ namespace Orly {
           : public TNAry {
         public:
 
-        /* TODO */
         using TWrapper = TWrapperBase<TTuple>;
 
         /* The type of our callback. */
@@ -459,7 +440,6 @@ namespace Orly {
           NO_COPY(TPin);
           public:
 
-          /* TODO */
           using TWrapper = TWrapperBase<TPin>;
 
           /* Do-little. */
@@ -500,12 +480,10 @@ namespace Orly {
 
     };  // Type
 
-    /* TODO */
     class TTypeVisitor {
       NO_COPY(TTypeVisitor);
       public:
 
-      /* TODO */
       virtual ~TTypeVisitor() {}
 
       virtual void operator()(const Type::TInt8 &rhs     ) const = 0;
@@ -545,18 +523,15 @@ namespace Orly {
 
       protected:
 
-      /* TODO */
       TTypeVisitor() {}
 
     };  // TTypeVisitor
 
 
-    /* TODO */
     class TTypeDoubleVisitor {
       NO_COPY(TTypeDoubleVisitor);
       public:
 
-      /* TODO */
       virtual ~TTypeDoubleVisitor() {}
 
       /* double visitor */
@@ -1325,7 +1300,6 @@ namespace Orly {
 
       protected:
 
-      /* TODO */
       TTypeDoubleVisitor() {}
 
     };  // TTypeDoubleVisitor

--- a/orly/server/failover_balancer.cc
+++ b/orly/server/failover_balancer.cc
@@ -36,7 +36,6 @@ class TCmd final
     Parse(argc, argv, TMeta());
   }
 
-  /* TODO  */
   Socket::TAddress Server1Addr;
   Socket::TAddress Server2Addr;
 

--- a/orly/server/meta_record.h
+++ b/orly/server/meta_record.h
@@ -34,34 +34,27 @@ namespace Orly {
 
   namespace Server {
 
-    /* TODO */
     class TMetaRecord {
       public:
 
-      /* TODO */
       class TEntry {
         public:
 
-        /* TODO */
         using TPackageFqName = std::vector<std::string>;
 
-        /* TODO */
         using TArgByName = std::map<std::string, Var::TVar>;
 
         /* Why not vector of bool?  Because up yours, STL explicit specialization with weird return types on operator[], that's why. */
         using TExpectedPredicateResults = std::vector<uint8_t>;
 
-        /* TODO */
         TEntry() {}
 
-        /* TODO */
         TEntry(
             const Base::TUuid &session_id, const std::optional<Base::TUuid> &user_id, const TPackageFqName &package_fq_name, const std::string &method_name, TArgByName &&arg_by_name,
             TExpectedPredicateResults &&expected_predicate_results, Base::Chrono::TTimePnt now, uint32_t random_seed)
             : SessionId(session_id), UserId(user_id), PackageFqName(package_fq_name), MethodName(method_name), ArgByName(std::move(arg_by_name)),
               ExpectedPredicateResults(std::move(expected_predicate_results)), RunTimestamp(now), RandomSeed(random_seed) {}
 
-        /* TODO */
         const TArgByName &GetArgByName() const {
           return ArgByName;
         }
@@ -70,12 +63,10 @@ namespace Orly {
           return ExpectedPredicateResults;
         }
 
-        /* TODO */
         const std::string &GetMethodName() const {
           return MethodName;
         }
 
-        /* TODO */
         const TPackageFqName &GetPackageFqName() const {
           return PackageFqName;
         }
@@ -88,66 +79,50 @@ namespace Orly {
           return RunTimestamp;
         }
 
-        /* TODO */
         const Base::TUuid &GetSessionId() const {
           return SessionId;
         }
 
-        /* TODO */
         const std::optional<Base::TUuid> &GetUserId() const {
           return UserId;
         }
 
         private:
 
-        /* TODO */
         Base::TUuid SessionId;
 
-        /* TODO */
         std::optional<Base::TUuid> UserId;
 
-        /* TODO */
         TPackageFqName PackageFqName;
 
-        /* TODO */
         std::string MethodName;
 
-        /* TODO */
         TArgByName ArgByName;
 
-        /* TODO */
         TExpectedPredicateResults ExpectedPredicateResults;
 
-        /* TODO */
         Base::Chrono::TTimePnt RunTimestamp;
 
-        /* TODO */
         uint32_t RandomSeed;
 
       };  // TMetaRecord::TEntry
 
-      /* TODO */
       using TEntryByUpdateId = std::map<Base::TUuid, TEntry>;
 
-      /* TODO */
       TMetaRecord() {}
 
-      /* TODO */
       TMetaRecord(const Base::TUuid &update_id, TEntry &&entry) {
         EntryByUpdateId.insert(std::make_pair(update_id, std::forward<TEntry>(entry)));
       }
 
-      /* TODO */
       const TEntry &GetEntry(const Base::TUuid &id) const;
 
-      /* TODO */
       const TEntryByUpdateId &GetEntryByUpdateId() const {
         return EntryByUpdateId;
       }
 
       private:
 
-      /* TODO */
       TEntryByUpdateId EntryByUpdateId;
 
     };  // TMetaRecord

--- a/orly/server/pov.h
+++ b/orly/server/pov.h
@@ -33,16 +33,13 @@ namespace Orly {
         : public Durable::TObj {
       public:
 
-      /* TODO */
       class TServer {
         public:
 
         virtual ~TServer() {}
 
-        /* TODO */
         virtual const Indy::L0::TManager::TPtr<Indy::TRepo> &GetGlobalRepo() const = 0;
 
-        /* TODO */
         virtual Orly::Indy::TManager *GetRepoManager() const = 0;
 
         protected:
@@ -84,7 +81,6 @@ namespace Orly {
         return Audience;
       }
 
-      /* TODO */
       virtual const char *GetKind() const noexcept override {
         return "Pov";
       }

--- a/orly/server/repo_tetris_manager.h
+++ b/orly/server/repo_tetris_manager.h
@@ -35,12 +35,10 @@ namespace Orly {
 
   namespace Server {
 
-    /* TODO */
     class TRepoTetrisManager final
         : public TTetrisManager {
       public:
 
-      /* TODO */
       TRepoTetrisManager(
           Base::TScheduler *scheduler,
           Indy::Fiber::TRunner::TRunnerCons &runner_cons,
@@ -53,10 +51,8 @@ namespace Orly {
           bool log_assertion_failures,
           bool commutative_fastlane = false);
 
-      /* TODO */
       virtual ~TRepoTetrisManager();
 
-      /* TODO */
       std::atomic<size_t> PushCount;
       std::atomic<size_t> PopCount;
       std::atomic<size_t> FailCount;
@@ -71,7 +67,6 @@ namespace Orly {
       /* If true, promote ALL ready assertion-free children per round (#234). */
       const bool CommutativeFastlane;
 
-      /* TODO */
       Base::TSigmaCalc TetrisSnapshotCPUTime;
       Base::TSigmaCalc TetrisSortCPUTime;
       Base::TSigmaCalc TetrisPlayCPUTime;
@@ -80,35 +75,27 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       class TPlayer final
           : public TTetrisManager::TPlayer {
         public:
 
-        /* TODO */
         TPlayer(TRepoTetrisManager *repo_tetris_manager, const Base::TUuid &parent_pov_id, const Base::TUuid &child_pov_id, bool is_paused, bool is_master);
 
-        /* TODO */
         virtual ~TPlayer();
 
         private:
 
-        /* TODO */
         class TChild {
           NO_COPY(TChild);
           public:
 
-          /* TODO */
           TChild(TPlayer *player, const Base::TUuid &child_pov_id);
 
-          /* TODO */
           bool Play(
               const std::unique_ptr<Indy::L1::TTransaction, std::function<void (Indy::L1::TTransaction *)>> &transaction, Indy::TContext &context);
 
-          /* TODO */
           bool Refresh(const std::unique_ptr<Indy::L1::TTransaction, std::function<void (Indy::L1::TTransaction *)>> &transaction);
 
-          /* TODO */
           static bool SortsBefore(const TChild *lhs, const TChild *rhs);
 
           /* True iff this child carries no assertions -- every refreshed entry
@@ -133,10 +120,8 @@ namespace Orly {
 
           private:
 
-          /* TODO */
           void Flush();
 
-          /* TODO */
           bool TestAssertions(Indy::TContext &context) const;
 
           /* The player which owns us.  Never null. */
@@ -151,13 +136,10 @@ namespace Orly {
           /* The repo which backs up this child pov. */
           Indy::L0::TManager::TPtr<Indy::TRepo> Repo;
 
-          /* TODO */
           std::shared_ptr<Indy::TUpdate> PeekedUpdate;
 
-          /* TODO */
           TMetaRecord MetaRecord;
 
-          /* TODO */
           std::unordered_map<Base::TUuid, Package::TFuncHolder::TPtr> FuncHolderByUpdateId;
 
         };  // TRepoTetrisManager::TPlayer::TChild
@@ -191,7 +173,6 @@ namespace Orly {
 
       };  // TRepoTetrisManager::TPlayer
 
-      /* TODO */
       virtual TTetrisManager::TPlayer *NewPlayer(const Base::TUuid &parent_pov_id, const Base::TUuid &child_pov_id, bool is_paused, bool is_master) override;
 
       private:
@@ -205,7 +186,6 @@ namespace Orly {
       /* Our manager of durables.  Never null. */
       Durable::TManager *DurableManager;
 
-      /* TODO */
       bool LogAssertionFailures;
 
     };  // TRepoTetrisManager

--- a/orly/server/server.cc
+++ b/orly/server/server.cc
@@ -378,7 +378,6 @@ class TIndexIdReader
 
   using TArena = Orly::Indy::Disk::TDiskArena<Indy::Disk::Util::LogicalPageSize, Indy::Disk::Util::LogicalBlockSize, Indy::Disk::Util::PhysicalBlockSize, Indy::Disk::Util::CheckedPage, 128, true>;
 
-  /* TODO */
   //typedef Indy::Disk::TStream<Indy::Disk::Util::LogicalPageSize, Indy::Disk::Util::LogicalBlockSize, Indy::Disk::Util::PhysicalBlockSize, Indy::Disk::Util::CheckedPage> TInStream;
   typedef Orly::Indy::Disk::TReadFile<Indy::Disk::Util::LogicalPageSize, Indy::Disk::Util::LogicalBlockSize, Indy::Disk::Util::PhysicalBlockSize, Indy::Disk::Util::CheckedPage> TMyReadFile;
 

--- a/orly/server/server.h
+++ b/orly/server/server.h
@@ -54,15 +54,12 @@ namespace Orly {
 
   namespace Server {
 
-    /* TODO */
     class TIndexType {
       public:
 
-      /* TODO */
       TIndexType(std::string &&package_key, Indy::TKey &&val)
           : PackageKey(std::move(package_key)), Val(std::move(val)) {}
 
-      /* TODO */
       inline size_t GetHash() const {
         return Base::ChainHashes(PackageKey, Val);
       }
@@ -75,7 +72,6 @@ namespace Orly {
         return PackageKey;
       }
 
-      /* TODO */
       inline const Indy::TKey &GetVal() const {
         return Val;
       }
@@ -112,58 +108,44 @@ namespace Orly {
     /* Forward Declarations. */
     class TServer;
 
-    /* TODO */
     class TIndyReporter {
       NO_COPY(TIndyReporter);
       public:
 
-      /* TODO */
       TIndyReporter(const TServer *server, Base::TScheduler *scheduler, int port_number);
 
       private:
 
-        /* TODO */
       void AcceptClientConnections();
 
-      /* TODO */
       void ServeClient(Base::TFd &fd);
 
-      /* TODO */
       void AddReport(std::stringstream &ss) const;
 
-      /* TODO */
       const TServer *Server;
 
-      /* TODO */
       Base::TFd Socket;
 
-      /* TODO */
       Base::TScheduler *Scheduler;
 
-      /* TODO */
       mutable Base::TTimer ReportTimer;
 
-      /* TODO */
       typedef std::chrono::system_clock TClock;
 
-      /* TODO */
       typedef std::chrono::time_point<TClock, std::chrono::nanoseconds> TTimePoint;
 
       static const size_t NanoToSecond = 1000000000UL;
 
     };  // TIndyReporter
 
-    /* TODO */
     class TServer final
         : public TSession::TServer, public Indy::Fiber::TRunnable,
           public TWs::TSessionManager {
       NO_COPY(TServer);
       public:
 
-      /* TODO */
       static constexpr size_t NumSlowRunners = 8UL;
 
-      /* TODO */
       using TTimePoint = std::chrono::time_point<std::chrono::system_clock>;
 
       /* Command-line arguments. */
@@ -213,73 +195,51 @@ namespace Orly {
         /* The number of files that can be in a single generation of temporary files before they get merged into the next generation. */
         size_t TempFileConsolidationThreshold;
 
-        /* TODO */
         std::string InstanceName;
 
-        /* TODO */
         size_t PageCacheSizeMB;
 
-        /* TODO */
         size_t BlockCacheSizeMB;
 
-        /* TODO */
         size_t FileServiceAppendLogMB;
 
-        /* TODO */
         size_t DiskMaxAioNum;
 
-        /* TODO */
         double HighDiskUtilizationThreshold;
 
-        /* TODO */
         bool DiscardOnCreate;
 
-        /* TODO */
         size_t ReplicationSyncBufMB;
 
-        /* TODO */
         size_t MergeMemInterval;
 
-        /* TODO */
         size_t MergeDiskInterval;
 
-        /* TODO */
         size_t ReplicationInterval;
 
-        /* TODO */
         size_t DurableWriteInterval;
 
-        /* TODO */
         size_t DurableMergeInterval;
 
-        /* TODO */
         std::string StartingState;
 
-        /* TODO */
         size_t NumMemMergeThreads;
 
-        /* TODO */
         size_t NumDiskMergeThreads;
 
         /* The number of threads to use for answering websocket requests. */
         size_t NumWsThreads;
 
-        /* TODO */
         size_t MaxRepoCacheSize;
 
-        /* TODO */
         std::vector<size_t> FastCoreVec;
 
-        /* TODO */
         std::vector<size_t> SlowCoreVec;
 
-        /* TODO */
         std::vector<size_t> DiskControllerCoreVec;
 
-        /* TODO */
         std::vector<size_t> MemMergeCoreVec;
 
-        /* TODO */
         std::vector<size_t> DiskMergeCoreVec;
 
         /* Fill the hardware-derived default core assignment into any of the
@@ -288,10 +248,8 @@ namespace Orly {
            flags override the defaults rather than appending to them (issue #240). */
         void ResolveCoreVecDefaults();
 
-        /* TODO */
         size_t NumFiberFrames;
 
-        /* TODO */
         size_t NumDiskEvents;
 
         /* The port on which we respond to HTTP by giving a status report. */
@@ -310,7 +268,6 @@ namespace Orly {
         /* Controls whether fsync is used when writing to disk */
         bool DoFsync;
 
-        /* TODO */
         bool LogAssertionFailures;
 
         /* If true, the global-POV merge promotes ALL ready commutative
@@ -337,37 +294,29 @@ namespace Orly {
 
         /******** Object Pools ********/
 
-        /* TODO */
         size_t DurableMappingPoolSize;
         size_t DurableMappingEntryPoolSize;
         size_t DurableLayerPoolSize;
         size_t DurableMemEntryPoolSize;
 
-        /* TODO */
         size_t RepoMappingPoolSize;
         size_t RepoMappingEntryPoolSize;
         size_t RepoDataLayerPoolSize;
 
-        /* TODO */
         size_t TransactionMutationPoolSize;
         size_t TransactionPoolSize;
 
-        /* TODO */
         size_t UpdatePoolSize;
         size_t UpdateEntryPoolSize;
 
-        /* TODO */
         size_t DiskBufferBlockPoolSize;
 
         /******** End Object Pools ********/
 
-        /* TODO */
         Socket::TAddress AddressOfMaster;
 
-        /* TODO */
         std::string PackageDirectory;
 
-        /* TODO */
         bool Create;
 
         protected:
@@ -416,7 +365,6 @@ namespace Orly {
         return RepoManager.get();
       }
 
-      /* TODO */
       virtual Base::TScheduler *GetScheduler() const override {
         assert(Scheduler);
         return Scheduler;
@@ -607,16 +555,12 @@ namespace Orly {
 
         };  // TServer::TConnection::TProtocol
 
-        /* TODO */
         TConnection(TServer *server, const Durable::TPtr<TSession> &session);
 
-        /* TODO */
         static void OnRelease(TConnection *connection);
 
-        /* TODO */
         TServer *const Server;
 
-        /* TODO */
         const Durable::TPtr<TSession> Session;
 
       };  // TServer::TConnection
@@ -657,13 +601,11 @@ namespace Orly {
 
       };  // TServer::TSessionPin
 
-      /* TODO */
       class TServeClientRunnable
           : public Indy::Fiber::TRunnable {
         NO_COPY(TServeClientRunnable);
         public:
 
-        /* TODO */
         TServeClientRunnable(TServer *server, Indy::Fiber::TRunner *runner, Base::TFd &&fd, const Socket::TAddress &client_address, bool is_memcache)
             : Server(server),
               Fd(fd),
@@ -679,11 +621,9 @@ namespace Orly {
           }
         }
 
-        /* TODO */
         virtual ~TServeClientRunnable() {
         }
 
-        /* TODO */
         void Serve() {
           if(IsMemcache) {
             Server->ServeMemcacheClient(std::move(Fd), ClientAddress);
@@ -696,17 +636,14 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         TServer *Server;
 
-        /* TODO */
         Base::TThreadLocalGlobalPoolManager<Indy::Fiber::TFrame, size_t, Indy::Fiber::TRunner *>::TThreadLocalPool *FramePool;
         Indy::Fiber::TFrame *Frame;
 
         /* TODO: Push <strm/fd.h> up to here, that should own our Fd and be our common Io library */
         Base::TFd Fd;
 
-        /* TODO */
         const Socket::TAddress ClientAddress;
 
         bool IsMemcache;
@@ -751,19 +688,15 @@ namespace Orly {
       /* Serves a client which speaks the memcached protocol. */
       void ServeMemcacheClient(Base::TFd &&fd, const Socket::TAddress &client_address);
 
-      /* TODO */
       void StateChangeCb(Orly::Indy::TManager::TState state);
 
       /* See <orly/protocol.h>. */
       void UninstallPackage(const std::vector<std::string> &package_name, uint64_t version);
 
-      /* TODO */
       void WaitForSlave();
 
-      /* TODO */
       Indy::Fiber::TFrame *Frame;
 
-      /* TODO */
       std::vector<Indy::Fiber::TFrame *> MergeMemFrameVec;
       std::vector<std::unique_ptr<Indy::Fiber::TRunner>> MergeMemRunnerVec;
       std::vector<Indy::Fiber::TFrame *> MergeDiskFrameVec;
@@ -778,7 +711,6 @@ namespace Orly {
       Indy::Fiber::TRunner WsRunner;
       std::unordered_set<Indy::Fiber::TRunner *> ForEachSchedCallbackExtraSet;
 
-      /* TODO */
       std::unordered_map<TIndexType, Base::TUuid> IndexByIndexId;
       std::unordered_set<Base::TUuid> IndexIdSet;
       Atom::TSuprena IndexMapArena;
@@ -790,16 +722,12 @@ namespace Orly {
       /* Used when not running in memory simulation mode. */
       std::unique_ptr<Indy::Disk::Util::TDiskEngine> DiskEngine;
 
-      /* TODO */
       std::unique_ptr<Orly::Indy::TManager> RepoManager;
 
-      /* TODO */
       Orly::Indy::L0::TManager::TPtr<Indy::TRepo> GlobalRepo;
 
-      /* TODO */
       Orly::Indy::TManager::TState RepoState;
 
-      /* TODO */
       Orly::Package::TManager PackageManager;
 
       /* This is necessary to make the type singletons and interners visible to the packages being loaded. */
@@ -832,16 +760,12 @@ namespace Orly {
       /* All our open connections. */
       std::unordered_map<Base::TUuid, std::weak_ptr<TConnection>> ConnectionBySessionId;
 
-      /* TODO */
       std::unique_ptr<TIndyReporter> Reporter;
 
-      /* TODO */
       std::shared_ptr<Orly::Indy::Disk::TIndyUtilReporter> UtilReporter;
 
-      /* TODO */
       std::shared_ptr<std::function<void (const Base::TFd &)>> WaitForSlaveActionCb;
 
-      /* TODO */
       bool InitFinished;
       std::condition_variable InitCond;
       std::mutex InitMutex;
@@ -852,7 +776,6 @@ namespace Orly {
       /* The thread on which WsRunner runs. */
       std::thread WsThread;
 
-      /* TODO */
       friend class TIndyReporter;
 
     };  // TServer

--- a/orly/server/session.h
+++ b/orly/server/session.h
@@ -53,21 +53,16 @@ namespace Orly {
       /* Convenience. */
       using TNotification = Notification::TNotification;
 
-      /* TODO */
       class TServer
           : public TPov::TServer {
         public:
 
-        /* TODO */
         virtual ~TServer() {}
 
-        /* TODO */
         virtual const std::shared_ptr<Durable::TManager> &GetDurableManager() const = 0;
 
-        /* TODO */
         virtual const Package::TManager &GetPackageManager() const = 0;
 
-        /* TODO */
         virtual Base::TScheduler *GetScheduler() const = 0;
 
         /* Write-backpressure high-watermark (#234); 0 disables. The accept path
@@ -98,16 +93,13 @@ namespace Orly {
 
         protected:
 
-        /* TODO */
         TServer(size_t num_runners) : RunnerCons(num_runners), SlowAssignmentCounter(0UL), FastAssignmentCounter(0UL) {}
 
-        /* TODO */
         void InitalizeFramePoolManager(size_t num_frames, size_t frame_stack_size, Indy::Fiber::TRunner *runner) {
           FramePoolManager = std::unique_ptr<Base::TThreadLocalGlobalPoolManager<Indy::Fiber::TFrame, size_t, Indy::Fiber::TRunner *>>(
             new Base::TThreadLocalGlobalPoolManager<Indy::Fiber::TFrame, size_t, Indy::Fiber::TRunner *>(num_frames, frame_stack_size, runner));
         }
 
-        /* TODO */
         Indy::Fiber::TRunner::TRunnerCons RunnerCons;
         std::vector<std::unique_ptr<Indy::Fiber::TRunner>> SlowRunnerVec;
         std::vector<std::unique_ptr<std::thread>> SlowRunnerThreadVec;
@@ -132,10 +124,8 @@ namespace Orly {
       /* Call back for each pending notification, in order of increasing sequence number. */
       bool ForEachNotification(const std::function<bool (uint32_t, const TNotification *)> &cb) const;
 
-      /* TODO */
       const TNotification *GetFirstNotification(uint32_t &seq_number);
 
-      /* TODO */
       virtual const char *GetKind() const noexcept override {
         return "Session";
       }
@@ -146,7 +136,6 @@ namespace Orly {
         return NotificationBySeqNumber.size();
       }
 
-      /* TODO */
       const Base::TEventSemaphore &GetNotificationSem() const {
         return NotificationSem;
       }
@@ -216,10 +205,8 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       TSession(Durable::TManager *manager, const Base::TUuid &id, const Durable::TTtl &ttl);
 
-      /* TODO */
       TSession(Durable::TManager *manager, const Base::TUuid &id, Io::TBinaryInputStream &strm);
 
       /* Calls Cleanup(). */
@@ -261,10 +248,8 @@ namespace Orly {
       /* Stream out. */
       virtual void Write(Io::TBinaryOutputStream &strm) const override;
 
-      /* TODO */
       void Cleanup();
 
-      /* TODO */
       Base::TUuid NewPov(
           TServer *server, const std::optional<Base::TUuid> &parent_pov_id, TPov::TAudience audience, TPov::TPolicy policy,
           const std::chrono::seconds &time_to_live);

--- a/orly/server/tetris_manager.h
+++ b/orly/server/tetris_manager.h
@@ -61,7 +61,6 @@ namespace Orly {
       /* Cause a player that was previously paused to resume normal operations. */
       void UnpausePlayer(const Base::TUuid &parent_pov_id);
 
-      /* TODO */
       void BecomeMaster();
 
       protected:
@@ -89,10 +88,8 @@ namespace Orly {
         /* Resume normal operations. */
         void Unpause();
 
-        /* TODO */
         void OnClose();
 
-        /* TODO */
         void BecomeMaster();
 
         protected:
@@ -163,7 +160,6 @@ namespace Orly {
         bool Unpaused;
         Indy::Fiber::TSafeSync UnpausedSync;
 
-        /* TODO */
         Base::TEventSemaphore CanWork;
 
         /* The fiber frame used to run our logic. */
@@ -188,7 +184,6 @@ namespace Orly {
       /* Call this in the destructor of your derived tetris manager.  It will block until all tetris has stopped. */
       void StopAllPlayers();
 
-      /* TODO */
       Base::TScheduler *GetScheduler() const {
         return Scheduler;
       }
@@ -216,7 +211,6 @@ namespace Orly {
       /* The ids of the parent points of view which are currently paused. */
       std::unordered_set<Base::TUuid> PausedSet;
 
-      /* TODO */
       bool IsMaster;
       //std::mutex MasterLock;
       Indy::Fiber::TFiberLock MasterFiberMutex;

--- a/orly/server/tetris_manager.test.cc
+++ b/orly/server/tetris_manager.test.cc
@@ -40,7 +40,6 @@ class TTetrisManager final
     : public Orly::Server::TTetrisManager {
   public:
 
-  /* TODO */
   class TPov {
     NO_COPY(TPov);
     public:

--- a/orly/synth/addr_ctor.h
+++ b/orly/synth/addr_ctor.h
@@ -34,36 +34,27 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TAddrCtor
         : public TExpr {
       NO_COPY(TAddrCtor);
       public:
 
-      /* TODO */
       TAddrCtor(const TExprFactory *expr_factory, const Package::Syntax::TAddrCtor *addr_ctor);
 
-      /* TODO */
       virtual ~TAddrCtor();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       void Cleanup();
 
-      /* TODO */
       const Package::Syntax::TAddrCtor *AddrCtor;
 
-      /* TODO */
       std::vector<std::pair<TAddrDir, TExpr *>> Members;
 
     };  // TAddrCtor

--- a/orly/synth/addr_member_expr.h
+++ b/orly/synth/addr_member_expr.h
@@ -28,39 +28,29 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
 
-    /* TODO */
     class TAddrMemberExpr
         : public TExpr {
       NO_COPY(TAddrMemberExpr);
       public:
 
-      /* TODO */
       TAddrMemberExpr(const TExprFactory *expr_factory, const Package::Syntax::TPostfixAddrMember *that);
 
-      /* TODO */
       virtual ~TAddrMemberExpr();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       const Package::Syntax::TPostfixAddrMember *AddrMember;
 
-      /* TODO */
       TExpr *Expr;
 
-      /* TODO */
       size_t Index;
 
     };  // TAddrMemberExpr

--- a/orly/synth/addr_type.h
+++ b/orly/synth/addr_type.h
@@ -31,29 +31,23 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TAddrType
         : public TType {
       NO_COPY(TAddrType);
       public:
 
-      /* TODO */
       TAddrType(const Package::Syntax::TAddrType *addr_type);
 
-      /* TODO */
       virtual ~TAddrType();
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
       void Cleanup();
 
-      /* TODO */
       virtual Type::TType ComputeSymbolicType() const;
 
-      /* TODO */
       std::vector<std::pair<TAddrDir, TType *>> Members;
 
     };  // TType

--- a/orly/synth/affix_expr.h
+++ b/orly/synth/affix_expr.h
@@ -30,39 +30,29 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TAffixExpr
         : public TExpr {
       NO_COPY(TAffixExpr);
       public:
 
-      /* TODO */
       typedef Expr::TExpr::TPtr (*TNew)(const Expr::TExpr::TPtr &expr, const TPosRange &pos_range);
 
-      /* TODO */
       TAffixExpr(TExpr *expr, TNew new_, const TPosRange &pos_range);
 
-      /* TODO */
       virtual ~TAffixExpr();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       TExpr *Expr;
 
-      /* TODO */
       TNew New;
 
-      /* TODO */
       const TPosRange PosRange;
 
     };  // TAffixExpr

--- a/orly/synth/assert_expr.h
+++ b/orly/synth/assert_expr.h
@@ -36,39 +36,29 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
 
-    /* TODO */
     class TAssertExpr
         : public TThatableExpr {
       NO_COPY(TAssertExpr);
       public:
 
-      /* TODO */
       TAssertExpr(const TExprFactory *expr_factory, const Package::Syntax::TAssertExpr *assert_expr);
 
-      /* TODO */
       virtual ~TAssertExpr();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
-      /* TODO */
       const Expr::TAssert::TPtr &GetSymbol() const;
 
-      /* TODO */
       virtual Expr::TThatable::TPtr GetThatableSymbol() const;
 
       private:
 
-      /* TODO */
       class TAssertCase {
         NO_COPY(TAssertCase);
         public:
@@ -91,21 +81,16 @@ namespace Orly {
 
       };  // TAssertCase
 
-      /* TODO */
       typedef std::vector<TAssertCase *> TAssertCaseVec;
 
       void Cleanup();
 
-      /* TODO */
       const Package::Syntax::TAssertExpr *AssertExpr;
 
-      /* TODO */
       TAssertCaseVec AssertCases;
 
-      /* TODO */
       TExpr *Expr;
 
-      /* TODO */
       mutable Expr::TAssert::TPtr Symbol;
 
     };  // TAssertExpr

--- a/orly/synth/atomic_type.h
+++ b/orly/synth/atomic_type.h
@@ -27,27 +27,21 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TAtomicType
         : public TType {
       NO_COPY(TAtomicType);
       public:
 
-      /* TODO */
       typedef Type::TType (*TGet)();
 
-      /* TODO */
       TAtomicType(TGet get);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       virtual Type::TType ComputeSymbolicType() const;
 
-      /* TODO */
       TGet Get;
 
     };  // TType

--- a/orly/synth/binary_type.h
+++ b/orly/synth/binary_type.h
@@ -26,36 +26,27 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TBinaryType
         : public TType {
       NO_COPY(TBinaryType);
       public:
 
-      /* TODO */
       typedef Type::TType (*TGet)(const Type::TType &, const Type::TType &);
 
-      /* TODO */
       TBinaryType(TType *lhs, TType *rhs, TGet get);
 
-      /* TODO */
       virtual ~TBinaryType();
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       virtual Type::TType ComputeSymbolicType() const;
 
-      /* TODO */
       TGet Get;
 
-      /* TODO */
       TType *Lhs;
 
-      /* TODO */
       TType *Rhs;
 
     };  // TType

--- a/orly/synth/collated_by_expr.h
+++ b/orly/synth/collated_by_expr.h
@@ -34,54 +34,40 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
 
-    /* TODO */
     class TCollatedByExpr
         : public TStartableExpr,
           public TThatableExpr {
       NO_COPY(TCollatedByExpr);
       public:
 
-      /* TODO */
       TCollatedByExpr(const TExprFactory *expr_factory, const Package::Syntax::TCollatedByExpr *collated_by_expr);
 
-      /* TODO */
       virtual ~TCollatedByExpr();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
-      /* TODO */
       const Expr::TCollatedBy::TPtr &GetSymbol() const;
 
-      /* TODO */
       virtual Expr::TStartable::TPtr GetStartableSymbol() const;
 
-      /* TODO */
       virtual Expr::TThatable::TPtr GetThatableSymbol() const;
 
       private:
 
-      /* TODO */
       const Package::Syntax::TCollatedByExpr *CollatedByExpr;
 
       TExpr *Seq;
 
-      /* TODO */
       TExpr *Reduce;
 
-      /* TODO */
       TExpr *Having;
 
-      /* TODO */
       mutable Expr::TCollatedBy::TPtr Symbol;
 
     };  // TCollatedByExpr

--- a/orly/synth/collected_by_expr.h
+++ b/orly/synth/collected_by_expr.h
@@ -32,50 +32,37 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
 
-    /* TODO */
     class TCollectedByExpr
         : public TLhsRhsableExpr {
       NO_COPY(TCollectedByExpr);
       public:
 
-      /* TODO */
       TCollectedByExpr(
           const TExprFactory *expr_factory,
           const Package::Syntax::TCollectedByExpr *collected_by_expr);
 
-      /* TODO */
       virtual ~TCollectedByExpr();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
-      /* TODO */
       const Expr::TCollectedBy::TPtr &GetSymbol() const;
 
-      /* TODO */
       virtual Expr::TLhsRhsable::TPtr GetLhsRhsableSymbol() const;
 
       private:
 
-      /* TODO */
       const Package::Syntax::TCollectedByExpr *CollectedByExpr;
 
-      /* TODO */
       TExpr *Lhs;
 
-      /* TODO */
       TExpr *Rhs;
 
-      /* TODO */
       mutable Expr::TCollectedBy::TPtr Symbol;
 
     };  // TCollectedByExpr

--- a/orly/synth/db_keys_expr.h
+++ b/orly/synth/db_keys_expr.h
@@ -35,140 +35,105 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TDbKeysExpr
         : public TExpr {
       NO_COPY(TDbKeysExpr);
       public:
 
-      /* TODO */
       TDbKeysExpr(const TExprFactory *expr_factory, const Package::Syntax::TDbKeysExpr *db_keys_expr);
 
-      /* TODO */
       virtual ~TDbKeysExpr();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
-      /* TODO */
       TType* GetValueType() {
         return ValueType;
       }
 
       private:
 
-      /* TODO */
       class TMember {
         NO_COPY(TMember);
         public:
 
-        /* TODO */
         virtual ~TMember();
 
-        /* TODO */
         virtual Expr::TExpr::TPtr Build() const = 0;
 
-        /* TODO */
         virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb) = 0;
 
-        /* TODO */
         virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb) = 0;
 
-        /* TODO */
         TAddrDir GetAddrDir() const {
           return AddrDir;
         }
 
         protected:
 
-        /* TODO */
         TMember(TAddrDir addr_dir);
 
         private:
 
-        /* TODO */
         TAddrDir AddrDir;
 
       };  // TMember
 
-      /* TODO */
       typedef std::vector<TMember *> TMemberVec;
 
-      /* TODO */
       class TFixedMember
           : public TMember {
         NO_COPY(TFixedMember);
         public:
 
-        /* TODO */
         TFixedMember(TAddrDir addr_dir, TExpr *expr);
 
-        /* TODO */
         virtual ~TFixedMember();
 
-        /* TODO */
         virtual Expr::TExpr::TPtr Build() const;
 
-        /* TODO */
         virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-        /* TODO */
         virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
         private:
 
-        /* TODO */
         TExpr *Expr;
 
       };  // TFixedMember
 
-      /* TODO */
       class TFreeMember
           : public TMember {
         NO_COPY(TFreeMember);
         public:
 
-        /* TODO */
         TFreeMember(TAddrDir addr_dir, TType *type, const TPosRange &pos_range);
 
-        /* TODO */
         virtual ~TFreeMember();
 
-        /* TODO */
         virtual Expr::TExpr::TPtr Build() const;
 
-        /* TODO */
         virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-        /* TODO */
         virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
         private:
 
-        /* TODO */
         TType *Type;
 
-        /* TODO */
         const TPosRange PosRange;
 
       };  // TFreeMember
 
-      /* TODO */
       void Cleanup();
 
-      /* TODO */
       const Package::Syntax::TDbKeysExpr *DbKeysExpr;
 
-      /* TODO */
       TType *ValueType;
 
-      /* TODO */
       TMemberVec Members;
 
     };  // TDbKeysExpr

--- a/orly/synth/def_factory.h
+++ b/orly/synth/def_factory.h
@@ -34,20 +34,16 @@ namespace Orly {
     /* Forward declaration. */
     class TExprFactory;
 
-    /* TODO */
     class TDefFactory
         : public Package::Syntax::TDef::TVisitor {
       public:
 
-      /* TODO */
       virtual ~TDefFactory();
 
       protected:
 
-      /* TODO */
       TDefFactory(const TExprFactory *expr_factory);
 
-      /* TODO */
       void NewDefs(const Package::Syntax::TOptDefSeq *opt_def_seq) const;
 
       virtual void operator()(const Package::Syntax::TInstallerDef *that) const = 0;
@@ -64,7 +60,6 @@ namespace Orly {
       virtual void operator()(const Package::Syntax::TPackageDef *that) const;
       virtual void operator()(const Package::Syntax::TTestDef *that) const;
 
-      /* TODO */
       const TExprFactory *ExprFactory;
 
     };  // TDefFactory

--- a/orly/synth/delete_stmt.h
+++ b/orly/synth/delete_stmt.h
@@ -30,29 +30,22 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExpr;
     class TExprFactory;
 
-    /* TODO */
     class TDeleteStmt
         : public TStmt {
       NO_COPY(TDeleteStmt);
       public:
 
-      /* TODO */
       TDeleteStmt(const TExprFactory *expr_factory, const Package::Syntax::TDeleteStmt *delete_stmt);
 
-      /* TODO */
       virtual ~TDeleteStmt();
 
-      /* TODO */
       virtual Symbol::Stmt::TStmt::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb) const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb) const;
 
       /* Do-little */
@@ -62,10 +55,8 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       const Package::Syntax::TDeleteStmt *DeleteStmt;
 
-      /* TODO */
       TExpr *Expr;
 
       /* The type of the value that is being deleted. */

--- a/orly/synth/dict_ctor.h
+++ b/orly/synth/dict_ctor.h
@@ -33,36 +33,27 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TDictCtor
         : public TExpr {
       NO_COPY(TDictCtor);
       public:
 
-      /* TODO */
       TDictCtor(const TExprFactory *expr_factory, const Package::Syntax::TDictCtor *dict_ctor);
 
-      /* TODO */
       virtual ~TDictCtor();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       void Cleanup();
 
-      /* TODO */
       const Package::Syntax::TDictCtor *DictCtor;
 
-      /* TODO */
       std::unordered_map<TExpr *, TExpr *> Members;
 
     };  // TDictCtor

--- a/orly/synth/effecting_expr.h
+++ b/orly/synth/effecting_expr.h
@@ -31,48 +31,35 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
 
-    /* TODO */
     class TEffectingExpr
         : public TThatableExpr {
       NO_COPY(TEffectingExpr);
       public:
 
-      /* TODO */
       TEffectingExpr(const TExprFactory *expr_factory, const Package::Syntax::TEffectingExpr *effecting_expr);
 
-      /* TODO */
       virtual ~TEffectingExpr();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
-      /* TODO */
       const Expr::TEffect::TPtr &GetSymbol() const;
 
-      /* TODO */
       virtual Expr::TThatable::TPtr GetThatableSymbol() const;
 
       private:
 
-      /* TODO */
       const Package::Syntax::TEffectingExpr *EffectingExpr;
 
-      /* TODO */
       TExpr *Expr;
 
-      /* TODO */
       TStmtBlock *StmtBlock;
 
-      /* TODO */
       mutable Expr::TEffect::TPtr Symbol;
 
     };  // TEffectingExpr

--- a/orly/synth/empty_ctor.h
+++ b/orly/synth/empty_ctor.h
@@ -34,30 +34,23 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TEmptyCtor
         : public TExpr {
       NO_COPY(TEmptyCtor);
       public:
 
-      /* TODO */
       TEmptyCtor(const Package::Syntax::TEmptyCtor *empty_ctor);
 
-      /* TODO */
       virtual ~TEmptyCtor();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       const Package::Syntax::TEmptyCtor *EmptyCtor;
 
-      /* TODO */
       TType *Type;
 
     };  // TEmptyCtor

--- a/orly/synth/exists_ctor.h
+++ b/orly/synth/exists_ctor.h
@@ -35,33 +35,25 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExistsCtor
         : public TExpr {
       NO_COPY(TExistsCtor);
       public:
 
-      /* TODO */
       TExistsCtor(const TExprFactory *expr_factory, const Package::Syntax::TPrefixExists *exists_ctor);
 
-      /* TODO */
       virtual ~TExistsCtor();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       const Package::Syntax::TPrefixExists *ExistsCtor;
 
-      /* TODO */
       TExpr *Expr;
 
-      /* TODO */
       TType *ValueType;
 
     };  // TExistsCtor

--- a/orly/synth/expr.h
+++ b/orly/synth/expr.h
@@ -32,26 +32,20 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExpr {
       NO_COPY(TExpr);
       public:
 
-      /* TODO */
       virtual ~TExpr() {}
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const = 0;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &) {}
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &) {}
 
       protected:
 
-      /* TODO */
       TExpr() {}
 
     };  // TExpr

--- a/orly/synth/filter_expr.h
+++ b/orly/synth/filter_expr.h
@@ -32,48 +32,35 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
 
-    /* TODO */
     class TFilterExpr
         : public TThatableExpr {
       NO_COPY(TFilterExpr);
       public:
 
-      /* TODO */
       TFilterExpr(const TExprFactory *expr_factory, const Package::Syntax::TInfixFilter *infix_filter);
 
-      /* TODO */
       virtual ~TFilterExpr();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
-      /* TODO */
       const Expr::TFilter::TPtr &GetSymbol() const;
 
-      /* TODO */
       virtual Expr::TThatable::TPtr GetThatableSymbol() const;
 
       private:
 
-      /* TODO */
       const Package::Syntax::TInfixFilter *InfixFilter;
 
-      /* TODO */
       TExpr *Lhs;
 
-      /* TODO */
       TExpr *Rhs;
 
-      /* TODO */
       mutable Expr::TFilter::TPtr Symbol;
 
     };  // TFilterExpr

--- a/orly/synth/func_def.h
+++ b/orly/synth/func_def.h
@@ -43,27 +43,21 @@ namespace Orly {
     class TParamFuncDef;
     class TPureFuncDef;
 
-    /* TODO */
     class TFuncDef
         : public TDef {
       NO_COPY(TFuncDef);
       public:
 
-      /* TODO */
       typedef std::unordered_set<TName> TParamNameSet;
 
-      /* TODO */
       virtual ~TFuncDef();
 
-      /* TODO */
       void AddParamName(const TName &name);
 
-      /* TODO */
       Symbol::TFunction::TPtr GetSymbol() const;
 
       protected:
 
-      /* TODO */
       TFuncDef(TScope *scope, const Package::Syntax::TFuncDef *func_def);
 
       /* Build a function def that has no backing CST node -- a synthetic
@@ -72,10 +66,8 @@ namespace Orly {
          See <orly/synth/when_expr.cc>. */
       TFuncDef(TScope *scope, const TName &name, const TPosRange &pos_range);
 
-      /* TODO */
       virtual void BuildSecondarySymbol();
 
-      /* TODO */
       void SetExpr(TExpr *expr);
 
       /* Install the lowered function symbol directly. Used by a subclass whose
@@ -95,39 +87,30 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       virtual TAction Build(int pass);
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
-      /* TODO */
       TExpr *Expr;
 
-      /* TODO */
       TParamNameSet ParamNames;
 
-      /* TODO */
       Symbol::TFunction::TPtr Symbol;
 
     };  // TFuncDef
 
-    /* TODO */
     template <>
     struct TDef::TInfo<TFuncDef> {
       static const char *Name;
     };
 
-    /* TODO */
     class TParamFuncDef
         : public TFuncDef {
       NO_COPY(TParamFuncDef);
       public:
 
-      /* TODO */
       TParamFuncDef(
           const TExprFactory *expr_factory,
           const Package::Syntax::TFuncDef *func_def,
@@ -135,46 +118,36 @@ namespace Orly {
 
       const Symbol::TParamDef::TPtr &GetParamDefSymbol() const;
 
-      /* TODO */
       TType *GetType() const;
 
       private:
 
-      /* TODO */
       void BuildSecondarySymbol();
 
-      /* TODO */
       TFuncDef *EnclosingFunc;
 
-      /* TODO */
       const Package::Syntax::TGivenExpr *GivenExpr;
 
-      /* TODO */
       Symbol::TParamDef::TPtr ParamDefSymbol;
 
-      /* TODO */
       TType *Type;
 
     };  // TParamFuncDef
 
-    /* TODO */
     template <>
     struct TDef::TInfo<TParamFuncDef> {
       static const char *Name;
     };
 
-    /* TODO */
     class TPureFuncDef
         : public TFuncDef {
       NO_COPY(TPureFuncDef);
       public:
 
-      /* TODO */
       TPureFuncDef(const TExprFactory *expr_factory, const Package::Syntax::TFuncDef *func_def);
 
     };  // TPureFuncDef
 
-    /* TODO */
     template <>
     struct TDef::TInfo<TPureFuncDef> {
       static const char *Name;

--- a/orly/synth/given_collector.h
+++ b/orly/synth/given_collector.h
@@ -31,7 +31,6 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TGivenCollector
         : public Package::Syntax::TExpr::TVisitor {
       public:

--- a/orly/synth/given_expr.h
+++ b/orly/synth/given_expr.h
@@ -30,30 +30,23 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TParamFuncDef;
 
-    /* TODO */
     class TGivenExpr
         : public TExpr {
       NO_COPY(TGivenExpr);
       public:
 
-      /* TODO */
       TGivenExpr(const TParamFuncDef *param_func_def, const Package::Syntax::TGivenExpr *given_expr);
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       const Package::Syntax::TGivenExpr *GivenExpr;
 
-      /* TODO */
       const TParamFuncDef *ParamFuncDef;
 
     };  // TGivenExpr

--- a/orly/synth/if_else_expr.h
+++ b/orly/synth/if_else_expr.h
@@ -27,43 +27,33 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TIfElseExpr
         : public TExpr {
       NO_COPY(TIfElseExpr);
       public:
 
-      /* TODO */
       TIfElseExpr(
           TExpr *true_case,
           TExpr *predicate,
           TExpr *false_case,
           const Package::Syntax::TIfExpr *if_expr);
 
-      /* TODO */
       virtual ~TIfElseExpr();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       const Package::Syntax::TIfExpr *IfExpr;
 
-      /* TODO */
       TExpr *FalseCase;
 
-      /* TODO */
       TExpr *Predicate;
 
-      /* TODO */
       TExpr *TrueCase;
 
     };  // TIfElseExpr

--- a/orly/synth/if_stmt.h
+++ b/orly/synth/if_stmt.h
@@ -35,29 +35,22 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExpr;
     class TStmtBlock;
 
-    /* TODO */
     class TIfStmt
         : public TStmt {
       NO_COPY(TIfStmt);
       public:
 
-      /* TODO */
       TIfStmt(const TExprFactory *expr_factory, const Package::Syntax::TIfStmt *if_stmt);
 
-      /* TODO */
       virtual ~TIfStmt();
 
-      /* TODO */
       virtual Symbol::Stmt::TStmt::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb) const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb) const;
 
       private:
@@ -98,16 +91,12 @@ namespace Orly {
 
       typedef std::vector<TIfClause *> TIfClauseVec;
 
-      /* TODO */
       void Cleanup();
 
-      /* TODO */
       const Package::Syntax::TIfStmt *IfStmt;
 
-      /* TODO */
       TIfClauseVec IfClauses;
 
-      /* TODO */
       TStmtBlock *OptElseBlock;
 
     };  // TIfStmt

--- a/orly/synth/import_def.h
+++ b/orly/synth/import_def.h
@@ -40,16 +40,13 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TImportDef
         : public TFuncDef {
       NO_COPY(TImportDef);
       public:
 
-      /* TODO */
       TImportDef(TScope *scope, const Package::Syntax::TImportDef *import_def);
 
-      /* TODO */
       virtual ~TImportDef();
 
       private:
@@ -72,7 +69,6 @@ namespace Orly {
 
     };  // TImportDef
 
-    /* TODO */
     template <>
     struct TDef::TInfo<TImportDef> {
       static const char *Name;

--- a/orly/synth/infix_expr.cc
+++ b/orly/synth/infix_expr.cc
@@ -26,26 +26,22 @@ using namespace Orly::Synth;
 TInfixExpr::TInfixExpr(TExpr *lhs, TExpr *rhs, TNew new_, const TPosRange &pos_range)
     : Lhs(Base::AssertTrue(lhs)), New(new_), Rhs(Base::AssertTrue(rhs)), PosRange(pos_range) {}
 
-/* TODO */
 TInfixExpr::~TInfixExpr() {
   delete Lhs;
   delete Rhs;
 }
 
-/* TODO */
 Expr::TExpr::TPtr TInfixExpr::Build() const {
   assert(Lhs);
   assert(Rhs);
   return New(Lhs->Build(), Rhs->Build(), PosRange);
 }
 
-/* TODO */
 void TInfixExpr::ForEachInnerScope(const std::function<void (TScope *)> &cb) {
   Lhs->ForEachInnerScope(cb);
   Rhs->ForEachInnerScope(cb);
 }
 
-/* TODO */
 void TInfixExpr::ForEachRef(const std::function<void (TAnyRef &)> &cb) {
   Lhs->ForEachRef(cb);
   Rhs->ForEachRef(cb);

--- a/orly/synth/infix_expr.h
+++ b/orly/synth/infix_expr.h
@@ -30,44 +30,33 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TInfixExpr
         : public TExpr {
       NO_COPY(TInfixExpr);
       public:
 
-      /* TODO */
       typedef Expr::TExpr::TPtr (*TNew)(const Expr::TExpr::TPtr &lhs,
                                         const Expr::TExpr::TPtr &rhs,
                                         const TPosRange &pos_range);
 
-      /* TODO */
       TInfixExpr(TExpr *lhs, TExpr *rhs, TNew new_, const TPosRange &pos_range);
 
-      /* TODO */
       virtual ~TInfixExpr();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       TExpr *Lhs;
 
-      /* TODO */
       TNew New;
 
-      /* TODO */
       TExpr *Rhs;
 
-      /* TODO */
       const TPosRange PosRange;
 
     };  // TInfixExpr

--- a/orly/synth/lhs_expr.h
+++ b/orly/synth/lhs_expr.h
@@ -29,28 +29,22 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
     class TLhsRhsableExpr;
 
-    /* TODO */
     class TLhsExpr
         : public TExpr {
       NO_COPY(TLhsExpr);
       public:
 
-      /* TODO */
       TLhsExpr(const TExprFactory *expr_factory, const Package::Syntax::TLhsExpr *lhs_expr);
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
       private:
 
-      /* TODO */
       const Package::Syntax::TLhsExpr *LhsExpr;
 
-      /* TODO */
       const TLhsRhsableExpr *LhsRhsableExpr;
 
     };  // TLhsExpr

--- a/orly/synth/lhsrhsable_expr.h
+++ b/orly/synth/lhsrhsable_expr.h
@@ -39,21 +39,17 @@ namespace Orly {
              The outer expr gets built before rhs expr so that when the special expr gets built,
              we have a outer expr symbol ready for it to point to. */
 
-    /* TODO */
     class TExprFactory;
 
-    /* TODO */
     class TLhsRhsableExpr
         : virtual public TExpr {
       NO_COPY(TLhsRhsableExpr);
       public:
 
-      /* TODO */
       TLhsRhsableExpr() = default;
 
       virtual ~TLhsRhsableExpr() = default;
 
-      /* TODO */
       virtual Expr::TLhsRhsable::TPtr GetLhsRhsableSymbol() const = 0;
 
     };  // TLhsRhsableExpr

--- a/orly/synth/list_ctor.h
+++ b/orly/synth/list_ctor.h
@@ -32,35 +32,27 @@ namespace Orly {
 
     class TExprFactory;
 
-    /* TODO */
     class TListCtor
         : public TExpr {
       NO_COPY(TListCtor);
       public:
 
-      /* TODO */
       TListCtor(const TExprFactory *expr_factory, const Package::Syntax::TListCtor *list_ctor);
 
-      /* TODO */
       virtual ~TListCtor();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
       void Cleanup();
 
-      /* TODO */
       const Package::Syntax::TListCtor *ListCtor;
 
-      /* TODO */
       std::vector<TExpr *> Exprs;
 
     };  // TListCtor

--- a/orly/synth/literal_expr.h
+++ b/orly/synth/literal_expr.h
@@ -28,21 +28,17 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TLiteralExpr
         : public TExpr {
       NO_COPY(TLiteralExpr);
       public:
 
-      /* TODO */
       TLiteralExpr(const Package::Syntax::TLiteralExpr *literal_expr);
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
       private:
 
-      /* TODO */
       const Package::Syntax::TLiteralExpr *LiteralExpr;
 
     };  // TLiteralExpr

--- a/orly/synth/mutate_stmt.h
+++ b/orly/synth/mutate_stmt.h
@@ -31,40 +31,30 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExpr;
     class TExprFactory;
 
-    /* TODO */
     class TMutateStmt
         : public TStmt {
       NO_COPY(TMutateStmt);
       public:
 
-      /* TODO */
       TMutateStmt(const TExprFactory *expr_factory, const Package::Syntax::TMutateStmt *mutate_stmt);
 
-      /* TODO */
       virtual ~TMutateStmt();
 
-      /* TODO */
       virtual Symbol::Stmt::TStmt::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb) const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb) const;
 
       private:
 
-      /* TODO */
       const Package::Syntax::TMutateStmt *MutateStmt;
 
-      /* TODO */
       TExpr *Lhs;
 
-      /* TODO */
       TExpr *Rhs;
 
     };  // TMutateStmt

--- a/orly/synth/new_expr.cc
+++ b/orly/synth/new_expr.cc
@@ -82,7 +82,6 @@ using namespace Orly;
 using namespace Orly::Package;
 using namespace Orly::Synth;
 
-/* TODO */
 TExprFactory::TExprFactory(
     TScope *outer_scope,
     TFuncDef *enclosing_func,

--- a/orly/synth/new_expr.h
+++ b/orly/synth/new_expr.h
@@ -29,17 +29,14 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TParamFuncDef;
     class TLhsRhsableExpr;
     class TStartableExpr;
     class TThatableExpr;
 
-    /* TODO */
     class TExprFactory {
       public:
 
-      /* TODO */
       TExprFactory(
           TScope *outer_scope,
           TFuncDef *enclosing_func = nullptr,
@@ -48,25 +45,18 @@ namespace Orly {
           TStartableExpr *startable_expr = nullptr,
           TThatableExpr *thatable_expr = nullptr);
 
-      /* TODO */
       TExpr *NewExpr(const Package::Syntax::TExpr *root) const;
 
-      /* TODO */
       TFuncDef *EnclosingFunc;
 
-      /* TODO */
       TScope *OuterScope;
 
-      /* TODO */
       TParamFuncDef *ParamFunc;
 
-      /* TODO */
       TLhsRhsableExpr *LhsRhsableExpr;
 
-      /* TODO */
       TStartableExpr *StartableExpr;
 
-      /* TODO */
       TThatableExpr *ThatableExpr;
 
     };  // TExprFactory

--- a/orly/synth/new_stmt.h
+++ b/orly/synth/new_stmt.h
@@ -28,40 +28,30 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExpr;
     class TExprFactory;
 
-    /* TODO */
     class TNewStmt
         : public TStmt {
       NO_COPY(TNewStmt);
       public:
 
-      /* TODO */
       TNewStmt(const TExprFactory *expr_factory, const Package::Syntax::TNewStmt *new_stmt);
 
-      /* TODO */
       virtual ~TNewStmt();
 
-      /* TODO */
       virtual Symbol::Stmt::TStmt::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb) const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb) const;
 
       private:
 
-      /* TODO */
       const Package::Syntax::TNewStmt *NewStmt;
 
-      /* TODO */
       TExpr *Lhs;
 
-      /* TODO */
       TExpr *Rhs;
 
     };  // TNewStmt

--- a/orly/synth/new_type.h
+++ b/orly/synth/new_type.h
@@ -27,7 +27,6 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     TType *NewType(const Package::Syntax::TType *root);
 
   }  // Synth

--- a/orly/synth/now_expr.h
+++ b/orly/synth/now_expr.h
@@ -27,21 +27,17 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TNowExpr
         : public TExpr {
       NO_COPY(TNowExpr);
       public:
 
-      /* TODO */
       TNowExpr(const Package::Syntax::TNowExpr *now_expr);
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
       private:
 
-      /* TODO */
       const Package::Syntax::TNowExpr *NowExpr;
 
     };  // TNowExpr

--- a/orly/synth/obj_ctor.h
+++ b/orly/synth/obj_ctor.h
@@ -35,36 +35,27 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TObjCtor
         : public TExpr {
       NO_COPY(TObjCtor);
       public:
 
-      /* TODO */
       TObjCtor(const TExprFactory *expr_factory, const Package::Syntax::TObjCtor *obj_ctor);
 
-      /* TODO */
       virtual ~TObjCtor();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       void Cleanup();
 
-      /* TODO */
       const Package::Syntax::TObjCtor *ObjCtor;
 
-      /* TODO */
       std::map<TName, TExpr *> Members;
 
     };  // TObjCtor

--- a/orly/synth/obj_member_expr.h
+++ b/orly/synth/obj_member_expr.h
@@ -31,16 +31,13 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
 
-    /* TODO */
     class TObjMemberExpr
         : public TExpr {
       NO_COPY(TObjMemberExpr);
       public:
 
-      /* TODO */
       TObjMemberExpr(const TExprFactory *expr_factory, const Package::Syntax::TPostfixObjMember *postfix_obj_member);
 
       /* Build `<source>.<name>` from an already-synthesized source
@@ -49,16 +46,12 @@ namespace Orly {
          See <orly/synth/when_expr.cc>. */
       TObjMemberExpr(TExpr *source, const TName &name, const TPosRange &pos_range);
 
-      /* TODO */
       virtual ~TObjMemberExpr();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
@@ -66,10 +59,8 @@ namespace Orly {
       /* The backing CST node, or null for the synthesized accessor. */
       const Package::Syntax::TPostfixObjMember *PostfixObjMember;
 
-      /* TODO */
       TExpr *Expr;
 
-      /* TODO */
       TName Name;
 
       /* Source position -- from the CST node when there is one, else

--- a/orly/synth/obj_type.h
+++ b/orly/synth/obj_type.h
@@ -31,29 +31,23 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TObjType
         : public TType {
       NO_COPY(TObjType);
       public:
 
-      /* TODO */
       TObjType(const Package::Syntax::TObjType *obj_type);
 
-      /* TODO */
       virtual ~TObjType();
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
       void Cleanup();
 
-      /* TODO */
       virtual Type::TType ComputeSymbolicType() const;
 
-      /* TODO */
       std::unordered_map<std::string, TType *> Members;
 
     };  // TType

--- a/orly/synth/package.h
+++ b/orly/synth/package.h
@@ -50,7 +50,6 @@ namespace Orly {
       /* Builds the symbol */
       void BuildSymbol();
 
-      /* TODO */
       const Package::TName &GetName() const;
 
       const Package::TName &GetIndexName() const;
@@ -75,7 +74,6 @@ namespace Orly {
         NO_COPY(TTopLevelDefFactory);
         public:
 
-        /* TODO */
         static void NewDefs(
             const TExprFactory *expr_factory,
             const Package::Syntax::TInstallerDef *&installer_def,
@@ -83,14 +81,12 @@ namespace Orly {
 
         private:
 
-        /* TODO */
         TTopLevelDefFactory(const TExprFactory *expr_factory, const Package::Syntax::TInstallerDef *&installer_def);
 
         virtual void operator()(const Package::Syntax::TInstallerDef *that) const;
         virtual void operator()(const Package::Syntax::TUpgraderDef *that) const;
         virtual void operator()(const Package::Syntax::TUninstallerDef *that) const;
 
-        /* TODO */
         const Package::Syntax::TInstallerDef *&InstallerDef;
 
       };  // TTopLevelDefFactory

--- a/orly/synth/postfix_call.h
+++ b/orly/synth/postfix_call.h
@@ -34,42 +34,31 @@ namespace Orly {
 
     class TExprFactory;
 
-    /* TODO */
     class TPostfixCall
         : public TExpr {
       NO_COPY(TPostfixCall);
       public:
 
-      /* TODO */
       TPostfixCall(const TExprFactory *expr_factory, const Package::Syntax::TPostfixCall *postfix_call);
 
-      /* TODO */
       virtual ~TPostfixCall();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       typedef std::map<TName, TExpr *> TArgMap;
 
-      /* TODO */
       void Cleanup();
 
-      /* TODO */
       const Package::Syntax::TPostfixCall *PostfixCall;
 
-      /* TODO */
       TArgMap Args;
 
-      /* TODO */
       TExpr *Expr;
 
     };  // TPostfixCall

--- a/orly/synth/postfix_cast.h
+++ b/orly/synth/postfix_cast.h
@@ -30,39 +30,29 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
 
-    /* TODO */
     class TPostfixCast
         : public TExpr {
       NO_COPY(TPostfixCast);
       public:
 
-      /* TODO */
       TPostfixCast(const TExprFactory *expr_factory, const Package::Syntax::TPostfixCast *postfix_cast);
 
-      /* TODO */
       virtual ~TPostfixCast();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       const Package::Syntax::TPostfixCast *PostfixCast;
 
-      /* TODO */
       TExpr *Lhs;
 
-      /* TODO */
       TType *Rhs;
 
     };  // TPostfixCast

--- a/orly/synth/postfix_is_known.h
+++ b/orly/synth/postfix_is_known.h
@@ -30,36 +30,27 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
 
-    /* TODO */
     class TPostfixIsKnown
         : public TExpr {
       NO_COPY(TPostfixIsKnown);
       public:
 
-      /* TODO */
       TPostfixIsKnown(const TExprFactory *expr_factory, const Package::Syntax::TPostfixIsKnown *postfix_is_known);
 
-      /* TODO */
       virtual ~TPostfixIsKnown();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       const Package::Syntax::TPostfixIsKnown *PostfixIsKnown;
 
-      /* TODO */
       TExpr *Expr;
 
     };  // TPostfixIsKnown

--- a/orly/synth/postfix_is_known_expr.h
+++ b/orly/synth/postfix_is_known_expr.h
@@ -31,39 +31,29 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
 
-    /* TODO */
     class TPostfixIsKnownExpr
         : public TExpr {
       NO_COPY(TPostfixIsKnownExpr);
       public:
 
-      /* TODO */
       TPostfixIsKnownExpr(const TExprFactory *expr_factory, const Package::Syntax::TPostfixIsKnownExpr *postfix_is_known_expr);
 
-      /* TODO */
       virtual ~TPostfixIsKnownExpr();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       const Package::Syntax::TPostfixIsKnownExpr *PostfixIsKnownExpr;
 
-      /* TODO */
       TExpr *Lhs;
 
-      /* TODO */
       TExpr *Rhs;
 
     };  // TPostfixIsKnownExpr

--- a/orly/synth/postfix_slice.h
+++ b/orly/synth/postfix_slice.h
@@ -29,48 +29,35 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
 
-    /* TODO */
     class TPostfixSlice
         : public TExpr {
       NO_COPY(TPostfixSlice);
       public:
 
-      /* TODO */
       TPostfixSlice(const TExprFactory *expr_factory, const Package::Syntax::TPostfixSlice *postfix_slice);
 
-      /* TODO */
       virtual ~TPostfixSlice();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       void Cleanup();
 
-      /* TODO */
       const Package::Syntax::TPostfixSlice *PostfixSlice;
 
-      /* TODO */
       bool Colon;
 
-      /* TODO */
       TExpr *Expr;
 
-      /* TODO */
       TExpr *OptLhs;
 
-      /* TODO */
       TExpr *OptRhs;
 
     };  // TPostfixSlice

--- a/orly/synth/prefix_start.h
+++ b/orly/synth/prefix_start.h
@@ -30,37 +30,28 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
     class TStartableExpr;
 
-    /* TODO */
     class TPrefixStart
         : public TExpr {
       NO_COPY(TPrefixStart);
       public:
 
-      /* TODO */
       TPrefixStart(const TExprFactory *expr_factory, const Package::Syntax::TPrefixStart *prefix_start);
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       const Package::Syntax::TPrefixStart *PrefixStart;
 
-      /* TODO */
       TExpr *Expr;
 
-      /* TODO */
       const TStartableExpr *StartableExpr;
 
     };  // TPrefixStart

--- a/orly/synth/range_ctor.h
+++ b/orly/synth/range_ctor.h
@@ -30,47 +30,35 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
 
-    /* TODO */
     class TRangeCtor
         : public TExpr {
       NO_COPY(TRangeCtor);
       public:
 
-      /* TODO */
       TRangeCtor(const TExprFactory *expr_factory, const Package::Syntax::TRangeCtor *range_ctor);
 
-      /* TODO */
       virtual ~TRangeCtor();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
       void Cleanup();
 
-      /* TODO */
       const Package::Syntax::TRangeCtor *RangeCtor;
 
-      /* TODO */
       bool EndIncluded;
 
-      /* TODO */
       TExpr *Start;
 
-      /* TODO */
       TExpr *OptStride;
 
-      /* TODO */
       TExpr *OptEnd;
 
     };  // TRangeCtor

--- a/orly/synth/read_expr.h
+++ b/orly/synth/read_expr.h
@@ -30,39 +30,29 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
 
-    /* TODO */
     class TReadExpr
         : public TExpr {
       NO_COPY(TReadExpr);
       public:
 
-      /* TODO */
       TReadExpr(const TExprFactory *expr_factory, const Package::Syntax::TReadExpr *read_expr);
 
-      /* TODO */
       virtual ~TReadExpr();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       const Package::Syntax::TReadExpr *ReadExpr;
 
-      /* TODO */
       TExpr *Expr;
 
-      /* TODO */
       TType *Type;
 
     };  // TReadExpr

--- a/orly/synth/reduce_expr.h
+++ b/orly/synth/reduce_expr.h
@@ -35,52 +35,38 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
 
-    /* TODO */
     class TReduceExpr
         : public TStartableExpr,
           public TThatableExpr {
       NO_COPY(TReduceExpr);
       public:
 
-      /* TODO */
       TReduceExpr(const TExprFactory *expr_factory, const Package::Syntax::TInfixReduce *infix_reduce);
 
-      /* TODO */
       virtual ~TReduceExpr();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
-      /* TODO */
       const Expr::TReduce::TPtr &GetSymbol() const;
 
-      /* TODO */
       virtual Expr::TStartable::TPtr GetStartableSymbol() const;
 
-      /* TODO */
       virtual Expr::TThatable::TPtr GetThatableSymbol() const;
 
       private:
 
-      /* TODO */
       const Package::Syntax::TInfixReduce *InfixReduce;
 
-      /* TODO */
       TExpr *Lhs;
 
-      /* TODO */
       TExpr *Rhs;
 
-      /* TODO */
       mutable Expr::TReduce::TPtr Symbol;
 
     };  // TReduceExpr

--- a/orly/synth/ref_expr.h
+++ b/orly/synth/ref_expr.h
@@ -31,27 +31,21 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TRefExpr
         : public TExpr {
       NO_COPY(TRefExpr);
       public:
 
-      /* TODO */
       TRefExpr(const Package::Syntax::TRefExpr *ref_expr);
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       const Package::Syntax::TRefExpr *RefExpr;
 
-      /* TODO */
       TDef::TRef<TFuncDef> FuncDef;
 
     };  // TRefExpr

--- a/orly/synth/ref_type.h
+++ b/orly/synth/ref_type.h
@@ -29,24 +29,19 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TRefType
         : public TType {
       NO_COPY(TRefType);
       public:
 
-      /* TODO */
       TRefType(const Package::Syntax::TRefType *ref_type);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       virtual Type::TType ComputeSymbolicType() const;
 
-      /* TODO */
       TDef::TRef<TTypeDef> TypeDef;
 
     };  // TType

--- a/orly/synth/rhs_expr.h
+++ b/orly/synth/rhs_expr.h
@@ -28,28 +28,22 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
     class TLhsRhsableExpr;
 
-    /* TODO */
     class TRhsExpr
         : public TExpr {
       NO_COPY(TRhsExpr);
       public:
 
-      /* TODO */
       TRhsExpr(const TExprFactory *expr_factory, const Package::Syntax::TRhsExpr *rhs_expr);
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
       private:
 
-      /* TODO */
       const Package::Syntax::TRhsExpr *RhsExpr;
 
-      /* TODO */
       const TLhsRhsableExpr *LhsRhsableExpr;
 
     };  // TRhsExpr

--- a/orly/synth/session_id_expr.h
+++ b/orly/synth/session_id_expr.h
@@ -28,21 +28,17 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TSessionIdExpr
         : public TExpr {
       NO_COPY(TSessionIdExpr);
       public:
 
-      /* TODO */
       TSessionIdExpr(const Package::Syntax::TSessionIdExpr *session_id_expr);
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
       private:
 
-      /* TODO */
       const Package::Syntax::TSessionIdExpr *SessionIdExpr;
 
     };  // TSessionIdExpr

--- a/orly/synth/set_ctor.h
+++ b/orly/synth/set_ctor.h
@@ -32,35 +32,27 @@ namespace Orly {
 
     class TExprFactory;
 
-    /* TODO */
     class TSetCtor
         : public TExpr {
       NO_COPY(TSetCtor);
       public:
 
-      /* TODO */
       TSetCtor(const TExprFactory *expr_factory, const Package::Syntax::TSetCtor *set_ctor);
 
-      /* TODO */
       virtual ~TSetCtor();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
       void Cleanup();
 
-      /* TODO */
       const Package::Syntax::TSetCtor *SetCtor;
 
-      /* TODO */
       std::unordered_set<TExpr *> Exprs;
 
     };  // TSetCtor

--- a/orly/synth/sort_expr.h
+++ b/orly/synth/sort_expr.h
@@ -33,51 +33,37 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
 
-    /* TODO */
     class TSortExpr
         : public TLhsRhsableExpr {
       NO_COPY(TSortExpr);
       public:
 
-      /* TODO */
       TSortExpr(const TExprFactory *expr_factory, const Package::Syntax::TInfixSort *infix_sort);
 
-      /* TODO */
       virtual ~TSortExpr();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
-      /* TODO */
       const Expr::TSort::TPtr &GetSymbol() const;
 
-      /* TODO */
       virtual Expr::TLhsRhsable::TPtr GetLhsRhsableSymbol() const;
 
       private:
 
-      /* TODO */
       void Cleanup();
 
-      /* TODO */
       const Package::Syntax::TInfixSort *InfixSort;
 
-      /* TODO */
       TExpr *Lhs;
 
-      /* TODO */
       TExpr *Rhs;
 
-      /* TODO */
       mutable Expr::TSort::TPtr Symbol;
 
     };  // TSortExpr

--- a/orly/synth/startable_expr.h
+++ b/orly/synth/startable_expr.h
@@ -33,21 +33,17 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
 
-    /* TODO */
     class TStartableExpr
         : virtual public TExpr {
       NO_COPY(TStartableExpr);
       public:
 
-      /* TODO */
       TStartableExpr() = default;
 
       virtual ~TStartableExpr() = default;
 
-      /* TODO */
       virtual Expr::TStartable::TPtr GetStartableSymbol() const = 0;
 
     };  // TStartableExpr

--- a/orly/synth/stmt.h
+++ b/orly/synth/stmt.h
@@ -33,29 +33,22 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExpr;
 
-    /* TODO */
     class TStmt {
       NO_COPY(TStmt);
       public:
 
-      /* TODO */
       virtual ~TStmt() {}
 
-      /* TODO */
       virtual Symbol::Stmt::TStmt::TPtr Build() const = 0;
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb) const = 0;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb) const = 0;
 
       protected:
 
-      /* TODO */
       TStmt() {}
 
     };  // TStmt

--- a/orly/synth/stmt_block.h
+++ b/orly/synth/stmt_block.h
@@ -34,27 +34,21 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExpr;
     class TExprFactory;
 
-    /* TODO */
     class TStmtBlock {
       NO_COPY(TStmtBlock);
       public:
 
       typedef std::vector<TStmt *> TStmtVec;
 
-      /* TODO */
       TStmtBlock(const TExprFactory *expr_factory, const Package::Syntax::TStmtBlock *stmt_block);
 
-      /* TODO */
       virtual ~TStmtBlock();
 
-      /* TODO */
       Symbol::Stmt::TStmtBlock::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb) const;
 
       /* Do-little */
@@ -64,13 +58,10 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       void Cleanup();
 
-      /* TODO */
       const Package::Syntax::TStmtBlock *StmtBlock;
 
-      /* TODO */
       TStmtVec Stmts;
 
     };  // TStmtBlock

--- a/orly/synth/str_replace.h
+++ b/orly/synth/str_replace.h
@@ -31,21 +31,17 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TStrReplace
         : public TExpr {
       NO_COPY(TStrReplace);
       public:
 
-      /* TODO */
       TStrReplace(const Package::Syntax::TBuiltInReplace *str_replace);
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
       private:
 
-      /* TODO */
       const Package::Syntax::TBuiltInReplace *StrReplace;
 
     };  // TStrReplace

--- a/orly/synth/test_def.h
+++ b/orly/synth/test_def.h
@@ -37,25 +37,19 @@ namespace Orly {
     class TWithClause;
     class TTestCaseBlock;
 
-    /* TODO */
     class TTestDef
         : public TDef {
       NO_COPY(TTestDef);
       public:
 
-      /* TODO */
       TTestDef(TScope *scope, const Package::Syntax::TTestDef *test_def);
 
-      /* TODO */
       virtual ~TTestDef();
 
-      /* TODO */
       virtual TAction Build(int pass);
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
@@ -64,13 +58,10 @@ namespace Orly {
 
       static TName GenName(const TPosRange &pos_range);
 
-      /* TODO */
       const Package::Syntax::TTestDef *TestDef;
 
-      /* TODO */
       TWithClause *OptWithClause;
 
-      /* TODO */
       TTestCaseBlock *TestCaseBlock;
 
     };  // TTestDef

--- a/orly/synth/test_kv_entry.h
+++ b/orly/synth/test_kv_entry.h
@@ -31,37 +31,28 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TTestKvEntry {
       NO_COPY(TTestKvEntry);
       public:
 
-      /* TODO */
       TTestKvEntry(
           const TExprFactory *expr_factory,
           const Package::Syntax::TTestKvEntry *test_kv_entry);
 
-      /* TODO */
       ~TTestKvEntry();
 
-      /* TODO */
       Symbol::Stmt::TNew::TPtr Build() const;
 
-      /* TODO */
       void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       const Package::Syntax::TTestKvEntry *TestKvEntry;
 
-      /* TODO */
       TExpr *Key;
 
-      /* TODO */
       TExpr *Val;
 
     };  // TTestKvEntry

--- a/orly/synth/that_expr.h
+++ b/orly/synth/that_expr.h
@@ -29,28 +29,22 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
     class TThatableExpr;
 
-    /* TODO */
     class TThatExpr
         : public TExpr {
       NO_COPY(TThatExpr);
       public:
 
-      /* TODO */
       TThatExpr(const TExprFactory *expr_factory, const Package::Syntax::TThatExpr *that_expr);
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
       private:
 
-      /* TODO */
       const Package::Syntax::TThatExpr *ThatExpr;
 
-      /* TODO */
       const TThatableExpr *ThatableExpr;
 
     };  // TThatExpr

--- a/orly/synth/thatable_expr.h
+++ b/orly/synth/thatable_expr.h
@@ -39,21 +39,17 @@ namespace Orly {
              The outer expr gets built before rhs expr so that when the special expr gets built,
              we have a outer expr symbol ready for it to point to. */
 
-    /* TODO */
     class TExprFactory;
 
-    /* TODO */
     class TThatableExpr
         : virtual public TExpr {
       NO_COPY(TThatableExpr);
       public:
 
-      /* TODO */
       TThatableExpr() = default;
 
       virtual ~TThatableExpr() = default;
 
-      /* TODO */
       virtual Expr::TThatable::TPtr GetThatableSymbol() const = 0;
 
     };  // TThatableExpr

--- a/orly/synth/time_diff_ctor.h
+++ b/orly/synth/time_diff_ctor.h
@@ -34,21 +34,17 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TTimeDiffCtor
         : public TExpr {
       NO_COPY(TTimeDiffCtor);
       public:
 
-      /* TODO */
       TTimeDiffCtor(const Package::Syntax::TTimeDiffCtor *time_diff_ctor);
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
       private:
 
-      /* TODO */
       const Package::Syntax::TTimeDiffCtor *TimeDiffCtor;
 
     };  // TTimeDiffCtor

--- a/orly/synth/time_pnt_ctor.h
+++ b/orly/synth/time_pnt_ctor.h
@@ -29,21 +29,17 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TTimePntCtor
         : public TExpr {
       NO_COPY(TTimePntCtor);
       public:
 
-      /* TODO */
       TTimePntCtor(const Package::Syntax::TTimePntCtor *time_pnt_ctor);
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
       private:
 
-      /* TODO */
       const Package::Syntax::TTimePntCtor *TimePntCtor;
 
     };  // TTimePntCtor

--- a/orly/synth/type.h
+++ b/orly/synth/type.h
@@ -33,31 +33,24 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TType {
       NO_COPY(TType);
       public:
 
-      /* TODO */
       virtual ~TType();
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb) = 0;
 
-      /* TODO */
       const Type::TType &GetSymbolicType() const;
 
       protected:
 
-      /* TODO */
       TType();
 
-      /* TODO */
       virtual Type::TType ComputeSymbolicType() const = 0;
 
       private:
 
-      /* TODO */
       mutable Type::TType CachedSymbolicType;
 
     };  // TType

--- a/orly/synth/type_def.h
+++ b/orly/synth/type_def.h
@@ -35,15 +35,12 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TTypeDef
         : public TDef {
       public:
 
-      /* TODO */
       TTypeDef(TScope *scope, const Package::Syntax::TTypeDef *type_def);
 
-      /* TODO */
       virtual ~TTypeDef();
 
       /* Computes (and caches) the def's symbolic type. While the
@@ -122,21 +119,16 @@ namespace Orly {
          intern the group via MakeRecGroup, caching every member's GroupType. */
       void ResolveScc() const;
 
-      /* TODO */
       virtual TAction Build(int pass);
 
-      /* TODO */
       virtual void ForEachPred(int pass, const std::function<bool (TDef *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
-      /* TODO */
       TType *Type;
 
     };  // TTypeDef
 
-    /* TODO */
     template <>
     struct TDef::TInfo<TTypeDef> {
       static const char *Name;

--- a/orly/synth/unary_type.h
+++ b/orly/synth/unary_type.h
@@ -27,33 +27,25 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TUnaryType
         : public TType {
       NO_COPY(TUnaryType);
       public:
 
-      /* TODO */
       typedef Type::TType (*TGet)(const Type::TType &);
 
-      /* TODO */
       TUnaryType(TType *type, TGet get);
 
-      /* TODO */
       virtual ~TUnaryType();
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       virtual Type::TType ComputeSymbolicType() const;
 
-      /* TODO */
       TType *Type;
 
-      /* TODO */
       TGet Get;
 
     };  // TType

--- a/orly/synth/union_map_expr.h
+++ b/orly/synth/union_map_expr.h
@@ -33,48 +33,35 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
 
-    /* TODO */
     class TUnionMapExpr
         : public TThatableExpr {
       NO_COPY(TUnionMapExpr);
       public:
 
-      /* TODO */
       TUnionMapExpr(const TExprFactory *expr_factory, const Package::Syntax::TUnionMapExpr *union_map_expr);
 
-      /* TODO */
       virtual ~TUnionMapExpr();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
-      /* TODO */
       const Expr::TUnionMap::TPtr &GetSymbol() const;
 
-      /* TODO */
       virtual Expr::TThatable::TPtr GetThatableSymbol() const;
 
       private:
 
-      /* TODO */
       const Package::Syntax::TUnionMapExpr *UnionMapExpr;
 
-      /* TODO */
       TExpr *Lhs;
 
-      /* TODO */
       TExpr *Rhs;
 
-      /* TODO */
       mutable Expr::TUnionMap::TPtr Symbol;
 
     };  // TUnionMapExpr

--- a/orly/synth/unknown_ctor.h
+++ b/orly/synth/unknown_ctor.h
@@ -32,30 +32,23 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TUnknownCtor
         : public TExpr {
       NO_COPY(TUnknownCtor);
       public:
 
-      /* TODO */
       TUnknownCtor(const Package::Syntax::TUnknownCtor *unknown_ctor);
 
-      /* TODO */
       virtual ~TUnknownCtor();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       const Package::Syntax::TUnknownCtor *UnknownCtor;
 
-      /* TODO */
       TType *Type;
 
     };  // TUnknownCtor

--- a/orly/synth/user_id_expr.h
+++ b/orly/synth/user_id_expr.h
@@ -28,21 +28,17 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TUserIdExpr
         : public TExpr {
       NO_COPY(TUserIdExpr);
       public:
 
-      /* TODO */
       TUserIdExpr(const Package::Syntax::TUserIdExpr *user_id_expr);
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
       private:
 
-      /* TODO */
       const Package::Syntax::TUserIdExpr *UserIdExpr;
 
     };  // TUserIdExpr

--- a/orly/synth/where_expr.h
+++ b/orly/synth/where_expr.h
@@ -37,28 +37,21 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
 
-    /* TODO */
     class TWhereExpr
         : public TExpr, public TScope {
       NO_COPY(TWhereExpr);
       public:
 
-      /* TODO */
       TWhereExpr(const TExprFactory *expr_factory, const Package::Syntax::TWhereExpr *where_expr);
 
-      /* TODO */
       ~TWhereExpr();
 
-      /* TODO */
       Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       void BuildSymbol();
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
       Symbol::TScope::TPtr GetScopeSymbol() const;
@@ -69,46 +62,35 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       class TLocalDefFactory
           : public TDefFactory {
         NO_COPY(TLocalDefFactory);
         public:
 
-        /* TODO */
         static void NewDefs(
               const TExprFactory *expr_factory,
               const Package::Syntax::TOptDefSeq *opt_def_seq);
 
         private:
 
-        /* TODO */
         TLocalDefFactory(const TExprFactory *expr_factory);
 
-        /* TODO */
         virtual void operator()(const Package::Syntax::TInstallerDef *that) const;
 
-        /* TODO */
         virtual void operator()(const Package::Syntax::TUpgraderDef *that) const;
 
-        /* TODO */
         virtual void operator()(const Package::Syntax::TUninstallerDef *that) const;
 
-        /* TODO */
         void OnTopLevel(const char *desc, const TPosRange &pos_range) const;
 
       };  // TLocalDefFactory
 
-      /* TODO */
       virtual void ForEachControlledRef(const std::function<void (TAnyRef &)> &cb) const;
 
-      /* TODO */
       const Package::Syntax::TWhereExpr *WhereExpr;
 
-      /* TODO */
       TExpr *Expr;
 
-      /* TODO */
       Expr::TWhere::TPtr Symbol;
 
     };  // TWhereExpr

--- a/orly/synth/while_expr.h
+++ b/orly/synth/while_expr.h
@@ -32,48 +32,35 @@ namespace Orly {
 
   namespace Synth {
 
-    /* TODO */
     class TExprFactory;
 
-    /* TODO */
     class TWhileExpr
         : public TThatableExpr {
       NO_COPY(TWhileExpr);
       public:
 
-      /* TODO */
       TWhileExpr(const TExprFactory *expr_factory, const Package::Syntax::TInfixWhile *infix_while);
 
-      /* TODO */
       virtual ~TWhileExpr();
 
-      /* TODO */
       virtual Expr::TExpr::TPtr Build() const;
 
-      /* TODO */
       virtual void ForEachInnerScope(const std::function<void (TScope *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
-      /* TODO */
       const Expr::TWhile::TPtr &GetSymbol() const;
 
-      /* TODO */
       virtual Expr::TThatable::TPtr GetThatableSymbol() const;
 
       private:
 
-      /* TODO */
       const Package::Syntax::TInfixWhile *InfixWhile;
 
-      /* TODO */
       TExpr *Lhs;
 
-      /* TODO */
       TExpr *Rhs;
 
-      /* TODO */
       mutable Expr::TWhile::TPtr Symbol;
 
     };  // TWhileExpr

--- a/orly/tracker.h
+++ b/orly/tracker.h
@@ -31,10 +31,8 @@ namespace Orly {
   class TTracker {
     public:
 
-    /* TODO */
     TTracker() {}
 
-    /* TODO */
     TTracker(const Base::TUuid &id, std::chrono::seconds ttl) : Id(id), TimeToLive(ttl) {}
 
     /* The id used to track. */

--- a/orly/type/bool.h
+++ b/orly/type/bool.h
@@ -25,7 +25,6 @@ namespace Orly {
 
   namespace Type {
 
-    /* TODO */
     class TBool : public TSingletonType<TBool> {
       NO_COPY(TBool);
       public:

--- a/orly/type/commutative_infix_visitor.h
+++ b/orly/type/commutative_infix_visitor.h
@@ -33,11 +33,9 @@ namespace Orly {
       NO_COPY(TCommutativeInfixVisitor);
       protected:
 
-      /* TODO */
       TCommutativeInfixVisitor(TType &type, const TPosRange &pos_range)
           : TInfixVisitor(type, pos_range) {}
 
-      /* TODO */
       virtual void operator()(const TAddr     *, const TAddr     *) const = 0;
       virtual void operator()(const TAddr     *, const TBool     *) const = 0;
       virtual void operator()(const TAddr     *, const TDict     *) const = 0;

--- a/orly/type/ensure_empty_object.h
+++ b/orly/type/ensure_empty_object.h
@@ -30,7 +30,6 @@ namespace Orly {
 
     class TType;
 
-    /* TODO */
     void EnsureEmptyObject(const Type::TType &type, const TPosRange &pos_range);
 
   }  // Type

--- a/orly/type/err.h
+++ b/orly/type/err.h
@@ -27,7 +27,6 @@ namespace Orly {
 
   namespace Type {
 
-    /* TODO */
     class TErr : public TUnaryType<TErr> {
       NO_COPY(TErr);
 

--- a/orly/type/get_prec.h
+++ b/orly/type/get_prec.h
@@ -46,7 +46,6 @@ namespace Orly {
       Variant
     };  // TPrec
 
-    /* TODO */
     TPrec GetPrec(const TType &type);
 
   }  // Type

--- a/orly/type/has_optional.h
+++ b/orly/type/has_optional.h
@@ -28,7 +28,6 @@ namespace Orly {
 
     class TType;
 
-    /* TODO */
     bool HasOptional(const TType &type);
 
   }  // Type

--- a/orly/type/id.h
+++ b/orly/type/id.h
@@ -26,7 +26,6 @@ namespace Orly {
 
   namespace Type {
 
-    /* TODO */
     class TId : public TSingletonType<TId> {
       NO_COPY(TId);
       public:

--- a/orly/type/impl.cc
+++ b/orly/type/impl.cc
@@ -40,17 +40,14 @@ namespace Orly {
 
   namespace Type {
 
-    /* TODO */
     template <typename TLhs>
     class TRhsVisitor
         : public TType::TVisitor {
       public:
 
-      /* TODO */
       TRhsVisitor(const TLhs *lhs, const TType::TDoubleVisitor &double_visitor)
           : Lhs(lhs), DoubleVisitor(double_visitor) {}
 
-      /* TODO */
       virtual void operator()(const TAddr *rhs) const {
         DoubleVisitor(Lhs, rhs);
       }
@@ -114,26 +111,21 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       const TLhs *Lhs;
 
-      /* TODO */
       const TType::TDoubleVisitor &DoubleVisitor;
 
     };  // TRhsVisitor<TLhs>
 
-    /* TODO */
     class TLhsVisitor
         : public TType::TVisitor {
       public:
 
-      /* TODO */
       TLhsVisitor(const TType &rhs, const TType::TDoubleVisitor &double_visitor)
           : Rhs(rhs), DoubleVisitor(double_visitor) {}
 
       virtual ~TLhsVisitor() {}
 
-      /* TODO */
       virtual void operator()(const TAddr *lhs) const {
         Rhs.Accept(TRhsVisitor<TAddr>(lhs, DoubleVisitor));
       }
@@ -197,10 +189,8 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       const TType &Rhs;
 
-      /* TODO */
       const TType::TDoubleVisitor &DoubleVisitor;
 
     };  // TLhsVisitor
@@ -239,7 +229,6 @@ std::string TType::GetMangledName() const {
   class TTypeVisitor : public TType::TVisitor {
     public:
 
-    /* TODO */
     TTypeVisitor(std::string &name) : Name(name) {}
 
     virtual void operator()(const TAddr *that) const {

--- a/orly/type/impl.h
+++ b/orly/type/impl.h
@@ -36,7 +36,6 @@ namespace Orly {
 
   namespace Type {
 
-    /* TODO */
     class TAddr;
     class TAny;
     class TBool;
@@ -64,103 +63,82 @@ namespace Orly {
     class TType {
       public:
 
-      /* TODO */
       class TVisitor;
 
-      /* TODO */
       class TDoubleVisitor;
 
-      /* TODO */
       class TImpl : public std::enable_shared_from_this<TImpl> {
         NO_COPY(TImpl);
 
 
         public:
 
-        /* TODO */
         TType AsType() const {
           return TType(shared_from_this());
         }
 
         protected:
 
-        /* TODO */
         TImpl() {}
 
-        /* TODO */
         virtual ~TImpl() {}
 
-        /* TODO */
         virtual void Accept(const TVisitor &visitor) const = 0;
 
-        /* TODO */
         virtual void Write(std::ostream &) const = 0;
 
-        /* TODO */
         friend class TType;
 
       };  // TImpl
 
-      /* TODO */
       TType() {
         Init();
       }
 
-      /* TODO */
       TType(TType &&that) {
         Init();
         std::swap(Impl, that.Impl);
       }
 
-      /* TODO */
       TType(const TType &that) {
         Impl = that.Impl;
       }
 
-      /* TODO */
       ~TType() {}
 
-      /* TODO */
       TType &operator=(TType &&that) {
         std::swap(Impl, that.Impl);
         return *this;
       }
 
-      /* TODO */
       TType &operator=(const TType &that) {
         return *this = TType(that);
       }
 
-      /* TODO */
       bool operator==(const TType &that) const {
         assert(Impl);
         assert(that.Impl);
         return Impl.get() == that.Impl.get();
       }
 
-      /* TODO */
       bool operator!=(const TType &that) const {
         assert(Impl);
         assert(that.Impl);
         return Impl.get() != that.Impl.get();
       }
 
-      /* TODO */
       operator bool() const;
 
-      /* TODO */
       void Accept(const TVisitor &visitor) const {
         assert(Impl);
         Impl->Accept(visitor);
       }
 
-      /* TODO */
       static void Accept(const TType &lhs, const TType &rhs, const TDoubleVisitor &double_visitor);
 
       template <typename TTarget>
       const TTarget *As() const;
 
-      /* TODO */
       size_t GetHash() const {
         assert(Impl);
         return reinterpret_cast<size_t>(Impl.get());
@@ -200,35 +178,28 @@ namespace Orly {
       template <typename TTarget>
       const TTarget *TryAs() const;
 
-      /* TODO */
       void Write(std::ostream &stream) const {
         Impl->Write(stream);
       }
 
       private:
 
-      /* TODO */
       TType(const std::shared_ptr<const TImpl> &impl) : Impl(impl) {
         assert(impl);
       }
 
-      /* TODO */
       void Init();
 
-      /* TODO */
       std::shared_ptr<const TImpl> Impl;
 
     };  // TType
 
-    /* TODO */
     template <typename TVal>
     struct TDt;
 
-    /* TODO */
     class TType::TVisitor {
       public:
 
-      /* TODO */
       virtual ~TVisitor();
 
       virtual void operator()(const TAddr     *that) const = 0;
@@ -272,19 +243,15 @@ namespace Orly {
 
       protected:
 
-      /* TODO */
       TVisitor();
 
     };  // TType::TVisitor;
 
-    /* TODO */
     class TType::TDoubleVisitor {
       public:
 
-      /* TODO */
       virtual ~TDoubleVisitor() {}
 
-      /* TODO */
       virtual void operator()(const TAddr *lhs, const TAddr *rhs) const = 0;
       virtual void operator()(const TAddr *lhs, const TAny *rhs) const = 0;
       virtual void operator()(const TAddr *lhs, const TBool *rhs) const = 0;
@@ -688,7 +655,6 @@ namespace Orly {
 
       protected:
 
-      /* TODO */
       TDoubleVisitor() {}
 
     };  // TDoubleVisitor
@@ -699,7 +665,6 @@ namespace Orly {
 
 namespace std {
 
-  /* TODO */
   inline ostream &operator<<(ostream &stream, const Orly::Type::TType &that) {
     that.Write(stream);
     return stream;

--- a/orly/type/infix_visitor.h
+++ b/orly/type/infix_visitor.h
@@ -32,17 +32,14 @@ namespace Orly {
 
   namespace Type {
 
-    /* TODO */
     class TInfixVisitor
         : public TType::TDoubleVisitor {
       NO_COPY(TInfixVisitor);
       protected:
 
-      /* TODO */
       TInfixVisitor(TType &type, const TPosRange &pos_range)
           : PosRange(pos_range), Type(type) {}
 
-      /* TODO */
       virtual void operator()(const TAddr     *, const TAddr     *) const = 0;
       virtual void operator()(const TAddr     *, const TBool     *) const = 0;
       virtual void operator()(const TAddr     *, const TDict     *) const = 0;
@@ -213,10 +210,8 @@ namespace Orly {
       virtual void operator()(const TTimePnt  *, const TTimeDiff *) const = 0;
       virtual void operator()(const TTimePnt  *, const TTimePnt  *) const = 0;
 
-      /* TODO */
       const TPosRange &PosRange;
 
-      /* TODO */
       TType &Type;
 
       private:

--- a/orly/type/managed_type.h
+++ b/orly/type/managed_type.h
@@ -71,7 +71,6 @@ namespace Orly {
 
       protected:
 
-      /* TODO */
       template <typename... TCompatArgs>
       static TType Get(TCompatArgs &&... args) {
         assert(Mutex);  // If this fails, you likely don't have an instance of TTypeCzar.
@@ -95,7 +94,6 @@ namespace Orly {
         }
       }
 
-      /* TODO */
       static void DeleteImpl(TInternedType *impl) {
         assert(impl);
         if (Mutex) {

--- a/orly/type/new_sabot.h
+++ b/orly/type/new_sabot.h
@@ -76,7 +76,6 @@ namespace Orly {
 
         };  // TUnary<TBase>::TPin
 
-        /* TODO */
         TUnary(const TType &elem)
             : Elem(elem) {}
 
@@ -132,7 +131,6 @@ namespace Orly {
 
         };  // TBinary<TBase>::TPin
 
-        /* TODO */
         TBinary(const TType &lhs, const TType &rhs)
             : Lhs(lhs), Rhs(rhs) {}
 

--- a/orly/type/obj.h
+++ b/orly/type/obj.h
@@ -34,7 +34,6 @@ namespace Orly {
 
   namespace Var {
 
-    /* TODO */
     class TVar;
 
   }  // Var
@@ -45,14 +44,12 @@ namespace Orly {
              elements come out in a stable, asciibetical order. */
     typedef std::map<std::string, TType> TObjElems;
 
-    /* TODO */
     class TObj : public TInternedType<TObj, TObjElems> {
       NO_COPY(TObj);
       public:
 
       typedef TObjElems TElems;
 
-      /* TODO */
       template <typename TCompound_>
       class Meta {
         NO_CONSTRUCTION(Meta);
@@ -60,38 +57,30 @@ namespace Orly {
 
         typedef TCompound_ TCompound;
 
-        /* TODO */
         class TAnyField {
           NO_COPY(TAnyField);
           public:
 
-          /* TODO */
           virtual ~TAnyField() {}
 
-          /* TODO */
           const std::string &GetName() const {
             return Name;
           }
 
-          /* TODO */
           const TAnyField *GetNextField() const {
             return NextField;
           }
 
-          /* TODO */
           virtual Type::TType GetType() const = 0;
 
-          /* TODO */
           virtual void GetVal(const TCompound &that, Var::TVar &out) const = 0;
 
-          /* TODO */
           static const TAnyField *GetFirstField() {
             return FirstField;
           }
 
           protected:
 
-          /* TODO */
           TAnyField(const char *name)
               : Name(name), NextField(0) {
             assert(name);
@@ -101,80 +90,64 @@ namespace Orly {
 
           private:
 
-          /* TODO */
           std::string Name;
 
-          /* TODO */
           TAnyField *NextField;
 
-          /* TODO */
           static TAnyField *FirstField, *LastField;
 
         };  // TAnyField
 
-        /* TODO */
         template <typename TVal>
         class TField
             : public TAnyField {
           NO_COPY(TField);
           public:
 
-          /* TODO */
           typedef TVal (TCompound::*TMember);
 
-          /* TODO */
           TField(const char *name, TMember member)
               : TAnyField(name), Member(member) {}
 
-          /* TODO */
           virtual Type::TType GetType() const {
             return Type::TDt<TVal>::GetType();
           }
 
-          /* TODO */
           virtual void GetVal(const TCompound &that, Var::TVar &out) const;
 
           private:
 
-          /* TODO */
           TMember Member;
 
         };  // TField<TVal>
 
-        /* TODO */
         class TClass {
           NO_COPY(TClass);
           public:
 
-          /* TODO */
           TClass(const char *name)
               : Name(name) {
             assert(!Class);
             Class = this;
           }
 
-          /* TODO */
           ~TClass() {
             assert(Class == this);
             Class = 0;
           }
 
-          /* TODO */
           const std::string &GetName() const {
             return Name;
           }
 
-          /* TODO */
           static const TClass *TryGetClass() {
             return Class;
           }
 
           private:
 
-          /* TODO */
           std::string Name;
 
-          /* TODO */
           static TClass *Class;
 
         };  // TClass
@@ -189,17 +162,14 @@ namespace Orly {
         return lhs->IsSubsetOf(rhs, is_optional) || rhs->IsSubsetOf(lhs, is_optional);
       }
 
-      /* TODO */
       const TObjElems &GetElems() const {
         return std::get<0>(GetKey());
       }
 
-      /* TODO */
       static TType Get(const TObjElems &elems) {
         return TInternedType::Get(elems);
       }
 
-      /* TODO */
       bool IsSubsetOf(const TObj *that, bool &is_optional) const {
         assert(that);
         for (auto iter : GetElems()) {
@@ -225,15 +195,12 @@ namespace Orly {
       friend class TInternedType;
     };  // TObj
 
-    /* TODO */
     template <typename TCompound>
     typename TObj::Meta<TCompound>::TAnyField *TObj::Meta<TCompound>::TAnyField::FirstField = 0;
 
-    /* TODO */
     template <typename TCompound>
     typename TObj::Meta<TCompound>::TAnyField *TObj::Meta<TCompound>::TAnyField::LastField = 0;
 
-    /* TODO */
     template <typename TCompound>
     typename TObj::Meta<TCompound>::TClass *TObj::Meta<TCompound>::TClass::Class = 0;
 

--- a/orly/type/object_collector.h
+++ b/orly/type/object_collector.h
@@ -32,7 +32,6 @@ namespace Orly {
 
     class TType;
 
-    /* TODO */
     void CollectObjects(const TType &type, std::unordered_set<TType> &object_set);
 
   }  // Type

--- a/orly/type/orlyify.h
+++ b/orly/type/orlyify.h
@@ -26,7 +26,6 @@ namespace Orly {
 
     class TType;
 
-    /* TODO */
     void Orlyify(std::ostream &stream, const TType &type);
 
   }  // Type

--- a/orly/type/real.h
+++ b/orly/type/real.h
@@ -27,7 +27,6 @@ namespace Orly {
 
   namespace Type {
 
-    /* TODO */
     class TReal : public TSingletonType<TReal> {
       NO_COPY(TReal);
       public:

--- a/orly/type/rt.h
+++ b/orly/type/rt.h
@@ -37,66 +37,54 @@ namespace Orly {
 
   namespace Type {
 
-    /* TODO */
     template <>
     struct TDt<bool> {
 
-      /* TODO */
       TType static GetType() {
         return TBool::Get();
       }
 
     };
 
-    /* TODO */
     template <typename TKey, typename TVal>
     struct TDt<Rt::TDict<TKey, TVal>> {
 
-      /* TODO */
       TType static GetType() {
         return TDict::Get(TDt<TKey>::GetType(), TDt<TVal>::GetType());
       }
 
     };
 
-    /* TODO */
     template <>
     struct TDt<int64_t> {
 
-      /* TODO */
       TType static GetType() {
         return TInt::Get();
       }
 
     };
 
-    /* TODO */
     template <typename TVal>
     struct TDt<std::vector<TVal>> {
 
-      /* TODO */
       TType static GetType() {
         return TList::Get(TDt<TVal>::GetType());
       }
 
     };
 
-    /* TODO */
     template <typename TAddr, typename TVal>
     struct TDt<Rt::TMutable<TAddr, TVal>> {
 
-      /* TODO */
       TType static GetType() {
         return TMutable::Get(TDt<TAddr>::GetType(), TDt<TVal>::GetType());
       }
 
     };
 
-    /* TODO */
     template <typename TVal>
     struct TDt<Rt::TOpt<TVal>> {
 
-      /* TODO */
       TType static GetType() {
         return TOpt::Get(TDt<TVal>::GetType());
       }
@@ -122,11 +110,9 @@ namespace Orly {
     }; // TDt<TCompound>
     */
 
-    /* TODO */
     template <>
     struct TDt<double> {
 
-      /* TODO */
       TType static GetType() {
         return TReal::Get();
       }
@@ -142,7 +128,6 @@ namespace Orly {
 
     };
 
-    /* TODO */
     template <typename TVal>
     struct TDt<Rt::TSet<TVal>> {
 
@@ -152,55 +137,45 @@ namespace Orly {
 
     };
 
-    /* TODO */
     template <>
     struct TDt<std::string> {
 
-      /* TODO */
       TType static GetType() {
         return TStr::Get();
       }
 
     };
 
-    /* TODO */
     template <>
     struct TDt<Base::Chrono::TTimeDiff> {
 
-      /* TODO */
       TType static GetType() {
         return TTimeDiff::Get();
       }
 
     };
 
-    /* TODO */
     template <>
     struct TDt<Base::Chrono::TTimePnt> {
 
-      /* TODO */
       TType static GetType() {
         return TTimePnt::Get();
       }
 
     };
 
-    /* TODO */
     template <>
     struct TDt<Orly::Rt::TUnknown> {
 
-      /* TODO */
       TType static GetType() {
         return TUnknown::Get();
       }
 
     };
 
-    /* TODO */
     template <>
     struct TDt<Base::TUuid> {
 
-      /* TODO */
       TType static GetType() {
         return TId::Get();
       }

--- a/orly/type/sabot_to_type.h
+++ b/orly/type/sabot_to_type.h
@@ -39,12 +39,10 @@ namespace Orly {
 
     };  // TSabotToTypeTranslationError
 
-    /* TODO */
     class TToTypeVisitor final
         : public Sabot::TTypeVisitor {
       public:
 
-      /* TODO */
       TToTypeVisitor(Type::TType &type)
           : Type(type) {
       }
@@ -81,15 +79,12 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       void OnUnary(const Sabot::Type::TUnary &type) const;
 
-      /* TODO */
       Type::TType &Type;
 
     };  // TToTypeVisitor
 
-    /* TODO */
     inline Type::TType ToType(const Sabot::Type::TAny &state) {
       Type::TType type;
       state.Accept(TToTypeVisitor(type));

--- a/orly/type/self_ref.h
+++ b/orly/type/self_ref.h
@@ -56,7 +56,6 @@ namespace Orly {
         return std::get<0>(GetKey());
       }
 
-      /* TODO */
       static TType Get(size_t depth) {
         return TInternedType::Get(depth);
       }

--- a/orly/type/seq.h
+++ b/orly/type/seq.h
@@ -29,7 +29,6 @@ namespace Orly {
 
   namespace Type {
 
-    /* TODO */
     class TSeq : public TUnaryType<TSeq> {
       NO_COPY(TSeq);
 

--- a/orly/type/set.h
+++ b/orly/type/set.h
@@ -26,7 +26,6 @@ namespace Orly {
 
   namespace Type {
 
-    /* TODO */
     class TSet : public TUnaryType<TSet> {
       NO_COPY(TSet);
 

--- a/orly/type/unknown.h
+++ b/orly/type/unknown.h
@@ -26,7 +26,6 @@ namespace Orly {
 
   namespace Type {
 
-    /* TODO */
     class TUnknown : public TSingletonType<TUnknown> {
       NO_COPY(TUnknown);
       public:

--- a/orly/type/variant.h
+++ b/orly/type/variant.h
@@ -64,7 +64,6 @@ namespace Orly {
         return std::get<0>(GetKey());
       }
 
-      /* TODO */
       static TType Get(const TVariantElems &elems) {
         return TInternedType::Get(elems);
       }

--- a/orly/var/addr.h
+++ b/orly/var/addr.h
@@ -35,64 +35,45 @@ namespace Orly {
 
       typedef TAddrDir TDir;
 
-      /* TODO */
       typedef std::vector<std::pair<TDir, TVar>> TAddrType;
       typedef TAddrType TElems;
 
-      /* TODO */
       virtual Var::TVar &Index(const TVar &);
 
-      /* TODO */
       virtual TAddr &Add(const TVar &);
 
-      /* TODO */
       virtual TAddr &And(const TVar &);
 
-      /* TODO */
       virtual TAddr &Div(const TVar &);
 
-      /* TODO */
       virtual TAddr &Exp(const TVar &);
 
-      /* TODO */
       virtual TAddr &Intersection(const TVar &);
 
-      /* TODO */
       virtual TAddr &Mod(const TVar &);
 
-      /* TODO */
       virtual TAddr &Mult(const TVar &);
 
-      /* TODO */
       virtual TAddr &Or(const TVar &);
 
-      /* TODO */
       virtual TAddr &Sub(const TVar &);
 
-      /* TODO */
       virtual TAddr &SymmetricDiff(const TVar &);
 
-      /* TODO */
       virtual TAddr &Union(const TVar &);
 
-      /* TODO */
       virtual TAddr &Xor(const TVar &);
 
-      /* TODO */
       const TAddrType &GetVal() const {
         return Val;
       }
 
-      /* TODO */
       virtual size_t GetHash() const;
 
-      /* TODO */
       virtual Type::TType GetType() const;
 
-      /* TODO */
       virtual void Touch();
 
-      /* TODO */
       virtual void Write(std::ostream &strm) const;
 
       private:
@@ -104,19 +85,14 @@ namespace Orly {
         SetHash();
       }*/
 
-      /* TODO */
       TAddr(const TAddrType &that);
 
-      /* TODO */
       virtual ~TAddr();
 
-      /* TODO */
       virtual void Accept(const TVisitor &visitor) const;
 
-      /* TODO */
       virtual TVar Copy() const;
 
-      /* TODO */
       void SetHash();
 
       /* TODO
@@ -144,16 +120,12 @@ namespace Orly {
       }
       */
 
-      /* TODO */
       TAddrType Val;
 
-      /* TODO */
       std::vector<std::pair<TDir, Type::TType>> TypeVec; //TODO: Can I get this from TType?
 
-      /* TODO */
       size_t Hash;
 
-      /* TODO */
       friend class TVar;
 
     };  // TAddr

--- a/orly/var/bool.h
+++ b/orly/var/bool.h
@@ -31,89 +31,63 @@ namespace Orly {
         : public TVar::TImpl {
       public:
 
-      /* TODO */
       virtual size_t GetHash() const;
 
-      /* TODO */
       virtual Var::TVar &Index(const TVar &);
 
-      /* TODO */
       virtual TBool &Add(const TVar &);
 
-      /* TODO */
       virtual TBool &And(const TVar &);
 
-      /* TODO */
       virtual TBool &Div(const TVar &);
 
-      /* TODO */
       virtual TBool &Exp(const TVar &);
 
-      /* TODO */
       virtual TBool &Intersection(const TVar &);
 
-      /* TODO */
       virtual TBool &Mod(const TVar &);
 
-      /* TODO */
       virtual TBool &Mult(const TVar &);
 
-      /* TODO */
       virtual TBool &Or(const TVar &);
 
-      /* TODO */
       virtual TBool &Sub(const TVar &);
 
-      /* TODO */
       virtual TBool &SymmetricDiff(const TVar &);
 
-      /* TODO */
       virtual TBool &Union(const TVar &);
 
-      /* TODO */
       virtual TBool &Xor(const TVar &);
 
-      /* TODO */
       bool GetVal() const {
         return Val;
       }
 
-      /* TODO */
       virtual Type::TType GetType() const;
 
-      /* TODO */
       virtual void Touch();
 
-      /* TODO */
       static TVar New(bool that);
 
-      /* TODO */
       virtual void Write(std::ostream &stream) const;
 
       private:
 
-      /* TODO */
       TBool(bool that);
 
-      /* TODO */
       virtual ~TBool();
 
-      /* TODO */
       virtual void Accept(const TVisitor &visitor) const;
 
-      /* TODO */
       virtual TVar Copy() const;
 
-      /* TODO */
       bool Val;
 
     };  // TBool
 
-    /* TODO */
     template <>
     struct TVar::TDt<bool> {
 
-      /* TODO */
       bool static As(const TVar &that) {
         TBool *ptr = dynamic_cast<TBool *>(that.Impl.get());
         if (ptr) {

--- a/orly/var/dict.h
+++ b/orly/var/dict.h
@@ -33,85 +33,61 @@ namespace Orly {
         : public TVar::TImpl {
       public:
 
-      /* TODO */
       typedef Rt::TDict<TVar, TVar> TDictType;
       typedef TDictType TElems;
 
-      /* TODO */
       virtual Var::TVar &Index(const TVar &);
 
-      /* TODO */
       virtual TDict &Add(const TVar &);
 
-      /* TODO */
       virtual TDict &And(const TVar &);
 
-      /* TODO */
       virtual TDict &Div(const TVar &);
 
-      /* TODO */
       virtual TDict &Exp(const TVar &);
 
-      /* TODO */
       virtual TDict &Intersection(const TVar &);
 
-      /* TODO */
       virtual TDict &Mod(const TVar &);
 
-      /* TODO */
       virtual TDict &Mult(const TVar &);
 
-      /* TODO */
       virtual TDict &Or(const TVar &);
 
-      /* TODO */
       virtual TDict &Sub(const TVar &);
 
-      /* TODO */
       virtual TDict &SymmetricDiff(const TVar &);
 
-      /* TODO */
       virtual TDict &Union(const TVar &);
 
-      /* TODO */
       virtual TDict &Xor(const TVar &);
 
-      /* TODO */
       const TDictType &GetVal() const {
         return Val;
       }
 
-      /* TODO */
       void Insert(const TDictType::const_iterator &begin, const TDictType::const_iterator &end);
 
-      /* TODO */
       void Remove(const Rt::TSet<TVar> &keys);
 
-      /* TODO */
       const Type::TType &GetKeyType() const {
         return KeyType;
       }
 
-      /* TODO */
       const Type::TType &GetValType() const {
         return ValType;
       }
 
-      /* TODO */
       virtual void Touch();
 
-      /* TODO */
       virtual size_t GetHash() const;
 
-      /* TODO */
       virtual Type::TType GetType() const;
 
-      /* TODO */
       virtual void Write(std::ostream &) const;
 
       private:
 
-      /* TODO */
       #if defined(ORLY_HOST)
       template <typename TVal, typename TKey>
       TDict(const Rt::TDict<TKey, TVal> &that) : KeyType(Type::TDt<TKey>::GetType()), ValType(Type::TDt<TVal>::GetType()) {
@@ -122,39 +98,28 @@ namespace Orly {
       }
       #endif
 
-      /* TODO */
       TDict(const Rt::TDict<TVar, TVar> &that, const Type::TType &key_type, const Type::TType &val_type);
 
-      /* TODO */
       virtual ~TDict();
 
-      /* TODO */
       virtual void Accept(const TVisitor &visitor) const;
 
-      /* TODO */
       virtual TVar Copy() const;
 
-      /* TODO */
       void SetHash();
 
-      /* TODO */
       TDictType Val;
 
-      /* TODO */
       Type::TType KeyType;
 
-      /* TODO */
       Type::TType ValType;
 
-      /* TODO */
       size_t Hash;
 
-      /* TODO */
       friend class TVar;
 
     };  // TDict
 
-    /* TODO */
     template <typename TKey, typename TVal>
     TVar TVar::Dict(const Rt::TDict<TKey, TVal> &that) {
       Rt::TDict<TVar, TVar> val;
@@ -164,11 +129,9 @@ namespace Orly {
       return (new TDict(val, Type::TDt<TKey>::GetType(), Type::TDt<TVal>::GetType()))->AsVar();
     }
 
-    /* TODO */
     template<typename TKey, typename TVal>
     struct TVar::TDt<Rt::TDict<TKey, TVal>> {
 
-      /* TODO */
       Rt::TDict<TKey, TVal> static As(const TVar &that) {
         TDict *ptr = dynamic_cast<TDict *>(that.Impl.get());
         if (ptr) {

--- a/orly/var/free.h
+++ b/orly/var/free.h
@@ -28,78 +28,54 @@ namespace Orly {
         : public TVar::TImpl {
       public:
 
-      /* TODO */
       virtual Var::TVar &Index(const TVar &);
 
-      /* TODO */
       virtual TFree &Add(const TVar &);
 
-      /* TODO */
       virtual TFree &And(const TVar &);
 
-      /* TODO */
       virtual TFree &Div(const TVar &);
 
-      /* TODO */
       virtual TFree &Exp(const TVar &);
 
-      /* TODO */
       virtual TFree &Intersection(const TVar &);
 
-      /* TODO */
       virtual TFree &Mod(const TVar &);
 
-      /* TODO */
       virtual TFree &Mult(const TVar &);
 
-      /* TODO */
       virtual TFree &Or(const TVar &);
 
-      /* TODO */
       virtual TFree &Sub(const TVar &);
 
-      /* TODO */
       virtual TFree &SymmetricDiff(const TVar &);
 
-      /* TODO */
       virtual TFree &Union(const TVar &);
 
-      /* TODO */
       virtual TFree &Xor(const TVar &);
 
-      /* TODO */
       virtual size_t GetHash() const;
 
-      /* TODO */
       virtual Type::TType GetType() const;
 
-      /* TODO */
       virtual void Touch();
 
-      /* TODO */
       virtual void Write(std::ostream &) const;
 
-      /* TODO */
       static TVar New(const Type::TType &type);
 
       private:
 
-      /* TODO */
       TFree(const Type::TType &type) : Type(type) {}
 
-      /* TODO */
       virtual ~TFree();
 
-      /* TODO */
       virtual void Accept(const TVisitor &visitor) const;
 
-      /* TODO */
       virtual TVar Copy() const;
 
-      /* TODO */
       Type::TType Type;
 
-      /* TODO */
       friend class TVar;
 
     };  // TFree

--- a/orly/var/id.h
+++ b/orly/var/id.h
@@ -30,89 +30,63 @@ namespace Orly {
         : public TVar::TImpl {
       public:
 
-      /* TODO */
       virtual Var::TVar &Index(const TVar &);
 
-      /* TODO */
       virtual TId &Add(const TVar &);
 
-      /* TODO */
       virtual TId &And(const TVar &);
 
-      /* TODO */
       virtual TId &Div(const TVar &);
 
-      /* TODO */
       virtual TId &Exp(const TVar &);
 
-      /* TODO */
       virtual TId &Intersection(const TVar &);
 
-      /* TODO */
       virtual TId &Mod(const TVar &);
 
-      /* TODO */
       virtual TId &Mult(const TVar &);
 
-      /* TODO */
       virtual TId &Or(const TVar &);
 
-      /* TODO */
       virtual TId &Sub(const TVar &);
 
-      /* TODO */
       virtual TId &SymmetricDiff(const TVar &);
 
-      /* TODO */
       virtual TId &Union(const TVar &);
 
-      /* TODO */
       virtual TId &Xor(const TVar &);
 
-      /* TODO */
       Base::TUuid GetVal() const {
         return Val;
       }
 
-      /* TODO */
       virtual size_t GetHash() const;
 
-      /* TODO */
       virtual Type::TType GetType() const;
 
-      /* TODO */
       virtual void Touch();
 
-      /* TODO */
       virtual void Write(std::ostream &) const;
 
-      /* TODO */
       static TVar New(const Base::TUuid &that);
 
       private:
 
-      /* TODO */
       TId(const Base::TUuid &that);
 
-      /* TODO */
       virtual ~TId();
 
-      /* TODO */
       virtual void Accept(const TVisitor &visitor) const;
 
-      /* TODO */
       virtual TVar Copy() const;
 
-      /* TODO */
       Base::TUuid Val;
 
     };  // TId
 
-    /* TODO */
     template <>
     struct TVar::TDt<Base::TUuid> {
 
-      /* TODO */
       Base::TUuid static As(const TVar &that) {
         TId *ptr = dynamic_cast<TId *>(that.Impl.get());
         if (ptr) {

--- a/orly/var/impl.cc
+++ b/orly/var/impl.cc
@@ -31,17 +31,14 @@ namespace Orly {
 
   namespace Var {
 
-    /* TODO */
     template <typename TLhs>
     class TRhsVisitor
         : public TVar::TVisitor {
       public:
 
-      /* TODO */
       TRhsVisitor(const TLhs *lhs, const TVar::TDoubleVisitor &double_visitor)
           : Lhs(lhs), DoubleVisitor(double_visitor) {}
 
-      /* TODO */
       virtual void operator()(const Var::TAddr *rhs) const {
         DoubleVisitor(Lhs, rhs);
       }
@@ -100,24 +97,19 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       const TLhs *Lhs;
 
-      /* TODO */
       const TVar::TDoubleVisitor &DoubleVisitor;
 
     };  // TRhsVisitor<TLhs>
 
-    /* TODO */
     class TLhsVisitor
         : public TVar::TVisitor {
       public:
 
-      /* TODO */
       TLhsVisitor(const TVar &rhs, const TVar::TDoubleVisitor &double_visitor)
           : Rhs(rhs), DoubleVisitor(double_visitor) {}
 
-      /* TODO */
       virtual void operator()(const Var::TAddr *lhs) const {
         Rhs.Accept(TRhsVisitor<Var::TAddr>(lhs, DoubleVisitor));
       }
@@ -175,10 +167,8 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       const TVar &Rhs;
 
-      /* TODO */
       const TVar::TDoubleVisitor &DoubleVisitor;
 
     };  // TLhsVisitor
@@ -960,21 +950,17 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       template <typename TVal>
       static int Compare(const TVal &lhs, const TVal &rhs) {
         return lhs < rhs ? -1 : lhs > rhs ? 1 : 0;
       }
 
-      /* TODO */
       static int CompareType(const Type::TType &lhs, const Type::TType &rhs) {
         return Compare(Type::GetPrec(lhs), Type::GetPrec(rhs));
       }
 
-      /* TODO */
       int &Comp;
 
-      /* TODO */
       bool IsEqeq;
 
     };  // TCompareDoubleVisitor

--- a/orly/var/impl.h
+++ b/orly/var/impl.h
@@ -43,7 +43,6 @@ namespace Orly {
 
   namespace Var {
 
-    /* TODO */
     class TAddr;
     class TBool;
     class TDict;
@@ -65,49 +64,36 @@ namespace Orly {
 
     // template <typename TVal> struct TRead;
 
-    /* TODO */
     class TVar {
       public:
 
-      /* TODO */
       template <typename TVal>
       struct TDt {
 
-        /* TODO */
         TVal static As(const TVar &);
 
       };
 
-      /* TODO */
       class TVisitor;
 
-      /* TODO */
       class TDoubleVisitor;
 
-      /* TODO */
       class TImpl {
         NO_COPY(TImpl);
         public:
 
-        /* TODO */
         virtual Var::TVar &Index(const TVar &) = 0;
 
-        /* TODO */
         virtual TImpl &Add(const TVar &) = 0;
 
-        /* TODO */
         virtual TImpl &And(const TVar &) = 0;
 
-        /* TODO */
         virtual TImpl &Div(const TVar &) = 0;
 
-        /* TODO */
         virtual TImpl &Exp(const TVar &) = 0;
 
-        /* TODO */
         virtual TImpl &Intersection(const TVar &) = 0;
 
-        /* TODO */
         virtual TImpl &Mod(const TVar &) = 0;
 
         /* The min / max merge-mutation operators (#213). Unlike the
@@ -117,64 +103,46 @@ namespace Orly {
         virtual TImpl &Max(const TVar &);
         virtual TImpl &Min(const TVar &);
 
-        /* TODO */
         virtual TImpl &Mult(const TVar &) = 0;
 
-        /* TODO */
         virtual TImpl &Or(const TVar &) = 0;
 
-        /* TODO */
         virtual TImpl &Sub(const TVar &) = 0;
 
-        /* TODO */
         virtual TImpl &SymmetricDiff(const TVar &) = 0;
 
-        /* TODO */
         virtual TImpl &Union(const TVar &) = 0;
 
-        /* TODO */
         virtual TImpl &Xor(const TVar &) = 0;
 
         protected:
 
-        /* TODO */
         typedef TVar::TVisitor TVisitor;
 
-        /* TODO */
         TImpl() {}
 
-        /* TODO */
         virtual ~TImpl();
 
-        /* TODO */
         TVar AsVar() {
           return TVar(this);
         }
 
-        /* TODO */
         virtual void Accept(const TVisitor &visitor) const = 0;
 
-        /* TODO */
         virtual TVar Copy() const = 0;
 
-        /* TODO */
         virtual size_t GetHash() const = 0;
 
-        /* TODO */
         virtual Type::TType GetType() const = 0;
 
-        /* TODO */
         virtual void Touch() = 0;
 
-        /* TODO */
         virtual void Write(std::ostream &) const = 0;
 
         private:
 
-        /* TODO */
         static void Delete(TImpl *impl);
 
-        /* TODO */
         friend class TVar;
 
       };  // TImpl
@@ -183,7 +151,6 @@ namespace Orly {
          See <orly/var/unknown.h>. */
       TVar();
 
-      /* TODO */
       ~TVar();
 
       /* Construct a new TVar from a bool.
@@ -215,13 +182,11 @@ namespace Orly {
          See <orly/var/time_pnt.h>. */
       TVar(const Base::Chrono::TTimePnt &that);
 
-      /* TODO */
       template <typename TVal>
       TVar(const Rt::TSet<TVal> &that) {
         *this = Set(that);
       }
 
-      /* TODO */
       template <typename TVal>
       TVar(const std::vector<TVal> &that) {
         *this = List(that);
@@ -234,7 +199,6 @@ namespace Orly {
         *this = Mutable(that);
       }
 
-      /* TODO */
       template <typename TKey, typename TVal>
       TVar(const Rt::TDict<TKey, TVal> &that) {
         *this = Dict(that);
@@ -246,7 +210,6 @@ namespace Orly {
         *this = Addr(that);
       } */
 
-      /* TODO */
       template <typename TVal>
       TVar(const Rt::TOpt<TVal> &that) {
         *this = Opt(that);
@@ -260,13 +223,10 @@ namespace Orly {
       template <typename TCompound>
       explicit TVar(const TCompound &that);
 
-      /* TODO */
       TVar(TVar &&that);
 
-      /* TODO */
       TVar(const TVar &that);
 
-      /* TODO */
       static TVar Addr(const std::vector<std::pair<TAddrDir, TVar>> &that);
 
       /* TODO
@@ -274,20 +234,15 @@ namespace Orly {
       static TVar Addr(const Rt::TAddr<TElements...> &that);
       */
 
-      /* TODO */
       static TVar Dict(const Rt::TDict<TVar, TVar> &that, const Type::TType &key_type, const Type::TType &val_type);
 
-      /* TODO */
       template <typename TKey, typename TVal>
       static TVar Dict(const Rt::TDict<TKey, TVal> &that);
 
-      /* TODO */
       static TVar Free(const Type::TType &type);
 
-      /* TODO */
       static TVar List(const std::vector<TVar> &that, const Type::TType &type);
 
-      /* TODO */
       template <typename TVal>
       static TVar List(const std::vector<TVal> &that);
 
@@ -296,20 +251,15 @@ namespace Orly {
       template <typename TAddr, typename TVal>
       static TVar Mutable(const Rt::TMutable<TAddr, TVal> &that);
 
-      /* TODO */
       static TVar Obj(const std::unordered_map<std::string, TVar> &map_);
 
-      /* TODO */
       static TVar Opt(const Rt::TOpt<TVar> &opt, const Type::TType &type);
 
-      /* TODO */
       template <typename TVal>
       static TVar Opt(const Rt::TOpt<TVal> &that);
 
-      /* TODO */
       static TVar Set(const Rt::TSet<TVar> &that, const Type::TType &type);
 
-      /* TODO */
       template <typename TVal>
       static TVar Set(const Rt::TSet<TVal> &that);
 
@@ -317,7 +267,6 @@ namespace Orly {
          tag, and its payload value.  See <orly/var/variant.h>. */
       static TVar Variant(const Type::TType &variant_type, const std::string &tag, const TVar &payload);
 
-      /* TODO */
       TVar Copy() const;
 
       template <typename TTarget>
@@ -329,193 +278,158 @@ namespace Orly {
       template <typename TTarget>
       const TTarget *TryAs() const;
 
-      /* TODO */
       TVar &operator=(TVar &&that);
 
-      /* TODO */
       TVar &operator=(const TVar &that);
 
-      /* TODO */
       bool operator==(const TVar &that) const;
 
-      /* TODO */
       bool operator!=(const TVar &that) const {
         return !(*this == that);
       }
 
-      /* TODO */
       bool operator<(const TVar &that) const;
 
-      /* TODO */
       bool operator<=(const TVar &that) const {
         return (*this < that) || (*this == that);
       }
 
-      /* TODO */
       bool operator>(const TVar &that) const;
 
-      /* TODO */
       bool operator>=(const TVar &that) const {
         return (*this > that) || (*this == that);
       }
 
-      /* TODO */
       explicit operator bool() const;
 
-      /* TODO */
       Var::TVar &Index(const TVar &key) {
         return Impl->Index(key);
       }
 
-      /* TODO */
       Var::TVar &Add(const TVar &rhs) {
         assert(*this);
         Impl->Add(rhs);
         return *this;
       }
 
-      /* TODO */
       Var::TVar &And(const TVar &rhs) {
         assert(*this);
         Impl->And(rhs);
         return *this;
       }
 
-      /* TODO */
       Var::TVar &Div(const TVar &rhs) {
         assert(*this);
         Impl->Div(rhs);
         return *this;
       }
 
-      /* TODO */
       Var::TVar &Exp(const TVar &rhs) {
         assert(*this);
         Impl->Exp(rhs);
         return *this;
       }
 
-      /* TODO */
       Var::TVar &Intersection(const TVar &rhs) {
         assert(*this);
         Impl->Intersection(rhs);
         return *this;
       }
 
-      /* TODO */
       Var::TVar &Mod(const TVar &rhs) {
         assert(*this);
         Impl->Mod(rhs);
         return *this;
       }
 
-      /* TODO */
       Var::TVar &Max(const TVar &rhs) {
         assert(*this);
         Impl->Max(rhs);
         return *this;
       }
 
-      /* TODO */
       Var::TVar &Min(const TVar &rhs) {
         assert(*this);
         Impl->Min(rhs);
         return *this;
       }
 
-      /* TODO */
       Var::TVar &Mult(const TVar &rhs) {
         assert(*this);
         Impl->Mult(rhs);
         return *this;
       }
 
-      /* TODO */
       Var::TVar &Or(const TVar &rhs) {
         assert(*this);
         Impl->Or(rhs);
         return *this;
       }
 
-      /* TODO */
       Var::TVar &Sub(const TVar &rhs) {
         assert(*this);
         Impl->Sub(rhs);
         return *this;
       }
 
-      /* TODO */
       Var::TVar &SymmetricDiff(const TVar &rhs) {
         assert(*this);
         Impl->SymmetricDiff(rhs);
         return *this;
       }
 
-      /* TODO */
       Var::TVar &Union(const TVar &rhs) {
         assert(*this);
         Impl->Union(rhs);
         return *this;
       }
 
-      /* TODO */
       Var::TVar &Xor(const TVar &rhs) {
         assert(*this);
         Impl->Xor(rhs);
         return *this;
       }
 
-      /* TODO */
       void Accept(const TVisitor &visitor) const {
         assert(Impl);
         Impl->Accept(visitor);
       }
 
-      /* TODO */
       int Compare(const TVar &that) const;
 
-      /* TODO */
       size_t GetHash() const {
         return Impl->GetHash();
       }
 
-      /* TODO */
       Type::TType GetType() const {
         return Impl->GetType();
       }
 
-      /* TODO */
       TVar &Reset() {
         return *this = TVar();
       }
 
-      /* TODO */
       void Touch() {
         Impl->Touch();
       }
 
-      /* TODO */
       static void Accept(
           const TVar &lhs, const TVar &rhs,
           const TDoubleVisitor &double_visitor);
 
-      /* TODO */
       void Write(std::ostream &stream) const {
         Impl->Write(stream);
       }
 
       private:
 
-      /* TODO */
       TVar(TImpl *impl)
           : Impl(impl, TImpl::Delete) {
         assert(impl);
       }
 
-      /* TODO */
       void Init();
 
-      /* TODO */
       std::shared_ptr<TImpl> Impl;
 
       template <typename TVal> friend TVal DynamicCast(const TVar &var);
@@ -524,25 +438,20 @@ namespace Orly {
 
     };  // TVar
 
-    /* TODO */
     template <>
     struct TVar::TDt<TVar> {
 
-      /* TODO */
       TVar static As(const TVar &rhs) {
         return rhs;
       }
 
     };
 
-    /* TODO */
     class TVar::TVisitor {
       public:
 
-      /* TODO */
       virtual ~TVisitor();
 
-      /* TODO */
       virtual void operator()(const Var::TAddr *that) const = 0;
       virtual void operator()(const Var::TBool *that) const = 0;
       virtual void operator()(const Var::TDict *that) const = 0;
@@ -570,19 +479,15 @@ namespace Orly {
 
       protected:
 
-      /* TODO */
       TVisitor() {}
 
     };  // TVisitor
 
-    /* TODO */
     class TVar::TDoubleVisitor {
       public:
 
-      /* TODO */
       virtual ~TDoubleVisitor();
 
-      /* TODO */
       virtual void operator()(const Var::TAddr *lhs, const Var::TAddr *rhs) const = 0;
       virtual void operator()(const Var::TAddr *lhs, const Var::TBool *rhs) const = 0;
       virtual void operator()(const Var::TAddr *lhs, const Var::TDict *rhs) const = 0;
@@ -919,13 +824,11 @@ namespace Orly {
 
       protected:
 
-      /* TODO */
       TDoubleVisitor() {}
 
     };  // TDoubleVisitor
 
 
-  /* TODO */
   inline std::ostream &operator<<(std::ostream &stream, const TVar &var) {
     var.Write(stream);
     return stream;

--- a/orly/var/int.h
+++ b/orly/var/int.h
@@ -32,93 +32,67 @@ namespace Orly {
         : public TVar::TImpl {
       public:
 
-      /* TODO */
       virtual Var::TVar &Index(const TVar &);
 
-      /* TODO */
       virtual TInt &Add(const TVar &);
 
-      /* TODO */
       virtual TInt &And(const TVar &);
 
-      /* TODO */
       virtual TInt &Div(const TVar &);
 
-      /* TODO */
       virtual TInt &Exp(const TVar &);
 
-      /* TODO */
       virtual TInt &Intersection(const TVar &);
 
       /* The max / min merge-mutation operators (#213). */
       virtual TInt &Max(const TVar &);
       virtual TInt &Min(const TVar &);
 
-      /* TODO */
       virtual TInt &Mod(const TVar &);
 
-      /* TODO */
       virtual TInt &Mult(const TVar &);
 
-      /* TODO */
       virtual TInt &Or(const TVar &);
 
-      /* TODO */
       virtual TInt &Sub(const TVar &);
 
-      /* TODO */
       virtual TInt &SymmetricDiff(const TVar &);
 
-      /* TODO */
       virtual TInt &Union(const TVar &);
 
-      /* TODO */
       virtual TInt &Xor(const TVar &);
 
-      /* TODO */
       int64_t GetVal() const {
         return Val;
       }
 
-      /* TODO */
       virtual size_t GetHash() const;
 
-      /* TODO */
       virtual Type::TType GetType() const;
 
-      /* TODO */
       virtual void Touch();
 
-      /* TODO */
       static TVar New(int64_t that);
 
-      /* TODO */
       virtual void Write(std::ostream &stream) const;
 
       private:
 
-      /* TODO */
       TInt(int64_t that);
 
-      /* TODO */
       virtual ~TInt();
 
-      /* TODO */
       virtual void Accept(const TVisitor &visitor) const;
 
-      /* TODO */
       virtual TVar Copy() const;
 
-      /* TODO */
       int64_t Val;
 
     };  // TInt
 
-    /* TODO */
     template <>
     struct TVar::TDt<int64_t> {
 
-      /* TODO */
       int64_t static As(const TVar &that) {
         const Orly::Var::TInt *ptr = dynamic_cast<const TInt *>(that.Impl.get());
         if (ptr) {

--- a/orly/var/jsonify.h
+++ b/orly/var/jsonify.h
@@ -26,7 +26,6 @@ namespace Orly {
 
     class TVar;
 
-    /* TODO */
     void Jsonify(std::ostream &stream, const TVar &var);
 
   }  // Var

--- a/orly/var/list.h
+++ b/orly/var/list.h
@@ -32,77 +32,55 @@ namespace Orly {
         : public TVar::TImpl {
       public:
 
-      /* TODO */
       typedef std::vector<TVar> TListType;
       typedef TListType TElems;
 
-      /* TODO */
       virtual Var::TVar &Index(const TVar &);
 
-      /* TODO */
       virtual TList &Add(const TVar &);
 
-      /* TODO */
       virtual TList &And(const TVar &);
 
-      /* TODO */
       virtual TList &Div(const TVar &);
 
-      /* TODO */
       virtual TList &Exp(const TVar &);
 
-      /* TODO */
       virtual TList &Intersection(const TVar &);
 
-      /* TODO */
       virtual TList &Mod(const TVar &);
 
-      /* TODO */
       virtual TList &Mult(const TVar &);
 
-      /* TODO */
       virtual TList &Or(const TVar &);
 
-      /* TODO */
       virtual TList &Sub(const TVar &);
 
-      /* TODO */
       virtual TList &SymmetricDiff(const TVar &);
 
-      /* TODO */
       virtual TList &Union(const TVar &);
 
-      /* TODO */
       virtual TList &Xor(const TVar &);
 
-      /* TODO */
       const Type::TType &GetElemType() const {
         return Type;
       }
 
-      /* TODO */
       const TListType &GetVal() const {
         return Val;
       }
 
-      /* TODO */
       void Append(const TListType &other);
 
-      /* TODO */
       virtual size_t GetHash() const;
 
-      /* TODO */
       virtual Type::TType GetType() const;
 
-      /* TODO */
       virtual void Touch();
 
-      /* TODO */
       virtual void Write(std::ostream &) const;
 
       private:
 
-      /* TODO */
       #if defined(ORLY_HOST)
       template <typename TVal>
       TList(const std::vector<TVal> &that) : Type(Type::TDt<TVal>::GetType()) {
@@ -113,36 +91,26 @@ namespace Orly {
       }
       #endif
 
-      /* TODO */
       TList(const std::vector<TVar> &that, const Type::TType &type);
 
-      /* TODO */
       virtual ~TList();
 
-      /* TODO */
       virtual void Accept(const TVisitor &visitor) const;
 
-      /* TODO */
       virtual TVar Copy() const;
 
-      /* TODO */
       void SetHash();
 
-      /* TODO */
       TListType Val;
 
-      /* TODO */
       Type::TType Type;
 
-      /* TODO */
       size_t Hash;
 
-      /* TODO */
       friend class TVar;
 
     };  // TList
 
-    /* TODO */
     template <typename TVal>
     TVar TVar::List(const std::vector<TVal> &that) {
       std::vector<TVar> val;
@@ -152,11 +120,9 @@ namespace Orly {
       return (new TList(val, Type::TDt<TVal>::GetType()))->AsVar();
     }
 
-    /* TODO */
     template<typename TVal>
     struct TVar::TDt<std::vector<TVal>> {
 
-      /* TODO */
       std::vector<TVal> static As(const TVar &that) {
         TList *ptr = dynamic_cast<TList *>(that.Impl.get());
         if (ptr) {

--- a/orly/var/mutable.h
+++ b/orly/var/mutable.h
@@ -33,46 +33,32 @@ namespace Orly {
         : public TVar::TImpl {
       public:
 
-      /* TODO */
       virtual Var::TVar &Index(const TVar &) final;
 
-      /* TODO */
       virtual TVar::TImpl &Add(const TVar &) final;
 
-      /* TODO */
       virtual TVar::TImpl &And(const TVar &) final;
 
-      /* TODO */
       virtual TVar::TImpl &Div(const TVar &) final;
 
-      /* TODO */
       virtual TVar::TImpl &Exp(const TVar &) final;
 
-      /* TODO */
       virtual TVar::TImpl &Intersection(const TVar &) final;
 
-      /* TODO */
       virtual TVar::TImpl &Mod(const TVar &) final;
 
-      /* TODO */
       virtual TVar::TImpl &Mult(const TVar &) final;
 
-      /* TODO */
       virtual TVar::TImpl &Or(const TVar &) final;
 
-      /* TODO */
       virtual TVar::TImpl &Sub(const TVar &) final;
 
-      /* TODO */
       virtual TVar::TImpl &SymmetricDiff(const TVar &) final;
 
-      /* TODO */
       virtual TVar::TImpl &Union(const TVar &) final;
 
-      /* TODO */
       virtual TVar::TImpl &Xor(const TVar &) final;
 
-      /* TODO */
       const Var::TVar &GetVal() const {
         return Val;
       }
@@ -81,52 +67,38 @@ namespace Orly {
         return Addr;
       }
 
-      /* TODO */
       virtual size_t GetHash() const;
 
-      /* TODO */
       virtual Type::TType GetType() const;
 
-      /* TODO */
       virtual void Touch();
 
-      /* TODO */
       virtual void Write(std::ostream &) const;
 
       private:
 
-      /* TODO */
       template <typename TAddr, typename TVal>
       TMutable(const Rt::TMutable<TAddr, TVal> &that)
             : Addr(that.GetOptAddr()), Val(that.GetVal()), Type(Type::TDt<Rt::TMutable<TAddr, TVal>>::GetType()) {
         SetHash();
       }
 
-      /* TODO */
       TMutable(const Var::TVar &addr, const Var::TVar &val);
 
-      /* TODO */
       virtual ~TMutable();
 
-      /* TODO */
       virtual void Accept(const TVisitor &visitor) const;
 
-      /* TODO */
       virtual TVar Copy() const;
 
-      /* TODO */
       void SetHash();
 
-      /* TODO */
       Var::TVar Addr, Val;
 
-      /* TODO */
       Type::TType Type;
 
-      /* TODO */
       size_t Hash;
 
-      /* TODO */
       friend class TVar;
 
     };  // TAddr
@@ -136,11 +108,9 @@ namespace Orly {
       return (new TMutable(that))->AsVar();
     }
 
-    /* TODO */
     template <typename TAddr, typename TVal>
     struct TVar::TDt<Rt::TMutable<TAddr, TVal>> {
 
-      /* TODO */
       Rt::TMutable<TAddr, TVal> static As(const TVar &that) {
         TMutable *ptr = dynamic_cast<TMutable *>(that.Impl.get());
         if (ptr) {

--- a/orly/var/new_sabot.h
+++ b/orly/var/new_sabot.h
@@ -55,60 +55,48 @@ namespace Orly {
 
     namespace SS {
 
-      /* TODO */
       class TDescMod final
           : public Sabot::Type::TDesc {
         public:
 
-        /* TODO */
         using TFactory = std::function<Sabot::Type::TAny *(void *)>;
 
-        /* TODO */
         using TPinBase = Sabot::Type::TDesc::TPin;
 
-        /* TODO */
         class TPin final
             : public TPinBase {
           public:
 
-          /* TODO */
           TPin(const TDescMod *desc_mod)
               : DescMod(desc_mod) {}
 
-          /* TODO */
           virtual TAny *NewElem(void *type_alloc) const override {
             return DescMod->Factory(type_alloc);
           }
 
           private:
 
-          /* TODO */
           const TDescMod *DescMod;
 
         };  // TDescNullary<TFoo>::TPin
 
-        /* TODO */
         TDescMod(TFactory &&factory)
             : Factory(std::move(factory)) {}
 
-        /* TODO */
         virtual TPinBase *Pin(void *alloc) const override {
           return new (alloc) TPin(this);
         }
 
         private:
 
-        /* TODO */
         TFactory Factory;
 
       };  // TDescMod
 
-      /* TODO */
       class TFreeDesc final
           : public Sabot::Type::TFree {
         public:
 
-        /* TODO */
         class TPin final
             : public Sabot::Type::TFree::TPin {
           public:
@@ -129,7 +117,6 @@ namespace Orly {
 
         };  // TFreeDesc::TPin
 
-        /* TODO */
         TFreeDesc(const Type::TType &elem)
             : Elem(elem) {}
 
@@ -167,7 +154,6 @@ namespace Orly {
         /* The type on which we are free. */
         Type::TType Type;
 
-        /* TODO */
         TAddrDir AddrDir;
 
       };  // TFree
@@ -224,57 +210,46 @@ namespace Orly {
 
       };  // TId
 
-      /* TODO */
       class TDesc final
           : public Sabot::State::TDesc {
         public:
 
-        /* TODO */
         using TPinBase = Sabot::State::TDesc::TPin;
 
-        /* TODO */
         class TPin final
             : public TPinBase {
           public:
 
-          /* TODO */
           TPin(const TDesc *desc)
               : TPinBase(desc), Desc(desc) {}
 
           private:
 
-          /* TODO */
           virtual Sabot::State::TAny *NewElemInRange(size_t, void *state_alloc) const override {
             return NewSabot(state_alloc, Desc->Var);
           }
 
-          /* TODO */
           const TDesc *Desc;
 
         };  // TDesc::TPin
 
-        /* TODO */
         TDesc(const Var::TVar &var)
             : Var(var) {}
 
-        /* TODO */
         virtual Sabot::Type::TDesc *GetDescType(void *buf) const override {
           return new (buf) Type::ST::TDesc(Var.GetType());
         }
 
-        /* TODO */
         virtual size_t GetElemCount() const override {
           return 1;
         }
 
-        /* TODO */
         virtual TPinBase *Pin(void *alloc) const override {
           return new (alloc) TPin(this);
         }
 
         private:
 
-        /* TODO */
         Var::TVar Var;
 
       };  // TDesc

--- a/orly/var/obj.cc
+++ b/orly/var/obj.cc
@@ -27,12 +27,10 @@ using namespace Orly;
 using namespace Orly::Var;
 using namespace Util;
 
-/* TODO */
 size_t TObj::GetHash() const {
   return Hash;
 }
 
-/* TODO */
 Type::TType TObj::GetType() const {
   return Type::TObj::Get(TypeMap);
 }

--- a/orly/var/obj.h
+++ b/orly/var/obj.h
@@ -33,7 +33,6 @@ namespace Orly {
 
   namespace Type {
 
-    /* TODO */
     template <typename TCompound>
     template <typename TVal>
     void TObj::Meta<TCompound>::TField<TVal>::GetVal(const TCompound &that, Var::TVar &out) const {
@@ -48,68 +47,48 @@ namespace Orly {
         : public TVar::TImpl {
       public:
 
-      /* TODO */
       virtual Var::TVar &Index(const TVar &);
 
-      /* TODO */
       virtual TObj &Add(const TVar &);
 
-      /* TODO */
       virtual TObj &And(const TVar &);
 
-      /* TODO */
       virtual TObj &Div(const TVar &);
 
-      /* TODO */
       virtual TObj &Exp(const TVar &);
 
-      /* TODO */
       virtual TObj &Intersection(const TVar &);
 
-      /* TODO */
       virtual TObj &Mod(const TVar &);
 
-      /* TODO */
       virtual TObj &Mult(const TVar &);
 
-      /* TODO */
       virtual TObj &Or(const TVar &);
 
-      /* TODO */
       virtual TObj &Sub(const TVar &);
 
-      /* TODO */
       virtual TObj &SymmetricDiff(const TVar &);
 
-      /* TODO */
       virtual TObj &Union(const TVar &);
 
-      /* TODO */
       virtual TObj &Xor(const TVar &);
 
-      /* TODO */
       template <typename TCompound, typename TVal>
       static void GetValFromField(const TCompound &compound, const typename Type::TObj::Meta<TCompound>::template TField<TVal> &field, TVar &out) {
         out = TVar(compound.*(field.Member));
       }
 
-      /* TODO */
       typedef std::unordered_map<std::string, TVar> TFieldsByName;
       typedef TFieldsByName TElems;
 
-      /* TODO */
       virtual size_t GetHash() const;
 
-      /* TODO */
       virtual Type::TType GetType() const;
 
-      /* TODO */
       virtual void Touch();
 
-      /* TODO */
       virtual void Write(std::ostream &) const;
 
-      /* TODO */
       const TFieldsByName &GetVal() const {
         return FieldsByName;
       }
@@ -137,34 +116,24 @@ namespace Orly {
       }
       */
 
-      /* TODO */
       TObj(const TFieldsByName &that);
 
-      /* TODO */
       virtual ~TObj();
 
-      /* TODO */
       virtual void Accept(const TVisitor &visitor) const;
 
-      /* TODO */
       virtual TVar Copy() const;
 
-      /* TODO */
       void SetHash();
 
-      /* TODO */
       TFieldsByName FieldsByName;
 
-      /* TODO */
       size_t Hash;
 
-      /* TODO */
       std::map<std::string, Type::TType> TypeMap;
 
-      /* TODO */
       static const TVar DefaultVar;
 
-      /* TODO */
       friend class TVar;
 
     };  // TObj
@@ -175,7 +144,6 @@ namespace Orly {
       *this = that.AsVar();
     }
 
-    /* TODO */
     template <typename TVal>
     TVal Var::TVar::TDt<TVal>::As(const TVar &that) {
       TObj *ptr = dynamic_cast<TObj *>(that.Impl.get());

--- a/orly/var/opt.h
+++ b/orly/var/opt.h
@@ -32,72 +32,51 @@ namespace Orly {
         : public TVar::TImpl {
       public:
 
-      /* TODO */
       typedef Rt::TOpt<TVar> TOptType;
 
-      /* TODO */
       virtual Var::TVar &Index(const TVar &);
 
-      /* TODO */
       virtual TOpt &Add(const TVar &);
 
-      /* TODO */
       virtual TOpt &And(const TVar &);
 
-      /* TODO */
       virtual TOpt &Div(const TVar &);
 
-      /* TODO */
       virtual TOpt &Exp(const TVar &);
 
-      /* TODO */
       virtual TOpt &Intersection(const TVar &);
 
-      /* TODO */
       virtual TOpt &Mod(const TVar &);
 
-      /* TODO */
       virtual TOpt &Mult(const TVar &);
 
-      /* TODO */
       virtual TOpt &Or(const TVar &);
 
-      /* TODO */
       virtual TOpt &Sub(const TVar &);
 
-      /* TODO */
       virtual TOpt &SymmetricDiff(const TVar &);
 
-      /* TODO */
       virtual TOpt &Union(const TVar &);
 
-      /* TODO */
       virtual TOpt &Xor(const TVar &);
 
-      /* TODO */
       const TOptType &GetVal() const {
         return Val;
       }
 
-      /* TODO */
       virtual size_t GetHash() const;
 
-      /* TODO */
       virtual Type::TType GetType() const;
 
-      /* TODO */
       Type::TType GetInnerType() const;
 
 
-      /* TODO */
       virtual void Touch();
 
-      /* TODO */
       virtual void Write(std::ostream &) const;
 
       private:
 
-      /* TODO */
       #if defined(ORLY_HOST)
       template <typename TVal>
       TOpt(const Rt::TOpt<TVal> &that) : Type(Type::TDt<TVal>::GetType()) {
@@ -108,31 +87,22 @@ namespace Orly {
       }
       #endif
 
-      /* TODO */
       TOpt(const Rt::TOpt<TVar> &that, const Type::TType &type);
 
-      /* TODO */
       virtual ~TOpt();
 
-      /* TODO */
       virtual void Accept(const TVisitor &visitor) const;
 
-      /* TODO */
       virtual TVar Copy() const;
 
-      /* TODO */
       void SetHash();
 
-      /* TODO */
       TOptType Val;
 
-      /* TODO */
       Type::TType Type;
 
-      /* TODO */
       size_t Hash;
 
-      /* TODO */
       friend class TVar;
 
     };  // TOpt
@@ -146,11 +116,9 @@ namespace Orly {
       return (new TOpt(val, Type::TDt<TVal>::GetType()))->AsVar();
     }
 
-    /* TODO */
     template <typename TVal>
     struct TVar::TDt<Rt::TOpt<TVal>> {
 
-      /* TODO */
       Rt::TOpt<TVal> static As(const TVar &that) {
         TOpt *ptr = dynamic_cast<TOpt *>(that.Impl.get());
         if (ptr) {

--- a/orly/var/orlyify.h
+++ b/orly/var/orlyify.h
@@ -26,7 +26,6 @@ namespace Orly {
 
     class TVar;
 
-    /* TODO */
     void Orlyify(std::ostream &stream, const TVar &var);
 
   }  // Var

--- a/orly/var/real.h
+++ b/orly/var/real.h
@@ -31,93 +31,67 @@ namespace Orly {
         : public TVar::TImpl {
       public:
 
-      /* TODO */
       virtual Var::TVar &Index(const TVar &);
 
-      /* TODO */
       virtual TReal &Add(const TVar &);
 
-      /* TODO */
       virtual TReal &And(const TVar &);
 
-      /* TODO */
       virtual TReal &Div(const TVar &);
 
-      /* TODO */
       virtual TReal &Exp(const TVar &);
 
-      /* TODO */
       virtual TReal &Intersection(const TVar &);
 
       /* The max / min merge-mutation operators (#213). */
       virtual TReal &Max(const TVar &);
       virtual TReal &Min(const TVar &);
 
-      /* TODO */
       virtual TReal &Mod(const TVar &);
 
-      /* TODO */
       virtual TReal &Mult(const TVar &);
 
-      /* TODO */
       virtual TReal &Or(const TVar &);
 
-      /* TODO */
       virtual TReal &Sub(const TVar &);
 
-      /* TODO */
       virtual TReal &SymmetricDiff(const TVar &);
 
-      /* TODO */
       virtual TReal &Union(const TVar &);
 
-      /* TODO */
       virtual TReal &Xor(const TVar &);
 
-      /* TODO */
       virtual size_t GetHash() const;
 
-      /* TODO */
       double GetVal() const {
         return Val;
       }
 
-      /* TODO */
       virtual Type::TType GetType() const;
 
-      /* TODO */
       virtual void Touch();
 
-      /* TODO */
       static TVar New(double that);
 
-      /* TODO */
       virtual void Write(std::ostream &stream) const;
 
       private:
 
-      /* TODO */
       TReal(double that);
 
-      /* TODO */
       virtual ~TReal();
 
-      /* TODO */
       virtual void Accept(const TVisitor &visitor) const;
 
-      /* TODO */
       virtual TVar Copy() const;
 
-      /* TODO */
       double Val;
 
     };  // TReal
 
-    /* TODO */
     template <>
     struct TVar::TDt<double> {
 
-      /* TODO */
       double static As(const TVar &that) {
         TReal *ptr = dynamic_cast<TReal *>(that.Impl.get());
         if (ptr) {

--- a/orly/var/sabot_to_var.h
+++ b/orly/var/sabot_to_var.h
@@ -39,12 +39,10 @@ namespace Orly {
 
     };  // TVarTranslationError
 
-    /* TODO */
     class TToVarVisitor final
         : public Sabot::TStateVisitor {
       public:
 
-      /* TODO */
       TToVarVisitor(Var::TVar &var)
           : Var(var) {
       }
@@ -80,12 +78,10 @@ namespace Orly {
 
       private:
 
-      /* TODO */
       Var::TVar &Var;
 
     };  // TToVarVisitor
 
-    /* TODO */
     inline Var::TVar ToVar(const Sabot::State::TAny &state) {
       Var::TVar var;
       state.Accept(TToVarVisitor(var));
@@ -96,7 +92,6 @@ namespace Orly {
 
   namespace Sabot {
 
-    /* TODO */
     inline void ToNative(const Sabot::State::TAny &state, Var::TVar &val) {
       val = Var::ToVar(state);
     }

--- a/orly/var/set.h
+++ b/orly/var/set.h
@@ -33,73 +33,52 @@ namespace Orly {
         : public TVar::TImpl {
       public:
 
-      /* TODO */
       typedef Rt::TSet<TVar> TSetType;
 
-      /* TODO */
       virtual Var::TVar &Index(const TVar &);
 
-      /* TODO */
       virtual TSet &Add(const TVar &);
 
-      /* TODO */
       virtual TSet &And(const TVar &);
 
-      /* TODO */
       virtual TSet &Div(const TVar &);
 
-      /* TODO */
       virtual TSet &Exp(const TVar &);
 
-      /* TODO */
       virtual TSet &Intersection(const TVar &);
 
-      /* TODO */
       virtual TSet &Mod(const TVar &);
 
-      /* TODO */
       virtual TSet &Mult(const TVar &);
 
-      /* TODO */
       virtual TSet &Or(const TVar &);
 
-      /* TODO */
       virtual TSet &Sub(const TVar &);
 
-      /* TODO */
       virtual TSet &SymmetricDiff(const TVar &);
 
-      /* TODO */
       virtual TSet &Union(const TVar &);
 
-      /* TODO */
       virtual TSet &Xor(const TVar &);
 
-      /* TODO */
       const Type::TType &GetElemType() const {
         return Type;
       }
 
-      /* TODO */
       const TSetType &GetVal() const {
         return Val;
       }
 
-      /* TODO */
       virtual size_t GetHash() const;
 
-      /* TODO */
       virtual void Write(std::ostream &) const;
 
-      /* TODO */
       virtual Type::TType GetType() const;
 
-      /* TODO */
       virtual void Touch();
 
       private:
 
-      /* TODO */
       #if defined(ORLY_HOST)
       template <typename TVal>
       TSet(const Rt::TSet<TVal> &that) : Type(Type::TDt<TVal>::GetType()) {
@@ -110,36 +89,26 @@ namespace Orly {
       }
       #endif
 
-      /* TODO */
       TSet(const Rt::TSet<TVar> &that, const Type::TType &type);
 
-      /* TODO */
       virtual ~TSet();
 
-      /* TODO */
       virtual void Accept(const TVisitor &visitor) const;
 
-      /* TODO */
       virtual TVar Copy() const;
 
-      /* TODO */
       void SetHash();
 
-      /* TODO */
       TSetType Val;
 
-      /* TODO */
       Type::TType Type;
 
-      /* TODO */
       size_t Hash;
 
-      /* TODO */
       friend class TVar;
 
     };  // TSet
 
-    /* TODO */
     template <typename TVal>
     TVar TVar::Set(const Rt::TSet<TVal> &that) {
       Rt::TSet<TVar> val;
@@ -149,11 +118,9 @@ namespace Orly {
       return (new TSet(val, Type::TDt<TVal>::GetType()))->AsVar();
     }
 
-    /* TODO */
     template<typename TVal>
     struct TVar::TDt<Rt::TSet<TVal>> {
 
-      /* TODO */
       Rt::TSet<TVal> static As(const TVar &that) {
         TSet *ptr = dynamic_cast<TSet *>(that.Impl.get());
         if (ptr) {

--- a/orly/var/str.h
+++ b/orly/var/str.h
@@ -31,89 +31,63 @@ namespace Orly {
         : public TVar::TImpl {
       public:
 
-      /* TODO */
       virtual Var::TVar &Index(const TVar &);
 
-      /* TODO */
       virtual TStr &Add(const TVar &);
 
-      /* TODO */
       virtual TStr &And(const TVar &);
 
-      /* TODO */
       virtual TStr &Div(const TVar &);
 
-      /* TODO */
       virtual TStr &Exp(const TVar &);
 
-      /* TODO */
       virtual TStr &Intersection(const TVar &);
 
-      /* TODO */
       virtual TStr &Mod(const TVar &);
 
-      /* TODO */
       virtual TStr &Mult(const TVar &);
 
-      /* TODO */
       virtual TStr &Or(const TVar &);
 
-      /* TODO */
       virtual TStr &Sub(const TVar &);
 
-      /* TODO */
       virtual TStr &SymmetricDiff(const TVar &);
 
-      /* TODO */
       virtual TStr &Union(const TVar &);
 
-      /* TODO */
       virtual TStr &Xor(const TVar &);
 
-      /* TODO */
       virtual size_t GetHash() const;
 
-      /* TODO */
       const std::string &GetVal() const {
         return Val;
       }
 
-      /* TODO */
       virtual Type::TType GetType() const;
 
-      /* TODO */
       virtual void Touch();
 
-      /* TODO */
       static TVar New(const std::string &that);
 
-      /* TODO */
       virtual void Write(std::ostream &strm) const;
 
       private:
 
-      /* TODO */
       TStr(const std::string &that);
 
-      /* TODO */
       virtual ~TStr();
 
-      /* TODO */
       virtual void Accept(const TVisitor &visitor) const;
 
-      /* TODO */
       virtual TVar Copy() const;
 
-      /* TODO */
       std::string Val;
 
     };  // TStr
 
-    /* TODO */
     template <>
     struct TVar::TDt<std::string> {
 
-      /* TODO */
       std::string static As(const TVar &that) {
         TStr *ptr = dynamic_cast<TStr *>(that.Impl.get());
         if (ptr) {

--- a/orly/var/time_diff.h
+++ b/orly/var/time_diff.h
@@ -32,89 +32,63 @@ namespace Orly {
         : public TVar::TImpl {
       public:
 
-      /* TODO */
       virtual Var::TVar &Index(const TVar &);
 
-      /* TODO */
       virtual TTimeDiff &Add(const TVar &);
 
-      /* TODO */
       virtual TTimeDiff &And(const TVar &);
 
-      /* TODO */
       virtual TTimeDiff &Div(const TVar &);
 
-      /* TODO */
       virtual TTimeDiff &Exp(const TVar &);
 
-      /* TODO */
       virtual TTimeDiff &Intersection(const TVar &);
 
-      /* TODO */
       virtual TTimeDiff &Mod(const TVar &);
 
-      /* TODO */
       virtual TTimeDiff &Mult(const TVar &);
 
-      /* TODO */
       virtual TTimeDiff &Or(const TVar &);
 
-      /* TODO */
       virtual TTimeDiff &Sub(const TVar &);
 
-      /* TODO */
       virtual TTimeDiff &SymmetricDiff(const TVar &);
 
-      /* TODO */
       virtual TTimeDiff &Union(const TVar &);
 
-      /* TODO */
       virtual TTimeDiff &Xor(const TVar &);
 
-      /* TODO */
       Base::Chrono::TTimeDiff GetVal() const {
         return Val;
       }
 
-      /* TODO */
       virtual size_t GetHash() const;
 
-      /* TODO */
       virtual Type::TType GetType() const;
 
-      /* TODO */
       virtual void Touch();
 
-      /* TODO */
       virtual void Write(std::ostream &strm) const;
 
-      /* TODO */
       static TVar New(const Base::Chrono::TTimeDiff &that);
 
       private:
 
-      /* TODO */
       TTimeDiff(const Base::Chrono::TTimeDiff &that);
 
-      /* TODO */
       virtual ~TTimeDiff();
 
-      /* TODO */
       virtual void Accept(const TVisitor &visitor) const;
 
-      /* TODO */
       virtual TVar Copy() const;
 
-      /* TODO */
       Base::Chrono::TTimeDiff Val;
 
     };  // TTimeDiff
 
-    /* TODO */
     template <>
     struct TVar::TDt<Base::Chrono::TTimeDiff> {
 
-      /* TODO */
       Base::Chrono::TTimeDiff static As(const TVar &that) {
         TTimeDiff *ptr = dynamic_cast<TTimeDiff *>(that.Impl.get());
         if (ptr) {

--- a/orly/var/time_pnt.h
+++ b/orly/var/time_pnt.h
@@ -32,89 +32,63 @@ namespace Orly {
         : public TVar::TImpl {
       public:
 
-      /* TODO */
       virtual Var::TVar &Index(const TVar &);
 
-      /* TODO */
       virtual TTimePnt &Add(const TVar &);
 
-      /* TODO */
       virtual TTimePnt &And(const TVar &);
 
-      /* TODO */
       virtual TTimePnt &Div(const TVar &);
 
-      /* TODO */
       virtual TTimePnt &Exp(const TVar &);
 
-      /* TODO */
       virtual TTimePnt &Intersection(const TVar &);
 
-      /* TODO */
       virtual TTimePnt &Mod(const TVar &);
 
-      /* TODO */
       virtual TTimePnt &Mult(const TVar &);
 
-      /* TODO */
       virtual TTimePnt &Or(const TVar &);
 
-      /* TODO */
       virtual TTimePnt &Sub(const TVar &);
 
-      /* TODO */
       virtual TTimePnt &SymmetricDiff(const TVar &);
 
-      /* TODO */
       virtual TTimePnt &Union(const TVar &);
 
-      /* TODO */
       virtual TTimePnt &Xor(const TVar &);
 
-      /* TODO */
       Base::Chrono::TTimePnt GetVal() const {
         return Val;
       }
 
-      /* TODO */
       virtual size_t GetHash() const;
 
-      /* TODO */
       virtual Type::TType GetType() const;
 
-      /* TODO */
       virtual void Touch();
 
-      /* TODO */
       virtual void Write(std::ostream &strm) const;
 
-      /* TODO */
       static TVar New(const Base::Chrono::TTimePnt &that);
 
       private:
 
-      /* TODO */
       TTimePnt(const Base::Chrono::TTimePnt &that);
 
-      /* TODO */
       virtual ~TTimePnt();
 
-      /* TODO */
       virtual void Accept(const TVisitor &visitor) const;
 
-      /* TODO */
       virtual TVar Copy() const;
 
-      /* TODO */
       Base::Chrono::TTimePnt Val;
 
     };  // TTimePnt
 
-    /* TODO */
     template <>
     struct TVar::TDt<Base::Chrono::TTimePnt> {
 
-      /* TODO */
       Base::Chrono::TTimePnt static As(const TVar &that) {
         TTimePnt *ptr = dynamic_cast<TTimePnt *>(that.Impl.get());
         if (ptr) {

--- a/orly/var/unknown.h
+++ b/orly/var/unknown.h
@@ -28,75 +28,52 @@ namespace Orly {
         : public TVar::TImpl {
       public:
 
-      /* TODO */
       virtual Var::TVar &Index(const TVar &);
 
-      /* TODO */
       virtual TUnknown &Add(const TVar &);
 
-      /* TODO */
       virtual TUnknown &And(const TVar &);
 
-      /* TODO */
       virtual TUnknown &Div(const TVar &);
 
-      /* TODO */
       virtual TUnknown &Exp(const TVar &);
 
-      /* TODO */
       virtual TUnknown &Intersection(const TVar &);
 
-      /* TODO */
       virtual TUnknown &Mod(const TVar &);
 
-      /* TODO */
       virtual TUnknown &Mult(const TVar &);
 
-      /* TODO */
       virtual TUnknown &Or(const TVar &);
 
-      /* TODO */
       virtual TUnknown &Sub(const TVar &);
 
-      /* TODO */
       virtual TUnknown &SymmetricDiff(const TVar &);
 
-      /* TODO */
       virtual TUnknown &Union(const TVar &);
 
-      /* TODO */
       virtual TUnknown &Xor(const TVar &);
 
-      /* TODO */
       virtual size_t GetHash() const;
 
-      /* TODO */
       virtual Type::TType GetType() const;
 
-      /* TODO */
       virtual void Touch();
 
-      /* TODO */
       virtual void Write(std::ostream &) const;
 
-      /* TODO */
       static TVar New();
 
       private:
 
-      /* TODO */
       TUnknown() {}
 
-      /* TODO */
       virtual ~TUnknown();
 
-      /* TODO */
       virtual void Accept(const TVisitor &visitor) const;
 
-      /* TODO */
       virtual TVar Copy() const;
 
-      /* TODO */
       friend class TVar;
 
     };  // TUnknown

--- a/orly/var/variant.h
+++ b/orly/var/variant.h
@@ -58,43 +58,30 @@ namespace Orly {
         : public TVar::TImpl {
       public:
 
-      /* TODO */
       virtual Var::TVar &Index(const TVar &);
 
-      /* TODO */
       virtual TVariant &Add(const TVar &);
 
-      /* TODO */
       virtual TVariant &And(const TVar &);
 
-      /* TODO */
       virtual TVariant &Div(const TVar &);
 
-      /* TODO */
       virtual TVariant &Exp(const TVar &);
 
-      /* TODO */
       virtual TVariant &Intersection(const TVar &);
 
-      /* TODO */
       virtual TVariant &Mod(const TVar &);
 
-      /* TODO */
       virtual TVariant &Mult(const TVar &);
 
-      /* TODO */
       virtual TVariant &Or(const TVar &);
 
-      /* TODO */
       virtual TVariant &Sub(const TVar &);
 
-      /* TODO */
       virtual TVariant &SymmetricDiff(const TVar &);
 
-      /* TODO */
       virtual TVariant &Union(const TVar &);
 
-      /* TODO */
       virtual TVariant &Xor(const TVar &);
 
       /* The active tag. */
@@ -107,34 +94,26 @@ namespace Orly {
         return Payload;
       }
 
-      /* TODO */
       virtual size_t GetHash() const;
 
       /* The full declared variant type (every arm), so all values of one
          declared variant report the same type. */
       virtual Type::TType GetType() const;
 
-      /* TODO */
       virtual void Touch();
 
-      /* TODO */
       virtual void Write(std::ostream &) const;
 
       private:
 
-      /* TODO */
       TVariant(const Type::TType &variant_type, const std::string &tag, const TVar &payload);
 
-      /* TODO */
       virtual ~TVariant();
 
-      /* TODO */
       virtual void Accept(const TVisitor &visitor) const;
 
-      /* TODO */
       virtual TVar Copy() const;
 
-      /* TODO */
       void SetHash();
 
       /* The full declared variant type (all arms). */
@@ -146,10 +125,8 @@ namespace Orly {
       /* The payload value carried by the active tag. */
       TVar Payload;
 
-      /* TODO */
       size_t Hash;
 
-      /* TODO */
       friend class TVar;
 
     };  // TVariant

--- a/third_party/mongoose/mongoose.h
+++ b/third_party/mongoose/mongoose.h
@@ -221,28 +221,23 @@ void mg_md5(char *buf, ...);
 
 namespace Mongoose {
 
-  /* TODO */
   class TMongoose {
     NO_COPY(TMongoose);
     protected:
 
-    /* TODO */
     TMongoose()
         : Handle(0) {}
 
-    /* TODO */
     virtual ~TMongoose() {
       assert(this);
       assert(!Handle);
     }
 
-    /* TODO */
     void Reset(const char **new_options) {
       Stop();
       Start(new_options);
     }
 
-    /* TODO */
     void Start(const char **options) {
       assert(this);
       Stop();
@@ -252,7 +247,6 @@ namespace Mongoose {
       }
     }
 
-    /* TODO */
     void Stop() {
       assert(this);
       if (Handle) {
@@ -261,17 +255,14 @@ namespace Mongoose {
       }
     }
 
-    /* TODO */
     virtual void *OnEvent(mg_event event, mg_connection *conn, const mg_request_info *request_info) = 0;
 
     private:
 
-    /* TODO */
     static void *Callback(mg_event event, mg_connection *conn, const mg_request_info *request_info) {
       return reinterpret_cast<TMongoose *>(request_info->user_data)->OnEvent(event, conn, request_info);
     }
 
-    /* TODO */
     mg_context *Handle;
 
   };  // TMongoose

--- a/tools/maint/strip_todo_stubs.py
+++ b/tools/maint/strip_todo_stubs.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Strip lines that are EXACTLY a bare `/* TODO */` doc-stub placeholder.
+
+Only whole-line bare stubs are removed (leading/trailing whitespace allowed).
+Anything with text -- `/* TODO: ... */`, `// TODO foo`, a trailing `/* TODO */`
+after code -- is left untouched. Removing a whole-line comment can never change
+compilation, so this is a safe, mechanical noise cleanup.
+"""
+import re
+import subprocess
+import sys
+
+# Exact bare block-comment stub on its own line: optional indent, /* TODO */,
+# optional trailing space. The `\s*\*/` right after TODO means a `: text` body
+# can't match.
+BARE = re.compile(r'^[ \t]*/\*\s*TODO\s*\*/[ \t]*$')
+
+EXCLUDE = {
+    'orly/indy/repo.h',  # handled by the doc-comment pilot (disjoint change)
+}
+
+def tracked_sources():
+    out = subprocess.check_output(
+        ['git', 'ls-files', '*.h', '*.cc', '*.cpp', '*.hpp'],
+        text=True,
+    )
+    return [p for p in out.splitlines() if p and p not in EXCLUDE]
+
+def main():
+    apply = '--apply' in sys.argv
+    total_lines = 0
+    changed_files = 0
+    per_file = []
+    for path in tracked_sources():
+        try:
+            with open(path, 'r', encoding='utf-8') as f:
+                lines = f.readlines()
+        except (UnicodeDecodeError, FileNotFoundError):
+            continue
+        kept = [ln for ln in lines if not BARE.match(ln.rstrip('\n'))]
+        removed = len(lines) - len(kept)
+        if removed:
+            changed_files += 1
+            total_lines += removed
+            per_file.append((removed, path))
+            if apply:
+                with open(path, 'w', encoding='utf-8') as f:
+                    f.writelines(kept)
+    per_file.sort(reverse=True)
+    print(f"{'APPLIED' if apply else 'DRY-RUN'}: "
+          f"{total_lines} bare /* TODO */ stub lines across {changed_files} files")
+    print("top 15 files:")
+    for removed, path in per_file[:15]:
+        print(f"  {removed:5d}  {path}")
+
+if __name__ == '__main__':
+    main()

--- a/tools/nycr/atom.h
+++ b/tools/nycr/atom.h
@@ -29,42 +29,33 @@ namespace Tools {
 
   namespace Nycr {
 
-    /* TODO */
     class TAtom
         : public TFinal {
       NO_COPY(TAtom);
       protected:
 
-      /* TODO */
       TAtom(const Syntax::TName *name, const Syntax::TOptSuper *opt_super, const Syntax::TPattern *pattern);
 
-      /* TODO */
       const std::string &GetPatternText() const {
         return PatternText;
       }
 
-      /* TODO */
       int GetPri() const {
         return Pri ? *Pri : 0;
       }
 
-      /* TODO */
       virtual Symbol::TAtom *GetSymbolAsAtom() const = 0;
 
-      /* TODO */
       virtual Symbol::TKind *GetSymbolAsKind() const;
 
       private:
 
-      /* TODO */
       std::string PatternText;
 
-      /* TODO */
       std::optional<int> Pri;
 
     };  // TAtom
 
-    /* TODO */
     template <>
     struct TDecl::TInfo<TAtom> {
       static const char *Name;

--- a/tools/nycr/base.h
+++ b/tools/nycr/base.h
@@ -27,38 +27,30 @@ namespace Tools {
 
   namespace Nycr {
 
-    /* TODO */
     class TBase;
 
-    /* TODO */
     class TBase
         : public TKind {
       NO_COPY(TBase);
       public:
 
-      /* TODO */
       TBase(const Syntax::TBase *decl);
 
-      /* TODO */
       Symbol::TBase *GetSymbolAsBase() const {
         assert(Symbol);
         return Symbol;
       }
 
-      /* TODO */
       virtual Symbol::TKind *GetSymbolAsKind() const;
 
       private:
 
-      /* TODO */
       virtual bool Build(int pass);
 
-      /* TODO */
       Symbol::TBase *Symbol;
 
     };  // TKind
 
-    /* TODO */
     template <>
     struct TDecl::TInfo<TBase> {
       static const char *Name;

--- a/tools/nycr/compound.h
+++ b/tools/nycr/compound.h
@@ -29,91 +29,69 @@ namespace Tools {
 
   namespace Nycr {
 
-    /* TODO */
     class TOperator;
 
-    /* TODO */
     class TCompound
         : public TFinal {
       NO_COPY(TCompound);
       protected:
 
-      /* TODO */
       TCompound(const Syntax::TName *name, const Syntax::TOptSuper *opt_super, const Syntax::TOptRhs *opt_rhs);
 
-      /* TODO */
       virtual ~TCompound();
 
-      /* TODO */
       void BuildMembers();
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
-      /* TODO */
       virtual Symbol::TCompound *GetSymbolAsCompound() const = 0;
 
-      /* TODO */
       virtual Symbol::TKind *GetSymbolAsKind() const;
 
-      /* TODO */
       Symbol::TOperator *TryGetOperator() const {
         return Operator ? Operator->GetSymbolAsOperator() : 0;
       }
 
       private:
 
-      /* TODO */
       class TMember {
         NO_COPY(TMember);
         public:
 
-        /* TODO */
         virtual ~TMember() {}
 
-        /* TODO */
         virtual void Build(Symbol::TCompound *compound) = 0;
 
-        /* TODO */
         virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb) = 0;
 
         protected:
 
-        /* TODO */
         TMember() {}
 
       };  // TMember
 
-      /* TODO */
       class TErrorMember
           : public TMember {
         NO_COPY(TErrorMember);
         public:
 
-        /* TODO */
         TErrorMember() {}
 
-        /* TODO */
         virtual void Build(Symbol::TCompound *compound);
 
-        /* TODO */
         virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       };  // TErrorMember
 
-      /* TODO */
       class TMemberWithKind
           : public TMember {
         NO_COPY(TMemberWithKind);
         public:
 
-        /* TODO */
         TMemberWithKind(const Syntax::TName *kind) : Kind(kind) {}
 
-        /* TODO */
         virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
-        /* TODO */
         Symbol::TKind *GetKind() const {
           assert(Kind);
           return Kind->GetSymbolAsKind();
@@ -121,54 +99,43 @@ namespace Tools {
 
         private:
 
-        /* TODO */
         TRef<TKind> Kind;
 
       };  // TMemberWithKind
 
-      /* TODO */
       class TAnonymousMember : public TMemberWithKind {
         NO_COPY(TAnonymousMember);
         public:
 
-        /* TODO */
         TAnonymousMember(const Syntax::TAnonymousMember *member)
             : TMemberWithKind(member->GetName()) {}
 
-        /* TODO */
         virtual void Build(Symbol::TCompound *compound);
 
       };  // TAnonymousMember
 
-      /* TODO */
       class TNamedMember
           : public TMemberWithKind {
         NO_COPY(TNamedMember);
         public:
 
-        /* TODO */
         TNamedMember(const Syntax::TNamedMember *member)
             : TMemberWithKind(member->GetKind()), Name(member->GetName()) {}
 
-        /* TODO */
         virtual void Build(Symbol::TCompound *compound);
 
         private:
 
-        /* TODO */
         const Syntax::TName *Name;
 
       };  // TNamedMember
 
-      /* TODO */
       std::vector<TMember *> Members;
 
-      /* TODO */
       TRef<TOperator> Operator;
 
     };  // TCompound
 
-    /* TODO */
     template <>
     struct TDecl::TInfo<TCompound> {
       static const char *Name;

--- a/tools/nycr/decl.h
+++ b/tools/nycr/decl.h
@@ -174,48 +174,34 @@ namespace Tools {
 
       };  // TRef<TObj>
 
-      /* TODO */
       TDecl(const Syntax::TName *name);
 
-      /* TODO */
       virtual ~TDecl();
 
-      /* TODO */
       virtual bool Build(int pass) = 0;
 
-      /* TODO */
       virtual void ForEachPred(int pass, const std::function<void (TDecl *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       enum TState { Unstarted, Started, Finished };
 
-      /* TODO */
       void Bind();
 
-      /* TODO */
       void BuildPredsAndSelf(int pass, bool &again);
 
-      /* TODO */
       static void ForEachUniqueDecl(const std::function<void (TDecl *)> &cb);
 
-      /* TODO */
       static TDecl *TryGetDecl(const Syntax::TName *name);
 
-      /* TODO */
       const Syntax::TName *Name;
 
-      /* TODO */
       int Readiness;
 
-      /* TODO */
       TState State;
 
-      /* TODO */
       static std::map<std::string, std::vector<TDecl *>> DeclsByName;
 
     };  // TDecl

--- a/tools/nycr/escape.h
+++ b/tools/nycr/escape.h
@@ -26,31 +26,24 @@ namespace Tools {
 
   namespace Nycr {
 
-    /* TODO */
     class TEscape {
       public:
 
-      /* TODO */
       enum TEscapeStyle { CStyle, XmlStyle };
 
-      /* TODO */
       TEscape(const std::string &text, TEscapeStyle escape_style = CStyle)
           : Text(text), EscapeStyle(escape_style) {}
 
-      /* TODO  */
       void Write(std::ostream &strm) const;
 
       private:
 
-      /* TODO  */
       const std::string &Text;
 
-      /* TODO  */
       const TEscapeStyle EscapeStyle;
 
     };  // TEscape
 
-    /* TODO */
     inline std::ostream &operator<<(std::ostream &strm, const Tools::Nycr::TEscape &that) {
       that.Write(strm);
       return strm;

--- a/tools/nycr/final.h
+++ b/tools/nycr/final.h
@@ -25,21 +25,17 @@ namespace Tools {
 
   namespace Nycr {
 
-    /* TODO */
     class TBase;
 
-    /* TODO */
     class TFinal
         : public TKind {
       NO_COPY(TFinal);
       protected:
 
-      /* TODO */
       TFinal(const Syntax::TName *name, const Syntax::TOptSuper *opt_super);
 
     };  // TFinal
 
-    /* TODO */
     template <>
     struct TDecl::TInfo<TFinal> {
       static const char *Name;

--- a/tools/nycr/indent.h
+++ b/tools/nycr/indent.h
@@ -25,25 +25,20 @@ namespace Tools {
 
   namespace Nycr {
 
-    /* TODO */
     class TIndent {
       public:
 
-      /* TODO */
       TIndent(size_t depth)
           : Depth(depth) {}
 
-      /* TODO  */
       void Write(std::ostream &strm) const;
 
       private:
 
-      /* TODO  */
       size_t Depth;
 
     };  // TIndent
 
-    /* TODO */
     inline std::ostream &operator<<(std::ostream &strm, const Tools::Nycr::TIndent &that) {
       that.Write(strm);
       return strm;

--- a/tools/nycr/keyword.h
+++ b/tools/nycr/keyword.h
@@ -26,19 +26,15 @@ namespace Tools {
 
   namespace Nycr {
 
-    /* TODO */
     class TKeyword
         : public TAtom {
       NO_COPY(TKeyword);
       public:
 
-      /* TODO */
       TKeyword(const Syntax::TKeyword *decl);
 
-      /* TODO */
       virtual Symbol::TAtom *GetSymbolAsAtom() const;
 
-      /* TODO */
       Symbol::TKeyword *GetSymbolAsKeyword() const {
         assert(Symbol);
         return Symbol;
@@ -46,15 +42,12 @@ namespace Tools {
 
       private:
 
-      /* TODO */
       virtual bool Build(int pass);
 
-      /* TODO */
       Symbol::TKeyword *Symbol;
 
     };  // TKeyword
 
-    /* TODO */
     template <>
     struct TDecl::TInfo<TKeyword> {
       static const char *Name;

--- a/tools/nycr/kind.h
+++ b/tools/nycr/kind.h
@@ -26,40 +26,31 @@ namespace Tools {
 
   namespace Nycr {
 
-    /* TODO */
     class TBase;
 
-    /* TODO */
     class TKind
         : public TDecl {
       NO_COPY(TKind);
       public:
 
-      /* TODO */
       virtual Symbol::TKind *GetSymbolAsKind() const = 0;
 
-      /* TODO */
       Symbol::TBase *TryGetBaseSymbol() const;
 
       protected:
 
-      /* TODO */
       TKind(const Syntax::TName *name, const Syntax::TOptSuper *opt_super);
 
-      /* TODO */
       virtual void ForEachPred(int pass, const std::function<void (TDecl *)> &cb);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
       private:
 
-      /* TODO */
       TRef<TBase> Super;
 
     };  // TKind
 
-    /* TODO */
     template <>
     struct TDecl::TInfo<TKind> {
       static const char *Name;

--- a/tools/nycr/language.h
+++ b/tools/nycr/language.h
@@ -30,22 +30,17 @@ namespace Tools {
 
   namespace Nycr {
 
-    /* TODO */
     class TBase;
 
-    /* TODO */
     class TLanguage
         : public TCompound {
       NO_COPY(TLanguage);
       public:
 
-      /* TODO */
       TLanguage(const Syntax::TLanguage *decl);
 
-      /* TODO */
       virtual Symbol::TCompound *GetSymbolAsCompound() const;
 
-      /* TODO */
       Symbol::TLanguage *GetSymbolAsLanguage() const {
         assert(Symbol);
         return Symbol;
@@ -53,21 +48,16 @@ namespace Tools {
 
       private:
 
-      /* TODO */
       virtual bool Build(int pass);
 
-      /* TODO */
       std::vector<Symbol::TName> Namespaces;
 
-      /* TODO */
       std::optional<int> Sr, Rr;
 
-      /* TODO */
       Symbol::TLanguage *Symbol;
 
     };  // TLanguage
 
-    /* TODO */
     template <>
     struct TDecl::TInfo<TLanguage> {
       static const char *Name;

--- a/tools/nycr/operator.h
+++ b/tools/nycr/operator.h
@@ -26,25 +26,19 @@ namespace Tools {
 
   namespace Nycr {
 
-    /* TODO */
     class TPrecLevel;
 
-    /* TODO */
     class TOperator
         : public TAtom {
       NO_COPY(TOperator);
       public:
 
-      /* TODO */
       TOperator(const Syntax::TOper *decl);
 
-      /* TODO */
       virtual void ForEachRef(const std::function<void (TAnyRef &)> &cb);
 
-      /* TODO */
       virtual Symbol::TAtom *GetSymbolAsAtom() const;
 
-      /* TODO */
       Symbol::TOperator *GetSymbolAsOperator() const {
         assert(Symbol);
         return Symbol;
@@ -52,21 +46,16 @@ namespace Tools {
 
       private:
 
-      /* TODO */
       virtual bool Build(int pass);
 
-      /* TODO */
       TRef<TPrecLevel> PrecLevel;
 
-      /* TODO */
       Symbol::TOperator::TAssoc Assoc;
 
-      /* TODO */
       Symbol::TOperator *Symbol;
 
     };  // TOperator
 
-    /* TODO */
     template <>
     struct TDecl::TInfo<TOperator> {
       static const char *Name;

--- a/tools/nycr/prec_level.h
+++ b/tools/nycr/prec_level.h
@@ -26,16 +26,13 @@ namespace Tools {
 
   namespace Nycr {
 
-    /* TODO */
     class TPrecLevel
         : public TDecl {
       NO_COPY(TPrecLevel);
       public:
 
-      /* TODO */
       TPrecLevel(const Syntax::TPrecLevel *decl);
 
-      /* TODO */
       Symbol::TPrecLevel *GetSymbol() const {
         assert(Symbol);
         return Symbol;
@@ -43,19 +40,16 @@ namespace Tools {
 
       private:
 
-      /* TODO */
       virtual bool Build(int pass);
 
       size_t Idx;
 
       static size_t NextIdx;
 
-      /* TODO */
       Symbol::TPrecLevel *Symbol;
 
     };  // TPrecLevel
 
-    /* TODO */
     template <>
     struct TDecl::TInfo<TPrecLevel> {
       static const char *Name;

--- a/tools/nycr/rule.h
+++ b/tools/nycr/rule.h
@@ -26,22 +26,17 @@ namespace Tools {
 
   namespace Nycr {
 
-    /* TODO */
     class TBase;
 
-    /* TODO */
     class TRule
         : public TCompound {
       NO_COPY(TRule);
       public:
 
-      /* TODO */
       TRule(const Syntax::TRule *decl);
 
-      /* TODO */
       virtual Symbol::TCompound *GetSymbolAsCompound() const;
 
-      /* TODO */
       Symbol::TRule *GetSymbolAsRule() const {
         assert(Symbol);
         return Symbol;
@@ -49,15 +44,12 @@ namespace Tools {
 
       private:
 
-      /* TODO */
       virtual bool Build(int pass);
 
-      /* TODO */
       Symbol::TRule *Symbol;
 
     };  // TRule
 
-    /* TODO */
     template <>
     struct TDecl::TInfo<TRule> {
       static const char *Name;

--- a/tools/nycr/symbol/anonymous_member.h
+++ b/tools/nycr/symbol/anonymous_member.h
@@ -29,29 +29,23 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       class TAnonymousMember
           : public TMemberWithKind {
         NO_COPY(TAnonymousMember);
         public:
 
-        /* TODO */
         TAnonymousMember(TCompound *compound, TKind *kind)
             : TMemberWithKind(kind) {
           assert(compound);
           SetCompound(compound);
         }
 
-        /* TODO */
         virtual ~TAnonymousMember();
 
-        /* TODO */
         virtual const TName &GetName() const;
 
-        /* TODO */
         virtual void WriteRhs(std::ostream &strm) const;
 
-      	/* TODO */
       	virtual void WriteXml(std::ostream &strm) const;
 
       };  // TAnonymousMember

--- a/tools/nycr/symbol/atom.h
+++ b/tools/nycr/symbol/atom.h
@@ -31,38 +31,31 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       class TAtom
           : public TFinal {
         public:
 
-        /* TODO */
         const std::string &GetPattern() const {
           return Pattern;
         }
 
-        /* TODO */
         const std::optional<int> &GetPri() const {
           return Pri;
         }
 
-        /* TODO */
         int GetPriAsInt() const {
           return Pri ? *Pri : 0;
         }
 
         protected:
 
-        /* TODO */
         TAtom(const TName &name, TAnyBase *base, const std::string &pattern, const std::optional<int> &pri)
             : TFinal(name, base), Pattern(pattern), Pri(pri) {}
 
         private:
 
-        /* TODO */
         std::string Pattern;
 
-        /* TODO */
         std::optional<int> Pri;
 
       };  // TAtom

--- a/tools/nycr/symbol/base.h
+++ b/tools/nycr/symbol/base.h
@@ -28,25 +28,20 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       class TBase
           : public TKind, public TKind::TAnyBase {
         NO_COPY(TBase);
         public:
 
-        /* TODO */
         TBase(const TName &name, TKind::TAnyBase *base = 0)
             : TKind(name, base) {}
 
-        /* TODO */
         virtual void Accept(const TVisitor &visitor) const;
 
         private:
 
-        /* TODO */
         virtual TBase *GetBase();
 
-        /* TODO */
         virtual bool HasBase(const TBase *target);
 
       };  // TBase

--- a/tools/nycr/symbol/bootstrap.h
+++ b/tools/nycr/symbol/bootstrap.h
@@ -26,7 +26,6 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       TLanguage *Bootstrap();
 
     }  // Symbol

--- a/tools/nycr/symbol/compound.h
+++ b/tools/nycr/symbol/compound.h
@@ -32,102 +32,78 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       class TOperator;
 
-      /* TODO */
       class TCompound
           : public TFinal {
         NO_COPY(TCompound);
         public:
 
-        /* TODO */
         class TMember {
           public:
 
-          /* TODO */
           virtual ~TMember();
 
-          /* TODO */
           TCompound *GetCompound() const {
             return Compound;
           }
 
-          /* TODO */
           virtual const TName &GetName() const = 0;
 
-          /* TODO */
           virtual const TKind *TryGetKind() const = 0;
 
-          /* TODO */
           virtual void WriteRhs(std::ostream &strm) const = 0;
 
-          /* TODO */
           virtual void WriteXml(std::ostream &strm) const = 0;
 
           protected:
 
-          /* TODO */
           TMember()
               : Compound(0) {}
 
-          /* TODO */
           void SetCompound(TCompound *compound);
 
           private:
 
-          /* TODO */
           TCompound *Compound;
 
         };  // TMember
 
-        /* TODO */
         typedef std::map<TName, TMember *> TMembersByName;
 
-        /* TODO */
         typedef std::vector<TMember *> TMembersInOrder;
 
-        /* TODO */
         const TMembersByName &GetMembersByName() const {
           return MembersByName;
         }
 
-        /* TODO */
         const TMembersInOrder &GetMembersInOrder() const {
           return MembersInOrder;
         }
 
-        /* TODO */
         void SetOperator(TOperator *oper) {
           Operator = oper;
         }
 
-        /* TODO */
         TOperator *TryGetOperator() const {
           return Operator;
         }
 
         protected:
 
-        /* TODO */
         TCompound(const TName &name, TAnyBase *base)
             : TFinal(name, base), Operator(0) {}
 
         private:
 
-        /* TODO */
         void OnJoin(TMember *member);
 
-        /* TODO */
         void OnPart(TMember *member);
 
-        /* TODO */
         TMembersByName MembersByName;
 
-        /* TODO */
         TMembersInOrder MembersInOrder;
 
-        /* TODO */
         TOperator *Operator;
 
       };  // TCompound

--- a/tools/nycr/symbol/error_member.h
+++ b/tools/nycr/symbol/error_member.h
@@ -29,36 +29,28 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       class TErrorMember
           : public TCompound::TMember {
         NO_COPY(TErrorMember);
         public:
 
-        /* TODO */
         TErrorMember(TCompound *compound) {
           assert(compound);
           SetCompound(compound);
         }
 
-        /* TODO */
         virtual ~TErrorMember();
 
-        /* TODO */
         virtual const TName &GetName() const;
 
-        /* TODO */
         virtual const TKind *TryGetKind() const;
 
-        /* TODO */
         virtual void WriteRhs(std::ostream &strm) const;
 
-        /* TODO */
         virtual void WriteXml(std::ostream &strm) const;
 
         private:
 
-        /* TODO */
         static const TName Name;
 
       };  // TErrorMember

--- a/tools/nycr/symbol/final.h
+++ b/tools/nycr/symbol/final.h
@@ -29,13 +29,11 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       class TFinal
           : public TKind {
         NO_COPY(TFinal);
         protected:
 
-        /* TODO */
         TFinal(const TName &name, TAnyBase *base)
             : TKind(name, base) {}
 

--- a/tools/nycr/symbol/for_each_final.h
+++ b/tools/nycr/symbol/for_each_final.h
@@ -30,7 +30,6 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       void ForEachFinal(
           const TBase *base, const std::function<void (const TFinal *)> &cb);
 

--- a/tools/nycr/symbol/for_each_known_kind.h
+++ b/tools/nycr/symbol/for_each_known_kind.h
@@ -29,7 +29,6 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       void ForEachKnownKind(
           const TKind *kind, const std::function<void (const TKind *)> &cb);
 

--- a/tools/nycr/symbol/keyword.h
+++ b/tools/nycr/symbol/keyword.h
@@ -30,16 +30,13 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       class TKeyword
           : public TAtom {
         public:
 
-        /* TODO */
         TKeyword(const TName &name, TAnyBase *base, const std::string &pattern, const std::optional<int> &pri)
             : TAtom(name, base, pattern, pri) {}
 
-        /* TODO */
         virtual void Accept(const TVisitor &visitor) const;
 
       };  // TKeyword

--- a/tools/nycr/symbol/kind.h
+++ b/tools/nycr/symbol/kind.h
@@ -30,114 +30,87 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       class TBase;
       class TKeyword;
       class TLanguage;
       class TOperator;
       class TRule;
 
-      /* TODO */
       class TKind {
         NO_COPY(TKind);
         public:
 
-        /* TODO */
         class TAnyBase {
           NO_COPY(TAnyBase);
           public:
 
-          /* TODO */
           typedef std::unordered_set<TKind *> TSubKinds;
 
-          /* TODO */
           const TSubKinds &GetSubKinds() const {
             return SubKinds;
           }
 
           protected:
 
-          /* TODO */
           TAnyBase() {}
 
-          /* TODO */
           virtual ~TAnyBase();
 
-          /* TODO */
           virtual TBase *GetBase() = 0;
 
-          /* TODO */
           virtual bool HasBase(const TBase *target) = 0;
 
-          /* TODO */
           TSubKinds SubKinds;
 
-          /* TODO */
           friend class TKind;
 
         };  // TBase
 
-        /* TODO */
         class TVisitor {
           public:
 
-          /* TODO */
           virtual ~TVisitor();
 
-          /* TODO */
           virtual void operator()(const TBase *that) const = 0;
 
-          /* TODO */
           virtual void operator()(const TKeyword *that) const = 0;
 
-          /* TODO */
           virtual void operator()(const TLanguage *that) const = 0;
 
-          /* TODO */
           virtual void operator()(const TOperator *that) const = 0;
 
-          /* TODO */
           virtual void operator()(const TRule *that) const = 0;
 
           protected:
 
-          /* TODO */
           TVisitor() {}
 
         };  // TVisitor
 
-        /* TODO */
         virtual ~TKind();
 
-        /* TODO */
         virtual void Accept(const TVisitor &visitor) const = 0;
 
-        /* TODO */
         TBase *GetBase() const {
           return Base ? Base->GetBase() : 0;
         }
 
-        /* TODO */
         const TName &GetName() const {
           return Name;
         }
 
-        /* TODO */
         bool HasBase(const TBase *target) const {
           return Base ? Base->HasBase(target) : false;
         }
 
         protected:
 
-        /* TODO */
         TKind(const TName &name, TAnyBase *base);
 
         private:
 
-        /* TODO */
         TName Name;
 
-        /* TODO */
         TAnyBase *Base;
 
       };  // TKind

--- a/tools/nycr/symbol/language.h
+++ b/tools/nycr/symbol/language.h
@@ -32,18 +32,14 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       class TLanguage
           : public TCompound {
         public:
 
-        /* TODO */
         typedef std::unordered_set<TLanguage *> TLanguages;
 
-        /* TODO */
         typedef std::vector<TName> TNamespaces;
 
-        /* TODO */
         TLanguage(
             const TName &name, TAnyBase *base, const TNamespaces &namespaces,
             const std::optional<int> &expected_sr, const std::optional<int> &expected_rr)
@@ -51,41 +47,32 @@ namespace Tools {
           Languages.insert(this);
         }
 
-        /* TODO */
         virtual ~TLanguage();
 
-        /* TODO */
         virtual void Accept(const TVisitor &visitor) const;
 
-        /* TODO */
         const std::optional<int> &GetExpectedRr() const {
           return ExpectedRr;
         }
 
-        /* TODO */
         const std::optional<int> &GetExpectedSr() const {
           return ExpectedSr;
         }
 
-        /* TODO */
         const TNamespaces &GetNamespaces() const {
           return Namespaces;
         }
 
-        /* TODO */
         static const TLanguages &GetLanguages() {
           return Languages;
         }
 
         private:
 
-        /* TODO */
         TNamespaces Namespaces;
 
-        /* TODO */
         std::optional<int> ExpectedSr, ExpectedRr;
 
-        /* TODO */
         static TLanguages Languages;
 
       };  // TLanguage

--- a/tools/nycr/symbol/member_with_kind.h
+++ b/tools/nycr/symbol/member_with_kind.h
@@ -29,23 +29,19 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       class TMemberWithKind
           : public TCompound::TMember {
         NO_COPY(TMemberWithKind);
         public:
 
-        /* TODO */
         TKind *GetKind() const {
           return Kind;
         }
 
-        /* TODO */
         virtual const TKind *TryGetKind() const;
 
         protected:
 
-        /* TODO */
         TMemberWithKind(TKind *kind)
             : Kind(kind) {
           assert(kind);
@@ -53,7 +49,6 @@ namespace Tools {
 
         private:
 
-        /* TODO */
         TKind *Kind;
 
       };  // TMemberWithKind

--- a/tools/nycr/symbol/name.h
+++ b/tools/nycr/symbol/name.h
@@ -36,147 +36,115 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       class TName {
         public:
 
-        /* TODO */
         TName() {}
 
-        /* TODO */
         TName(TName &&that) {
           std::swap(Parts, that.Parts);
         }
 
-        /* TODO */
         TName(const TName &that)
             : Parts(that.Parts) {}
 
-        /* TODO */
         TName(const char *that) {
           Init(that, that + strlen(that));
         }
 
-        /* TODO */
         TName(const std::string &that) {
           Init(that.data(), that.data() + that.size());
         }
 
-        /* TODO */
         TName &operator=(TName &&that) {
           std::swap(Parts, that.Parts);
           return *this;
         }
 
-        /* TODO */
         TName &operator=(const TName &that) {
           return *this = TName(that);
         }
 
-        /* TODO */
         TName &operator=(const char *that) {
           return *this = TName(that);
         }
 
-        /* TODO */
         TName &operator=(const std::string &that) {
           return *this = TName(that);
         }
 
-        /* TODO */
         bool operator<(const TName &that) const;
 
-        /* TODO */
         void WriteLower(std::ostream &strm) const;
 
-        /* TODO */
         void WriteUpper(std::ostream &strm) const;
 
-	/* TODO */
 	void WriteXml(std::ostream &strm) const;
 
         private:
 
-        /* TODO */
         void Init(const char *start, const char *limit);
 
-        /* TODO */
         std::vector<std::string> Parts;
 
       };  // TName
 
-      /* TODO */
       class TLower {
         public:
 
-        /* TODO */
         TLower(const TName &name)
             : Name(name) {}
 
-        /* TODO */
         const TName &Name;
 
       };  // TLower
 
-      /* TODO */
       class TUpper {
         public:
 
-        /* TODO */
         TUpper(const TName &name)
             : Name(name) {}
 
-        /* TODO */
         const TName &Name;
 
       };  // TUpper
 
-      /* TODO */
       class TType {
         public:
 
-        /* TODO */
         TType(const TName &name)
             : Name(name) {}
 
-        /* TODO */
         const TName &Name;
 
       };  // TType
 
-      /* TODO */
       class TXml {
       public:
 
-	/* TODO */
       TXml(const TName &name)
 	: Name(name) {}
 
-	/* TODO */
 	const TName &Name;
 
       }; // TXml
 
-/* TODO */
 inline std::ostream &operator<<(std::ostream &strm, const Tools::Nycr::Symbol::TLower &that) {
   that.Name.WriteLower(strm);
   return strm;
 }
 
-/* TODO */
 inline std::ostream &operator<<(std::ostream &strm, const Tools::Nycr::Symbol::TUpper &that) {
   that.Name.WriteUpper(strm);
   return strm;
 }
 
-/* TODO */
 inline std::ostream &operator<<(std::ostream &strm, const Tools::Nycr::Symbol::TType &that) {
   strm << 'T';
   that.Name.WriteUpper(strm);
   return strm;
 }
 
-/* TODO */
 inline std::ostream &operator<<(std::ostream &strm, const Tools::Nycr::Symbol::TXml &that) {
   that.Name.WriteXml(strm);
   return strm;

--- a/tools/nycr/symbol/named_member.h
+++ b/tools/nycr/symbol/named_member.h
@@ -29,34 +29,27 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       class TNamedMember
           : public TMemberWithKind {
         NO_COPY(TNamedMember);
         public:
 
-        /* TODO */
         TNamedMember(TCompound *compound, TKind *kind, const TName &name)
             : TMemberWithKind(kind), Name(name) {
           assert(compound);
           SetCompound(compound);
         }
 
-        /* TODO */
         virtual ~TNamedMember();
 
-        /* TODO */
         virtual const TName &GetName() const;
 
-        /* TODO */
         virtual void WriteRhs(std::ostream &strm) const;
 
-        /* TODO */
         virtual void WriteXml(std::ostream &strm) const;
 
         private:
 
-        /* TODO */
         TName Name;
 
       };  // TNamedMember

--- a/tools/nycr/symbol/operator.h
+++ b/tools/nycr/symbol/operator.h
@@ -31,48 +31,38 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       class TPrecLevel;
 
-      /* TODO */
       class TOperator
           : public TAtom {
         public:
 
-        /* TODO */
         enum TAssoc { Left, NonAssoc, Right };
 
-        /* TODO */
         TOperator(
             const TName &name, TAnyBase *base, const std::string &pattern, const std::optional<int> &pri, TPrecLevel *prec_level, TAssoc assoc)
             : TAtom(name, base, pattern, pri), PrecLevel(prec_level), Assoc(assoc) {
           assert(prec_level);
         }
 
-        /* TODO */
         virtual void Accept(const TVisitor &visitor) const;
 
-        /* TODO */
         TAssoc GetAssoc() const {
           return Assoc;
         }
 
-        /* TODO */
         size_t GetPrecLevelIdx() const {
           return PrecLevel->GetIdx();
         }
 
-        /* TODO */
         TPrecLevel *GetPrecLevel() const {
           return PrecLevel;
         }
 
         private:
 
-        /* TODO */
         TPrecLevel *PrecLevel;
 
-        /* TODO */
         TAssoc Assoc;
 
       };  // TOperator

--- a/tools/nycr/symbol/output_file.h
+++ b/tools/nycr/symbol/output_file.h
@@ -116,7 +116,6 @@ namespace Tools {
       };  // TUnderscore
 
 
-    /* TODO */
     enum TCommentStyle { CStyle, XmlStyle };
 
     /* Creates an output file and writes its header comment. Returns an open stream to the file. */

--- a/tools/nycr/symbol/prec_level.h
+++ b/tools/nycr/symbol/prec_level.h
@@ -31,44 +31,34 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       class TPrecLevel {
         NO_COPY(TPrecLevel);
         public:
 
-        /* TODO */
         typedef std::vector<TPrecLevel *> TPrecLevels;
 
-        /* TODO */
         TPrecLevel(const TName &name, size_t idx);
 
-        /* TODO */
         virtual ~TPrecLevel();
 
-        /* TODO */
         size_t GetIdx() const {
           return Idx;
         }
 
-        /* TODO */
         const TName &GetName() const {
           return Name;
         }
 
-        /* TODO */
         static const TPrecLevels &GetPrecLevels() {
           return PrecLevels;
         }
 
         private:
 
-        /* TODO */
         TName Name;
 
-        /* TODO */
         size_t Idx;
 
-        /* TODO */
         static TPrecLevels PrecLevels;
 
       };  // TPrecLevel

--- a/tools/nycr/symbol/rule.h
+++ b/tools/nycr/symbol/rule.h
@@ -29,16 +29,13 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       class TRule
           : public TCompound {
         public:
 
-        /* TODO */
         TRule(const TName &name, TAnyBase *base = 0)
             : TCompound(name, base) {}
 
-        /* TODO */
         virtual void Accept(const TVisitor &visitor) const;
 
       };  // TRule

--- a/tools/nycr/symbol/write_bison.h
+++ b/tools/nycr/symbol/write_bison.h
@@ -26,7 +26,6 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       void WriteBison(const char *root, const char *branch, const char *atom, const TLanguage *language);
 
     }  // Symbol

--- a/tools/nycr/symbol/write_cst.h
+++ b/tools/nycr/symbol/write_cst.h
@@ -27,7 +27,6 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       void WriteCst(const char *root, const char *branch, const char *atom, const TLanguage *language);
 
     }  // Symbol

--- a/tools/nycr/symbol/write_dump.h
+++ b/tools/nycr/symbol/write_dump.h
@@ -27,7 +27,6 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       void WriteDump(const char *root, const char *branch, const char *atom, const TLanguage *language);
 
     }  // Symbol

--- a/tools/nycr/symbol/write_flex.h
+++ b/tools/nycr/symbol/write_flex.h
@@ -26,7 +26,6 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       void WriteFlex(const char *root, const char *branch, const char *atom, const TLanguage *language);
 
     }  // Symbol

--- a/tools/nycr/symbol/write_nycr.h
+++ b/tools/nycr/symbol/write_nycr.h
@@ -29,10 +29,8 @@ namespace Tools {
 
     namespace Symbol {
 
-      /* TODO */
       void WriteNycr(const char *root, const char *branch, const char *atom, const TLanguage *language);
 
-      /* TODO */
       void WriteNycrDecl(const TKind *kind, std::ostream &strm);
 
     }  // Symbol

--- a/tools/nycr/symbol/write_xml.h
+++ b/tools/nycr/symbol/write_xml.h
@@ -30,11 +30,9 @@ namespace Tools {
       enum { NoIndent, Indent };
       enum { NoEndl, Endl };
 
-      /* TODO */
       class TXmlTag {
       public:
 
-	/* TODO */
 	enum TXmlTagType {
 	  AnonymousMember,
 	  Association,
@@ -60,28 +58,22 @@ namespace Tools {
 	  Rule
 	};
 
-	/* TODO */
         static const char *TXmlTagStr[];
 
-	/* TODO */
       TXmlTag(TXmlTagType type, bool is_open, bool has_indent = Indent, bool has_endl = Endl)
 	: Type(type), IsOpen(is_open), HasIndent(has_indent), HasEndl(has_endl) {}
 
-	/* TODO */
 	void Write(std::ostream &strm) const;
 
       private:
 
-	/* TODO */
 	const TXmlTagType Type;
 	const bool IsOpen, HasIndent, HasEndl;
 
       }; // TXmlTag
 
-      /* TODO */
       void WriteXml(const char *root, const char *branch, const char *atom, const TLanguage *language);
 
-      /* TODO */
       inline std::ostream &operator<<(std::ostream &strm, const TXmlTag &that) {
         that.Write(strm);
         return strm;


### PR DESCRIPTION
## What

Strip the bare `/* TODO */` doc-stub placeholders that the 2014 house style put above almost every declaration. **5,677 lines removed across 338 files; zero insertions.**

These were never real TODOs — they're empty doc-comment placeholders meant to be filled in with a description and never were. They carry no information and drown out the ~475 TODOs that actually say something, making `grep TODO` useless as a backlog.

## Scope & safety

- Removes only lines that are **exactly** a bare `/* TODO */` stub (optional surrounding whitespace). Anything with content — `/* TODO: ... */`, `// TODO foo`, a trailing `/* TODO */` after code — is **left untouched**, as are all genuine doc-comments already in the tree.
- `orly/indy/repo.h` is **excluded**: its stubs are being replaced with real doc-comments in a separate change, so the two stay on disjoint files.
- **Comments-only, proven**: for every one of the 338 touched files, the source with all comments stripped is byte-identical before and after. A whole-line comment deletion cannot change compilation; a debug build spanning the heavily-stripped indy/server headers (`context_xrepo.test`, `tetris_manager.test`, `fiber.test`) is clean.
- Reproducible via `tools/maint/strip_todo_stubs.py` (included).

## Why now

This is the cheap, high-leverage half of the TODO cleanup: it makes a leftover `TODO` in the tree actually *mean* something. The complementary half — writing real doc-comments for the non-obvious engine headers — is being done selectively, per-file, where accuracy can be verified against the implementation (see the `repo.h` pilot).

No behavior change.