### PR TITLE
docs(indy): real doc-comments for repo.h (TODO-stub pilot)

### DIFF
--- a/orly/indy/repo.h
+++ b/orly/indy/repo.h
@@ -739,7 +739,6 @@ namespace Orly {
     }
 
     inline void TRepo::SetReleasedUpTo(TSequenceNumber released_up_to) {
-      std::cout << "SetReleasedUpTo(" << released_up_to << ")" << std::endl;
       ReleasedUpTo = released_up_to;
     }
 

--- a/orly/indy/repo.h
+++ b/orly/indy/repo.h
@@ -43,29 +43,40 @@ namespace Orly {
 
     namespace L1 {
 
-      /* TODO */
       class TTransaction;
 
     }  // L1
 
-    /* TODO */
+    /* An indy storage repo: the LSM-backed store for one point-of-view (POV).
+       Derives from the L0 manager's TRepo, which supplies identity, status, and
+       the copy-on-write set of data layers (a TMapping over TDataLayers). A repo
+       holds an in-memory memtable (CurMemoryLayer), zero or more disk layers,
+       and a per-repo sequence-number counter (NextUpdate). Each repo optionally
+       has a ParentRepo; while it holds un-promoted updates it joins the parent's
+       Tetris merge, which promotes those updates upward -- so a child's durable
+       home is its parent, ultimately the parentless safe root (= the global
+       POV). See docs/architecture.md for the POV / sequence-number / merge
+       model. Abstract: instantiated as TFastRepo (memory-only) or TSafeRepo
+       (disk-backed). */
     class TRepo
         : public L0::TManager::TRepo {
       NO_COPY(TRepo);
       public:
 
-      /* TODO */
       using TParentRepo = L0::TManager::TRepo::TParentRepo;
 
-      /* TODO */
+      /* An immutable, consistent read snapshot of the repo: the pinned disk
+         layer set (Mapping), the pinned live memtable (CurrentMemoryLayer), the
+         [lower, upper] sequence-number window, and NextId -- all captured
+         atomically under Repo->DataLock. A present/update walker reads through a
+         TView, so the layers it scans cannot be freed mid-walk; the TView must
+         outlive any walker built from it. */
       class TView {
         NO_COPY(TView);
         public:
 
-        /* TODO */
         TView(const L0::TManager::TPtr<TRepo> &repo);
 
-        /* TODO */
         TView(TRepo *repo);
 
         /* Tag selecting the snapshot ctor below. */
@@ -78,27 +89,30 @@ namespace Orly {
            re-lock the non-recursive DataLock. */
         TView(TRepo *repo, TDataLockHeld);
 
-        /* TODO */
+        /* Releases (Decr) the pinned mapping and memtable under MappingLock. */
         ~TView();
 
-        /* TODO */
+        /* The pinned snapshot of the live memtable. */
         const TMemoryLayer *GetCurMem() const;
 
-        /* TODO */
+        /* The pinned snapshot of the disk-layer set; iterate its entry
+           collection to get one TDataLayer per disk file. */
         const TMapping *GetMapping() const;
 
-        /* TODO */
+        /* Count of mapping entries (disk layers); used to size the walker merge
+           structures (+1 for the memtable). */
         inline size_t GetNumEntries() const;
 
-        /* TODO */
+        /* The repo's NextUpdate as of the snapshot. */
         inline TSequenceNumber GetNextId() const {
           return NextId;
         }
 
-        /* TODO */
+        /* Oldest in-window sequence number (LowestSeqNum at snapshot), or unset
+           if the repo was empty -- walkers bail when either bound is unset. */
         const std::optional<TSequenceNumber> &GetLower() const;
 
-        /* TODO */
+        /* Newest in-window sequence number (HighestSeqNum at snapshot). */
         const std::optional<TSequenceNumber> &GetUpper() const;
 
         private:
@@ -107,22 +121,22 @@ namespace Orly {
            Repo. The caller MUST hold Repo->DataLock; both ctors funnel here. */
         void Snapshot();
 
-        /* TODO */
+        /* The repo this is a snapshot of. */
         TRepo *Repo;
 
-        /* TODO */
+        /* Pinned (Incr'd) live memtable at snapshot time. */
         TMemoryLayer *CurrentMemoryLayer;
 
-        /* TODO */
+        /* Pinned (Incr'd) disk-layer set at snapshot time. */
         TMapping *Mapping;
 
-        /* TODO */
+        /* Snapshot of LowestSeqNum / HighestSeqNum -- the sequence-number
+           window the walkers filter each item against. */
         std::optional<TSequenceNumber> LowerBound;
 
-        /* TODO */
         std::optional<TSequenceNumber> UpperBound;
 
-        /* TODO */
+        /* Snapshot of NextUpdate. */
         TSequenceNumber NextId;
 
       };  // TView
@@ -145,31 +159,41 @@ namespace Orly {
          This is also the total number of updates ever pushed to this repo. */
       inline const std::optional<TSequenceNumber> &GetSequenceNumberLimit() const;
 
-      /* TODO */
+      /* The sequence number the next update pushed here will take (= NextUpdate). */
       inline TSequenceNumber GetNextSequenceNumber() const;
 
-      /* TODO */
+      /* Force the NextUpdate counter. Used to seed a fresh child/test repo's
+         numbering from its parent so reads fold in the right order. */
       inline void SetNextSequenceNumber(TSequenceNumber next_id);
 
-      /* TODO */
+      /* Set the high-water mark of updates already promoted to the parent
+         (entries at or below this may be dropped on the next mem/disk merge). */
       inline void SetReleasedUpTo(TSequenceNumber released_up_to);
 
-      /* TODO */
+      /* Reserve `num` consecutive sequence numbers in one shot and return the
+         first; the bulk counterpart of AppendUpdate's per-update bookkeeping. */
       inline TSequenceNumber UseSequenceNumbers(size_t num);
 
-      /* TODO */
+      /* The high-water mark set by SetReleasedUpTo / ReleaseUpdate. */
       inline TSequenceNumber GetReleasedUpTo() const;
 
-      /* TODO */
+      /* This repo's parent in the repo tree (mirrors the POV tree), or unset
+         for the global root. */
       virtual inline const TParentRepo &GetParentRepo() const;
 
-      /* TODO */
+      /* Ingest an already-prepared memtable as a new data layer. A safe repo
+         first flushes it to a disk file (wrapped as a TDiskLayer); a fast repo
+         keeps the memory layer. Builds a new mapping including it and enqueues a
+         disk merge once enough layers accumulate. */
       void AddImportLayer(TMemoryLayer *mem_layer, Base::TEventSemaphore &sem, Disk::Util::TVolume::TDesc::TStorageSpeed storage_speed);
 
-      /* TODO */
+      /* Wrap an existing on-disk file (named by gen_id, with its saved sequence
+         range and key count) as a new disk layer in a new mapping. */
       void AddFileToRepo(size_t gen_id, TSequenceNumber low_saved, TSequenceNumber high_saved, size_t num_keys);
 
-      /* TODO */
+      /* Register a replication-synced file: allocate a generation id, hand the
+         blocks to the disk engine, then AddFileToRepo it. Returns the gen_id.
+         TSafeRepo implements this; TFastRepo (no disk) throws. */
       virtual size_t AddSyncedFileToRepo(size_t starting_block_id,
                                          size_t starting_block_offset,
                                          size_t file_length,
@@ -183,39 +207,47 @@ namespace Orly {
          There is no notification when the update is actually deleted. */
       void ReleaseUpdate(TSequenceNumber sequence_number, bool ensure_or_discard);
 
-      /* TODO */
+      /* Open a present-walker over the key range [from, to]: yields the merged
+         current value per key across all layers in the view, in key order. With
+         ignore_tombstone, deleted keys are skipped. */
       virtual std::unique_ptr<Indy::TPresentWalker> NewPresentWalker(const std::unique_ptr<TView> &view,
                                                                      const TIndexKey &from,
                                                                      const TIndexKey &to,
                                                                      bool ignore_tombstone = false);
 
-      /* TODO */
+      /* Open a present-walker for a single key. exact_point marks a fully-bound
+         point read so each layer may seek straight to the key instead of
+         head-scanning its line (#257). */
       virtual std::unique_ptr<Indy::TPresentWalker> NewPresentWalker(const std::unique_ptr<TView> &view,
                                                                      const TIndexKey &key,
                                                                      bool ignore_tombstone = false,
                                                                      bool exact_point = false);
 
-      /* TODO */
+      /* Open an update-walker over the sequence-number range [from, to]: yields
+         raw updates (the change log) in sequence order, merged across layers.
+         Used by the promote-to-parent and replication paths. */
       virtual std::unique_ptr<Indy::TUpdateWalker> NewUpdateWalker(const std::unique_ptr<TView> &view,
                                                                    TSequenceNumber from,
                                                                    const std::optional<TSequenceNumber> &to);
 
-      /* TODO */
+      /* Open-ended update-walker from `from` to the newest update. */
       virtual std::unique_ptr<Indy::TUpdateWalker> NewUpdateWalker(const std::unique_ptr<TView> &view,
                                                                    TSequenceNumber from);
 
-      /* TODO */
+      /* Trim the oldest on-disk generation below the release horizon (root repo
+         only). Memory-only TFastRepo has nothing to tail. */
       virtual void StepTail(size_t block_slots_available) = 0;
 
       protected:
 
-      /* TODO */
+      /* Construct a fresh, empty repo under `manager` (id, ttl, optional parent). */
       TRepo(L0::TManager *manager,
             const Base::TUuid &repo_id,
             const TTtl &ttl,
             const std::optional<L0::TManager::TPtr<L0::TManager::TRepo>> &parent_repo);
 
-      /* TODO */
+      /* Reconstruct a repo with pre-existing sequence bounds, next-update
+         counter, and status (e.g. reloading saved state). */
       TRepo(L0::TManager *manager,
             const Base::TUuid &repo_id,
             const TTtl &ttl,
@@ -225,68 +257,86 @@ namespace Orly {
             TSequenceNumber next_update,
             TStatus status);
 
-      /* TODO */
       virtual ~TRepo();
 
-      /* TODO */
+      /* Push an update into the memtable (under DataLock): stamp it with the
+         next sequence number, advance HighestSeqNum / set LowestSeqNum, insert
+         into CurMemoryLayer, and join the parent's Tetris if not already in it.
+         Returns the assigned sequence number. */
       std::optional<TSequenceNumber> AppendUpdate(TUpdate *update, TSequenceNumber &next_update) NO_THROW;
 
-      /* TODO */
+      /* Drop the oldest unpopped update by advancing LowestSeqNum (under
+         DataLock); when the memtable drains, clears the bounds and Parts Tetris.
+         Returns the popped sequence number. */
       std::optional<TSequenceNumber> PopLowest(TSequenceNumber &next_update) NO_THROW;
 
-      /* TODO */
+      /* Reconstruct the single oldest-unpopped update (the one Tetris Peeks to
+         promote to the parent). Holds DataLock across the whole walk (#237). */
       std::shared_ptr<TUpdate> GetLowestUpdate();
 
-      /* TODO */
+      /* Flip the repo's status (Normal / Paused / Failed) and join or Part the
+         parent's Tetris accordingly. */
       std::optional<TSequenceNumber> ChangeStatus(TStatus, TSequenceNumber &next_update) NO_THROW;
 
-      /* TODO */
+      /* Mem-merge step: seal CurMemoryLayer into the mapping and start a fresh
+         one, then consolidate the trailing memtables. The parentless safe root
+         flushes the result to a new disk file; child / fast repos keep it in
+         memory, dropping entries already released to the parent. */
       virtual void StepMergeMem() override;
 
-      /* TODO */
+      /* Disk-merge step: compact adjacent same-generation disk files. Only
+         TSafeRepo has disk files; TFastRepo asserts it is never called. */
       virtual void StepMergeDisk(size_t block_slots_available) = 0;
 
-      /* TODO */
+      /* Copy-on-write a new data layer into the mapping; returns the layer count. */
       size_t AddMapping(TDataLayer *layer);
 
-      /* TODO */
+      /* Pin (Incr) the current mapping so a reader can hold it across a walk. */
       TMapping *AcquireCurrentMapping();
 
-      /* TODO */
+      /* Unpin (Decr) a mapping acquired via AcquireCurrentMapping. */
       void ReleaseMapping(TMapping *mapping);
 
-      /* TODO */
+      /* Serializes the mem-merge body of StepMergeMem (one per repo at a time). */
       std::mutex MemMergeLock;
 
-      /* TODO */
+      /* Guards the memtable + sequence-number state (LowestSeqNum,
+         HighestSeqNum, NextUpdate, ReleasedUpTo, CurMemoryLayer inserts, Tetris
+         join/part). Non-recursive; lock order is DataLock -> MappingLock. */
       std::mutex DataLock;
 
-      /* TODO */
+      /* After a mem merge, drop this repo from the manager's dirty set if no
+         memtable still holds data; otherwise re-enqueue another mem merge. */
       void CheckRemoveDirty();
 
-      /* TODO */
+      /* The live memtable that AppendUpdate inserts into. */
       TMemoryLayer *CurMemoryLayer;
 
       private:
 
-      /* TODO */
+      /* A repo's concrete present-walker: builds one sub-walker per data layer
+         (each disk layer + the memtable) and k-way-merges them through MinHeap,
+         yielding the newest entry per key in key order. (Same-key entries are
+         all yielded, not shadowed, so the context-level fold can compose
+         commutative writes -- see Refresh.) */
       class TPresentWalker
           : public Indy::TPresentWalker {
         NO_COPY(TPresentWalker);
         public:
 
-        /* TODO */
+        /* Range walk [from, to]; builds the per-layer sub-walkers serially. */
         TPresentWalker(const std::unique_ptr<TView> &view,
                        const TIndexKey &from,
                        const TIndexKey &to,
                        bool ignore_tombstone);
 
+        /* Single-key walk; builds the per-layer sub-walkers in parallel across
+           fibers (see PrepVec / TRunnablePrep). exact_point enables seek. */
         TPresentWalker(const std::unique_ptr<TView> &view,
                        const TIndexKey &key,
                        bool ignore_tombstone,
                        bool exact_point);
 
-        /* TODO */
         inline virtual ~TPresentWalker() {}
 
         /* True iff. we have an item. */
@@ -300,13 +350,16 @@ namespace Orly {
 
         private:
 
-        /* TODO */
+        /* A fiber task that builds one layer's sub-walker off the local frame
+           pool and signals the shared TSync barrier on completion -- lets the
+           single-key ctor construct all per-layer walkers concurrently. Move is
+           forbidden (it throws), so PrepVec must be reserved to its final size
+           up front. */
         class TRunnablePrep
             : public Indy::Fiber::TRunnable {
           NO_COPY(TRunnablePrep);
           public:
 
-          /* TODO */
           TRunnablePrep(TDataLayer *layer, TPresentWalker *walker, Fiber::TSync *sync)
               : Layer(layer), Walker(walker), Sync(sync) {
             Frame = Fiber::TFrame::LocalFramePool->Alloc();
@@ -318,16 +371,15 @@ namespace Orly {
             }
           }
 
-          /* TODO */
           TRunnablePrep(Orly::Indy::TRepo::TPresentWalker::TRunnablePrep &&) {
             throw std::logic_error("Moving TRunnablePrep is not allowed. This means you did not pre-allocate enough space to hold them.");
           }
 
-          /* TODO */
           virtual ~TRunnablePrep() {
           }
 
-          /* TODO */
+          /* Fiber body: build this layer's sub-walker, append it to the parent
+             walker's WalkerVec, signal the barrier, and free the frame. */
           void Compute() {
             //printf("TRunnablePrep::Compute()\n");
             assert(Walker);
@@ -341,51 +393,55 @@ namespace Orly {
 
           private:
 
-          /* TODO */
+          /* The fiber frame this task runs on (from the local frame pool). */
           Fiber::TFrame *Frame;
 
-          /* TODO */
+          /* The data layer to build a sub-walker for. */
           TDataLayer *Layer;
 
-          /* TODO */
+          /* The parent walker to append the sub-walker into. */
           TPresentWalker *Walker;
 
-          /* TODO */
+          /* Barrier the ctor waits on for all prep tasks to finish. */
           Fiber::TSync *Sync;
 
         };  // TRunnablePrep
 
-        /* TODO */
+        /* Prime the first item (asserts none emitted yet). */
         inline void Init();
 
-        /* TODO */
+        /* Advance to the next item on each ++ (asserts an item was emitted). */
         inline void Refresh();
 
-        /* TODO */
+        /* Range start key (also the lookup key for the single-key ctor). */
         TIndexKey From;
 
-        /* TODO */
+        /* Range end key (unset for the single-key ctor). */
         TIndexKey To;
 
-        /* TODO */
+        /* The snapshot read through; held by reference, so it must outlive this
+           walker. Lower/Upper copy the view's sequence-number window for the
+           per-item filter. */
         const std::unique_ptr<TView> &View;
         const TSequenceNumber Lower;
         const TSequenceNumber Upper;
 
-        /* TODO */
+        /* One sub-walker per data layer (disk layers + memtable); PrepVec holds
+           the fiber tasks that build them for the single-key ctor. */
         std::vector<std::unique_ptr<Indy::TPresentWalker>> WalkerVec;
         std::vector<TRunnablePrep> PrepVec;
 
-        /* TODO */
+        /* K-way merge front: the current item of each sub-walker, keyed by its
+           WalkerVec index; pops key-ascending, newest-sequence-first. */
         Util::TMinHeap<TItem, size_t> MinHeap;
 
-        /* TODO */
+        /* True while the heap still has items to yield. */
         bool Valid;
 
-        /* TODO */
+        /* The current item (lazily refreshed; mutable for the const accessors). */
         mutable TItem Item;
 
-        /* TODO */
+        /* When set, deleted keys (tombstones) are skipped. */
         const bool IgnoreTombstone;
 
         /* Fully-bound point read: layers may seek instead of head-scan (#257).
@@ -395,18 +451,21 @@ namespace Orly {
 
       };  // TPresentWalker
 
-      /* TODO */
+      /* A repo's concrete update-walker: walks raw updates (the change log) in
+         sequence-number order, merged across layers via MergeSorter. Unlike
+         TPresentWalker (the current value per key), it yields whole updates by
+         sequence number -- the form the promote-to-parent and replication paths
+         consume. */
       class TUpdateWalker
           : public Indy::TUpdateWalker {
         NO_COPY(TUpdateWalker);
         public:
 
-        /* TODO */
+        /* Walk updates with sequence number in [from, to]. */
         TUpdateWalker(const std::unique_ptr<TView> &view,
                       TSequenceNumber from,
                       const std::optional<TSequenceNumber> &to);
 
-        /* TODO */
         virtual ~TUpdateWalker();
 
         /* True iff. we have an item. */
@@ -420,50 +479,48 @@ namespace Orly {
 
         private:
 
-        /* TODO */
+        /* Advance to the next update in sequence order. */
         void Refresh();
 
-        /* TODO */
+        /* Sequence-number window being walked. */
         TSequenceNumber From;
-
-        /* TODO */
         std::optional<TSequenceNumber> To;
 
-        /* TODO */
+        /* The snapshot read through; held by reference, must outlive the walker. */
         const std::unique_ptr<TView> &View;
 
-        /* TODO */
+        /* Per-layer sub-walker plus its element index in the merge sorter. */
         std::unordered_map<const TDataLayer *, std::pair<std::unique_ptr<Indy::TUpdateWalker>, size_t>> WalkerMap;
 
-        /* TODO */
+        /* Orders the per-layer sub-walkers by lowest current sequence number,
+           backed by the SorterAlloc element array. */
         Util::TMergeSorter<TSequenceNumber, const TDataLayer *> MergeSorter;
-
-        /* TODO */
         Util::TMergeSorter<TSequenceNumber, const TDataLayer *>::TMergeElement *SorterAlloc;
 
-        /* TODO */
+        /* True while the sorter still has updates to yield. */
         bool Valid;
 
-        /* TODO */
+        /* The current update (mutable for the const accessors). */
         mutable TItem Item;
 
       };  // TUpdateWalker
 
-      /* TODO */
+      /* This repo's parent in the repo tree (unset for the global root). */
       TParentRepo ParentRepo;
 
-      /* TODO */
+      /* Sequence number of the oldest unpopped update; unset when the memtable
+         is empty (paired set/unset with HighestSeqNum). */
       std::optional<TSequenceNumber> LowestSeqNum;
 
-      /* TODO */
+      /* Sequence number of the newest update (also the total ever pushed). */
       std::optional<TSequenceNumber> HighestSeqNum;
 
-      /* TODO */
+      /* The sequence number the next pushed update will take. */
       TSequenceNumber NextUpdate;
 
       protected:
 
-      /* TODO */
+      /* Manager GC hook: visit the parent-repo pointer so it is kept reachable. */
       virtual bool ForEachDependentPtr(const std::function<bool (L0::TManager::TAnyPtr &)> &cb) noexcept override {
         if (ParentRepo) {
           cb(*ParentRepo);
@@ -471,32 +528,37 @@ namespace Orly {
         return true;
       }
 
-      /* TODO */
+      /* High-water mark of updates already promoted to the parent; entries at or
+         below it may be dropped on the next mem/disk merge. */
       TSequenceNumber ReleasedUpTo;
 
       private:
 
-      /* TODO */
+      /* Whether this repo is currently a registered child in its parent's Tetris
+         merge. Gating Join on !InTetris makes it idempotent and lets a join that
+         failed under memory pressure retry on the next AppendUpdate (#250). */
       bool InTetris;
 
-      /* TODO */
+      /* Transactions drive AppendUpdate / PopLowest / promotion, so they reach
+         the protected mutators. */
       friend class L1::TTransaction;
 
     };  // TRepo
 
-    /* TODO */
+    /* A memory-only repo (Fast policy): its data lives entirely in memtables and
+       is promoted to the parent -- it never writes disk files. The disk-only
+       operations (StepMergeDisk, StepTail, AddSyncedFileToRepo) are therefore
+       unreachable here and assert/throw if called. */
     class TFastRepo
         : public Orly::Indy::TRepo {
       NO_COPY(TFastRepo);
       public:
 
-      /* TODO */
       TFastRepo(L0::TManager *manager,
                 const Base::TUuid &repo_id,
                 const TTtl &ttl,
                 const std::optional<L0::TManager::TPtr<L0::TManager::TRepo>> &parent_repo);
 
-      /* TODO */
       TFastRepo(L0::TManager *manager,
                 const Base::TUuid &repo_id,
                 const TTtl &ttl,
@@ -506,21 +568,20 @@ namespace Orly {
                 TSequenceNumber next_update,
                 TStatus status);
 
-      /* TODO */
       virtual ~TFastRepo();
 
       private:
 
-      /* TODO */
+      /* false -- a fast repo is memory-only. */
       virtual bool IsSafeRepo() const override;
 
-      /* TODO */
+      /* Unreachable: a fast repo has no disk files. Asserts false. */
       virtual void StepMergeDisk(size_t block_slots_available) override;
 
-      /* TODO */
+      /* Unreachable: a fast repo has no disk tail. Asserts false. */
       virtual void StepTail(size_t block_slots_available) override;
 
-      /* TODO */
+      /* Unreachable: a fast repo cannot host synced files. Throws. */
       virtual size_t AddSyncedFileToRepo(size_t starting_block_id,
                                          size_t starting_block_offset,
                                          size_t file_length,
@@ -530,19 +591,21 @@ namespace Orly {
 
     };  // TFastRepo
 
-    /* TODO */
+    /* A disk-backed repo (Safe policy): memtables are flushed to on-disk
+       generation files, which are then compacted (StepMergeDisk) and tailed
+       (StepTail). It implements the disk write/merge/remove operations, the
+       per-file walkers, and reload-from-disk. Owns the generation-id counter and
+       the disk-merge lock. */
     class TSafeRepo
         : public Orly::Indy::TRepo {
       NO_COPY(TSafeRepo);
       public:
 
-      /* TODO */
       TSafeRepo(L0::TManager *manager,
                 const Base::TUuid &repo_id,
                 const TTtl &ttl,
                 const std::optional<L0::TManager::TPtr<L0::TManager::TRepo>> &parent_repo);
 
-      /* TODO */
       TSafeRepo(L0::TManager *manager,
                 const Base::TUuid &repo_id,
                 const TTtl &ttl,
@@ -552,31 +615,33 @@ namespace Orly {
                 TSequenceNumber next_update,
                 TStatus status);
 
-      /* TODO */
       virtual ~TSafeRepo();
 
-      /* TODO */
+      /* Compact adjacent same-generation disk files into one new file. */
       virtual void StepMergeDisk(size_t block_slots_available) override;
 
-      /* TODO */
+      /* Trim the oldest disk generation below the release horizon (root only). */
       virtual void StepTail(size_t block_slots_available) override;
 
-      /* TODO */
+      /* Rebuild a TSafeRepo from its on-disk generation files (static factory). */
       static TSafeRepo *ReConstructFromDisk(L0::TManager *manager,
                                             const Base::TUuid &repo_id,
                                             const TDeadline &deadline);
 
       protected:
 
-      /* TODO */
+      /* Allocate the next monotonic generation id (++NextGenId). */
       inline size_t GetNextGenId();
 
       private:
 
-      /* TODO */
+      /* true -- a safe repo is disk-backed. */
       virtual bool IsSafeRepo() const override;
 
-      /* TODO */
+      /* Merge the given disk generations into one new file. Two-phase: a raw
+         merge, then a commutative fold (TFoldDataFile) if any non-Assign entries
+         are present. can_tail/can_tail_tombstone allow dropping data below the
+         release horizon at the root. Returns the new generation id. */
       virtual size_t MergeFiles(const std::vector<size_t> &gen_id_vec,
                                 Disk::Util::TVolume::TDesc::TStorageSpeed storage_speed,
                                 size_t max_block_cache_read_slots_allowed,
@@ -588,10 +653,11 @@ namespace Orly {
                                 bool can_tail,
                                 bool can_tail_tombstone) override;
 
-      /* TODO */
+      /* Reclaim a generation file's blocks and drop its per-scheduler caches. */
       virtual void RemoveFile(size_t gen_id) override;
 
-      /* TODO */
+      /* Serialize a memtable to a new on-disk generation file; returns its
+         generation id (and, by reference, its saved sequence range / key count). */
       virtual size_t WriteFile(TMemoryLayer *memory_layer,
                                Disk::Util::TVolume::TDesc::TStorageSpeed storage_speed,
                                TSequenceNumber &out_saved_low_seq,
@@ -599,7 +665,8 @@ namespace Orly {
                                size_t &out_num_keys,
                                TSequenceNumber release_up_to) override;
 
-      /* TODO */
+      /* Register a replication-synced file: allocate a gen_id, hand the blocks to
+         the disk engine, then AddFileToRepo it. */
       virtual size_t AddSyncedFileToRepo(size_t starting_block_id,
                                          size_t starting_block_offset,
                                          size_t file_length,
@@ -607,22 +674,23 @@ namespace Orly {
                                          TSequenceNumber high_saved,
                                          size_t num_keys) override;
 
-      /* TODO */
+      /* Open a present-walker over a single on-disk generation file (range). */
       virtual std::unique_ptr<Orly::Indy::TPresentWalker> NewPresentWalkerFile(size_t /*gen_id*/,
                                                                                const TIndexKey &/*from*/,
                                                                                const TIndexKey &/*to*/) const override;
 
-      /* TODO */
+      /* Open a present-walker over a single on-disk generation file (single key). */
       virtual std::unique_ptr<Orly::Indy::TPresentWalker> NewPresentWalkerFile(size_t /*gen_id*/,
                                                                                const TIndexKey &/*key*/) const override;
 
-      /* TODO */
+      /* Open an update-walker over a single on-disk generation file. */
       virtual std::unique_ptr<Orly::Indy::TUpdateWalker> NewUpdateWalkerFile(size_t /*gen_id*/, TSequenceNumber /*from*/) const override;
 
-      /* TODO */
+      /* The monotonic generation-id counter (seeded from the highest existing
+         file generation at construction). */
       std::atomic<size_t> NextGenId;
 
-      /* TODO */
+      /* Serializes selection/marking of disk layers for compaction and tailing. */
       std::mutex MergeLock;
 
     };  // TSafeRepo


### PR DESCRIPTION
## What

Replace the bare `/* TODO */` doc-stub placeholders in `orly/indy/repo.h` with real doc-comments. A pilot for the wider TODO cleanup, on one of the densest engine headers (the LSM storage repo behind every POV).

Almost entirely comments (the doc-comment rewrite is byte-identical with comments stripped); plus one tiny code cleanup folded in: removing a stray `std::cout` debug print in `TRepo::SetReleasedUpTo` (noted below). Builds clean (`context_fold.test`).

## Approach (the dual policy)

- **Trivial members** (forwarding ctors/dtors, the `TParentRepo` typedef, NO_COPY-style boilerplate) → strip the stub.
- **Non-obvious API + architecturally-meaningful members** → a real doc-comment, derived from the implementation (`repo.cc`, ~1.5k lines) and the indy model in `docs/architecture.md` — not guessed from the signature.

After this, `grep TODO orly/indy/repo.h` returns nothing.

## What's now documented

- `TRepo` — the LSM repo backing a point-of-view: memtable + disk layers + per-repo sequence counter, and how it joins its parent's Tetris merge to promote updates upward.
- `TView` — the pinned, consistent read snapshot, and why it's captured under `DataLock` and must outlive its walkers.
- The sequence-number API (`AppendUpdate` / `PopLowest` / `UseSequenceNumbers` / `ReleasedUpTo` …) and the `LowestSeqNum`/`HighestSeqNum`/`NextUpdate` invariant.
- The mem→disk→tail merge step machinery (`StepMergeMem` / `StepMergeDisk` / `StepTail` / `MergeFiles` / `WriteFile`), and what a "generation" is.
- The present/update walkers — the k-way min-heap merge across layers, and the fiber-parallel construction of per-layer sub-walkers in the single-key path.
- The `TFastRepo` (memory-only) vs `TSafeRepo` (disk-backed) split, including why the disk ops are unreachable on the fast repo.

## Scope

Disjoint from #271 (the bulk stub-strip), which deliberately leaves `repo.h` to this change. No behavior change.

Also removes a stray `std::cout` debug print that `TRepo::SetReleasedUpTo` emitted on every call (release/merge write path) — the one non-comment change in this PR.