### PR TITLE
chore(server): remove dead is_new_version guard in InstallPackage

### DIFF
--- a/orly/server/server.cc
+++ b/orly/server/server.cc
@@ -2139,11 +2139,12 @@ void TServer::InstallPackage(const vector<string> &package_name, uint64_t versio
   }
 
   // Callback for just before we make the packages installed / available for use.
-  auto pre_install_cb = [this](Package::TLoaded::TPtr pkg_ptr, bool is_new_version) -> void {
-    //TODO: This is broken badly if we install two independently-generated same-version packages.
-    if (!is_new_version) {
-      return;
-    }
+  auto pre_install_cb = [this](Package::TLoaded::TPtr pkg_ptr, bool /*is_new_version*/) -> void {
+    /* The package manager only invokes this for a genuinely new or upgraded
+       version: a same-version reinstall is a no-op short-circuited in
+       TManager::Load before this callback runs, so is_new_version is always
+       true here. (It once guarded against re-registering indexes for a repeated
+       version; that case can no longer reach this code.) */
     std::lock_guard<std::mutex> lock(IndexMapMutex);
     const auto &type_by_index_map = pkg_ptr->GetIndexByIndexId();
     for (const auto &addr_pair : type_by_index_map) {


### PR DESCRIPTION
## What

Remove a stale TODO and the dead code it guarded in `TServer::InstallPackage`'s pre-install callback.

## Finding

The callback carried:

```cpp
//TODO: This is broken badly if we install two independently-generated same-version packages.
if (!is_new_version) {
  return;
}
```

Investigated end to end: **`is_new_version` is structurally always `true`.** The package manager hardcodes it at both production sites (`package/manager.cc:83,88`), and a same-version reinstall is short-circuited with `continue` in `TManager::Load` *before* the callback is ever invoked (`manager.cc:73-79`). So:

- the `if (!is_new_version) return;` branch is **dead** — it never fires;
- the "broken badly" scenario (two same-version packages both reaching the index-registration logic) is **unreachable** — the manager no-ops the second install upstream.

The TODO predates the upstream same-version no-op that closed the hole it worried about. Not a live bug.

## Change

Drop the dead branch and the stale TODO; anonymize the now-unused `is_new_version` parameter and document why it's ignored (same-version reinstall is a no-op upstream, so this only ever runs for a genuinely new/upgraded version). The callback signature is unchanged (it must still match the manager's `std::function`).

No behavior change; `orlyi` builds clean.