### PR TITLE
fix(base/socket): typed address-parse errors instead of throw 0

### DIFF
--- a/base/socket/address.cc
+++ b/base/socket/address.cc
@@ -102,12 +102,14 @@ TAddress::TAddress(istream &&strm) {
         }
         if (isxdigit(c) || c == '.' || c == ':') {
           if (csr >= end) {
-            throw 0; // TODO(#275)
+            THROW_ERROR(TAddressTooLong);
           }
           *csr++ = c;
           strm.ignore();
         } else {
-          throw 0; // TODO(#275)
+          THROW_ERROR(TBadAddressSyntax)
+              << "unexpected character '" << static_cast<char>(c)
+              << "' in IPv6 address";
         }
       }
     } else {
@@ -116,7 +118,7 @@ TAddress::TAddress(istream &&strm) {
         int c = strm.peek();
         if (isxdigit(c) || c == '.') {
           if (csr >= end) {
-            throw 0; // TODO(#275)
+            THROW_ERROR(TAddressTooLong);
           }
           *csr++ = c;
           strm.ignore();

--- a/base/socket/address.h
+++ b/base/socket/address.h
@@ -48,6 +48,12 @@ namespace Socket {
     DEFINE_ERROR(TPathTooLong, std::runtime_error,
                  "UNIX domain socket path too long");
 
+    DEFINE_ERROR(TAddressTooLong, std::runtime_error,
+                 "socket address too long");
+
+    DEFINE_ERROR(TBadAddressSyntax, std::runtime_error,
+                 "malformed socket address");
+
     /* The amount of storage space available in an address. */
     static const socklen_t MaxLen = sizeof(sockaddr_storage);
 


### PR DESCRIPTION
The istream `TAddress` parser threw a bare `int 0` on a too-long address (v4 and v6) and on an invalid character in a v6 literal — uncatchable as anything meaningful, useless if it escapes. Add `TAddressTooLong` and `TBadAddressSyntax` (`DEFINE_ERROR`, same pattern as the existing `TAddress::TPathTooLong`) and throw those, naming the offending character.

Gate: integration build of all five tier-1 fixes green; `base/socket/address.test` passes; lang_test 156/2 xfail.

Closes #275.