### PR TITLE
fix(base): make TTimer monotonic

### DIFF
--- a/base/timer.h
+++ b/base/timer.h
@@ -73,9 +73,9 @@ namespace Base {
     duration Total;
   };
 
-  //TODO(#281):  this should actually be a monotonic clock. For now keeping the old behavior / semantics.
-  /* Easy-access generic timer. */
-  using TTimer = TGenericTimer<std::chrono::system_clock>;
+  /* Easy-access generic timer. Monotonic, so measured intervals are immune
+     to wall-clock steps (NTP adjustments, manual clock changes). */
+  using TTimer = TGenericTimer<std::chrono::steady_clock>;
 
   /* Easy-access timer which gives the cpu time for the given thread. */
   using TCPUTimer = TGenericTimer<Base::cpu_clock>;


### PR DESCRIPTION
`Base::TTimer` aliased `TGenericTimer<system_clock>`, so a wall-clock step (NTP adjustment, manual change) mid-interval could skew or negate measured laps. `TGenericTimer` never exposes its time_points — only durations — so `steady_clock` is a drop-in with correct interval semantics. All users (session latency timing, server report timer, present-walk timer) are pure interval measurements.

Gate: integration build green; lang_test 156/2 xfail.

Closes #281.