### PR TITLE
perf(rt): make dict-from-tuple-sequence cast linear, not quadratic

### DIFF
--- a/orly/rt/postfix_cast.h
+++ b/orly/rt/postfix_cast.h
@@ -334,8 +334,10 @@ namespace Orly {
       static TDict<TToKey, TToVal> Do(const TTupleGen &from) {
         TDict<TToKey, TToVal> to;
         for(auto it = from->NewCursor(); it; ++it) {
-          //TODO(#359): A += would make this SOOO much more efficient.
-          to = to + CastAs<TDict<TToKey, TToVal>, TFinalTuple>::Do(*it);
+          /* insert_or_assign keeps dict-`+` semantics: a later duplicate key
+             overrides an earlier one. */
+          to.insert_or_assign(CastAs<TToKey, TFromKey>::Do(std::get<0>(*it)),
+                              CastAs<TToVal, TFromVal>::Do(std::get<1>(*it)));
         }
         return to;
       }


### PR DESCRIPTION
`CastAs<TDict, TGenerator<tuple>>` rebuilt the whole accumulator every element (`to = to + one_pair_dict`), copying the map each iteration — O(n²). Cast the key/value directly and `insert_or_assign` into the accumulator: O(n log n), preserving dict-`+`'s last-wins override semantics for duplicate keys.

This is the `seq as {k:v}` runtime path, so the full lang_test suite is the behavioral gate: 156 passed / 2 xfail, plus `orly/rt/postfix_cast.test` (13/13).

Closes #359.