### PR TITLE
chore(indy,server): remove CompactOpemMap, a called no-op since 2014

### DIFF
--- a/orly/indy/manager_base.cc
+++ b/orly/indy/manager_base.cc
@@ -261,10 +261,6 @@ void TManager::SetTetrisManager(Orly::Server::TTetrisManager *tetris_manager) {
   TetrisManager = tetris_manager;
 }
 
-void TManager::CompactOpemMap() {
-  //throw std::logic_error("TODO(#278): Implement CompactOpenMap()");
-}
-
 void TManager::RunLayerCleaner() {
   if (Engine->IsDiskBased()) {
     /* if this is a disk based engine, allocate event pools */

--- a/orly/indy/manager_base.h
+++ b/orly/indy/manager_base.h
@@ -618,8 +618,6 @@ namespace Orly {
 
         inline size_t GetTempFileConsolThresh() const;
 
-        void CompactOpemMap();
-
         void RunLayerCleaner();
 
         void RunMergeMem();

--- a/orly/server/server.cc
+++ b/orly/server/server.cc
@@ -1626,8 +1626,6 @@ void TServer::CleanHouse() {
     //DEBUG_LOG("housecleaner: cleaning");
     DurableManager->Clean();
     //DEBUG_LOG("housecleaner: done cleaning");
-    RepoManager->CompactOpemMap();
-    //DEBUG_LOG("housecleaner: done compacting");
   }
 }
 


### PR DESCRIPTION
`TManager::CompactOpemMap()` (typo and all) has an empty body — its only content was a commented-out 'implement me' throw — yet the server housecleaner invoked it every cycle. No open-map compaction was ever designed; the housecleaner's real work (`DurableManager->Clean()`) is untouched. Delete the method and the call, same dead-intent cleanup as #273.

Gate: integration build green; lang_test 156/2 xfail.

Closes #278.