### PR TITLE
fix(rt): implement Match and MatchLess for tuples

### DIFF
--- a/orly/rt/tuple.h
+++ b/orly/rt/tuple.h
@@ -18,6 +18,10 @@
 
 #pragma once
 
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
 #include <base/class_traits.h>
 #include <orly/desc.h>
 #include <orly/rt/operator.h>
@@ -26,16 +30,29 @@ namespace Orly {
 
   namespace Rt {
 
-    /* Match two tuples. */
+    /* Match two tuples: structural, elementwise Match (so element types with
+       their own Match semantics -- nested tuples, optionals, containers --
+       compare through it, not through raw operator==). */
     template <typename... TArgs>
-    bool Match(const std::tuple<TArgs...> &/*lhs*/, const std::tuple<TArgs...> &/*rhs*/) {
-      throw std::runtime_error("TODO(#362): Match for tuple");
+    bool Match(const std::tuple<TArgs...> &lhs, const std::tuple<TArgs...> &rhs) {
+      return [&]<std::size_t... Idx>(std::index_sequence<Idx...>) {
+        return (Match(std::get<Idx>(lhs), std::get<Idx>(rhs)) && ...);
+      }(std::index_sequence_for<TArgs...>{});
     }
 
-    /* MatchLess two tuples. */
+    /* MatchLess two tuples: lexicographic -- MatchLess of the first
+       elementwise non-Match; false when every element Matches. */
     template <typename... TArgs>
-    bool MatchLess(const std::tuple<TArgs...> &/*lhs*/, const std::tuple<TArgs...> &/*rhs*/) {
-      throw std::runtime_error("TODO(#362): MatchLess for tuple");
+    bool MatchLess(const std::tuple<TArgs...> &lhs, const std::tuple<TArgs...> &rhs) {
+      bool less = false;
+      [&]<std::size_t... Idx>(std::index_sequence<Idx...>) {
+        /* The fold short-circuits at the first non-Match element, whose
+           MatchLess decides the order. */
+        ((Match(std::get<Idx>(lhs), std::get<Idx>(rhs))
+              ? true
+              : (less = MatchLess(std::get<Idx>(lhs), std::get<Idx>(rhs)), false)) && ...);
+      }(std::index_sequence_for<TArgs...>{});
+      return less;
     }
 
     template <typename TVal>

--- a/orly/rt/tuple.test.cc
+++ b/orly/rt/tuple.test.cc
@@ -95,6 +95,35 @@ FIXTURE(Hash) {
       });
 }
 
+/* Direct (qualified) Match/MatchLess calls -- the code-generated
+   object/variant comparison path, issue #362. */
+FIXTURE(MatchTuple) {
+  EXPECT_TRUE (Orly::Rt::Match(empty_addr, empty_addr));
+  EXPECT_TRUE (Orly::Rt::Match(addr_1, addr_1));
+  EXPECT_FALSE(Orly::Rt::Match(addr_1, addr_2));
+  /* Nested tuple elements match structurally. */
+  EXPECT_TRUE (Orly::Rt::Match(addr_9, addr_9));
+  EXPECT_FALSE(Orly::Rt::Match(addr_10, std::tuple<int64_t, std::tuple<int64_t>>(1, std::tuple<int64_t>(3))));
+}
+
+FIXTURE(MatchLessTuple) {
+  EXPECT_FALSE(Orly::Rt::MatchLess(empty_addr, empty_addr));
+  /* Lexicographic: first differing element decides. */
+  EXPECT_TRUE (Orly::Rt::MatchLess(addr_1, addr_2));   // (5,2,1) < (6,2,1)
+  EXPECT_FALSE(Orly::Rt::MatchLess(addr_2, addr_1));
+  EXPECT_FALSE(Orly::Rt::MatchLess(addr_1, addr_1));   // equal -> not less
+  EXPECT_TRUE (Orly::Rt::MatchLess(addr_3, addr_4));   // (5,2.0,1) < (5,2.1,1)
+  EXPECT_FALSE(Orly::Rt::MatchLess(addr_4, addr_3));
+  /* A trailing element only decides when the earlier ones Match. */
+  std::tuple<int64_t, int64_t> lo(5, 1), hi(5, 2);
+  EXPECT_TRUE (Orly::Rt::MatchLess(lo, hi));
+  EXPECT_FALSE(Orly::Rt::MatchLess(hi, lo));
+  /* TDesc elements order through their own (reversed) comparison. */
+  std::tuple<Orly::TDesc<int64_t>, int64_t> da(5, 1), db(6, 1);
+  EXPECT_TRUE (Orly::Rt::MatchLess(db, da));
+  EXPECT_FALSE(Orly::Rt::MatchLess(da, db));
+}
+
 struct TPnt {
   public:
   TPnt(int x, int y) : X(x), Y(y) {}


### PR DESCRIPTION
`Rt::Match`/`Rt::MatchLess` over `std::tuple` threw a placeholder `runtime_error`. Only *qualified* calls ever hit it — code-generated object/variant comparisons over address-typed fields — because the `TSet`/`TDict` comparator's dependent call resolves to the generic `operator<` fallback under two-phase lookup. Implemented as elementwise `Match` and lexicographic `MatchLess` via `index_sequence` pack folds, so element types with their own semantics (nested tuples, `TDesc`, optionals) compare through `Match`/`MatchLess` rather than raw operators.

Gate: integration build green; `tuple.test` extended with direct-call fixtures (equality, lexicographic order, empty/nested tuples, `TDesc` reversal), 8/8; lang_test suite clean.

Closes #362.