### PR TITLE
chore(jhm): dedup GetInputName between bison and flex jobs

### DIFF
--- a/jhm/jobs/bison.cc
+++ b/jhm/jobs/bison.cc
@@ -32,23 +32,12 @@ const static vector<vector<string>> OutExtensions = {
   {"bison", "hh"}
 };
 
-//TODO(#335): this is duplicated / copied in both bison.cc and flex.cc
-static std::optional<TRelPath> GetInputName(const TRelPath &output) {
-  for (const auto &ext : OutExtensions) {
-    if (output.Path.EndsWith(ext)) {
-      return TRelPath(AddExtension(DropExtension(TPath(output.Path), ext.size()), {"y"}));
-    }
-  }
-  return std::optional<TRelPath>();
-}
-
-
 TJobProducer TBison::GetProducer() {
 
   return TJobProducer{
     "bison",
     OutExtensions,
-    GetInputName,
+    [](const TRelPath &output) { return TryGetInputName(output, OutExtensions, {"y"}); },
     //TODO(#344): Should be able to eliminate the lambda wrapper here...
     [] (TEnv &env, TFile *in_file) -> unique_ptr<TJob> {
       return unique_ptr<TJob>(new TBison(env, in_file));

--- a/jhm/jobs/flex.cc
+++ b/jhm/jobs/flex.cc
@@ -32,22 +32,12 @@ const static vector<vector<string>> OutExtensions = {
   {"flex","cc"},
 };
 
-//TODO(#335): this is duplicated / copied in both bison.cc and flex.cc
-static std::optional<TRelPath> GetInputName(const TRelPath &output) {
-  for (const auto &ext : OutExtensions) {
-    if (output.Path.EndsWith(ext)) {
-      return TRelPath(AddExtension(DropExtension(TPath(output.Path), ext.size()), {"l"}));
-    }
-  }
-  return std::optional<TRelPath>();
-}
-
 TJobProducer TFlex::GetProducer() {
 
   return TJobProducer{
     "flex",
     OutExtensions,
-    GetInputName,
+    [](const TRelPath &output) { return TryGetInputName(output, OutExtensions, {"l"}); },
     //TODO(#344): Should be able to eliminate the lambda wrapper here...
     [] (TEnv &env, TFile *in_file) -> unique_ptr<TJob> {
       return unique_ptr<TFlex>(new TFlex(env, in_file));

--- a/jhm/jobs/util.cc
+++ b/jhm/jobs/util.cc
@@ -44,3 +44,14 @@ TFile *Jhm::GetOutputWithExtension(unordered_set<TFile *> output_set, const vect
   assert(false);
   __builtin_unreachable();
 }
+
+optional<TRelPath> Jhm::TryGetInputName(const TRelPath &output,
+                                        const vector<vector<string>> &out_exts,
+                                        const vector<string> &src_ext) {
+  for (const auto &ext : out_exts) {
+    if (output.Path.EndsWith(ext)) {
+      return TRelPath(AddExtension(DropExtension(Base::TPath(output.Path), ext.size()), src_ext));
+    }
+  }
+  return nullopt;
+}

--- a/jhm/jobs/util.h
+++ b/jhm/jobs/util.h
@@ -33,4 +33,11 @@ namespace Jhm {
                                            TEnv &env,
                                            const TRelPath &input);
   TFile *GetOutputWithExtension(std::unordered_set<TFile *> output_set, const std::vector<std::string> &ext);
+
+  /* The TJobProducer::TryGetInput shape shared by single-source producers
+     (bison, flex): if `output` ends with one of `out_exts`, the input is
+     `output` with that extension swapped for `src_ext`; otherwise nothing. */
+  std::optional<TRelPath> TryGetInputName(const TRelPath &output,
+                                          const std::vector<std::vector<std::string>> &out_exts,
+                                          const std::vector<std::string> &src_ext);
 }


### PR DESCRIPTION
The identical extension-swap loop lived as a copied static in bison.cc and flex.cc, differing only in the source extension. Factored into `Jhm::TryGetInputName` (jobs/util), matching `TJobProducer::TryGetInput`'s shape; each producer passes a one-line lambda with its own source extension.

Gate: jhm rebuilds itself green; integration build + lang_test clean.

Closes #335.