### PR TITLE
fix(synth): include the optional with clause in TTestDef's pos range

### DIFF
--- a/orly/synth/get_pos_range.cc
+++ b/orly/synth/get_pos_range.cc
@@ -516,8 +516,13 @@ TPosRange Orly::Synth::GetPosRange(const Package::Syntax::TTestCaseBlock *that) 
 
 template <>
 TPosRange Orly::Synth::GetPosRange(const Package::Syntax::TTestDef *that) {
-  // TODO(#380): account for the optional with clause
-  return Orly::Synth::GetPosRange(that->GetTestKwd(), that->GetSemi());
+  /* The optional with clause precedes the test keyword; when present, the
+     definition's range starts at `with`. */
+  auto with_clause = TryGetNode<Package::Syntax::TWithClause,
+                                Package::Syntax::TNoWithClause>(that->GetOptWithClause());
+  return with_clause
+      ? Orly::Synth::GetPosRange(with_clause->GetWithKwd(), that->GetSemi())
+      : Orly::Synth::GetPosRange(that->GetTestKwd(), that->GetSemi());
 }
 
 template <>


### PR DESCRIPTION
`GetPosRange(TTestDef)` spanned only test-keyword → semicolon, so diagnostics on a `with { ... } test { ... };` definition pointed past the with clause that is part of the construct. When the clause is present (`TryGetNode` over the CST optional), the range now starts at its `with` keyword.

Gate: orlyc build green; integration build + lang_test clean.

Closes #380.