### PR TITLE
fix(synth): reject duplicate literal keys in dict constructors

### DIFF
--- a/orly/synth/dict_ctor.cc
+++ b/orly/synth/dict_ctor.cc
@@ -19,9 +19,12 @@
 #include <orly/synth/dict_ctor.h>
 
 #include <cassert>
+#include <set>
 
+#include <base/as_str.h>
 #include <orly/error.h>
 #include <orly/expr/dict.h>
+#include <orly/expr/literal.h>
 #include <orly/synth/cst_utils.h>
 #include <orly/synth/get_pos_range.h>
 
@@ -54,9 +57,19 @@ TDictCtor::~TDictCtor() {
 
 Expr::TExpr::TPtr TDictCtor::Build() const {
   Expr::TDict::TMemberMap members;
+  /* Non-constant keys can only collide at runtime, but two equal literal
+     keys are a compile-time mistake -- catch them here. */
+  std::set<Var::TVar> literal_keys;
   for (auto member : Members) {
-    /* TODO(#378): Detect duplicate constant keys and throw */
-    auto result = members.emplace(std::make_pair((member.first)->Build(), (member.second)->Build()));
+    auto key = (member.first)->Build();
+    if (auto literal = std::dynamic_pointer_cast<Expr::TLiteral>(key)) {
+      if (!literal_keys.insert(literal->GetVal()).second) {
+        throw TCompileError(HERE, GetPosRange(DictCtor),
+            Base::AsStr("duplicate key ", literal->GetVal(),
+                        " in dictionary constructor").c_str());
+      }
+    }
+    auto result = members.emplace(std::make_pair(std::move(key), (member.second)->Build()));
     assert(result.second);
   }
   return Expr::TDict::New(members, GetPosRange(DictCtor));

--- a/tests/lang_tests/samples/collections.orly
+++ b/tests/lang_tests/samples/collections.orly
@@ -54,8 +54,9 @@ obj_access_2 = <{.a: 1, .b: true}>.a;
 
 /* Dics */
 dic_1 = (sidious) where { sidious = {1: true, 2: false, 3: true}; };
+/* Duplicate literal keys in a dict constructor are a compile error (#378). */
 dic_2 = (maul) where {
-  maul = {true: 3.14, true: 2.71, false: 0.0, false: 0.0};
+  maul = {true: 3.14, false: 0.0};
 };
 dic_3 = (tyranus) where {
   tyranus = {


### PR DESCRIPTION
`{1: \"a\", 1: \"c\"}` silently built with one of the pairs. Two equal literal keys are a compile-time mistake: `TDictCtor::Build` now tracks literal keys in a `Var::TVar` set and throws `TCompileError` naming the duplicated key, with the constructor's pos range (`3:7-3:31 duplicate key 1L in dictionary constructor`). Non-literal keys are untouched — they can only collide at runtime.

One corpus fix rode along: `samples/collections.orly` deliberately built a bool-keyed dict with duplicate literal keys (`{true: 3.14, true: 2.71, ...}`) — 2014-era pinning of the old silent behavior; it's deduped with a comment citing this change. The sample is compile-only (no `.state` baseline to regenerate).

Gate: verified rejection + normal/mixed dicts compile; integration build + lang_test clean.

Closes #378.