### PR TITLE
chore(jhm): retire the stale -o flag TODO in make_dep_file

### DIFF
--- a/jhm/make_dep_file.cc
+++ b/jhm/make_dep_file.cc
@@ -161,7 +161,6 @@ int main(int argc, const char *argv[]) {
   std::signal(SIGPIPE, SIG_IGN);
 
   if (argc < 3) {
-    //TODO(#343): add '-o' to specify output filename.
     cout << "USAGE: " << argv[0] << "input_name output_name [misc_flags]\n"
          << " Produces a JSON dependency file (.dep) containing the headers/dependencies of a given source file";
     return -1;


### PR DESCRIPTION
Investigated for the tier-2 sweep: the output filename has been a positional parameter (`argv[2]`, in the very usage line the TODO sits above) for as long as the tool has existed, and jhm's dep job passes it (`jhm/jobs/dep.cc`). Nothing to add — the 2014 comment predates its own file's interface.

Closes #343.