### PR TITLE
chore(server): typed exception for untestable tetris assertions

### DIFF
--- a/orly/server/repo_tetris_manager.cc
+++ b/orly/server/repo_tetris_manager.cc
@@ -214,8 +214,9 @@ bool TRepoTetrisManager::TPlayer::TChild::TestAssertions(Indy::TContext &context
     const auto &entry = MetaRecord.GetEntry(item.first);
     if(entry.GetPackageFqName() == Mynde::PackageName) {
       if(entry.GetMethodName() != "set") {
-        //TODO(#376): Should probably be a custom exception that inherits from std::runtime_error...
-        throw std::runtime_error("Only memcache set is supported for update assertions at the moment. And that has none.");
+        THROW_ERROR(TUnsupportedAssertion)
+            << "only memcache 'set' (which carries no assertion) is supported; got method '"
+            << entry.GetMethodName() << "'";
       }
       return true;
     }

--- a/orly/server/repo_tetris_manager.h
+++ b/orly/server/repo_tetris_manager.h
@@ -21,9 +21,11 @@
 #include <cassert>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <unordered_map>
 
 #include <base/class_traits.h>
+#include <base/thrower.h>
 #include <orly/indy/context.h>
 #include <orly/indy/manager.h>
 #include <orly/package/manager.h>
@@ -38,6 +40,11 @@ namespace Orly {
     class TRepoTetrisManager final
         : public TTetrisManager {
       public:
+
+      /* Thrown when an update carries an assertion Tetris cannot test --
+         today, any memcache update other than a bare `set`. */
+      DEFINE_ERROR(TUnsupportedAssertion, std::runtime_error,
+                   "update assertion not supported by tetris");
 
       TRepoTetrisManager(
           Base::TScheduler *scheduler,


### PR DESCRIPTION
`TestAssertions` threw a bare `std::runtime_error` when an update's assertion can't be tested (any memcache method other than `set`). Adds `TRepoTetrisManager::TUnsupportedAssertion` (`DEFINE_ERROR`) and names the offending method in the message.

First half of #376; the frame re-activation queue half stays open there. Gate: batch integration build + make test green; lang_test 156/2 xfail.

Refs #376.