### PR TITLE
fix(expr,synth): more actionable compiler diagnostics

### DIFF
--- a/orly/expr/function_app.cc
+++ b/orly/expr/function_app.cc
@@ -19,8 +19,11 @@
 #include <orly/expr/function_app.h>
 
 #include <iomanip>
+#include <string>
+#include <vector>
 
 #include <base/as_str.h>
+#include <base/split.h>
 #include <orly/error.h>
 #include <orly/expr/ref.h>
 #include <orly/expr/util.h>
@@ -117,11 +120,12 @@ Type::TType TFunctionApp::GetTypeImpl() const {
   auto params = function->GetParams();
   bool is_sequence = false;
   // Iterate through the parameters we need and check if it was given in the arguments
+  std::vector<std::string> missing_params;
   for (auto param : params) {
     auto arg = function_app_args.find(param.first /* name */);
     if (arg == function_app_args.end()) { // expected argument not found
-      // TODO(#314): Tell them exactly which parameters are missing
-      throw TExprError(HERE, GetPosRange(), "Function call with missing expected argument");
+      missing_params.push_back(param.first);
+      continue;
     }
     // Found
     auto arg_type = (arg->second)->GetExpr()->GetType();
@@ -135,9 +139,17 @@ Type::TType TFunctionApp::GetTypeImpl() const {
        in this position (#128 Option A). */
     if (!unwrapped_arg_type.Is<Type::TAny>()
         && unwrapped_arg_type != param_type && Type::TOpt::Get(unwrapped_arg_type) != param_type) {
-      throw TExprError(HERE, GetPosRange(), "Function call with parameter type mismatch");
+      throw TExprError(HERE, GetPosRange(),
+          Base::AsStr("argument ", std::quoted(param.first), " has type ", arg_type,
+                      ", but the parameter expects ", param_type).c_str());
     }
     function_app_args.erase(arg);
+  }
+  if (!missing_params.empty()) {
+    throw TExprError(HERE, GetPosRange(),
+        Base::AsStr("function call is missing argument",
+                    missing_params.size() > 1 ? "s: " : ": ",
+                    Base::Join(missing_params, ", ")).c_str());
   }
   if (!function_app_args.empty()) {
     for (auto function_app_arg : function_app_args) {

--- a/orly/synth/scope_and_def.cc
+++ b/orly/synth/scope_and_def.cc
@@ -181,9 +181,11 @@ TAction TDef::BuildHelper(int pass) {
       case InProgress: {
         // We have encountered ourself during a predecessor walk.  This means we have a cycle.
         const TName &name = GetName();
-        GetContext().AddError(name.GetPosRange(), Base::AsStr(std::quoted(name.GetText()), " has a cycle in its build dependencies"));
+        GetContext().AddError(name.GetPosRange(),
+            Base::AsStr(std::quoted(name.GetText()),
+                        " has a cycle in its build dependencies (detected in "
+                        "definition-build pass ", pass, ')'));
         action = Fail;
-        /* TODO(#314): Provide a mechanism to customize this error message so that we can describe the pass in which the cycle was found. */
         break;
       }
       case Shiny: {


### PR DESCRIPTION
- A call with missing arguments now collects and names **every** missing parameter in one error (`function call is missing arguments: x, y`), matching the existing unexpected-argument diagnostics; a type mismatch names the argument and both types.
- The dependency-cycle error reports which definition-build pass detected the cycle.

Two #314 sites stay open: the mutable-in-mutable clean error needs the synth type-builder callbacks generalized from raw function pointers to `std::function` (a real refactor), and the mutate assign-visitor message similarly needs a custom comparison visitor.

Gate: batch integration build + make test green; lang_test 156/2 xfail.

Refs #314.