### PR TITLE
chore(jhm): static New factories replace per-producer lambda wrappers

### DIFF
--- a/jhm/jobs/bison.cc
+++ b/jhm/jobs/bison.cc
@@ -38,10 +38,7 @@ TJobProducer TBison::GetProducer() {
     "bison",
     OutExtensions,
     [](const TRelPath &output) { return TryGetInputName(output, OutExtensions, {"y"}); },
-    //TODO(#344): Should be able to eliminate the lambda wrapper here...
-    [] (TEnv &env, TFile *in_file) -> unique_ptr<TJob> {
-      return unique_ptr<TJob>(new TBison(env, in_file));
-    }
+    TBison::New
   };
 }
 

--- a/jhm/jobs/bison.cc
+++ b/jhm/jobs/bison.cc
@@ -32,23 +32,12 @@ const static vector<vector<string>> OutExtensions = {
   {"bison", "hh"}
 };
 
-//TODO(#335): this is duplicated / copied in both bison.cc and flex.cc
-static std::optional<TRelPath> GetInputName(const TRelPath &output) {
-  for (const auto &ext : OutExtensions) {
-    if (output.Path.EndsWith(ext)) {
-      return TRelPath(AddExtension(DropExtension(TPath(output.Path), ext.size()), {"y"}));
-    }
-  }
-  return std::optional<TRelPath>();
-}
-
-
 TJobProducer TBison::GetProducer() {
 
   return TJobProducer{
     "bison",
     OutExtensions,
-    GetInputName,
+    [](const TRelPath &output) { return TryGetInputName(output, OutExtensions, {"y"}); },
     //TODO(#344): Should be able to eliminate the lambda wrapper here...
     [] (TEnv &env, TFile *in_file) -> unique_ptr<TJob> {
       return unique_ptr<TJob>(new TBison(env, in_file));

--- a/jhm/jobs/bison.h
+++ b/jhm/jobs/bison.h
@@ -37,6 +37,12 @@ namespace Jhm {
 
       private:
       TBison(TEnv &env, TFile *input);
+
+      /* The TJobProducer::MakeJob callback (GetProducer passes it; no
+         per-producer lambda needed). */
+      static std::unique_ptr<TJob> New(TEnv &env, TFile *in_file) {
+        return std::unique_ptr<TJob>(new TBison(env, in_file));
+      }
       TEnv &Env;
     };
 

--- a/jhm/jobs/compile_c_family.cc
+++ b/jhm/jobs/compile_c_family.cc
@@ -71,10 +71,7 @@ TJobProducer TCompileCFamily::GetCProducer() {
     "compile_c",
     {{"o"}},
     bind(GetInputName, _1, false),
-    //TODO(#344): Should be able to eliminate the lambda wrapper here...
-    [] (TEnv &env, TFile *in_file) -> unique_ptr<TJob> {
-      return unique_ptr<TJob>(new TCompileCFamily(env, in_file, false));
-    }
+    TCompileCFamily::New<false>
   };
 }
 
@@ -83,10 +80,7 @@ TJobProducer TCompileCFamily::GetCppProducer() {
     "compile_cpp",
     {{"o"}},
     bind(GetInputName, _1, true),
-    //TODO(#344): Should be able to eliminate the lambda wrapper here...
-    [] (TEnv &env, TFile *in_file) -> unique_ptr<TJob> {
-      return unique_ptr<TJob>(new TCompileCFamily(env, in_file, true));
-    }
+    TCompileCFamily::New<true>
   };
 }
 

--- a/jhm/jobs/compile_c_family.h
+++ b/jhm/jobs/compile_c_family.h
@@ -43,6 +43,13 @@ namespace Jhm {
       private:
       TCompileCFamily(TEnv &env, TFile *input, bool is_cpp);
 
+      /* The TJobProducer::MakeJob callback, one instantiation per
+         producer (GetCProducer / GetCppProducer). */
+      template <bool IsCpp>
+      static std::unique_ptr<TJob> New(TEnv &env, TFile *in_file) {
+        return std::unique_ptr<TJob>(new TCompileCFamily(env, in_file, IsCpp));
+      }
+
       TEnv &Env;
       // NOTE: We could make IsCpp be constant / CompileCFamily be templated on it
       // But that results in more ug than the tiny perf benefit is worth.

--- a/jhm/jobs/dep.cc
+++ b/jhm/jobs/dep.cc
@@ -45,10 +45,7 @@ TJobProducer TDep::GetProducer() {
     "dep",
     {{"dep"}},
     GetInputName,
-    //TODO(#344): Should be able to eliminate the lambda wrapper here...
-    [] (TEnv &env, TFile *in_file) -> unique_ptr<TJob> {
-      return unique_ptr<TDep>(new TDep(env, in_file));
-    }
+    TDep::New
   };
 }
 

--- a/jhm/jobs/dep.h
+++ b/jhm/jobs/dep.h
@@ -38,6 +38,12 @@ namespace Jhm {
       private:
       TDep(TEnv &env, TFile *input);
 
+      /* The TJobProducer::MakeJob callback (GetProducer passes it; no
+         per-producer lambda needed). */
+      static std::unique_ptr<TJob> New(TEnv &env, TFile *in_file) {
+        return std::unique_ptr<TJob>(new TDep(env, in_file));
+      }
+
       TEnv &Env;
       TSet<TFile*> Needs;
 

--- a/jhm/jobs/flex.cc
+++ b/jhm/jobs/flex.cc
@@ -38,10 +38,7 @@ TJobProducer TFlex::GetProducer() {
     "flex",
     OutExtensions,
     [](const TRelPath &output) { return TryGetInputName(output, OutExtensions, {"l"}); },
-    //TODO(#344): Should be able to eliminate the lambda wrapper here...
-    [] (TEnv &env, TFile *in_file) -> unique_ptr<TJob> {
-      return unique_ptr<TFlex>(new TFlex(env, in_file));
-    }
+    TFlex::New
   };
 }
 

--- a/jhm/jobs/flex.cc
+++ b/jhm/jobs/flex.cc
@@ -32,22 +32,12 @@ const static vector<vector<string>> OutExtensions = {
   {"flex","cc"},
 };
 
-//TODO(#335): this is duplicated / copied in both bison.cc and flex.cc
-static std::optional<TRelPath> GetInputName(const TRelPath &output) {
-  for (const auto &ext : OutExtensions) {
-    if (output.Path.EndsWith(ext)) {
-      return TRelPath(AddExtension(DropExtension(TPath(output.Path), ext.size()), {"l"}));
-    }
-  }
-  return std::optional<TRelPath>();
-}
-
 TJobProducer TFlex::GetProducer() {
 
   return TJobProducer{
     "flex",
     OutExtensions,
-    GetInputName,
+    [](const TRelPath &output) { return TryGetInputName(output, OutExtensions, {"l"}); },
     //TODO(#344): Should be able to eliminate the lambda wrapper here...
     [] (TEnv &env, TFile *in_file) -> unique_ptr<TJob> {
       return unique_ptr<TFlex>(new TFlex(env, in_file));

--- a/jhm/jobs/flex.h
+++ b/jhm/jobs/flex.h
@@ -37,6 +37,12 @@ namespace Jhm {
 
       private:
       TFlex(TEnv &env, TFile *input);
+
+      /* The TJobProducer::MakeJob callback (GetProducer passes it; no
+         per-producer lambda needed). */
+      static std::unique_ptr<TJob> New(TEnv &env, TFile *in_file) {
+        return std::unique_ptr<TJob>(new TFlex(env, in_file));
+      }
       TEnv &Env;
     };
 

--- a/jhm/jobs/link.cc
+++ b/jhm/jobs/link.cc
@@ -49,10 +49,7 @@ TJobProducer TLink::GetProducer() {
     "link",
     {{""}},
     GetInputName,
-    //TODO(#344): Should be able to eliminate the lambda wrapper here...
-    [] (TEnv &env, TFile *in_file) -> unique_ptr<TJob> {
-      return unique_ptr<TJob>(new TLink(env, in_file));
-    }
+    TLink::New
   };
 }
 

--- a/jhm/jobs/link.h
+++ b/jhm/jobs/link.h
@@ -39,6 +39,12 @@ namespace Jhm {
       private:
       TLink(TEnv &env, TFile *input);
 
+      /* The TJobProducer::MakeJob callback (GetProducer passes it; no
+         per-producer lambda needed). */
+      static std::unique_ptr<TJob> New(TEnv &env, TFile *in_file) {
+        return std::unique_ptr<TJob>(new TLink(env, in_file));
+      }
+
       TEnv &Env;
       std::unordered_map<TFile*, TFile*> NeededDepToObj;
       TSet<TFile*> AntiNeeds;

--- a/jhm/jobs/nycr.cc
+++ b/jhm/jobs/nycr.cc
@@ -53,9 +53,7 @@ TJobProducer TNycrLang::GetProducer() {
     "nycr_lang",
     {{"nycr","lang"}},
     GetNycrLangInputName,
-    [](TEnv &env, TFile *in_file) -> unique_ptr<TJob> {
-      return unique_ptr<TJob>(new TNycrLang(env, in_file));
-    }
+    TNycrLang::New
   };
 }
 
@@ -133,10 +131,7 @@ TJobProducer TNycr::GetProducer() {
     "nycr",
     LangSuffixes,
     GetInputName,
-    //TODO(#344): Should be able to eliminate the lambda wrapper here...
-    [] (TEnv &env, TFile *in_file) -> unique_ptr<TJob> {
-      return unique_ptr<TJob>(new TNycr(env, in_file));
-    }
+    TNycr::New
   };
 }
 

--- a/jhm/jobs/nycr.h
+++ b/jhm/jobs/nycr.h
@@ -39,6 +39,12 @@ namespace Jhm {
       private:
       TNycrLang(TEnv &env, TFile *input);
 
+      /* The TJobProducer::MakeJob callback (GetProducer passes it; no
+         per-producer lambda needed). */
+      static std::unique_ptr<TJob> New(TEnv &env, TFile *in_file) {
+        return std::unique_ptr<TJob>(new TNycrLang(env, in_file));
+      }
+
       TEnv &Env;
     };
 
@@ -55,6 +61,12 @@ namespace Jhm {
 
       private:
       TNycr(TEnv &env, TFile *input);
+
+      /* The TJobProducer::MakeJob callback (GetProducer passes it; no
+         per-producer lambda needed). */
+      static std::unique_ptr<TJob> New(TEnv &env, TFile *in_file) {
+        return std::unique_ptr<TJob>(new TNycr(env, in_file));
+      }
 
       TEnv &Env;
       TFile *Need;

--- a/jhm/jobs/util.cc
+++ b/jhm/jobs/util.cc
@@ -44,3 +44,14 @@ TFile *Jhm::GetOutputWithExtension(unordered_set<TFile *> output_set, const vect
   assert(false);
   __builtin_unreachable();
 }
+
+optional<TRelPath> Jhm::TryGetInputName(const TRelPath &output,
+                                        const vector<vector<string>> &out_exts,
+                                        const vector<string> &src_ext) {
+  for (const auto &ext : out_exts) {
+    if (output.Path.EndsWith(ext)) {
+      return TRelPath(AddExtension(DropExtension(Base::TPath(output.Path), ext.size()), src_ext));
+    }
+  }
+  return nullopt;
+}

--- a/jhm/jobs/util.h
+++ b/jhm/jobs/util.h
@@ -33,4 +33,11 @@ namespace Jhm {
                                            TEnv &env,
                                            const TRelPath &input);
   TFile *GetOutputWithExtension(std::unordered_set<TFile *> output_set, const std::vector<std::string> &ext);
+
+  /* The TJobProducer::TryGetInput shape shared by single-source producers
+     (bison, flex): if `output` ends with one of `out_exts`, the input is
+     `output` with that extension swapped for `src_ext`; otherwise nothing. */
+  std::optional<TRelPath> TryGetInputName(const TRelPath &output,
+                                          const std::vector<std::vector<std::string>> &out_exts,
+                                          const std::vector<std::string> &src_ext);
 }


### PR DESCRIPTION
Every `TJobProducer` repeated a three-line lambda newing its job. Each job class now carries a private static `New` matching the MakeJob callback shape (a member template `New<IsCpp>` for the two-producer compile_c_family), and `GetProducer` passes it directly — eight lambdas deleted, constructors stay private.

(First cut used one namespace-level `MakeJob<T>` template befriended per class; gcc never implicitly instantiated the befriended specialization at the address-taken use site, leaving undefined references at link. The per-class static avoids the instantiation subtlety entirely.)

Stacked on #393 (same files); its commit shows here until that merges. Gate: batch integration build + make test green; lang_test 156/2 xfail.

Closes #344.