### PR TITLE
chore(base,jhm): value-returning EmplaceOrFail; use InsertOrFail in env

### DIFF
--- a/base/util/stl.h
+++ b/base/util/stl.h
@@ -76,6 +76,21 @@ namespace Util {
     assert(res);
   }
 
+  /* InsertOrFail's value-returning sibling (a separate name, since the two
+     would differ only by return type): emplace, fail an assertion on a
+     duplicate, and hand back a reference to the inserted element for call
+     sites that need it. */
+  template <typename TContainer, typename... TArgs>
+  typename TContainer::value_type &EmplaceOrFail(TContainer &container, TArgs &&...args) {
+    auto [iter, res] = container.emplace(std::forward<TArgs>(args)...);
+    if (!res) {
+      syslog(LOG_ERR, "[EmplaceOrFail]");
+      Server::BacktraceToLog();
+    }
+    assert(res);
+    return *iter;
+  }
+
   /* Inserts the pointer-type value into the associative container under the given key.  If the container already contains a value for the key,
      the old value is deleted and replaced with the new one. */
   template <typename TContainer>

--- a/jhm/env.cc
+++ b/jhm/env.cc
@@ -41,8 +41,7 @@ unordered_set<TJob *> TJobFactory::GetPotentialJobs(TEnv &env, TFile *out_file) 
     for_each(range.first, range.second, [&ret](const pair<TFile*, TJob *> &pair) {
       // NOTE: job can be a nullptr, which is valid in the cache to indicate "no jobs exist".
       if (pair.second) {
-        // TODO(#341): InsertOrFail.
-        ret.insert(pair.second);
+        InsertOrFail(ret, pair.second);
       }
     });
   } else {
@@ -77,8 +76,7 @@ unordered_set<TJob *> TJobFactory::GetPotentialJobs(TEnv &env, TFile *out_file) 
       assert(Contains(job->GetOutput(), out_file));
 
       // Add ourself to the cache map, as well as the set of jobs being returned.
-      // TODO(#341): InsertOrFail.
-      ret.insert(job);
+      InsertOrFail(ret, job);
       JobsByOutput.emplace(out_file, job);
     }
 

--- a/jhm/env.h
+++ b/jhm/env.h
@@ -24,6 +24,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include <base/util/stl.h>
 #include <jhm/config.h>
 #include <jhm/file.h>
 #include <jhm/job.h>
@@ -39,11 +40,7 @@ namespace Jhm {
 
     public:
     TValue *Add(TKey &&key, std::unique_ptr<TValue> &&item) {
-      //TODO(#341): Add a new InsertOrFail which can handle this
-      auto result = ManagedThings.emplace(std::move(key), std::move(item));
-      assert(result.second);
-
-      return result.first->second.get();
+      return Util::EmplaceOrFail(ManagedThings, std::move(key), std::move(item)).second.get();
     }
 
     TValue *TryGet(const TKey &key) {


### PR DESCRIPTION
Adds `Util::EmplaceOrFail` — `InsertOrFail`'s value-returning sibling (a separate name, since overloading on return type alone is impossible) — and uses it in `TInterner::Add`. The two env.cc cache inserts flagged for InsertOrFail now use it, so a duplicate job in the ready cache fails an assertion instead of being silently swallowed.

Gate: batch integration build + make test green; lang_test 156/2 xfail.

Closes #341.