### PR TITLE
perf(package): parse names in place with string_view

### DIFF
--- a/orly/package/name.cc
+++ b/orly/package/name.cc
@@ -42,10 +42,18 @@ static inline const char *find(char sep, const char *start, const char *limit) {
   return 0;
 }
 
-TName TName::Parse(const std::string &name) {
+TName TName::Parse(std::string_view name) {
   TName res;
-  Split("/", name, res.Name);
-
+  if (!name.empty()) {  /* matches Split()'s no-pieces-for-empty behavior */
+    for (size_t pos = 0;;) {
+      const auto slash = name.find('/', pos);
+      res.Name.emplace_back(name.substr(pos, slash - pos));
+      if (slash == std::string_view::npos) {
+        break;
+      }
+      pos = slash + 1;
+    }
+  }
   if (!IsValidNamespace(res.Name)) {
     THROW_ERROR(std::runtime_error) << "Invalid package name " << std::quoted(name);
   }
@@ -56,13 +64,9 @@ TVersionedName TVersionedName::Parse(const TPiece<const char> &name) {
 
   auto dot_pos = find('.', name.GetLimit() - 1, name.GetStart() - 1);
   if (!dot_pos) {
-    //TODO(#357): Excess copy here.
-    string tmp;
-    return {TName::Parse(Assign(tmp, name)), 0};
+    return {TName::Parse(std::string_view(name.GetStart(), name.GetSize())), 0};
   }
-  //TODO(#357): Excess copy here
-  string tmp;
-  return {TName::Parse(Assign(tmp, TPiece<const char>(name.GetStart(), dot_pos))),
+  return {TName::Parse(std::string_view(name.GetStart(), dot_pos - name.GetStart())),
                         TConvertProxy(TPiece<const char>(dot_pos + 1, name.GetLimit()))};
 }
 

--- a/orly/package/name.h
+++ b/orly/package/name.h
@@ -25,6 +25,7 @@
 #include <cassert>
 #include <ostream>
 #include <string>
+#include <string_view>
 
 #include <base/hash.h>
 #include <base/piece.h>
@@ -35,7 +36,9 @@ namespace Orly {
   namespace Package {
 
     struct TName {
-      static TName Parse(const std::string &name);
+      /* Parses in place -- callers hand any string-ish source (std::string,
+         literal, or a slice of a larger buffer) without a temporary copy. */
+      static TName Parse(std::string_view name);
 
       bool operator==(const TName &that) const {
         return Name == that.Name;


### PR DESCRIPTION
`TName::Parse` takes `std::string_view` and splits in place, so `TVersionedName::Parse` no longer copies the whole piece into a temp string before splitting (the two flagged excess copies). `std::string` callers convert implicitly; empty-input behavior matches the old `Split()` exactly (no pieces).

Gate: batch integration build + make test green (incl. `package/name.test`); lang_test 156/2 xfail — every orlyc package load exercises this path.

Closes #357.