### PR TITLE
csv_to_bin: scan doubles in place instead of slurping the field

### DIFF
--- a/orly/csv_to_bin/level3.cc
+++ b/orly/csv_to_bin/level3.cc
@@ -19,6 +19,7 @@
 #include <orly/csv_to_bin/level3.h>
 
 #include <limits>
+#include <stdexcept>
 
 using namespace std;
 using namespace Orly::CsvToBin;
@@ -105,12 +106,72 @@ TLevel3 &TLevel3::operator>>(int64_t &that) {
 }
 
 TLevel3 &TLevel3::operator>>(double &that) {
-  /* TODO(#313): Yeah, this is cheating.  We really shouldn't be consuming all the
-     bytes in the field and then translating just the prefix into a number.
-     We should scan property to conserve the rest of the field. */
+  /* Scan just the bytes that spell the number, leaving anything after it
+     in the field.  We collect the accepted bytes and let stod() do the
+     actual translation so we keep its precision. */
   string temp;
-  *this >> temp;
-  that = stod(temp);
+  uint8_t c = Peek();
+  if (c == '+' || c == '-') {
+    temp += static_cast<char>(Pop());
+  }
+  c = CanPeek() ? tolower(Peek()) : 0;
+  if (c == 'i' || c == 'n') {
+    const char *kwd = (c == 'i') ? "inf" : "nan";
+    MatchKeyword(kwd);
+    if (c == 'i' && CanPeek() && tolower(Peek()) == 'i') {
+      MatchKeyword("inity");
+    }
+    temp += kwd;
+  } else {
+    bool has_digits = false;
+    while (CanPeek() && isdigit(Peek())) {
+      temp += static_cast<char>(Pop());
+      has_digits = true;
+    }
+    if (CanPeek() && Peek() == '.') {
+      temp += static_cast<char>(Pop());
+      while (CanPeek() && isdigit(Peek())) {
+        temp += static_cast<char>(Pop());
+        has_digits = true;
+      }
+    }
+    if (!has_digits) {
+      if (CanPeek()) {
+        THROW_ERROR(TSyntaxError)
+            << "expected floating-point number, found '"
+            << static_cast<char>(Peek()) << '\'';
+      }
+      THROW_ERROR(TSyntaxError)
+          << "expected floating-point number, found end of field";
+    }
+    if (CanPeek() && tolower(Peek()) == 'e') {
+      temp += static_cast<char>(Pop());
+      if (CanPeek() && (Peek() == '+' || Peek() == '-')) {
+        temp += static_cast<char>(Pop());
+      }
+      bool has_exp_digits = false;
+      while (CanPeek() && isdigit(Peek())) {
+        temp += static_cast<char>(Pop());
+        has_exp_digits = true;
+      }
+      if (!has_exp_digits) {
+        if (CanPeek()) {
+          THROW_ERROR(TSyntaxError)
+              << "expected exponent of floating-point number, found '"
+              << static_cast<char>(Peek()) << '\'';
+        }
+        THROW_ERROR(TSyntaxError)
+            << "expected exponent of floating-point number, "
+               "found end of field";
+      }
+    }
+  }
+  try {
+    that = stod(temp);
+  } catch (const out_of_range &) {
+    THROW_ERROR(TNumberOutOfRange)
+        << "floating-point number is out of range";
+  }
   return *this;
 }
 

--- a/orly/csv_to_bin/level3.test.cc
+++ b/orly/csv_to_bin/level3.test.cc
@@ -17,6 +17,7 @@
    limitations under the License. */
 
 #include <orly/csv_to_bin/level3.h>
+#include <cmath>
 #include <optional>
 
 #include <base/strm/mem/static_in.h>
@@ -68,6 +69,86 @@ FIXTURE(OneLiner) {
   EXPECT_FALSE(h.has_value());
   EXPECT_TRUE(i.has_value());
   EXPECT_EQ(*i, 101);
+}
+
+FIXTURE(Doubles) {
+  Strm::Mem::TStaticIn mem(
+      "98.6,-1.5e3,+.5,720.,1E-2,inf,-Infinity,NAN");
+  TLevel1 level1(&mem, Simple);
+  TLevel2 level2(level1);
+  TLevel3 level3(level2);
+  double a, b, c, d, e, f, g, h;
+  level3
+      >> StartOfFile >> StartOfRecord
+      >> StartOfField >> a >> EndOfField
+      >> StartOfField >> b >> EndOfField
+      >> StartOfField >> c >> EndOfField
+      >> StartOfField >> d >> EndOfField
+      >> StartOfField >> e >> EndOfField
+      >> StartOfField >> f >> EndOfField
+      >> StartOfField >> g >> EndOfField
+      >> StartOfField >> h >> EndOfField
+      >> EndOfRecord >> EndOfFile;
+  EXPECT_EQ(a, 98.6);
+  EXPECT_EQ(b, -1500.0);
+  EXPECT_EQ(c, 0.5);
+  EXPECT_EQ(d, 720.0);
+  EXPECT_EQ(e, 0.01);
+  EXPECT_TRUE(std::isinf(f) && f > 0);
+  EXPECT_TRUE(std::isinf(g) && g < 0);
+  EXPECT_TRUE(std::isnan(h));
+}
+
+FIXTURE(DoubleConservesRestOfField) {
+  /* Reading a double must consume only the bytes that spell the number,
+     leaving the rest of the field for further extraction. */
+  Strm::Mem::TStaticIn mem("98.6F 12e3rpm");
+  TLevel1 level1(&mem, Simple);
+  TLevel2 level2(level1);
+  TLevel3 level3(level2);
+  double a, b;
+  string rest;
+  level3
+      >> StartOfFile >> StartOfRecord >> StartOfField
+      >> a >> rest >> EndOfField
+      >> EndOfRecord >> EndOfFile;
+  EXPECT_EQ(a, 98.6);
+  EXPECT_EQ(rest, "F 12e3rpm");
+  Strm::Mem::TStaticIn mem2("12e3rpm");
+  TLevel1 level1b(&mem2, Simple);
+  TLevel2 level2b(level1b);
+  TLevel3 level3b(level2b);
+  level3b
+      >> StartOfFile >> StartOfRecord >> StartOfField
+      >> b >> rest >> EndOfField
+      >> EndOfRecord >> EndOfFile;
+  EXPECT_EQ(b, 12000.0);
+  EXPECT_EQ(rest, "rpm");
+}
+
+FIXTURE(BadDoubles) {
+  auto parse = [](const char *text) {
+    Strm::Mem::TStaticIn mem(text);
+    TLevel1 level1(&mem, Simple);
+    TLevel2 level2(level1);
+    TLevel3 level3(level2);
+    double dummy;
+    level3 >> StartOfFile >> StartOfRecord >> StartOfField >> dummy;
+  };
+  auto no_number = [&parse] { parse("abc"); };
+  EXPECT_THROW_FUNC(TLevel3::TSyntaxError, no_number);
+  auto lone_sign = [&parse] { parse("+"); };
+  EXPECT_THROW_FUNC(TLevel3::TSyntaxError, lone_sign);
+  auto lone_point = [&parse] { parse("."); };
+  EXPECT_THROW_FUNC(TLevel3::TSyntaxError, lone_point);
+  auto empty_exp = [&parse] { parse("12e"); };
+  EXPECT_THROW_FUNC(TLevel3::TSyntaxError, empty_exp);
+  auto bad_exp = [&parse] { parse("12e+x"); };
+  EXPECT_THROW_FUNC(TLevel3::TSyntaxError, bad_exp);
+  auto bad_kwd = [&parse] { parse("-nap"); };
+  EXPECT_THROW_FUNC(TLevel3::TSyntaxError, bad_kwd);
+  auto too_big = [&parse] { parse("1e999"); };
+  EXPECT_THROW_FUNC(TLevel3::TNumberOutOfRange, too_big);
 }
 
 FIXTURE(Scanner) {


### PR DESCRIPTION
Closes #313.

`TLevel3::operator>>(double&)` admitted it was cheating: it consumed every remaining byte of the field into a string and let `stod()` translate just the prefix, silently discarding whatever followed the number.

This reworks it to scan the number's bytes directly — optional sign, digits with optional fraction and exponent, plus the `inf`/`infinity`/`nan` keywords `stod()` already accepted (case-insensitive, matching the keyword handling elsewhere in level 3). Only the bytes that spell the number are consumed, so the rest of the field is conserved for further extraction — the same behavior the `int64_t` extractor already has. The accepted bytes are still handed to `stod()` for the actual translation, so precision is unchanged.

Behavior changes beyond the streaming fix, both bringing doubles in line with the int extractor:

- Trailing garbage after the number is no longer silently swallowed; it stays in the field (and `EndOfField` will object if you don't consume it, e.g. with `SkipBytes`).
- Malformed numbers (`abc`, lone `+`/`.`, `12e`, `12e+x`) raise `TSyntaxError` and out-of-range values (`1e999`) raise `TNumberOutOfRange`, instead of `stod()`'s raw `std::invalid_argument`/`std::out_of_range` escaping. Leading whitespace, which `stod()` used to skip, is now a syntax error — same as ints.

New fixtures cover the grammar (fraction-only, trailing point, exponents, signed infinity, NaN), the conserve-the-rest-of-the-field behavior, and the error cases.

Tested: `orly/csv_to_bin/*.test` all pass.
