### PR TITLE
fix(code_gen): real hash mixing for TMutablePart and generated objects

### DIFF
--- a/orly/code_gen/effect.h
+++ b/orly/code_gen/effect.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <unordered_map>
 
+#include <base/hash.h>
 #include <orly/code_gen/cpp_printer.h>
 #include <orly/code_gen/package_base.h>
 #include <orly/error.h>
@@ -64,8 +65,11 @@ namespace std {
     typedef Orly::CodeGen::TMutablePart argument_type;
 
     result_type operator()(const argument_type &that) const {
-      //TODO(#295): Use a better hash
-      return std::hash<Orly::CodeGen::TPtrC<Orly::CodeGen::TInline>>()(that.Mutable) ^ that.Index;
+      /* Boost-style mix instead of the old xor-with-small-int, which barely
+         perturbed the pointer hash's low bits (#295). */
+      return Base::CombineHashes(
+          std::hash<Orly::CodeGen::TPtrC<Orly::CodeGen::TInline>>()(that.Mutable),
+          std::hash<uint32_t>()(that.Index));
     }
   }; //hash<Orly::CodeGen::TMutablePart>
 }

--- a/orly/code_gen/obj.cc
+++ b/orly/code_gen/obj.cc
@@ -101,6 +101,7 @@ void Orly::CodeGen::GenObjHeader(const std::string &out_dir, const Type::TType &
       << Eol
       << "#include <cassert>" << Eol
       << Eol
+      << "#include <base/hash.h>" << Eol  // CombineHashes in the generated GetHash (#295)
       << "#include <orly/rt/tuple.h>" << Eol // NOTE: This is only needed when the object contains an addr.
       << "#include <orly/rt/containers.h>" << Eol
       << "#include <orly/rt/obj.h>" << Eol
@@ -206,18 +207,13 @@ void Orly::CodeGen::GenObjHeader(const std::string &out_dir, const Type::TType &
         /* helper functions (hash, equality, getters, etc.) */
             << "size_t GetHash() const {" << Eol
             << "  assert(this);" << Eol
-            << "  return  ";
-        /* TODO(#295): Better hash function. */
-        if(obj_core_type->GetElems().empty()) {
-          out << "0";
+            << "  size_t hash = 0;" << Eol;
+        /* Fold the member hashes through CombineHashes: the old `^` join
+           meant two equal members cancelled to zero (#295). */
+        for (const auto &it : obj_core_type->GetElems()) {
+          out << "  hash = Base::CombineHashes(hash, std::hash<" << it.second << ">()(V" << it.first << "));" << Eol;
         }
-        out << Base::Join(obj_core_type->GetElems(),
-                          " ^ ",
-                          [](TCppPrinter &out,
-                             const TObj::TElems::value_type &it) {
-                            out << "std::hash<" << it.second << ">()(V" << it.first << ')';
-                          })
-            << ';' << Eol
+        out << "  return hash;" << Eol
             << '}' << Eol
             << Eol
             << (Type::HasOptional(obj_type) ? "TOpt<bool>" : "bool") << " EqEq(const " << obj_class_name


### PR DESCRIPTION
TMutablePart xor'ed a pointer hash with a small index; generated objects xor'ed member hashes so two equal members cancelled to zero (every <{.x:n,.y:n}> hashed to 0). Both now Base::CombineHashes; generated headers include base/hash.h. Gate: 24-branch integration on post-#407 master — full build, no-op rebuild check, make test, targeted suites, lang_test. Closes #295.