### PR TITLE
fix(jhm): aggregate errors instead of flying the first one

### DIFF
--- a/jhm/jhm.cc
+++ b/jhm/jhm.cc
@@ -193,18 +193,27 @@ class TJhm : public TCmd {
     // Break the cyclic dependency by registering these back.
     env.SetFuncs(bind(&TWorkFinder::IsBuildable, &work_finder, _1), bind(&TWorkFinder::IsFileDone, &work_finder, _1));
 
-    // TODO(#333): Gather exceptions here, rather than letting first one fly.
+    /* Resolve every target before failing, so one bad target name doesn't
+       hide the rest. */
     TSet<TFile *> target_files;
+    vector<string> target_errors;
+    auto add_target = [&](const string &name) {
+      try {
+        InsertOrFail(target_files, FindFile(cwd, env, work_finder, name));
+      } catch (const exception &ex) {
+        target_errors.emplace_back(ex.what());
+      }
+    };
 
     // Either build the explicitly specified targets, or the default targets
     if (!Targets.empty()) {
       for(const auto &target: Targets) {
-        InsertOrFail(target_files, FindFile(cwd, env, work_finder, target));
+        add_target(target);
       }
     } else {
       // Add the default targets
       for(const auto &target: env.GetConfig().Read<vector<string>>({"targets"})) {
-        InsertOrFail(target_files, FindFile(cwd, env, work_finder, '/' + target));
+        add_target('/' + target);
       }
 
       // Add the tests if we're supposed to by default
@@ -243,6 +252,11 @@ class TJhm : public TCmd {
           target_files.insert(tests.begin(), tests.end());
         }
       }
+    }
+
+    if (!target_errors.empty()) {
+      THROW_ERROR(runtime_error) << "failed to resolve " << target_errors.size()
+                                 << " target(s): " << Join(target_errors, "; ");
     }
 
     // Add all target files as needed

--- a/jhm/work_finder.cc
+++ b/jhm/work_finder.cc
@@ -218,15 +218,21 @@ TJob *TWorkFinder::TryGetProducer(TFile *file) {
 
     if (IsBuildable(input_file)) {
       bool found_self = false;
-      //TODO(#333): Collect / hold errors at this loop, re throw after last iteration.
+      /* Register every output before throwing, so one conflict doesn't hide
+         the rest of the job's conflicting outputs. */
+      vector<string> conflicts;
       for (TFile *f : job->GetOutput()) {
         if (!Producers.emplace(f, job).second) {
           if (Producers.at(f) != job) {
-            THROW_ERROR(runtime_error) << "Multiple producers for file "
-                                       << f <<  ". Producers: " << Producers.at(f) << ", " << job;
+            conflicts.push_back(
+                AsStr(f, " (producers: ", Producers.at(f), ", ", job, ')'));
           }
         }
         found_self |= f == file;
+      }
+      if (!conflicts.empty()) {
+        THROW_ERROR(runtime_error) << "Multiple producers for file(s): "
+                                   << Join(conflicts, "; ");
       }
       assert(found_self && "Make sure we found ourselves");
 


### PR DESCRIPTION
Target resolution gathers every bad target into one error; producer registration lists all of a job's conflicting outputs instead of the first. Gate: 24-branch integration on post-#407 master — full build, no-op rebuild check, make test, targeted suites, lang_test. Closes #333.