### PR TITLE
chore(code_gen): delete the dead object-comparison machinery

### DIFF
--- a/orly/code_gen/obj.cc
+++ b/orly/code_gen/obj.cc
@@ -52,9 +52,6 @@ void TObjCtor::WriteExpr(TCppPrinter &out) const {
 }
 
 
-void Orly::CodeGen::GenObjComparison(const Type::TType &, const Type::TType &, TCppPrinter &) {
-  NOT_IMPLEMENTED();
-}
 
 /* a < that.a || (a == that.a && (b < that.b || (b == that.b && c < that.c)) ) */
 void WriteLessExpr(TCppPrinter &out, Type::TObjElems::const_iterator iter, const Type::TObjElems::const_iterator &iter_end) {

--- a/orly/code_gen/obj.h
+++ b/orly/code_gen/obj.h
@@ -54,7 +54,6 @@ namespace Orly {
     }; // TObjCtor
 
 
-    void GenObjComparison(const Type::TType &obj1, const Type::TType &obj2, TCppPrinter &strm);
     void GenObjHeader(const std::string &out_dir, const Type::TType &obj_type);
     void GenObjInclude(const Type::TType &obj, TCppPrinter &strm);
 

--- a/orly/code_gen/package.cc
+++ b/orly/code_gen/package.cc
@@ -288,10 +288,6 @@ void TPackage::WriteCc(TCppPrinter &out, const TRelPath &rel_path) const {
       << "using namespace Orly::Rt;" << Eol
       << Eol;
 
-  for(auto &it: NeededObjectComparisons) {
-    GenObjComparison(it.first, it.second, out);
-  }
-
   //Define all the unit test functions and their meta information
   for(auto &it: Tests) {
     it->Write(out);

--- a/orly/code_gen/package.h
+++ b/orly/code_gen/package.h
@@ -67,7 +67,6 @@ namespace Orly {
       TTests Tests;
       TExports Exports;
       TTypes Objects;
-      std::unordered_set<std::pair<Type::TType, Type::TType>> NeededObjectComparisons;
       std::unordered_set<Package::TName> NeededPackages;
     }; // TPackage
 


### PR DESCRIPTION
NeededObjectComparisons was never populated, its loop could never run, and GenObjComparison was NOT_IMPLEMENTED — superseded by generated member comparisons (#91). Gate: 24-branch integration on post-#407 master — full build, no-op rebuild check, make test, targeted suites, lang_test. Closes #303 as superseded.