### PR TITLE
fix(base): enable safe time-based UUIDs; real uuid validation

### DIFF
--- a/base/uuid.cc
+++ b/base/uuid.cc
@@ -26,8 +26,10 @@ using namespace Base;
 const TUuid TUuid::Null;
 
 bool TUuid::IsValidUuid(const char *s) {
-  //TODO(#291): Make more sophisticated.
-  return strlen(s) == 36;
+  /* Let libuuid do the real parse instead of the old length-36 check,
+     which accepted any 36 characters. */
+  uuid_t scratch;
+  return uuid_parse(s, scratch) == 0;
 }
 
 TUuid::TUuid(TAlgo that) {
@@ -48,9 +50,13 @@ TUuid::TUuid(TAlgo that) {
       break;
     }
     case TimeAndMACSafe: {
-      /* TODO(#291): We cannot currently support this mode because uuid_generate_time_safe() isn't in our OS build.
-         When it becomes available, call it here and only throw TUnsafeError if the function returns an error. */
-      throw TUnsafeError();
+      /* Available since util-linux 2.20; the 2014 OS build lacked it. A
+         non-zero return means the system could not guarantee uniqueness
+         (no uuidd and no synchronized clock counter). */
+      if (uuid_generate_time_safe(Data) != 0) {
+        throw TUnsafeError();
+      }
+      break;
     }
     case Twister: {
       /* acquire Twister lock */ {

--- a/base/uuid.test.cc
+++ b/base/uuid.test.cc
@@ -99,3 +99,26 @@ FIXTURE(BinaryStrm) {
   }
   EXPECT_EQ(actual, expected);
 }
+
+FIXTURE(IsValidUuid) {
+  EXPECT_TRUE(TUuid::IsValidUuid(Lower));
+  EXPECT_TRUE(TUuid::IsValidUuid(Upper));
+  EXPECT_FALSE(TUuid::IsValidUuid(""));
+  EXPECT_FALSE(TUuid::IsValidUuid("1b4e28ba-2fa1-11d2-883f"));  // too short
+  /* 36 characters, but not a uuid -- the old length-only check passed this. */
+  EXPECT_FALSE(TUuid::IsValidUuid("this-is-36-characters-of-not-a-uuid!"));
+  /* Right shape, non-hex digit. */
+  EXPECT_FALSE(TUuid::IsValidUuid("1b4e28ba-2fa1-11d2-883f-b9a761bdeZfb"));
+}
+
+FIXTURE(TimeAndMACSafe) {
+  /* The safe generator either produces a uuid or throws TUnsafeError when
+     the system can't guarantee uniqueness (e.g. no uuidd on a CI box);
+     both are valid outcomes, anything else is a bug. */
+  try {
+    TUuid id(TUuid::TimeAndMACSafe);
+    EXPECT_TRUE(static_cast<bool>(id));
+  } catch (const TUuid::TUnsafeError &) {
+    // Acceptable: this host can't make the guarantee.
+  }
+}


### PR DESCRIPTION
TimeAndMACSafe now calls uuid_generate_time_safe (present since util-linux 2.20; the 2014 OS build lacked it), throwing TUnsafeError only on a genuine no-guarantee return. IsValidUuid parses with uuid_parse instead of counting 36 chars. New fixtures for both. Gate: 24-branch integration on post-#407 master — full build, no-op rebuild check, make test, targeted suites, lang_test. Closes #291.