### PR TITLE
chore(package): retire TFuncHolder's stale invoke TODO

### DIFF
--- a/orly/package/loaded.h
+++ b/orly/package/loaded.h
@@ -83,7 +83,9 @@ namespace Orly {
 
     }; // TLoaded
 
-    // TODO(#355): A function to make a call to the actual orly function. Note in Spa we build a closure object around this.
+    /* Holds one exported function of a loaded package (and pins the package
+       alive); Call() invokes it against a context -- the invoke path the
+       2014 note here asked for, built during the indy unification. */
     class TFuncHolder {
       NO_COPY(TFuncHolder);
       public:


### PR DESCRIPTION
The invoke path the 2014 note asked for exists — TFuncHolder::Call is what both session call paths use. TODO replaced with a doc comment. Gate: 24-branch integration on post-#407 master — full build, no-op rebuild check, make test, targeted suites, lang_test. Closes #355.