### PR TITLE
test(package): real coverage for name parsing

### DIFF
--- a/orly/package/name.test.cc
+++ b/orly/package/name.test.cc
@@ -18,9 +18,12 @@
 
 #include <orly/package/name.h>
 
+#include <stdexcept>
+
 #include <base/test/kit.h>
 
 #include <base/as_str.h>
+#include <base/syntax_error.h>
 
 using namespace std;
 using namespace Base;
@@ -33,7 +36,6 @@ using namespace Orly::Package;
    "A"
 */
 
-//TODO(#375): Nowhere near all of package_name.cc is tested here.
 FIXTURE(VersionedNameWithScope) {
   const TVersionedName package = TVersionedName::Parse(AsPiece("scope/sample.1"));
   EXPECT_EQ(package.Name, (TName{{"scope", "sample"}}));
@@ -50,4 +52,48 @@ FIXTURE(VersionedNameWithoutScope) {
   EXPECT_TRUE(package.Name == TName{{"sample"}});
   EXPECT_EQ(package.Version, 1000u);
   EXPECT_EQ(AsStr(package.GetSoRelPath()), "sample.1000.so");
+}
+
+FIXTURE(UnversionedDefaultsToZero) {
+  const TVersionedName package = TVersionedName::Parse(AsPiece("scope/sample"));
+  EXPECT_EQ(package.Name, (TName{{"scope", "sample"}}));
+  EXPECT_EQ(package.Version, 0u);
+}
+
+FIXTURE(DeepScope) {
+  const TVersionedName package = TVersionedName::Parse(AsPiece("a/b/c.3"));
+  EXPECT_EQ(package.Name, (TName{{"a", "b", "c"}}));
+  EXPECT_EQ(package.Version, 3u);
+  EXPECT_EQ(AsStr(package.GetSoRelPath()), "a/b/c.3.so");
+}
+
+FIXTURE(LastDotSplitsVersion) {
+  /* The version is everything after the LAST dot. */
+  const TVersionedName package = TVersionedName::Parse(AsPiece("scope/sam.ple.7"));
+  EXPECT_EQ(package.Name, (TName{{"scope", "sam.ple"}}));
+  EXPECT_EQ(package.Version, 7u);
+}
+
+FIXTURE(VersionedNameEquality) {
+  const TVersionedName a = TVersionedName::Parse(AsPiece("scope/sample.1"));
+  const TVersionedName b = TVersionedName::Parse(AsPiece("scope/sample.1"));
+  const TVersionedName c = TVersionedName::Parse(AsPiece("scope/sample.2"));
+  const TVersionedName d = TVersionedName::Parse(AsPiece("other/sample.1"));
+  EXPECT_TRUE(a == b);
+  EXPECT_FALSE(a == c);  // same name, different version
+  EXPECT_FALSE(a == d);  // same version, different name
+}
+
+FIXTURE(InvalidNames) {
+  /* An empty namespace component is invalid. */
+  EXPECT_THROW(std::runtime_error, []() {
+    TName::Parse("scope//sample");
+  });
+  EXPECT_THROW(std::runtime_error, []() {
+    TName::Parse("/scope");
+  });
+  /* A non-numeric version is a syntax error. */
+  EXPECT_THROW(Base::TSyntaxError, []() {
+    TVersionedName::Parse(AsPiece("sample.x"));
+  });
 }


### PR DESCRIPTION
Pins the unversioned default, deep scopes, the last-dot version split, TVersionedName equality, invalid namespaces, and non-numeric versions throwing TSyntaxError. Stacked on #404's string_view parse. Gate: 24-branch integration on post-#407 master — full build, no-op rebuild check, make test, targeted suites, lang_test. Closes #375.