### PR TITLE
chore(jhm): resolve the two residual hardening notes

### DIFF
--- a/jhm/jobs/nycr.cc
+++ b/jhm/jobs/nycr.cc
@@ -174,7 +174,9 @@ vector<string> TNycr::GetCmd() {
   }
   MarkAllOutputsKnown();
 
-  //TODO(#345): use nycr in path?
+  /* Deliberately the explicit bootstrap path, not `nycr` from PATH: the
+     build must always run the nycr it just bootstrapped, not whatever a
+     caller's environment happens to resolve. */
   return vector<string> {
     GetNycrPath(Env),
     "-a",

--- a/jhm/work_finder.cc
+++ b/jhm/work_finder.cc
@@ -176,7 +176,7 @@ bool TWorkFinder::ProcessResult(TJobRunner::TResult &result) {
         Ready.push(job);
       }
     }
-    // TODO(#345): Assert this succeeds (It should be guaranteed to)
+    // Erasing a valid, non-empty range (guarded above) cannot fail.
     ToFinish.erase(range.first, range.second);
   }
 


### PR DESCRIPTION
The ToFinish-erase assert is moot (guarded non-empty valid range — documented); the 'nycr from PATH?' musing answered with a decision: the explicit bootstrap path stays, hermetically. Gate: 24-branch integration on post-#407 master — full build, no-op rebuild check, make test, targeted suites, lang_test. Closes #345.