### PR TITLE
fix(code_gen): dedup TWith's child-function handling with TFunction

### DIFF
--- a/orly/code_gen/function.cc
+++ b/orly/code_gen/function.cc
@@ -125,6 +125,69 @@ void TFunction::WriteArgs(TCppPrinter &out) const {
               });
 }
 
+void TFunction::WriteOrderedChildFuncs(const unordered_set<shared_ptr<TInlineFunc>> &child_funcs,
+                                            TCppPrinter &out) {
+  vector<shared_ptr<TInlineFunc>> ordered_funcs;
+  unordered_set<shared_ptr<const TInline>> finished;
+  unordered_set<shared_ptr<TInlineFunc>> working_set(child_funcs.begin(), child_funcs.end());
+  unordered_set<shared_ptr<const TInline>> cur_set;
+  for (const auto &func : working_set) {
+    cur_set.insert(func->Body);
+  }
+  while (working_set.size() > 0) {
+    for (auto &func : working_set) {
+      bool can_write = true;
+      unordered_set<shared_ptr<const TInline>> depends_on;
+      func->Body->AppendDependsOn(depends_on);
+      for (const auto &dependency : depends_on) {
+        if (dependency && finished.find(dependency) == finished.end() && cur_set.find(dependency) != cur_set.end()) {
+          can_write = false;
+        }
+      }
+      if (can_write || working_set.size() == 1) {
+        ordered_funcs.push_back(func);
+        finished.insert(func->Body);
+        working_set.erase(func);
+        break;
+      }
+    }
+  }
+
+  //Write out inner functions (forward decl followed by definitions).
+  for(auto &func: ordered_funcs) {
+    func->WriteDecl(out);
+    out << ';' << Eol;
+  }
+
+  if(!ordered_funcs.empty()) {
+    out << Eol;
+  }
+
+  for(auto &func: ordered_funcs) {
+    func->WriteDef(out);
+    out << ';' << Eol;
+  }
+
+  if(!ordered_funcs.empty()) {
+    out << Eol;
+  }
+}
+
+void TFunction::GatherChildFuncs(const L0::TPackage *package,
+                                     const Expr::TExpr::TPtr &expr,
+                                     const TIdScope::TPtr &id_scope,
+                                     unordered_set<shared_ptr<TInlineFunc>> &child_funcs) {
+  Expr::ForEachExpr(expr, [&](const Expr::TExpr::TPtr &sub_expr) {
+    const Expr::TWhere *where = sub_expr->TryAs<Expr::TWhere>();
+    if(where) {
+      for(auto &func: where->GetFunctions()) {
+        child_funcs.insert(TInnerFunc::New(package, func, id_scope));
+      }
+    }
+    return false;
+  });
+}
+
 void TFunction::WriteBody(TCppPrinter &out) const {
 
   assert(Body); // NOTE: If this assertion fails, it means that Build() function probably wasn't called.
@@ -134,50 +197,7 @@ void TFunction::WriteBody(TCppPrinter &out) const {
   /* Indented output */ {
     TIndent indent(out);
 
-    vector<shared_ptr<TInlineFunc>> ordered_funcs;
-    unordered_set<shared_ptr<const TInline>> finished;
-    unordered_set<shared_ptr<TInlineFunc>> working_set(ChildFuncs.begin(), ChildFuncs.end());
-    unordered_set<shared_ptr<const TInline>> cur_set;
-    for (const auto &func : working_set) {
-      cur_set.insert(func->Body);
-    }
-    while (working_set.size() > 0) {
-      for (auto &func : working_set) {
-        bool can_write = true;
-        unordered_set<shared_ptr<const TInline>> depends_on;
-        func->Body->AppendDependsOn(depends_on);
-        for (const auto &dependency : depends_on) {
-          if (dependency && finished.find(dependency) == finished.end() && cur_set.find(dependency) != cur_set.end()) {
-            can_write = false;
-          }
-        }
-        if (can_write || working_set.size() == 1) {
-          ordered_funcs.push_back(func);
-          finished.insert(func->Body);
-          working_set.erase(func);
-          break;
-        }
-      }
-    }
-
-    //Write out inner functions (forward decl followed by definitions).
-    for(auto &func: ordered_funcs) {
-      func->WriteDecl(out);
-      out << ';' << Eol;
-    }
-
-    if(!ordered_funcs.empty()) {
-      out << Eol;
-    }
-
-    for(auto &func: ordered_funcs) {
-      func->WriteDef(out);
-      out << ';' << Eol;
-    }
-
-    if(!ordered_funcs.empty()) {
-      out << Eol;
-    }
+    WriteOrderedChildFuncs(ChildFuncs, out);
 
     CodeScope.WriteStart(out);
     out << "return ";
@@ -204,15 +224,6 @@ void TFunction::PostCtor(const TNamedArgs &args, const Expr::TExpr::TPtr &expr, 
     //NOTE: It is critical we don't copy, move, etc. the arg or the Ref in it will point to the wrong thing.
     Args.insert(make_pair(arg.first, TArg::New(Package, CodeScope.NewArg(), arg.second)));
   }
-  //NOTE: This is copied in test.cc TWith ctor as the local function gather_child_funcs
   //Gather child functions
-  Expr::ForEachExpr(Expr, [this](const Expr::TExpr::TPtr &expr) {
-    const Expr::TWhere *where = expr->TryAs<Expr::TWhere>();
-    if(where) {
-      for(auto &func: where->GetFunctions()) {
-        ChildFuncs.insert(TInnerFunc::New(Package, func, CodeScope.GetIdScope()));
-      }
-    }
-    return false;
-  });
+  GatherChildFuncs(Package, Expr, CodeScope.GetIdScope(), ChildFuncs);
 }

--- a/orly/code_gen/function.h
+++ b/orly/code_gen/function.h
@@ -43,6 +43,24 @@ namespace Orly {
     /* Base class for code gen functions. See leaf classes TTopFunc, TInnerFunc, TImplicitFunc for instantiable
        instanecs. */
     class TFunction : public std::enable_shared_from_this<TFunction> {
+      public:
+
+      /* Emits the given child functions -- forward decls, then definitions --
+         with the definitions ordered so a function that uses a sibling is
+         emitted after that sibling. Shared by WriteBody and TWith::Write
+         (#311; the TWith copy had drifted and lacked the dependency
+         ordering). A static member (not a free function) so it can reach
+         TFunction::Body. */
+      static void WriteOrderedChildFuncs(const std::unordered_set<std::shared_ptr<TInlineFunc>> &child_funcs,
+                                         TCppPrinter &out);
+
+      /* Collects a TInnerFunc for every where-clause function under `expr`
+         into `child_funcs`. Shared by the TFunction ctor and TWith (#311). */
+      static void GatherChildFuncs(const L0::TPackage *package,
+                                   const Expr::TExpr::TPtr &expr,
+                                   const TIdScope::TPtr &id_scope,
+                                   std::unordered_set<std::shared_ptr<TInlineFunc>> &child_funcs);
+
       NO_COPY(TFunction);
       public:
 

--- a/orly/code_gen/test.cc
+++ b/orly/code_gen/test.cc
@@ -188,25 +188,10 @@ void TTestBlock::WriteMeta(TCppPrinter &out) const {
 
 void TWith::Write(TCppPrinter &out) const {
 
-  //TODO(#311): This is copied from TFunction
-  //Write out inner functions (forward decl followed by definitions).
-  for(auto &func: ChildFuncs) {
-    func->WriteDecl(out);
-    out << ';' << Eol;
-  }
-
-  if(!ChildFuncs.empty()) {
-    out << Eol;
-  }
-
-  for(auto &func: ChildFuncs) {
-    func->WriteDef(out);
-    out << ';' << Eol;
-  }
-
-  if(!ChildFuncs.empty()) {
-    out << Eol;
-  }
+  /* Shared with TFunction::WriteBody (#311); also fixes the drift where
+     this copy emitted definitions unordered, so a child function that used
+     a sibling could be emitted before it. */
+  TFunction::WriteOrderedChildFuncs(ChildFuncs, out);
 
   CodeScope->WriteStart(out);
   for(auto &it: News) {
@@ -224,18 +209,9 @@ void TWith::Write(TCppPrinter &out) const {
 TWith::TWith(const L0::TPackage *package, const Symbol::Test::TWithClause::TPtr &symbol) :  CodeScope(new TCodeScope(TIdScope::New())), Package(package) {
   TScopeCtx ctx(CodeScope.get());
 
-  //Gather child functions
+  //Gather child functions (shared with the TFunction ctor, #311).
   auto gather_child_functions = [this, package](const Expr::TExpr::TPtr &expr) {
-    //TODO(#311): This is copied from function.cc TFunction ctor.
-    Expr::ForEachExpr(expr, [this, package](const Expr::TExpr::TPtr &expr) {
-      const Expr::TWhere *where = expr->TryAs<Expr::TWhere>();
-      if(where) {
-        for(auto &func: where->GetFunctions()) {
-          ChildFuncs.insert(TInnerFunc::New(package, func, CodeScope->GetIdScope()));
-        }
-      }
-      return false;
-    });
+    TFunction::GatherChildFuncs(package, expr, CodeScope->GetIdScope(), ChildFuncs);
   };
 
   for(auto &it: symbol->GetNewStmts()) {
@@ -243,7 +219,6 @@ TWith::TWith(const L0::TPackage *package, const Symbol::Test::TWithClause::TPtr 
     gather_child_functions(it->GetRhs()->GetExpr());
   }
 
-  //TODO(#311): This is copied from TFunction
   for(auto &it: ChildFuncs) {
     it->Build();
   }


### PR DESCRIPTION
The copied blocks had drifted: TFunction gained dependency-ordered emission, TWith's copy still emitted set-order — mutually-referencing with-block helpers could generate uncompilable C++. Both share TFunction::WriteOrderedChildFuncs / ::GatherChildFuncs now. Gate: 24-branch integration on post-#407 master — full build, no-op rebuild check, make test, targeted suites, lang_test. Closes #311.