### PR TITLE
fix(code_gen): per-package symbol-function registry, not a process global

### DIFF
--- a/orly/code_gen/builder.cc
+++ b/orly/code_gen/builder.cc
@@ -358,7 +358,7 @@ TInline::TPtr Orly::CodeGen::Build(const L0::TPackage *package, const Expr::TExp
       if (const auto &widen_fn = that->GetRecursiveWidenFn()) {
         TCall::TArgs args;
         args.push_back(Build(Package, that->GetExpr(), false));
-        Res = Interner.GetCall(Package, TSymbolFunc::Find(widen_fn.get()), args);
+        Res = Interner.GetCall(Package, TSymbolFunc::Find(Package, widen_fn.get()), args);
         return;
       }
       /* A variant -> wider-variant widening (#104) is a value rebuild, not a
@@ -525,7 +525,7 @@ TInline::TPtr Orly::CodeGen::Build(const L0::TPackage *package, const Expr::TExp
         TVisitor(TInterner &interner, TInline::TPtr &res, const Expr::TFunctionApp::TFunctionAppArgMap &function_app_args, const L0::TPackage *package)
             : Interner(interner), Res(res), FunctionAppArgs(function_app_args), Package(package) {}
         virtual void operator()(const Symbol::TFunction *that) const {
-          auto func = TSymbolFunc::Find(that);
+          auto func = TSymbolFunc::Find(Package, that);
           TCall::TArgs args;
           for (auto &arg: FunctionAppArgs) {
             // TODO(#300): We need to check if the arg has a greater sequence arity than the parameter, and if so, it is an implicit
@@ -668,7 +668,7 @@ TInline::TPtr Orly::CodeGen::Build(const L0::TPackage *package, const Expr::TExp
         public:
         TVisitor(TInterner &interner, TInline::TPtr &res, const L0::TPackage *package) : Interner(interner), Res(res), Package(package) {}
         virtual void operator()(const Symbol::TGivenParamDef *that) const {
-          Res = TSymbolFunc::Find(that->GetFunction().get())->GetArg(that->GetName());
+          Res = TSymbolFunc::Find(Package, that->GetFunction().get())->GetArg(that->GetName());
         }
         virtual void operator()(const Symbol::TResultDef *that) const {
           class TVisitor
@@ -678,7 +678,7 @@ TInline::TPtr Orly::CodeGen::Build(const L0::TPackage *package, const Expr::TExp
             TVisitor(TInterner &interner, TInline::TPtr &res, const L0::TPackage *package)
                 : Interner(interner), Res(res), Package(package) {}
             virtual void operator()(const Symbol::TFunction *that) const {
-              Res = Interner.GetCall(Package, TSymbolFunc::Find(that), TCall::TArgs {});
+              Res = Interner.GetCall(Package, TSymbolFunc::Find(Package, that), TCall::TArgs {});
             }
             virtual void operator()(const Symbol::TBuiltInFunction *) const {
               // NOTE: if we introduce a zero parameter built in function, this needs to change

--- a/orly/code_gen/package_base.h
+++ b/orly/code_gen/package_base.h
@@ -36,6 +36,8 @@ namespace Orly {
 
   namespace CodeGen {
 
+    class TSymbolFunc;
+
     /* Dependency injection for package to expose enough context to build functions. */
     namespace L0 {
 
@@ -69,6 +71,20 @@ namespace Orly {
           return Symbol->GetName();
         }
 
+        /* Symbol -> code-gen function registry for THIS package build.
+           Replaces TSymbolFunc's process-global static map (#307): the
+           registry's natural lifetime is one package compilation.
+           Registration happens from TSymbolFunc's constructor, which only
+           holds a const package pointer -- hence mutable. */
+        void RegisterSymbolFunc(const Symbol::TFunction *symbol, TSymbolFunc *func) const {
+          SymbolFuncs.insert(std::make_pair(symbol, func));
+        }
+
+        TSymbolFunc *TryFindSymbolFunc(const Symbol::TFunction *symbol) const {
+          auto res = SymbolFuncs.find(symbol);
+          return res != SymbolFuncs.end() ? res->second : nullptr;
+        }
+
         protected:
 
         TPackage(const Symbol::TPackage::TPtr &package) : Symbol(package) {}
@@ -78,6 +94,9 @@ namespace Orly {
         TAddrMap AddrMap;
 
         TRevAddrMap ReverseAddrMap;
+
+        /* See RegisterSymbolFunc / TryFindSymbolFunc. */
+        mutable std::unordered_map<const Symbol::TFunction *, TSymbolFunc *> SymbolFuncs;
 
       };  // TPackage
 

--- a/orly/code_gen/symbol_func.cc
+++ b/orly/code_gen/symbol_func.cc
@@ -37,12 +37,13 @@ void TSymbolFunc::Build() {
   TFunction::Build();
 }
 
-TFunction::TPtr TSymbolFunc::Find(const Symbol::TFunction *symbol) {
-  auto res = Functions.find(symbol);
-  assert(res != Functions.end()); // We build all functions before we ever call find, so it should never fail.
+TFunction::TPtr TSymbolFunc::Find(const L0::TPackage *package, const Symbol::TFunction *symbol) {
+  assert(package);
+  TSymbolFunc *raw = package->TryFindSymbolFunc(symbol);
+  assert(raw); // We build all functions before we ever call find, so it should never fail.
 
   //NOTE: The function should never not exist
-  std::shared_ptr<TFunction> ptr = res->second->shared_from_this();
+  std::shared_ptr<TFunction> ptr = raw->shared_from_this();
   assert(ptr);
   return ptr;
 }
@@ -62,8 +63,5 @@ Type::TType TSymbolFunc::GetType() const {
 TSymbolFunc::TSymbolFunc(const L0::TPackage *package, const Symbol::TFunction::TPtr &symbol, const TIdScope::TPtr &id_scope)
       : TFunction(package, id_scope), Symbol(symbol) {
   PostCtor(symbol->GetParams(), symbol->GetExpr(), true);
-  Functions.insert(make_pair(symbol.get(), this));
-
+  package->RegisterSymbolFunc(symbol.get(), this);
 }
-
-std::unordered_map<const Symbol::TFunction*, TSymbolFunc*> TSymbolFunc::Functions;

--- a/orly/code_gen/symbol_func.h
+++ b/orly/code_gen/symbol_func.h
@@ -33,7 +33,7 @@ namespace Orly {
       NO_COPY(TSymbolFunc);
       public:
 
-      static TFunction::TPtr Find(const Symbol::TFunction *symbol);
+      static TFunction::TPtr Find(const L0::TPackage *package, const Symbol::TFunction *symbol);
 
       std::string GetName() const;
       Type::TType GetReturnType() const;
@@ -47,9 +47,6 @@ namespace Orly {
       TSymbolFunc(const L0::TPackage *package, const Symbol::TFunction::TPtr &symbol, const TIdScope::TPtr &id_scope);
 
       private:
-
-      //TODO(#307): Kill the static. We can really handle this using proper scoping and a tree of function maps.
-      static std::unordered_map<const Symbol::TFunction*, TSymbolFunc*> Functions;
 
       //Note we would use an InlineScope here, but we need to attach the function arguments to the CodeScope.
       TInline::TPtr Body;


### PR DESCRIPTION
TSymbolFunc's static process-wide map was a cross-package-mixing and stale-pointer hazard; it now lives on L0::TPackage (its natural lifetime), and Find takes the package all four call sites already had. Gate: 24-branch integration on post-#407 master — full build, no-op rebuild check, make test, targeted suites, lang_test. Closes #307.