### PR TITLE
fix(code_gen): user_id context var emits the method that exists

### DIFF
--- a/orly/code_gen/context_var.cc
+++ b/orly/code_gen/context_var.cc
@@ -50,7 +50,10 @@ void TContextVar::WriteExpr(TCppPrinter &out) const {
   switch(Op) {
     case SessionId: out << "GetSessionId";
       break;
-    case UserId: out << "GetAccountId"; //TODO(#310): UserId
+    /* The runtime context API is GetUserId (package/rt.h); the old
+       GetAccountId emission named a method that exists nowhere, so any
+       package using the user_id context var failed to compile (#310). */
+    case UserId: out << "GetUserId";
       break;
     case Now: out << "Now";
       break;

--- a/tests/lang_tests/general/context_vars.orly
+++ b/tests/lang_tests/general/context_vars.orly
@@ -1,0 +1,15 @@
+/* The three context variables. Before #310 the user_id emission called a
+   runtime method that didn't exist (GetAccountId), so any package using it
+   failed to compile the generated C++. */
+package #1;
+
+uid = user_id;
+sid = session_id;
+right_now = now;
+
+test {
+  /* orlyc's test session carries no user, so user_id is unknown. */
+  tuid: user_id is unknown;
+  /* session_id is a stable id within one evaluation. */
+  tsid: session_id == session_id;
+};


### PR DESCRIPTION
UserId emitted ctx.GetAccountId(), which exists nowhere — the surface was uncompilable since 2014. Now emits GetUserId, with a new lang test pinning user_id/session_id/now including the no-user default. Gate: 24-branch integration on post-#407 master — full build, no-op rebuild check, make test, targeted suites, lang_test. Closes #310.