### PR TITLE
test(base): real convert/url_decode coverage; fix a 2014 underflow wrap

### DIFF
--- a/base/convert.h
+++ b/base/convert.h
@@ -109,17 +109,24 @@ namespace Base {
         //Check for overflow/underflow
         if(!err_msg) {
           if(positive) {
-            if((cur_val > std::numeric_limits<TVal>::max() / 10) || (std::numeric_limits<TVal>::max() - cur_val * 10) < digit_val) {
+            if((cur_val > std::numeric_limits<TVal>::max() / 10) || digit_val > std::numeric_limits<TVal>::max() - cur_val * 10) {
               err_msg = "Int overflowed type bounds.";
             }
           } else {
-            //Digit is negative, since number is negative.
-            if((cur_val < std::numeric_limits<TVal>::min() / 10) || (std::numeric_limits<TVal>::min() - cur_val * 10) > digit_val) {
+            /* Digits subtract, since the number is negative: underflow iff
+               cur*10 - digit < min, i.e. cur*10 < min + digit (min + a small
+               positive digit can't overflow; cur*10 is safe under the first
+               disjunct's guard). The old check compared min - cur*10 > digit,
+               which is never true -- it let e.g. LONG_MIN-1 wrap silently. */
+            if((cur_val < std::numeric_limits<TVal>::min() / 10) || cur_val * 10 < std::numeric_limits<TVal>::min() + digit_val) {
               err_msg = "Int underflowed type bounds.";
             }
           }
+        }
 
-          //Add to value
+        //Add to value -- only while in bounds; folding in the digit that
+        //tripped the check would itself be signed overflow (UB).
+        if(!err_msg) {
           cur_val *= 10;
           if(positive) {
             cur_val += digit_val;

--- a/base/convert.h
+++ b/base/convert.h
@@ -182,18 +182,6 @@ namespace Base {
       return *this;
     }
 
-    /* Parse bool  (see jhm.py fod valid methods of expression) */
-    bool TryReadBool(bool &output);
-    void ReadBool(bool &output);
-
-    /* Parse float */
-    bool TryReadFloat(float &output, bool sign_required=false);
-    void ReadFloat(float &output, bool sign_required=false);
-
-    /* Parse double */
-    bool TryReadDouble(double &output, bool sign_required=false);
-    void ReadDouble(double &output, bool sign_required=false);
-
     operator bool() const {
       return Working;
     }

--- a/base/convert.test.cc
+++ b/base/convert.test.cc
@@ -24,7 +24,6 @@
 
 using namespace Base;
 
-//TODO(#334): Get to full coverage. Currently just a compile test.
 FIXTURE(Int) {
   int i;
   TConverter(AsPiece("42")).ReadInt(i);
@@ -44,4 +43,67 @@ FIXTURE(ProxyInt) {
   EXPECT_EQ(i, 123);
   size_t size = TConvertProxy(AsPiece("456"));
   EXPECT_EQ(size, 456ul);
+}
+
+FIXTURE(Signs) {
+  int i;
+  TConverter(AsPiece("+42")).ReadInt(i);
+  EXPECT_EQ(i, 42);
+  TConverter(AsPiece("-42")).ReadInt(i);
+  EXPECT_EQ(i, -42);
+  /* Leading whitespace is consumed. */
+  TConverter(AsPiece("  123")).ReadInt(i);
+  EXPECT_EQ(i, 123);
+}
+
+FIXTURE(SignRequired) {
+  int i;
+  /* Without a sign, a sign-required TryReadInt declines without consuming. */
+  EXPECT_FALSE(TConverter(AsPiece("42")).TryReadInt(i, true /*sign_required*/));
+  EXPECT_TRUE(TConverter(AsPiece("-42")).TryReadInt(i, true));
+  EXPECT_EQ(i, -42);
+  EXPECT_THROW(TSyntaxError, []() {
+    int val;
+    TConverter(AsPiece("42")).ReadInt(val, true /*sign_required*/);
+  });
+}
+
+FIXTURE(SyntaxErrors) {
+  /* No digits at all. */
+  EXPECT_THROW(TSyntaxError, []() {
+    int val;
+    TConverter(AsPiece("abc")).ReadInt(val);
+  });
+  /* A sign with no digits after it. */
+  EXPECT_THROW(TSyntaxError, []() {
+    int val;
+    TConverter(AsPiece("+x")).ReadInt(val);
+  });
+}
+
+FIXTURE(Bounds) {
+  /* One past LONG_MAX / LONG_MIN overflow the type. */
+  EXPECT_THROW(TSyntaxError, []() {
+    long val;
+    TConverter(AsPiece("9223372036854775808")).ReadInt(val);
+  });
+  EXPECT_THROW(TSyntaxError, []() {
+    long val;
+    TConverter(AsPiece("-9223372036854775809")).ReadInt(val);
+  });
+}
+
+FIXTURE(Digits) {
+  int d = -1;
+  TConverter csr(AsPiece("7a"));
+  EXPECT_TRUE(csr.TryReadDigit(d));
+  EXPECT_EQ(d, 7);
+  EXPECT_FALSE(csr.TryReadDigit(d));  // 'a' is not a digit
+}
+
+FIXTURE(ProxyRejectsTrailingJunk) {
+  EXPECT_THROW(TSyntaxError, []() {
+    int val = TConvertProxy(AsPiece("12x"));
+    (void)val;
+  });
 }

--- a/base/web/url_decode.test.cc
+++ b/base/web/url_decode.test.cc
@@ -54,4 +54,29 @@ FIXTURE(Empty) {
   EXPECT_EQ(result_buf, "{\"likes\":[],\"userref\":\"test2\",\"content\":\"aaa\",\"cid\":1}");
 }
 
-//TODO(#334): Test for error cases
+FIXTURE(PlusIsSpace) {
+  string result_buf;
+  UrlDecode(AsPiece("a+b+c"), result_buf);
+  EXPECT_EQ(result_buf, "a b c");
+}
+
+FIXTURE(ErrorCases) {
+  /* A '%' escape truncated by end of input. */
+  EXPECT_THROW(TUrlDecodeError, []() {
+    string result_buf;
+    UrlDecode(AsPiece("foo%"), result_buf);
+  });
+  EXPECT_THROW(TUrlDecodeError, []() {
+    string result_buf;
+    UrlDecode(AsPiece("foo%2"), result_buf);
+  });
+  /* A non-hex character in either escape position. */
+  EXPECT_THROW(TUrlDecodeError, []() {
+    string result_buf;
+    UrlDecode(AsPiece("foo%G2bar"), result_buf);
+  });
+  EXPECT_THROW(TUrlDecodeError, []() {
+    string result_buf;
+    UrlDecode(AsPiece("foo%2Gbar"), result_buf);
+  });
+}


### PR DESCRIPTION
convert.test grows from a compile test to full coverage of the implemented surface; url_decode.test gains the error cases. The new Bounds fixture caught a real bug: the negative-branch underflow check compared `min - cur*10 > digit` (never true), so one-past-LONG_MIN silently wrapped — fixed overflow-free (UBSan-verified), and the tripping digit is no longer folded in (was signed-overflow UB). Six never-defined ReadBool/Float/Double declarations deleted. Gate: 24-branch integration on post-#407 master — full build, no-op rebuild check, make test, targeted suites, lang_test. Closes #334.