### PR TITLE
docs: fill or retarget the five placeholder doc spots

### DIFF
--- a/base/class_traits.h
+++ b/base/class_traits.h
@@ -12,7 +12,16 @@
    the code to tell what the overarching behavior of a class is
   (NO_CONSTRUCTION, NO_COPY, etc.)
 
-  TODO(#315): Generic blurb about how to insert/use these in classes (Just after the '{')
+   Usage: place the macro on its own line immediately after the class's
+   opening brace, before any access specifier or member -- the macro leaves
+   the class at an access level of its own, so what follows should restate
+   the level it wants:
+
+      class TFoo {
+        NO_COPY(TFoo);
+        public:
+        ...
+      };
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/jhm/env.cc
+++ b/jhm/env.cc
@@ -141,7 +141,11 @@ vector<string> CopyAppendVector(const vector<string> &src, string &&val) {
   return ret;
 }
 
-//TODO(#315):
+/* Pins the tree layout for a build: the source tree (root/<proj_name>), the
+   output tree (root/out[_<proj>]/<config>), and the layered config search
+   list (project config over root config, mixins over both), then registers
+   the built-in job producers. Throws on the reserved config name 'root' and
+   when no config file in the search list exists. */
 TEnv::TEnv(const TTree &root, const string &proj_name, const string &config, const string &config_mixin)
     : Root(root),
       Src(CopyAppendVector(Root.Root, string(proj_name))),

--- a/jhm/jhm.cc
+++ b/jhm/jhm.cc
@@ -2,12 +2,10 @@
 
    JHM build system.
 
-   TODO(#315):
-    - Make it so that we minimize the amount of stuff which builds up in the foreground thread / we keep the worker
-      queue busier all the time
-    - Remove Stdout/Stderr printing from work_finder.h, so it's more portable
-    - Make jobs and files const more of the time.
-    - Eliminate the Ready queue. It just slows us down a little / makes unnecessary extra looping happen...
+   The scheduling/throughput improvement backlog that used to sit here as a
+   wish list lives in the tracker: #347 covers keeping the workers busier,
+   replacing the ready queue, and gating per-job stdout/stderr printing;
+   #349 covers parallelizing test-report production.
 
    Copyright 2010-2026 Atomic Kismet Company
 

--- a/orly/code_gen/obj.cc
+++ b/orly/code_gen/obj.cc
@@ -379,7 +379,7 @@ void Orly::CodeGen::GenObjHeader(const std::string &out_dir, const Type::TType &
         out << ": public TStateVisitor {" << Eol
             << "NO_COPY(TToNativeVisitor);" << Eol
             << "public:" << Eol
-            << "/* TODO(#315) */" << Eol
+            << "/* Captures the object to fill in during the visit. */" << Eol
             << "TToNativeVisitor(Orly::Rt::Objects::" << obj_class_name << " &out) : Out(out) {}" << Eol
             << "/* Overrides. */" << Eol
             << "virtual void operator()(const State::TFree &/*state*/) const override       { throw; }" << Eol

--- a/orly/server/session.h
+++ b/orly/server/session.h
@@ -199,8 +199,10 @@ namespace Orly {
       /* The id of the global point of view. */
       static const Base::TUuid GlobalPovId;
 
-      //TODO(#315): This should be private...
-      /* Add the given pov to the collection of povs we'll keep open. */
+      /* Add the given pov to the collection of povs we'll keep open.
+         Public only because the memcache connection path constructs its
+         private pov outside the session (server.cc); when #371 moves that
+         to pooled, session-owned povs, this can go private. */
       void AddPov(const Durable::TPtr<TPov> &pov);
 
       private:


### PR DESCRIPTION
class_traits usage blurb; jhm.cc's wish list becomes tracker pointers (#347/#349); TEnv ctor documented; AddPov's 'should be private' retargeted at #371 with the reason it can't be yet; the generated TToNativeVisitor ctor gets a real emitted comment instead of a /* TODO */ in every generated header. Gate: 24-branch integration on post-#407 master — full build, no-op rebuild check, make test, targeted suites, lang_test. Closes #315.