### PR TITLE
chore: relocate GenCode from orly/type to orly/code_gen

### DIFF
--- a/orly/code_gen/obj.cc
+++ b/orly/code_gen/obj.cc
@@ -28,7 +28,7 @@
 #include <base/split.h>
 #include <base/time_maps.h>
 #include <orly/type.h>
-#include <orly/type/gen_code.h>
+#include <orly/code_gen/type.h>
 #include <orly/type/object_collector.h>
 
 using namespace std;
@@ -340,7 +340,7 @@ void Orly::CodeGen::GenObjHeader(const std::string &out_dir, const Type::TType &
                       ", ",
                       [](TCppPrinter &out, const TObj::TElems::value_type &it) {
                         out << "{\"" << it.first << "\", ";
-                        Type::GenCode(out.GetOstream(), it.second);
+                        CodeGen::GenCode(out.GetOstream(), it.second);
                         out << '}';
                       })
         << "});" << Eol

--- a/orly/code_gen/package.cc
+++ b/orly/code_gen/package.cc
@@ -31,7 +31,7 @@
 #include <orly/expr/walker.h>
 #include <orly/expr/where.h>
 #include <orly/package/api_version.h>
-#include <orly/type/gen_code.h>
+#include <orly/code_gen/type.h>
 #include <orly/type/impl.h>
 #include <orly/type/object_collector.h>
 #include <orly/type/orlyify.h>
@@ -349,12 +349,12 @@ void TPackage::WriteCc(TCppPrinter &out, const TRelPath &rel_path) const {
                 ", ",
                 [](TCppPrinter &out, TFunction::TArgs::const_reference arg) {
                   out << "{\"" << arg.first << "\", ";
-                  Type::GenCode(out.GetOstream(), arg.second->GetType());
+                  CodeGen::GenCode(out.GetOstream(), arg.second->GetType());
                   out << '}';
                 })
         << "}," << Eol
         << "/* ret */ "; //NOTE: GetOstream at the start of a line will cause indent to not be printed.
-      Type::GenCode(out.GetOstream(), it->GetReturnType());
+      CodeGen::GenCode(out.GetOstream(), it->GetReturnType());
       out << ',' << Eol
           << "RF_" << it->GetName() << Eol;
     }

--- a/orly/code_gen/type.cc
+++ b/orly/code_gen/type.cc
@@ -1,6 +1,6 @@
-/* <orly/type/gen_code.cc>
+/* <orly/code_gen/type.cc>
 
-   Implements <orly/type/gen_code.h>.
+   Implements <orly/code_gen/type.h>.
 
    Copyright 2010-2026 Atomic Kismet Company
 
@@ -16,7 +16,7 @@
    See the License for the specific language governing permissions and
    limitations under the License. */
 
-#include <orly/type/gen_code.h>
+#include <orly/code_gen/type.h>
 
 #include <base/not_implemented.h>
 #include <base/split.h>
@@ -213,6 +213,6 @@ class TCodeGenVisitor : public TType::TVisitor {
   bool EquationMode;
 };
 
-void Orly::Type::GenCode(ostream &strm, const TType &type) {
+void Orly::CodeGen::GenCode(ostream &strm, const TType &type) {
   type.Accept(TCodeGenVisitor(strm));
 }

--- a/orly/code_gen/type.h
+++ b/orly/code_gen/type.h
@@ -1,11 +1,10 @@
-/* <orly/type/gen_code.h>
+/* <orly/code_gen/type.h>
 
    `GenCode(stream, type)`: writes the C++ source representation of
    an orly `TType` (e.g. `Orly::Rt::TDict<int64_t, std::string>` for
    a `dict<int64_t, str>`). Called by orlyc when emitting code-gen
-   output. The in-file `TODO(#381): move to <orly/code_gen/type.h>` comment
-   is honest -- this helper has more in common with the code-gen
-   layer than the type layer.
+   output. Lived in orly/type/ as gen_code.h until #381; it emits
+   code, so it belongs to the code-gen layer.
 
    Copyright 2010-2026 Atomic Kismet Company
 
@@ -29,11 +28,10 @@
 
 namespace Orly {
 
-  namespace Type {
+  namespace CodeGen {
 
-    //TODO(#381): move to <orly/code_gen/type.h>
-    void GenCode(std::ostream &strm, const TType &type);
+    void GenCode(std::ostream &strm, const Type::TType &type);
 
-  }  // Type
+  }  // CodeGen
 
 }  // Orly

--- a/orly/code_gen/typed_leaf.cc
+++ b/orly/code_gen/typed_leaf.cc
@@ -18,7 +18,7 @@
 
 #include <orly/code_gen/typed_leaf.h>
 
-#include <orly/type/gen_code.h>
+#include <orly/code_gen/type.h>
 #include <orly/type/unwrap.h>
 
 using namespace Orly::CodeGen;
@@ -36,7 +36,7 @@ void TTypedLeaf::WriteExpr(TCppPrinter &out) const {
     case Free:
       #if 0
       out << "Var::TVar::Free(";
-      Type::GenCode(out.GetOstream(), Type::UnwrapSequence(GetReturnType()));
+      CodeGen::GenCode(out.GetOstream(), Type::UnwrapSequence(GetReturnType()));
       out << ')';
       break;
       #endif

--- a/orly/code_gen/variant.cc
+++ b/orly/code_gen/variant.cc
@@ -28,7 +28,7 @@
 #include <orly/rt/runtime_error.h>
 #include <orly/code_gen/obj.h>
 #include <orly/type.h>
-#include <orly/type/gen_code.h>
+#include <orly/code_gen/type.h>
 #include <orly/type/obj.h>
 #include <orly/type/group_ref.h>
 #include <orly/type/object_collector.h>
@@ -929,7 +929,7 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
             { size_t i = 0;
               for (const auto &ne : nv_elems) {
                 out << "    case " << i << ": return Var::TVar::Variant(";
-                Type::GenCode(out.GetOstream(), elem.second);
+                CodeGen::GenCode(out.GetOstream(), elem.second);
                 out << ", \"" << ne.first << "\", Var::TVar(";
                 if (ne.second.Is<Type::TSelfRef>()) {
                   out << "Rt::DeepUnbox<" << class_name << ">(V" << ne.first << ')';
@@ -1049,7 +1049,7 @@ void Orly::CodeGen::GenVariantHeader(const std::string &out_dir, const Type::TTy
                       ", ",
                       [](TCppPrinter &out, const TVariant::TElems::value_type &it) {
                         out << "{\"" << it.first << "\", ";
-                        Type::GenCode(out.GetOstream(), it.second);
+                        CodeGen::GenCode(out.GetOstream(), it.second);
                         out << '}';
                       })
         << "});" << Eol
@@ -1868,7 +1868,7 @@ void Orly::CodeGen::GenVariantGroupHeader(const std::string &out_dir, const Type
           << "struct TDt<Rt::Variants::" << class_of(m) << "> {" << Eol
           << "  static TType GetType() {" << Eol
           << "    return ";
-      Type::GenCode(out.GetOstream(), m);
+      CodeGen::GenCode(out.GetOstream(), m);
       out << ";" << Eol
           << "  }" << Eol
           << "};" << Eol;


### PR DESCRIPTION
orly/type/gen_code.{h,cc} → orly/code_gen/type.{h,cc}, namespace Type→CodeGen: it emits C++, so it belongs to the code-gen layer, as its own header said since 2014. All seven call sites updated. Gate: 24-branch integration on post-#407 master — full build, no-op rebuild check, make test, targeted suites, lang_test. Closes #381.