### PR TITLE
fix(jhm): delete a failed job's partial outputs

### DIFF
--- a/jhm/work_finder.cc
+++ b/jhm/work_finder.cc
@@ -114,6 +114,15 @@ bool TWorkFinder::ProcessResult(TJobRunner::TResult &result) {
     Base::EchoOutput(move(result.Stdout));
     cout << "STDERR: \n";
     Base::EchoOutput(move(result.Stderr));
+    /* Forcefully delete whatever partial output the failed job left behind
+       (and its cache file): a half-written output with a fresh timestamp
+       would satisfy the next run's cache check and poison incremental
+       builds (#346). ENOENT is fine -- the job may have died before
+       creating anything. */
+    for (TFile *out_file : result.Job->GetOutput()) {
+      unlink(AsStr(out_file->GetPath()).c_str());
+      unlink(GetCacheFilename(out_file).c_str());
+    }
     return true;
   }
   // Check if the job is actually complete or not

--- a/jhm/work_finder.h
+++ b/jhm/work_finder.h
@@ -121,8 +121,11 @@ namespace Jhm {
     std::function<TFile *(const std::string &)> TryGetFileFromPath;
 
     // Runs the work queuPops things off work queue
-    // TODO(#346): runs itself in a seperate process group (setpgid) so it can easily wait for all child processes
-    // TODO(#346): Forcefully deletes all bad output
+    /* A failed job's partial outputs are deleted in ProcessResult (#346).
+       Running jobs in their own process group (the other half of that old
+       note) is deliberately NOT done: it would detach children from the
+       terminal's group, so Ctrl-C on jhm would orphan running compiles;
+       the runner already tracks its children explicitly. */
     // Launch the IO pump, wait/manage all the subprocesses, and notify the work finder / env when things are completed.
     // Calls a standardized callback on completion of each command.
     TJobRunner Runner;


### PR DESCRIPTION
A job dying mid-write left a fresh-timestamped partial output that satisfied the next cache check. The failure path now unlinks declared outputs + cache files. The setpgid half is declined in place: it would orphan running compiles on Ctrl-C. Gate: 24-branch integration on post-#407 master — full build, no-op rebuild check, make test, targeted suites, lang_test. Closes #346.