### PR TITLE
nycr/jhm: write generated outputs via temp file + atomic rename

### DIFF
--- a/jhm/jobs/bison.cc
+++ b/jhm/jobs/bison.cc
@@ -15,6 +15,7 @@
    limitations under the License. */
 
 #include <jhm/jobs/bison.h>
+#include <filesystem>
 #include <optional>
 
 #include <jhm/env.h>
@@ -31,6 +32,15 @@ const static vector<vector<string>> OutExtensions = {
   {"bison","cc"},
   {"bison", "hh"}
 };
+
+/* Bison writes its outputs (the .cc, the .hh, and the -rall report)
+   incrementally in place, so a dep scan racing this job could read a
+   truncated header (#406).  Generate into this temp directory next to the
+   target instead; IsComplete() renames everything into place, so a reader
+   only ever sees a missing file or a complete one. */
+static string GetTmpDir(const string &cc_path) {
+  return cc_path + ".tmp.d";
+}
 
 TJobProducer TBison::GetProducer() {
 
@@ -55,7 +65,21 @@ const unordered_set<TFile*> TBison::GetNeeds() {
 
 vector<string> TBison::GetCmd() {
   TFile *primary_output = GetOutputWithExtension(GetOutput(), {"cc"});
-  return vector<string>{"bison","-rall","-o" + primary_output->GetPath(), GetInput()->GetPath()};
+  const string &cc_path = primary_output->GetPath();
+  const string tmp_dir = GetTmpDir(cc_path);
+  const size_t slash = cc_path.rfind('/');
+  assert(slash != string::npos);
+  /* Clear any leftovers from an earlier failed run. */
+  filesystem::remove_all(tmp_dir);
+  filesystem::create_directory(tmp_dir);
+  /* --file-prefix-map keeps the #line directives and the header's include
+     guard pointing at the final paths, so the output is byte-identical to an
+     in-place run.  The '#include "<name>.bison.hh"' bison emits into the .cc
+     uses the basename only, which the temp directory preserves. */
+  return vector<string>{"bison", "-rall",
+                        "--file-prefix-map=" + tmp_dir + "/=" + cc_path.substr(0, slash + 1),
+                        "-o" + tmp_dir + cc_path.substr(slash),
+                        GetInput()->GetPath()};
 }
 
 
@@ -66,6 +90,14 @@ TTimestamp TBison::GetCmdTimestamp() const {
 
 bool TBison::IsComplete() {
   TFile *cc = GetOutputWithExtension(GetOutput(), {"cc"});
+  /* Atomically move everything bison generated into place (see GetTmpDir);
+     rename within a directory can't leave a partially written file visible. */
+  const filesystem::path tmp_dir = GetTmpDir(cc->GetPath());
+  const filesystem::path out_dir = tmp_dir.parent_path();
+  for (const auto &entry : filesystem::directory_iterator(tmp_dir)) {
+    filesystem::rename(entry.path(), out_dir / entry.path().filename());
+  }
+  filesystem::remove(tmp_dir);
   cc->PushComputedConfig(
       TJson::TObject{{"cmd", TJson::TObject{{"g++", Env.GetConfig().GetEntry({"cmd", "bison", "g++"})}}}});
   return true;

--- a/tools/nycr/nycr.cc
+++ b/tools/nycr/nycr.cc
@@ -30,6 +30,7 @@
 #include <tools/nycr/cst_redirect.h>
 #include <tools/nycr/symbol/bootstrap.h>
 #include <tools/nycr/symbol/language.h>
+#include <tools/nycr/symbol/output_file.h>
 #include <tools/nycr/symbol/write_bison.h>
 #include <tools/nycr/symbol/write_cst.h>
 #include <tools/nycr/symbol/write_dump.h>
@@ -87,10 +88,10 @@ class TNycr : public Base::TCmd {
       if (!GetContext().HasErrors()) {
         const Symbol::TLanguage::TLanguages &languages = Symbol::TLanguage::GetLanguages();
         if (LanguageReport && !LanguageReportFile.empty()) {
-          ofstream out(LanguageReportFile);
-          if (!out.is_open()) {
-            THROW << "Unable to open language report output file " << LanguageReportFile;
-          }
+          /* Written via a temp file + atomic rename, like every generated
+             output, so a racing reader never sees a partial report (#406). */
+          Symbol::TOutputFile out;
+          out.Open(string(LanguageReportFile));
 
           // NOTE: We're hand-converting the list into json, because that's wayyyy easier for now
           out
@@ -101,6 +102,7 @@ class TNycr : public Base::TCmd {
                             strm << '"' << Symbol::TLower(language->GetName()) << '"';
                           })
             << ']';
+          out.Commit();
         }
         while (!languages.empty()) {
           Symbol::TLanguage *language = *languages.begin();

--- a/tools/nycr/symbol/output_file.cc
+++ b/tools/nycr/symbol/output_file.cc
@@ -18,6 +18,8 @@
 
 #include <tools/nycr/symbol/output_file.h>
 
+#include <cstdio>
+
 #include <base/no_default_case.h>
 #include <base/thrower.h>
 
@@ -64,7 +66,41 @@ void TUnderscore::Write(ostream &strm) const {
   }
 }
 
-void Tools::Nycr::Symbol::CreateOutputFile(const char *root, const char *branch, const char *atom, const TLanguage *language, const char *ext, ofstream &strm, TCommentStyle comment_style) {
+void TOutputFile::Open(string &&path) {
+  assert(!is_open());
+  FinalPath = std::move(path);
+  TmpPath = FinalPath + ".tmp";
+  open(TmpPath);
+  if (!is_open()) {
+    THROW << "could not open \"" << TmpPath << '"';
+  }
+}
+
+void TOutputFile::Commit() {
+  assert(!TmpPath.empty());
+  flush();
+  bool ok = good();
+  close();
+  if (!ok) {
+    THROW << "error writing \"" << TmpPath << '"';
+  }
+  if (rename(TmpPath.c_str(), FinalPath.c_str()) != 0) {
+    THROW << "could not rename \"" << TmpPath << "\" to \"" << FinalPath << '"';
+  }
+  TmpPath.clear();
+}
+
+TOutputFile::~TOutputFile() {
+  if (TmpPath.empty()) {
+    return;
+  }
+  if (is_open()) {
+    close();
+  }
+  remove(TmpPath.c_str());
+}
+
+void Tools::Nycr::Symbol::CreateOutputFile(const char *root, const char *branch, const char *atom, const TLanguage *language, const char *ext, TOutputFile &strm, TCommentStyle comment_style) {
   assert(root);
   assert(language);
   assert(ext);
@@ -72,11 +108,7 @@ void Tools::Nycr::Symbol::CreateOutputFile(const char *root, const char *branch,
 
   temp << root << '/' << atom << '.' << TLower(language->GetName()) << ext;
 
-  string name = temp.str();
-  strm.open(name);
-  if (!strm.is_open()) {
-    THROW << "could not open \"" << name << '"';
-  }
+  strm.Open(temp.str());
 
   const char *comment_open;
   const char *comment_close;

--- a/tools/nycr/symbol/output_file.h
+++ b/tools/nycr/symbol/output_file.h
@@ -19,7 +19,9 @@
 #pragma once
 
 #include <cassert>
+#include <exception>
 #include <fstream>
+#include <string>
 
 #include <tools/nycr/symbol/language.h>
 
@@ -118,8 +120,44 @@ namespace Tools {
 
     enum TCommentStyle { CStyle, XmlStyle };
 
+    /* An output stream that writes to a '.tmp'-suffixed sibling of the target
+       file and atomically rename()s it into place on Commit().  A reader
+       racing the generator (such as a jhm dep scan, #406) can therefore never
+       observe a partially written file: the target path either does not exist
+       yet, still holds its old content, or holds the complete new content.
+       Destruction without Commit() -- say, because an exception unwound the
+       writer -- discards the temporary and leaves the target untouched. */
+    class TOutputFile final : public std::ofstream {
+      public:
+
+      TOutputFile() = default;
+
+      TOutputFile(const TOutputFile &) = delete;
+      TOutputFile &operator=(const TOutputFile &) = delete;
+
+      /* Discards the temporary if Commit() was never reached.  (The base
+         destructor is noexcept, so we cannot throw here; a writer that
+         forgets to commit loses its output, which jhm's output-existence
+         check reports loudly.) */
+      ~TOutputFile();
+
+      /* Opens the '.tmp' sibling of 'path' for writing. */
+      void Open(std::string &&path);
+
+      /* Closes the stream and renames the temporary to the target path.
+         Throws if the stream went bad or the rename fails. */
+      void Commit();
+
+      private:
+
+      /* The path we ultimately produce and the temporary we write to.
+         TmpPath is cleared once the temporary is renamed away. */
+      std::string FinalPath, TmpPath;
+
+    };  // TOutputFile
+
     /* Creates an output file and writes its header comment. Returns an open stream to the file. */
-    void CreateOutputFile(const char *root, const char *branch, const char *atom, const TLanguage *language, const char *ext, std::ofstream &strm, TCommentStyle comment_style = CStyle);
+    void CreateOutputFile(const char *root, const char *branch, const char *atom, const TLanguage *language, const char *ext, TOutputFile &strm, TCommentStyle comment_style = CStyle);
 
 /* Standard inserter for Tools::Nycr::Symbol::TPath. */
 inline std::ostream &operator<<(std::ostream &strm, const Tools::Nycr::Symbol::TPath &that) {

--- a/tools/nycr/symbol/write_bison.cc
+++ b/tools/nycr/symbol/write_bison.cc
@@ -84,7 +84,7 @@ static void CollectOperators(const TKind *kind, vector<const TOperator *> &ops) 
 static void WriteBisonCc(const char *root, const char *branch, const char *atom, const TLanguage *language) {
   assert(root);
   assert(language);
-  ofstream strm;
+  TOutputFile strm;
   CreateOutputFile(root, branch, atom, language, ".y", strm);
   strm
       << "%{" << endl
@@ -159,13 +159,15 @@ static void WriteBisonCc(const char *root, const char *branch, const char *atom,
       << "void " << TUnderscore(language) << "error(const YYLTYPE *loc, void*, Tools::Nycr::TContext &ctx, char const *msg) {" << endl
       << "  ctx.AddError(Tools::Nycr::TPosRange(Tools::Nycr::TPos(loc->first_line, loc->first_column), Tools::Nycr::TPos(loc->last_line, loc->last_column)), msg);" << endl
       << '}' << endl;
+  strm.Commit();
 }
 
 static void WriteBisonH(const char *root, const char *branch, const char *atom, const TLanguage *language) {
-  ofstream strm;
+  TOutputFile strm;
   CreateOutputFile(root, branch, atom, language, ".bison.h", strm);
   strm
       << "#pragma once" << endl;
+  strm.Commit();
 }
 
 static void WriteRule(const TKind *kind, ostream &strm) {

--- a/tools/nycr/symbol/write_cst.cc
+++ b/tools/nycr/symbol/write_cst.cc
@@ -55,7 +55,7 @@ void Tools::Nycr::Symbol::WriteCst(const char *root, const char *branch, const c
 
 static void WriteCstH(const char *root, const char *branch, const char *atom, const TLanguage *language) {
   assert(language);
-  ofstream strm;
+  TOutputFile strm;
   CreateOutputFile(root, branch, atom, language, ".cst.h", strm);
   strm
       << "#pragma once" << endl << endl
@@ -90,11 +90,12 @@ static void WriteCstH(const char *root, const char *branch, const char *atom, co
       strm << "}  // " << TUpper(*iter) << endl;
     }
   }
+  strm.Commit();
 }
 
 static void WriteCstCc(const char *root, const char *branch, const char *atom, const TLanguage *language) {
   assert(language);
-  ofstream strm;
+  TOutputFile strm;
   CreateOutputFile(root, branch, atom, language, ".cst.cc", strm);
   strm
       << "#include <" << TPath(branch, atom, language) << ".cst.h>" << endl << endl
@@ -143,6 +144,7 @@ static void WriteCstCc(const char *root, const char *branch, const char *atom, c
       << "  return ctx;" << endl
       << '}' << endl;
   ForEachKnownKind(language, bind(WriteDef, _1, ref(strm)));
+  strm.Commit();
 }
 
 static void WriteDecl(const TKind *kind, const string &namespace_prefix, ostream &strm) {

--- a/tools/nycr/symbol/write_dump.cc
+++ b/tools/nycr/symbol/write_dump.cc
@@ -29,7 +29,7 @@ using namespace Tools::Nycr::Symbol;
 void Tools::Nycr::Symbol::WriteDump(const char *root, const char *branch, const char *atom, const TLanguage *language) {
   assert(root);
   assert(language);
-  ofstream strm;
+  TOutputFile strm;
   CreateOutputFile(root, branch, atom, language, ".dump.cc", strm);
   strm
       << "#include <cstdio>" << endl
@@ -72,4 +72,5 @@ void Tools::Nycr::Symbol::WriteDump(const char *root, const char *branch, const 
       << "  }" << endl
       << "  return result;" << endl
       << "}" << endl;
+  strm.Commit();
 }

--- a/tools/nycr/symbol/write_flex.cc
+++ b/tools/nycr/symbol/write_flex.cc
@@ -83,7 +83,7 @@ static bool CompareAtoms(const TAtom *lhs, const TAtom *rhs) {
 static void WriteFlexCc(const char *root, const char *branch, const char *atom, const TLanguage *language) {
   assert(root);
   assert(language);
-  ofstream strm;
+  TOutputFile strm;
   CreateOutputFile(root, branch, atom, language, ".l", strm);
   strm
       << "%option noyywrap nodefault bison-bridge bison-locations reentrant" << endl
@@ -163,11 +163,13 @@ static void WriteFlexCc(const char *root, const char *branch, const char *atom, 
       << ". {" << endl
       << "  " << TUnderscore(language) << "error(yylloc, nullptr, *yyextra.ctx, \"illegal char\");" << endl
       << '}' << endl;
+  strm.Commit();
 }
 
 static void WriteFlexH(const char *root, const char *branch, const char *atom, const TLanguage *language) {
-  ofstream strm;
+  TOutputFile strm;
   CreateOutputFile(root, branch, atom, language, ".flex.h", strm);
   strm
       << "#pragma once" << endl;
+  strm.Commit();
 }

--- a/tools/nycr/symbol/write_nycr.cc
+++ b/tools/nycr/symbol/write_nycr.cc
@@ -39,9 +39,10 @@ using namespace Tools::Nycr::Symbol;
 void Tools::Nycr::Symbol::WriteNycr(const char *root, const char *branch, const char *atom, const TLanguage *language) {
   assert(root);
   assert(language);
-  ofstream strm;
+  TOutputFile strm;
   CreateOutputFile(root, branch, atom, language, ".nycr", strm);
   ForEachKnownKind(language, bind(WriteNycrDecl, _1, ref(strm)));
+  strm.Commit();
 }
 
 void Tools::Nycr::Symbol::WriteNycrDecl(const TKind *kind, ostream &strm) {

--- a/tools/nycr/symbol/write_xml.cc
+++ b/tools/nycr/symbol/write_xml.cc
@@ -86,11 +86,12 @@ void TXmlTag::Write(ostream &strm) const {
 
 void Tools::Nycr::Symbol::WriteXml(const char *root, const char *branch, const char *atom, const TLanguage *language) {
   assert(language);
-  ofstream strm;
+  TOutputFile strm;
   CreateOutputFile(root, branch, atom, language, ".xml", strm, XmlStyle);
   strm << TXmlTag(TXmlTag::Document, Open);
   ForEachKnownKind(language, bind(WriteElem, _1, ref(strm)));
   strm << TXmlTag(TXmlTag::Document, Close);
+  strm.Commit();
 }
 
 static void WriteElem(const TKind *kind, ostream &strm) {


### PR DESCRIPTION
Closes #406.

A dep scan (`g++ -M -MG`) can legitimately race the job that generates a header it discovers via `#include` — jhm cannot order the two, because the include isn't known until the scan runs, and `-MG` only tolerates *missing* generated headers, not partially written ones. Both nycr and bison wrote their outputs incrementally in place, so a racing reader could observe a truncated file and die with `unterminated #ifndef` (or, quietly worse, record an incomplete dep list from a prefix that happened to preprocess cleanly). The observed CI victim (`orly.checkpoint.bison.hh`) is actually **bison's** output, not nycr's, so the hardening covers both producers:

- **nycr**: every generated output (all nine per language, plus the `-l` language report) now goes through a new `TOutputFile`, which writes `<target>.tmp` and atomically `rename()`s it into place on `Commit()`. An exception before the commit discards the temporary and leaves the target untouched. Commit is explicit rather than destructor-driven because `~basic_ofstream` is `noexcept`, so a committing destructor couldn't report failure; a writer that forgets to commit trips jhm's output-existence check loudly.
- **jhm bison job**: generates into `<target>.cc.tmp.d/` and renames everything (`.cc`, `.hh`, the `-rall` report) into place in `IsComplete()`, which runs before dependents unblock. `--file-prefix-map` keeps `#line` directives and the header's include guard pointing at the final paths, and the `#include` bison embeds in the `.cc` uses the basename only, which the temp dir preserves — output is **byte-identical** to an in-place run (verified against bison 3.8.2, which CI and the README's Ubuntu 24.04 baseline provide).

flex needs no change: its `.flex.cc` is consumed only as an ordered job input (the flake's failing dep scan had it as the *input*, with the truncated *bison* header as the discovered include), never discovered mid-write.

After this, a reader can only ever observe a missing file (`-MG` handles that), the old complete file, or the new complete file — the partial-read window is gone, killing the flake class rather than the one symptom.

Verified: bootstrap + full from-scratch `orly/orlyc` build with the modified toolchain at full parallelism; generated outputs byte-identical to master's (modulo the build-root paths bison embeds); no `.tmp`/`.tmp.d` leftovers anywhere in the out tree; incremental regeneration over existing outputs works (atomic replace).