### PR TITLE
server: surface TServer startup failures instead of terminating or limping

### DIFF
--- a/clients/python/orly/__init__.py
+++ b/clients/python/orly/__init__.py
@@ -127,7 +127,9 @@ class Client:
         return self.session_id
 
     def resume_session(self, session_id):
-        self.session_id = self.send(f"resume session {lit(session_id)};")
+        # The console grammar takes the session id as a braced IdExpr
+        # (``resume session {uuid};``), not a quoted string.
+        self.session_id = self.send(f"resume session {{{session_id}}};")
         return self.session_id
 
     def install(self, package, version):

--- a/orly/indy/disk/util/orly_dm.cc
+++ b/orly/indy/disk/util/orly_dm.cc
@@ -136,6 +136,19 @@ class TCmd final
 int main(int argc, char *argv[]) {
   ::TCmd cmd(argc, argv);
   Base::TLog log(cmd);
+  /* Devices are named as in /proc/partitions ("loop0"); tolerate the
+     natural "/dev/loop0" spelling instead of crashing on a doubled path
+     ("/sys/block//dev/loop0/...", #435). */
+  {
+    std::set<std::string> normalized;
+    for (const auto &device : cmd.DeviceSet) {
+      static const std::string dev_prefix = "/dev/";
+      normalized.insert(
+          device.compare(0, dev_prefix.size(), dev_prefix) == 0
+              ? device.substr(dev_prefix.size()) : device);
+    }
+    cmd.DeviceSet = std::move(normalized);
+  }
   Base::TScheduler scheduler(Base::TScheduler::TPolicy(1, 64, milliseconds(10)));
   if(cmd.ZeroSuperBlock) {
     const auto &device_set = cmd.DeviceSet;

--- a/orly/server/server.cc
+++ b/orly/server/server.cc
@@ -783,6 +783,13 @@ TServer::TServer(TScheduler *scheduler, const TCmd &cmd)
   /* Run the WsRunner's thread. */
   WsThread = thread([this] { WsRunner.Run(); });
 
+  /* From here on we own live runner threads.  If the rest of construction
+     throws, unwinding would destroy joinable std::threads -- an instant
+     std::terminate that masks the real error ("terminate called without an
+     active exception", #435).  Catch, stop and join everything we started,
+     then let the exception out. */
+  try {
+
   auto launch_fast_fiber_sched = [this](size_t core, Fiber::TRunner *runner) {
     cpu_set_t mask;
     CPU_ZERO(&mask);
@@ -842,13 +849,34 @@ TServer::TServer(TScheduler *scheduler, const TCmd &cmd)
     Fiber::TFrame::LocalFramePool->Free(Frame);
     throw;
   }
-  std::unique_lock<std::mutex> lock(InitMutex);
-  while (!InitFinished) {
-    InitCond.wait(lock);
+  /* handshake scope */ {
+    std::unique_lock<std::mutex> lock(InitMutex);
+    while (!InitFinished) {
+      InitCond.wait(lock);
+    }
+  }
+  if (InitError) {
+    std::rethrow_exception(InitError);
   }
 
   /* Launch the websockets server. */
   Ws.reset(TWs::New(this, cmd.NumWsThreads, cmd.WsPortNumber));
+
+  } catch (const std::exception &ex) {
+    /* We cannot unwind: several members' destructors (the durable manager,
+       the repo manager) require the fiber context this thread does not
+       have -- the same contradiction that keeps orlyi and orlyc from ever
+       destroying a TServer.  Until teardown is a first-class operation,
+       report the real error and exit; the alternative is std::terminate
+       from a joinable-thread destructor with the message lost (#435). */
+    syslog(LOG_ERR, "TServer failed to initialize: %s", ex.what());
+    std::cerr << "TServer failed to initialize: " << ex.what() << std::endl;
+    _exit(EXIT_FAILURE);
+  } catch (...) {
+    syslog(LOG_ERR, "TServer failed to initialize: unknown error");
+    std::cerr << "TServer failed to initialize: unknown error" << std::endl;
+    _exit(EXIT_FAILURE);
+  }
 }
 
 void TServer::Init() {
@@ -1259,6 +1287,9 @@ void TServer::Init() {
     DEBUG_LOG("TServer::Init end");
   } catch (const std::exception &ex) {
     syslog(LOG_ERR, "TServer::Init() caught exception [%s]", ex.what());
+    /* Hand the failure to the constructor; swallowing it here would leave a
+       half-built server accepting connections it cannot serve (#435). */
+    InitError = std::current_exception();
   }
   std::lock_guard<std::mutex> lock(InitMutex);
   InitFinished = true;

--- a/orly/server/server.h
+++ b/orly/server/server.h
@@ -770,6 +770,11 @@ namespace Orly {
       std::condition_variable InitCond;
       std::mutex InitMutex;
 
+      /* Set by Init() if it fails; the constructor rethrows it after the
+         InitFinished handshake so a server that could not initialize does
+         not limp along half-built (#435). */
+      std::exception_ptr InitError;
+
       /* The websockets server object */
       std::unique_ptr<TWs> Ws;
 


### PR DESCRIPTION
First slice of #435 (restart-spike fallout): make startup failure a reportable event.

**The limping server.** `TServer::Init()` caught every exception, logged one syslog line, and set `InitFinished` anyway — so the constructor proceeded to start the WebSocket listener on a half-built server. In the spike this produced an orlyi that could not serve anything but happily accepted connections. Init now stores the failure in an `exception_ptr`; the constructor rethrows it after the handshake.

**The masked error.** Any exception escaping the constructor after the runner threads start (a port bind failure, a bad core vector, and now the rethrown init error) unwound into joinable `std::thread` destructors → `std::terminate`, printing `terminate called without an active exception` with the real message lost. I initially implemented a full stop-and-join unwind, but member destructors hit the standing teardown contradiction (`~TDurableManager` runs `TSingleSem::Pop()`, which asserts fiber context — verified with a live backtrace). So until teardown is a first-class operation, the constructor reports the real error and `_exit(EXIT_FAILURE)`s, mirroring orlyc's documented leak-and-exit policy.

Before: exit 134, backtrace, no clue. After: `TServer failed to initialize: Address already in use`, exit 1.

**Two small companions from the same spike:**
- `orly_dm` crashed with an unhandled `system_error` when given `/dev/loop0` instead of `loop0` (it built `/sys/block//dev/loop0/...`); device names are now normalized to accept both spellings.
- The Python client's `resume_session()` sent the session id as a quoted string where the console grammar wants a braced IdExpr (`resume session {uuid};`) — evidence session resume had never been exercised. It now works against a restarted disk-backed server (verified in the spike).

Tested: bind-conflict startup now fails cleanly with the real message (was SIGABRT); `orly_dm /dev/loop0` works; disk-backed restart cycle re-verified with the fixed binary (all three generations of spike data read back); orlyc lang-test compile+test pass through the modified constructor path.


(The installed-package-registry work originally appended here landed separately in a follow-up PR, since this one merged first.)
