### PR TITLE
server: persist the installed-package registry across restarts

### DIFF
--- a/orly/indy/manager.cc
+++ b/orly/indy/manager.cc
@@ -1288,6 +1288,46 @@ void TManager::SaveIndexNamespaceMapping(const Base::TUuid &index_id, const std:
   }
 }
 
+void TManager::SaveInstalledPackage(const std::vector<std::string> &package_name, uint64_t version, bool installed) {
+  void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
+  /* Perform transaction on System repo to save this record */ {
+    TSuprena arena;
+    auto transaction = NewTransaction();
+    auto update = TUpdate::NewUpdate(TUpdate::TOpByKey{ {
+      TIndexKey(SystemPackageIndexId, TKey(make_tuple(package_name, static_cast<int64_t>(version)), &arena, state_alloc)),
+      TKey(installed, &arena, state_alloc)} }, TKey(), TKey(TUuid(TUuid::Twister), &arena, state_alloc));
+    transaction->Push(SystemRepo, update);
+    transaction->Prepare();
+    transaction->CommitAction();
+  }
+}
+
+std::vector<std::pair<std::vector<std::string>, uint64_t>> TManager::GetInstalledPackages() {
+  void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
+  TSuprena arena;
+  std::vector<std::pair<std::vector<std::string>, uint64_t>> ret;
+  /* The walker yields an entry per update layer for the same key, newest
+     first; only the first (current) one counts -- the same reason
+     GetIndexNamespaceMapping()'s emplace is first-wins.  Without the dedupe
+     an uninstall would be shadowed by its older install record. */
+  std::set<std::tuple<std::vector<std::string>, int64_t>> seen;
+  auto view = make_unique<Indy::TRepo::TView>(SystemRepo);
+  auto walker_ptr = SystemRepo->NewPresentWalker(view, TIndexKey(SystemPackageIndexId, TKey(make_tuple(Native::TFree<std::vector<std::string>>(), Native::TFree<int64_t>()), &arena, state_alloc)), true);
+  for (auto &walker = *walker_ptr; walker; ++walker) {
+    std::tuple<std::vector<std::string>, int64_t> name_and_version;
+    bool installed = false;
+    Sabot::ToNative(*Sabot::State::TAny::TWrapper((*walker).Key.NewState((*walker).KeyArena, state_alloc)), name_and_version);
+    Sabot::ToNative(*Sabot::State::TAny::TWrapper((*walker).Op.NewState((*walker).OpArena, state_alloc)), installed);
+    if (!seen.insert(name_and_version).second) {
+      continue;
+    }
+    if (installed) {
+      ret.emplace_back(std::get<0>(name_and_version), static_cast<uint64_t>(std::get<1>(name_and_version)));
+    }
+  }
+  return ret;
+}
+
 std::unordered_map<Base::TUuid, std::string> TManager::GetIndexNamespaceMapping() {
   void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
   TSuprena arena;

--- a/orly/indy/manager.h
+++ b/orly/indy/manager.h
@@ -39,6 +39,8 @@ namespace Orly {
     const Base::TUuid SystemRepoIndexId("9D3DAB7C-2D75-452C-8200-30180FF584F1");
     /* The index id of the system repo space used to store index namespace mappings */
     const Base::TUuid SystemIDNSIndexId("9154D7AE-FA10-42D5-9A10-AC68664B0092");
+    /* The index id of the system repo space used to remember installed packages across restarts (#435) */
+    const Base::TUuid SystemPackageIndexId("552C39C6-8D48-4760-9AF0-E3A08EBFA9AC");
 
     class TManager
         : public L1::TManager, public DurableManager::TManager {
@@ -436,6 +438,13 @@ namespace Orly {
       void SaveIndexNamespaceMapping(const Base::TUuid &index_id, const std::string &namespace_name);
 
       std::unordered_map<Base::TUuid, std::string> GetIndexNamespaceMapping();
+
+      /* Record in the system repo that the given package version is (or is
+         no longer) installed, so a restarted server can reinstall it (#435). */
+      void SaveInstalledPackage(const std::vector<std::string> &package_name, uint64_t version, bool installed);
+
+      /* The (package name, version) pairs currently recorded as installed. */
+      std::vector<std::pair<std::vector<std::string>, uint64_t>> GetInstalledPackages();
 
       void OnSlaveJoin(const Base::TFd &fd);
 

--- a/orly/server/server.cc
+++ b/orly/server/server.cc
@@ -1109,6 +1109,29 @@ void TServer::Init() {
       });
     }
 
+    /* Reinstall the packages recorded as installed when this image was last
+       running (#435).  The .so files must still be in the package directory;
+       a missing or broken package is logged and skipped rather than keeping
+       the whole server down.  Runs on the BG runner because the walker needs
+       the read-file cache and the installs run repo transactions. */
+    if (!Cmd.Create) {
+      Indy::Fiber::TJumpRunnable reinstall_jumper([this] {
+        for (const auto &pkg : RepoManager->GetInstalledPackages()) {
+          try {
+            InstallPackage(pkg.first, pkg.second);
+          } catch (const std::exception &ex) {
+            ostringstream names;
+            for (const auto &name : pkg.first) {
+              names << '[' << name << ']';
+            }
+            syslog(LOG_ERR, "could not reinstall package [%s] version [%ld] from the previous run: %s",
+                   names.str().c_str(), pkg.second, ex.what());
+          }
+        }
+      });
+      reinstall_jumper(FramePoolManager.get(), &BGFastRunner);
+    }
+
     /* TODO(#366) : durable manager does not support create=false */
     DurableManager = make_shared<Orly::Indy::Disk::TDurableManager>(Scheduler,
                                                                     RunnerCons,
@@ -2225,6 +2248,8 @@ void TServer::InstallPackage(const vector<string> &package_name, uint64_t versio
     }
   };
   PackageManager.Install({{{package_name}, version}}, pre_install_cb);
+  /* Remember the install across restarts (#435). */
+  RepoManager->SaveInstalledPackage(package_name, version, true);
   ostringstream strm;
   for (const auto &name: package_name) {
     strm << '[' << name << ']';
@@ -2759,6 +2784,8 @@ void TServer::StateChangeCb(Orly::Indy::TManager::TState state) {
 
 void TServer::UninstallPackage(const vector<string> &package_name, uint64_t version) {
   PackageManager.Uninstall(unordered_set<Package::TVersionedName>{Package::TVersionedName{{package_name}, version}});
+  /* Clear the persistent record (#435). */
+  RepoManager->SaveInstalledPackage(package_name, version, false);
 }
 
 void TServer::WaitForSlave() {


### PR DESCRIPTION
Gap 1 of #435 (follow-up to #436, which merged before this commit was pushed to its branch).

A restarted server (`--create=false`) forgot which packages were installed even though the data and the index-id mappings survived — every client had to reinstall the `.so` before it could touch its own data.

`(package name, version) → installed` records now live in the system repo under a new index id (`SystemPackageIndexId`), mirroring the index-namespace-mapping machinery: written on install and uninstall, walked at `--create=false` startup, and each recorded package reinstalled from the package directory before the server starts serving. A missing or broken `.so` is logged and skipped rather than keeping the server down.

One engine subtlety surfaced by live cycle-testing: the present walker yields an entry per update layer for the same key, newest first — the reader must dedupe first-wins (the same contract `GetIndexNamespaceMapping()`'s `emplace` relies on). The first cut appended stale layers, so an uninstall was shadowed by its older install record and the package resurrected after restart; fixed and re-verified.

Verified on a disk-backed loopback instance across full stop/restart cycles: install → restart → auto-reinstall serving pre-restart data with no client install; uninstall → restart → stays uninstalled with a clean `non-installed package` error and can be freshly installed; orlyc's embedded mem-sim server (which also runs `InstallPackage`) passes lang tests unchanged.