### PR TITLE
ci: gate restart durability with an end-to-end stop/restart test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
-          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex ccache
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind ccache
           version: 1.2
 
       - name: Set up ccache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,53 @@ jobs:
           ../out_orly/release/orly/server/orlyi --help > /tmp/orlyi-help.txt
           test -s /tmp/orlyi-help.txt
 
+  restart-test:
+    name: restart durability (tests/restart_test.sh)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install system dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        with:
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex ccache
+          version: 1.2
+
+      - name: Set up ccache
+        run: |
+          for c in gcc g++ cc c++; do
+            sudo ln -sf "$(command -v ccache)" "/usr/local/bin/$c"
+          done
+          {
+            echo "CCACHE_DIR=$HOME/.ccache"
+            echo "CCACHE_MAXSIZE=2G"
+            echo "CCACHE_COMPRESS=1"
+          } >> "$GITHUB_ENV"
+
+      - name: Cache ccache
+        if: github.event_name != 'schedule'
+        uses: actions/cache@v5
+        with:
+          path: ~/.ccache
+          key: orly-ccache-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
+          restore-keys: |
+            orly-ccache-${{ runner.os }}-${{ github.job }}-
+            orly-ccache-${{ runner.os }}-
+
+      - name: Install python websocket-client
+        run: pip3 install --break-system-packages websocket-client
+
+      - name: make debug
+        run: make debug
+
+      # Write -> stop -> restart -> read on a real (loopback) disk volume,
+      # including installed-package-registry survival (#435).  This is the
+      # only job that exercises --create=false, so restart durability can
+      # never silently rot again.
+      - name: tests/restart_test.sh
+        run: ./tests/restart_test.sh
+
   lang-tests:
     name: lang_test.py
     runs-on: ubuntu-24.04

--- a/orly/indy/manager.cc
+++ b/orly/indy/manager.cc
@@ -1288,6 +1288,46 @@ void TManager::SaveIndexNamespaceMapping(const Base::TUuid &index_id, const std:
   }
 }
 
+void TManager::SaveInstalledPackage(const std::vector<std::string> &package_name, uint64_t version, bool installed) {
+  void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
+  /* Perform transaction on System repo to save this record */ {
+    TSuprena arena;
+    auto transaction = NewTransaction();
+    auto update = TUpdate::NewUpdate(TUpdate::TOpByKey{ {
+      TIndexKey(SystemPackageIndexId, TKey(make_tuple(package_name, static_cast<int64_t>(version)), &arena, state_alloc)),
+      TKey(installed, &arena, state_alloc)} }, TKey(), TKey(TUuid(TUuid::Twister), &arena, state_alloc));
+    transaction->Push(SystemRepo, update);
+    transaction->Prepare();
+    transaction->CommitAction();
+  }
+}
+
+std::vector<std::pair<std::vector<std::string>, uint64_t>> TManager::GetInstalledPackages() {
+  void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
+  TSuprena arena;
+  std::vector<std::pair<std::vector<std::string>, uint64_t>> ret;
+  /* The walker yields an entry per update layer for the same key, newest
+     first; only the first (current) one counts -- the same reason
+     GetIndexNamespaceMapping()'s emplace is first-wins.  Without the dedupe
+     an uninstall would be shadowed by its older install record. */
+  std::set<std::tuple<std::vector<std::string>, int64_t>> seen;
+  auto view = make_unique<Indy::TRepo::TView>(SystemRepo);
+  auto walker_ptr = SystemRepo->NewPresentWalker(view, TIndexKey(SystemPackageIndexId, TKey(make_tuple(Native::TFree<std::vector<std::string>>(), Native::TFree<int64_t>()), &arena, state_alloc)), true);
+  for (auto &walker = *walker_ptr; walker; ++walker) {
+    std::tuple<std::vector<std::string>, int64_t> name_and_version;
+    bool installed = false;
+    Sabot::ToNative(*Sabot::State::TAny::TWrapper((*walker).Key.NewState((*walker).KeyArena, state_alloc)), name_and_version);
+    Sabot::ToNative(*Sabot::State::TAny::TWrapper((*walker).Op.NewState((*walker).OpArena, state_alloc)), installed);
+    if (!seen.insert(name_and_version).second) {
+      continue;
+    }
+    if (installed) {
+      ret.emplace_back(std::get<0>(name_and_version), static_cast<uint64_t>(std::get<1>(name_and_version)));
+    }
+  }
+  return ret;
+}
+
 std::unordered_map<Base::TUuid, std::string> TManager::GetIndexNamespaceMapping() {
   void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
   TSuprena arena;

--- a/orly/indy/manager.h
+++ b/orly/indy/manager.h
@@ -39,6 +39,8 @@ namespace Orly {
     const Base::TUuid SystemRepoIndexId("9D3DAB7C-2D75-452C-8200-30180FF584F1");
     /* The index id of the system repo space used to store index namespace mappings */
     const Base::TUuid SystemIDNSIndexId("9154D7AE-FA10-42D5-9A10-AC68664B0092");
+    /* The index id of the system repo space used to remember installed packages across restarts (#435) */
+    const Base::TUuid SystemPackageIndexId("552C39C6-8D48-4760-9AF0-E3A08EBFA9AC");
 
     class TManager
         : public L1::TManager, public DurableManager::TManager {
@@ -436,6 +438,13 @@ namespace Orly {
       void SaveIndexNamespaceMapping(const Base::TUuid &index_id, const std::string &namespace_name);
 
       std::unordered_map<Base::TUuid, std::string> GetIndexNamespaceMapping();
+
+      /* Record in the system repo that the given package version is (or is
+         no longer) installed, so a restarted server can reinstall it (#435). */
+      void SaveInstalledPackage(const std::vector<std::string> &package_name, uint64_t version, bool installed);
+
+      /* The (package name, version) pairs currently recorded as installed. */
+      std::vector<std::pair<std::vector<std::string>, uint64_t>> GetInstalledPackages();
 
       void OnSlaveJoin(const Base::TFd &fd);
 

--- a/orly/server/server.cc
+++ b/orly/server/server.cc
@@ -1109,6 +1109,29 @@ void TServer::Init() {
       });
     }
 
+    /* Reinstall the packages recorded as installed when this image was last
+       running (#435).  The .so files must still be in the package directory;
+       a missing or broken package is logged and skipped rather than keeping
+       the whole server down.  Runs on the BG runner because the walker needs
+       the read-file cache and the installs run repo transactions. */
+    if (!Cmd.Create) {
+      Indy::Fiber::TJumpRunnable reinstall_jumper([this] {
+        for (const auto &pkg : RepoManager->GetInstalledPackages()) {
+          try {
+            InstallPackage(pkg.first, pkg.second);
+          } catch (const std::exception &ex) {
+            ostringstream names;
+            for (const auto &name : pkg.first) {
+              names << '[' << name << ']';
+            }
+            syslog(LOG_ERR, "could not reinstall package [%s] version [%ld] from the previous run: %s",
+                   names.str().c_str(), pkg.second, ex.what());
+          }
+        }
+      });
+      reinstall_jumper(FramePoolManager.get(), &BGFastRunner);
+    }
+
     /* TODO(#366) : durable manager does not support create=false */
     DurableManager = make_shared<Orly::Indy::Disk::TDurableManager>(Scheduler,
                                                                     RunnerCons,
@@ -2225,6 +2248,8 @@ void TServer::InstallPackage(const vector<string> &package_name, uint64_t versio
     }
   };
   PackageManager.Install({{{package_name}, version}}, pre_install_cb);
+  /* Remember the install across restarts (#435). */
+  RepoManager->SaveInstalledPackage(package_name, version, true);
   ostringstream strm;
   for (const auto &name: package_name) {
     strm << '[' << name << ']';
@@ -2759,6 +2784,8 @@ void TServer::StateChangeCb(Orly::Indy::TManager::TState state) {
 
 void TServer::UninstallPackage(const vector<string> &package_name, uint64_t version) {
   PackageManager.Uninstall(unordered_set<Package::TVersionedName>{Package::TVersionedName{{package_name}, version}});
+  /* Clear the persistent record (#435). */
+  RepoManager->SaveInstalledPackage(package_name, version, false);
 }
 
 void TServer::WaitForSlave() {

--- a/tests/restart_test.sh
+++ b/tests/restart_test.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# End-to-end restart-durability test (#435): verify that a disk-backed orlyi
+# gives data back after a stop/restart, and that the installed-package
+# registry follows suit.
+#
+#   cycle 1: create volume, install kv, write keys, stop
+#   cycle 2: restart --create=false; package must auto-reinstall and the
+#            data must read back with NO client install; then uninstall, stop
+#   cycle 3: restart; package must STAY uninstalled (clean error)
+#
+# Needs root for losetup and the /proc/partitions device scan; run under
+# sudo or on a CI runner with passwordless sudo.  Ports 19600-19603.
+set -e
+cd "$(dirname "$0")/.."
+REPO_ROOT="$PWD"
+ORLY_OUT="${ORLY_OUT:-$REPO_ROOT/../out_orly/debug}"
+WORK="$(mktemp -d)"
+LOOP=""
+SRV_PID=""
+
+cleanup() {
+  [ -n "$SRV_PID" ] && sudo kill -9 "$SRV_PID" 2>/dev/null || true
+  [ -n "$LOOP" ] && sudo losetup -d "$LOOP" 2>/dev/null || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+echo "[1/8] compile kv package"
+cat > "$WORK/kv.orly" <<'ORLY'
+package #1;
+read_val = (*<['values', n]>::(int?)) where { n = given::(int); };
+write_val = ((true) effecting { new <['values', n]> <- x; } ) where {
+  n = given::(int);
+  x = given::(int);
+};
+ORLY
+"$ORLY_OUT/orly/orlyc" --skip-tests -o "$WORK" "$WORK/kv.orly"
+mkdir "$WORK/packages" && touch "$WORK/packages/__orly__" && cp "$WORK/kv.1.so" "$WORK/packages/"
+
+echo "[2/8] create loopback volume"
+truncate -s 3G "$WORK/disk.img"
+LOOP="$(sudo losetup -fP --show "$WORK/disk.img")"
+sudo "$ORLY_OUT/orly/indy/disk/util/orly_dm" --create-volume --device-speed=fast \
+     --instance-name=restart_test --num-devices=1 "$(basename "$LOOP")"
+
+start_server() {  # $1 = create true|false, $2 = log tag
+  sudo "$ORLY_OUT/orly/server/orlyi" \
+    --create="$1" --instance_name=restart_test --starting_state=SOLO \
+    --port_number=19600 --slave_port_number=19601 --ws_port_number=19602 \
+    --reporting_port_number=19603 --connection_backlog=10 \
+    --package_dir="$WORK/packages" --max_parallel_frames=4000 \
+    --page_cache_size=256 --block_cache_size=64 --do_fsync --no_realtime \
+    > "$WORK/orlyi-$2.log" 2>&1 &
+  SRV_PID=$!
+  for _ in $(seq 1 60); do
+    ss -tln 2>/dev/null | grep -q ':19600' && return 0
+    if ! sudo kill -0 "$SRV_PID" 2>/dev/null; then
+      echo "orlyi ($2) died during startup:"; tail -20 "$WORK/orlyi-$2.log"; exit 1
+    fi
+    sleep 5
+  done
+  echo "orlyi ($2) never came up:"; tail -20 "$WORK/orlyi-$2.log"; exit 1
+}
+
+stop_server() {
+  # SIGINT, grace period for the mergers to have flushed (we slept before
+  # calling), then make sure it is gone.
+  sudo kill -INT "$SRV_PID" 2>/dev/null || true
+  sleep 10
+  sudo kill -9 "$SRV_PID" 2>/dev/null || true
+  SRV_PID=""
+  sleep 2
+}
+
+client() { PYTHONPATH="$REPO_ROOT/clients/python" python3 -c "$1"; }
+
+echo "[3/8] start fresh (create=true), install, write"
+start_server true run1
+client "
+import orly
+c = orly.connect('ws://127.0.0.1:19602/', timeout=10, recv_timeout=60)
+c.new_session(); c.install('kv', 1); pov = c.new_pov()
+for n in range(1, 11):
+    c.call(pov, 'kv', 'write_val', {'n': n, 'x': n * 100})
+assert c.call(pov, 'kv', 'read_val', {'n': 5}) == 500
+c.close()"
+
+echo "[4/8] flush window, stop"
+sleep 75
+stop_server
+
+echo "[5/8] restart (create=false): data + package must survive"
+start_server false run2
+client "
+import orly
+c = orly.connect('ws://127.0.0.1:19602/', timeout=10, recv_timeout=60)
+c.new_session(); pov = c.new_pov()
+vals = [c.call(pov, 'kv', 'read_val', {'n': n}) for n in range(1, 11)]
+assert vals == [n * 100 for n in range(1, 11)], f'data lost: {vals}'
+print('   data + auto-reinstalled package OK:', vals)
+c.uninstall('kv', 1)
+c.close()"
+
+echo "[6/8] flush window, stop"
+sleep 75
+stop_server
+
+echo "[7/8] restart: uninstall must have survived"
+start_server false run3
+client "
+import orly
+c = orly.connect('ws://127.0.0.1:19602/', timeout=10, recv_timeout=60)
+c.new_session(); pov = c.new_pov()
+try:
+    c.call(pov, 'kv', 'read_val', {'n': 1})
+    raise SystemExit('package resurrected after uninstall+restart')
+except orly.OrlyError as ex:
+    assert 'non-installed' in str(ex), str(ex)
+print('   uninstall persisted OK')
+c.close()"
+stop_server
+
+echo "[8/8] PASS: restart durability verified"


### PR DESCRIPTION
Final piece of the #435 sequencing: lock in what the restart spike proved works.

`tests/restart_test.sh` stands up a **disk-backed** orlyi on a loopback volume (`losetup` + `orly_dm`, needs the runner's passwordless sudo) and drives the full durability cycle:

1. `--create=true`: install the kv package, write keys 1-10, verify, flush window, SIGINT.
2. `--create=false`: assert all data reads back **and** the package auto-reinstalls with no client `install` (exercises #437's registry); then uninstall, flush, stop.
3. `--create=false` again: assert the package stays uninstalled with a clean `non-installed` error.

The new `restart-test` CI job (mirrors the lang-tests job's ccache/deps setup) runs it on every push/PR. It's the only job in the suite that exercises `--create=false`, so the surviving surface — global data, package registry, multi-generation data files — can never silently rot again. It would also have caught the walker-layer-dedupe bug found while building #437.

Includes the #437 commit (the registry is what step 2 asserts); once #437 merges this PR reduces to the test + workflow. Verified green end-to-end locally on a loopback volume (~6 minutes).