### PR TITLE
server: fix tetris teardown races — Stop() UAF, StopAllPlayers deadlock, fixture in-flight sync (#280)

### DIFF
--- a/orly/server/tetris_manager.cc
+++ b/orly/server/tetris_manager.cc
@@ -18,6 +18,8 @@
 
 #include <orly/server/tetris_manager.h>
 
+#include <thread>
+
 #include <base/debug_log.h>
 #include <orly/indy/disk/util/volume_manager.h>
 
@@ -36,6 +38,11 @@ void TTetrisManager::Join(const TUuid &parent_pov_id, const TUuid &child_pov_id)
   /* Lock the map and locate (or create) the slot where this parent pov's player would be. */
   //lock_guard<mutex> lock(Mutex);
   Fiber::TFiberLock::TLock lock(FiberMutex);
+  if (Stopping) {
+    /* We're tearing down: no new players.  The piece stays unpromoted, exactly as if it had
+       arrived just after the player it would have joined was stopped. */
+    return;
+  }
   auto iter = PlayerByParentPovId.insert(pair<TUuid, TPlayer *>(parent_pov_id, nullptr)).first;
   TPlayer *&player = iter->second;
   if (player) {
@@ -116,17 +123,26 @@ void TTetrisManager::TPlayer::Pause() {
 }
 
 void TTetrisManager::TPlayer::Stop() {
-  assert(!Stopped);
-  /* Make a semaphore so we can know when the player has actually stopped. */
-  CanWork.Push();
-  Stopped = true;
-  StoppedSync.WaitForMore(1);
-  /* NOTE: After we set ChildCount to zero, the other thread could destroy this object at any time.
-     We must therefore not dereference 'this' from here down. */
+  assert(!StopFlag.load());
+  /* Park a flag from our own stack where Main() can find it, then zero the child count so
+     Main() falls out of its loop and self-destructs.  Main() flips the flag through a stack
+     copy of the pointer after 'delete this' completes, so we never dereference 'this' once
+     the count hits zero and the player never touches our stack after the flip. */
+  std::atomic<bool> stopped(false);
+  StopFlag.store(&stopped);
   ChildCount = 0;
-  /* Wait for the player thread to stop. */
-  /* TODO(#280) FIX: clearly StoppedSync is referencing this... */
-  StoppedSync.Sync();
+  /* Wake the player in case it is still waiting for permission to work. */
+  CanWork.Push();
+  /* Wait for the player fiber to finish self-destructing.  It runs on the manager's fiber
+     scheduler, a different thread, so yielding here cannot starve it.  Server shutdown tears
+     us down from a plain thread, so only fiber-yield when we actually are a fiber. */
+  while (!stopped.load()) {
+    if (Fiber::TFrame::LocalFrame) {
+      Fiber::YieldSlow();
+    } else {
+      std::this_thread::yield();
+    }
+  }
 }
 
 void TTetrisManager::TPlayer::Unpause() {
@@ -143,17 +159,17 @@ void TTetrisManager::TPlayer::OnClose() {
 }
 
 TTetrisManager::TPlayer::~TPlayer() {
-  if (Stopped) {
-    StoppedSync.Complete();
-    Stopped = false;
-  }
   Fiber::FreeMyFrame(FramePool);
+  /* Last: once this count drops, StopAllPlayers() may return and the manager's owner may start
+     destroying povs, so nothing after this line may touch shared state. */
+  --(TetrisManager->LivePlayerCount);
 }
 
 TTetrisManager::TPlayer::TPlayer(TTetrisManager *tetris_manager)
-    : TetrisManager(tetris_manager), ChildCount(1), Stopped(nullptr), /*Paused(nullptr), */ Paused(false), /*Unpaused(nullptr)*/ Unpaused(false) {
+    : TetrisManager(tetris_manager), ChildCount(1), StopFlag(nullptr), /*Paused(nullptr), */ Paused(false), /*Unpaused(nullptr)*/ Unpaused(false) {
   assert(tetris_manager);
   assert(Fiber::TFrame::LocalFramePool);
+  ++(tetris_manager->LivePlayerCount);
   FramePool = Fiber::TFrame::LocalFramePool;
   TetrisFrame = FramePool->Alloc();
 }
@@ -224,7 +240,13 @@ void TTetrisManager::TPlayer::Main() {
       }
     }
     //DEBUG_LOG("tetris player %p: self-destructing", this);
+    /* If a Stop() is waiting on us, its stack flag must flip only after we are completely
+       dead.  Copy the pointer to our stack first; 'this' is invalid after the delete. */
+    std::atomic<bool> *stop_flag = StopFlag.load();
     delete this;
+    if (stop_flag) {
+      stop_flag->store(true);
+    }
     //DEBUG_LOG("tetris player %p: exiting Main()", this);
   } catch (const std::exception &ex) {
     syslog(LOG_EMERG, "TetrisManager::Player exception: %s", ex.what());
@@ -241,7 +263,7 @@ TTetrisManager::TTetrisManager(Base::TScheduler *scheduler,
                                Base::TThreadLocalGlobalPoolManager<Indy::Fiber::TFrame, size_t, Indy::Fiber::TRunner *> *frame_pool_manager,
                                const std::function<void (Indy::Fiber::TRunner *)> &runner_setup_cb,
                                bool is_master)
-    : Scheduler(scheduler), FiberScheduler(runner_cons), IsMaster(is_master) {
+    : Scheduler(scheduler), FiberScheduler(runner_cons), Stopping(false), LivePlayerCount(0UL), IsMaster(is_master) {
   assert(scheduler);
   Base::TEventSemaphore setup_is_complete;
   auto launch_sched = [this, runner_setup_cb, &setup_is_complete](Fiber::TRunner *runner,
@@ -268,12 +290,31 @@ TTetrisManager::~TTetrisManager() {
 }
 
 void TTetrisManager::StopAllPlayers() {
-  //lock_guard<mutex> lock(Mutex);
-  Fiber::TFiberLock::TLock lock(FiberMutex);
-  for (const auto &item: PlayerByParentPovId) {
+  /* Snatch the whole player map under the lock, but do the actual stopping after releasing it:
+     a player that is mid-Play() may be re-entering the manager right now (promotion calls back
+     into Join()/Part(), e.g. from indy/repo.cc AppendUpdate), and Stop() waits for that player
+     to die -- waiting while holding FiberMutex deadlocks the pair (#280).  Once 'Stopping' is
+     set, Join() stops spawning players, so the map stays empty for our caller's destructor. */
+  std::unordered_map<TUuid, TPlayer *> players;
+  /* extra */ {
+    Fiber::TFiberLock::TLock lock(FiberMutex);
+    Stopping = true;
+    players.swap(PlayerByParentPovId);
+  }
+  for (const auto &item: players) {
     item.second->Stop();
   }
-  PlayerByParentPovId.clear();
+  /* Also wait out the players that already left the map on their own: a player whose last child
+     parted is erased immediately but its fiber can still be finishing the round, touching povs our
+     caller is about to destroy.  Their destructors drop this count as their final shared-state
+     touch, so once it reads zero no player can interfere with the teardown. */
+  while (LivePlayerCount.load()) {
+    if (Fiber::TFrame::LocalFrame) {
+      Fiber::YieldSlow();
+    } else {
+      std::this_thread::yield();
+    }
+  }
 }
 
 void TTetrisManager::BecomeMaster() {

--- a/orly/server/tetris_manager.h
+++ b/orly/server/tetris_manager.h
@@ -100,7 +100,7 @@ namespace Orly {
 
         /* A players always dies by self-destruction, either because the last of its children parts from it
            or because the manager calls Stop().  If the player is self-destructing as a result of Stop(),
-           this destructor will unblock the stopper. */
+           Main() unblocks the stopper after the delete completes. */
         virtual ~TPlayer();
 
         /* Overide to respond to a child pov joining to us.
@@ -142,11 +142,12 @@ namespace Orly {
            FiberMutex while the player's own Main() fiber reads it unlocked each round (#262 follow-up: TSan data race). */
         std::atomic<size_t> ChildCount;
 
-        /* Usually this pointer is null; however, Stop() points us at a semaphore we are to push in our destructor.  That's
-           how we unblock Stop(). */
-        //Base::TEventSemaphore *Stopped;
-        bool Stopped;
-        Indy::Fiber::TSafeSync StoppedSync;
+        /* Usually null; Stop() points this at a flag on its own stack.  Main() copies the pointer
+           to its stack before 'delete this' and flips the flag as its very last act, so neither side
+           touches this object (or the stopper's stack) after the other is done with it.  The old
+           handshake had Stop() wait on a member TSafeSync that the destructor completed, letting the
+           stopper's wakeup race the delete (#280). */
+        std::atomic<std::atomic<bool> *> StopFlag;
 
         /* Usually this pointer is null; however, Pause() points us at a semaphore we are to push when we are paused.  That's
            how we unblock Pause(). */
@@ -210,6 +211,17 @@ namespace Orly {
 
       /* The ids of the parent points of view which are currently paused. */
       std::unordered_set<Base::TUuid> PausedSet;
+
+      /* Set (under FiberMutex) by StopAllPlayers() before it stops the players it snatched from the
+         map.  Join() checks it so a piece that lands mid-teardown doesn't spawn a fresh player that
+         nobody would ever stop. */
+      bool Stopping;
+
+      /* The number of players constructed but not yet destroyed.  A player whose last child parted
+         leaves the map immediately but keeps running until its Main() finishes the round and
+         self-destructs; StopAllPlayers() spins this count down to zero so no player fiber can still
+         be touching povs (or us) when our caller's destructor starts tearing them down (#280). */
+      std::atomic<size_t> LivePlayerCount;
 
       bool IsMaster;
       //std::mutex MasterLock;

--- a/orly/server/tetris_manager.test.cc
+++ b/orly/server/tetris_manager.test.cc
@@ -22,6 +22,7 @@
 #include <queue>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #include <base/event_semaphore.h>
 #include <base/scheduler.h>
@@ -66,7 +67,8 @@ class TTetrisManager final
     void Push(int value) {
       //lock_guard<mutex> Lock(Mutex);
       TFiberLock::TLock lock(FiberMutex);
-      if (Values.empty()) {
+      if (!Announced) {
+        Announced = true;
         IsEmpty.WaitForMore(1UL);
         if (ParentPov) {
           TetrisManager->Join(ParentPov->Id, Id);
@@ -75,16 +77,18 @@ class TTetrisManager final
       Values.push(value);
     }
 
-    /* Sum all the values in this pov's queue, emptying the queue in the process. */
+    /* Sum all the values in this pov's queue, emptying the queue in the process.
+       The values go straight to the caller, so unlike TryPop() we can announce the drain here. */
     int Sum() {
       int result = 0;
       //lock_guard<mutex> Lock(Mutex);
       TFiberLock::TLock lock(FiberMutex);
-      if (!Values.empty()) {
-        do {
-          result += Values.front();
-          Values.pop();
-        } while (!Values.empty());
+      while (!Values.empty()) {
+        result += Values.front();
+        Values.pop();
+      }
+      if (Announced) {
+        Announced = false;
         IsEmpty.Complete();
         if (ParentPov) {
           TetrisManager->Part(ParentPov->Id, Id);
@@ -101,22 +105,37 @@ class TTetrisManager final
 
     /* Try to pop a value off this pov's queue.
        If the queue is non-empty, pop the next value off it, return the value via out-param, and return true.
-       If the queue is empty, leave the out-param alone and return false. */
-    bool TryPop(int &value) {
+       If the queue is empty, leave the out-param alone and return false.
+       If the pop empties the queue, 'drained' is set, but we do NOT announce the drain here: the
+       popped value is still in flight in the player's hands until it lands in the parent pov, and
+       announcing early lets WaitUntilEmpty() ripple to the root ahead of the data, so the fixture's
+       final Sum() misses whatever is still in a player's stack (#280).  The player must call
+       ConfirmDrained() after pushing to its parent. */
+    bool TryPop(int &value, bool &drained) {
       //lock_guard<mutex> Lock(Mutex);
       TFiberLock::TLock lock(FiberMutex);
       bool success = !Values.empty();
       if (success) {
         value = Values.front();
         Values.pop();
-        if (Values.empty()) {
-          IsEmpty.Complete();
-          if (ParentPov) {
-            TetrisManager->Part(ParentPov->Id, Id);
-          }
-        }
+        drained = Values.empty();
       }
       return success;
+    }
+
+    /* Called by the player after the value(s) it popped from us have been pushed onward to our
+       parent.  Only now is it safe to tell waiters we're empty and part from the player.  If a
+       fresh Push() landed in the meantime, the occupancy episode simply continues and the player
+       will pop us again. */
+    void ConfirmDrained() {
+      TFiberLock::TLock lock(FiberMutex);
+      if (Values.empty() && Announced) {
+        Announced = false;
+        IsEmpty.Complete();
+        if (ParentPov) {
+          TetrisManager->Part(ParentPov->Id, Id);
+        }
+      }
     }
 
     /* Blocks as long as there are values in this pov's queue. */
@@ -158,6 +177,11 @@ class TTetrisManager final
 
     /* Readable only when the queue has no values in it. */
     mutable TSafeSync IsEmpty;
+
+    /* True while we have an open occupancy episode: we've done IsEmpty.WaitForMore() and (if we
+       have a parent) joined tetris, and the matching Complete()/Part() hasn't happened yet.
+       Covered by 'FiberMutex'. */
+    bool Announced = false;
 
     /* Convers 'Values', below. */
     //mutex Mutex;
@@ -249,19 +273,28 @@ class TTetrisManager final
         TFiberLock::TLock lock(FiberMutex);
         child_povs = ChildPovs;
       }
-      /* Sum all the values we can pop from the children. */
+      /* Sum all the values we can pop from the children, remembering which children we popped dry. */
       int sum = 0;
       bool popped = false;
+      std::vector<TPov *> drained_povs;
       for (auto *pov: child_povs) {
         int value;
-        if (pov->TryPop(value)) {
+        bool drained = false;
+        if (pov->TryPop(value, drained)) {
           sum += value;
           popped = true;
+          if (drained) {
+            drained_povs.push_back(pov);
+          }
         }
       }
-      /* If we popped at least one value, push the sum to the parent. */
+      /* If we popped at least one value, push the sum to the parent.  This must happen BEFORE we
+         confirm any drains: the drain announcement must not outrun the data (#280). */
       if (popped) {
         ParentPov->Push(sum);
+      }
+      for (auto *pov: drained_povs) {
+        pov->ConfirmDrained();
       }
     }
 


### PR DESCRIPTION
Closes #280.

The 50x re-measure the issue asked for (post-#407 master) says this is real and independent of #386: the debug `tetris_manager.test` loop failed **6/300** runs (lost updates: `Sum()` of 36/66/69 vs the expected 72), and the TSan binary reported the teardown race **50/50** runs. Digging in found three distinct defects, all in the teardown/ordering family:

## 1. `Stop()` use-after-free (the filed bug)

`Stop()` waited on `StoppedSync`, a member of the very player that self-destructs: `~TPlayer` called `StoppedSync.Complete()`, which reschedules the stopper, and the stopper's wakeup path then re-reads the sync's members (`Finished`/`WaitingFor` asserts, the TSan acquire) on memory that `delete this` frees concurrently. Same class as the #407 `TJumpRunnable` bug — signal, then keep touching the object the signal releases.

The new handshake inverts ownership: `Stop()` parks a `std::atomic<bool>` from **its own stack** in the player's `StopFlag`, zeroes `ChildCount`, and spin-yields on the flag. `Main()` copies the pointer to its stack, runs `delete this` to completion, and flips the flag as its very last act. Neither side can see the other's memory after it dies.

## 2. `StopAllPlayers()` deadlock (found by inspection while fixing 1)

`StopAllPlayers()` held `FiberMutex` across every `Stop()`, but a player that is mid-`Play()` re-enters the manager through that same mutex (promotion calls `Join()`/`Part()` back through `indy/repo.cc` `AppendUpdate`/`PopUpdate`). Stopper waits for the player; player waits for the stopper's lock. Now the map is snatched under the lock and the stopping happens outside it, with a `Stopping` flag so `Join()` can't spawn a fresh player nobody would stop.

`StopAllPlayers()` also now waits for **self-destructing players that already left the map**: a player whose last child parted is erased immediately, but its fiber can still be finishing the round, touching povs the caller's destructor is about to delete — that is exactly the pair of TSan stacks CI hit in run 28557633168 (`~TTetrisManager` freeing povs vs a player fiber still in `TPov::Push`). Players now count themselves in `LivePlayerCount` (ctor/dtor), and `StopAllPlayers()` spins it to zero before returning.

## 3. The lost-update flake is the fixture's own sync race

`TPov::TryPop()` announced "empty" (both `IsEmpty.Complete()` and tetris `Part`) at pop time — while the popped value was still in the player's stack, en route to the parent pov. The emptiness wave could ripple private→shared→root ahead of the data, so the fixture's `WaitUntilEmpty()` chain all passed and the final `Sum()` read the global pov before some in-flight partial sum landed (deficits of 3/6/36 = one to several in-flight `Play()` sums). The fixture now announces a drain only after the player has pushed onward: `TryPop()` just reports `drained`, the player pushes the sum to the parent **first**, then calls the new `ConfirmDrained()`, with an `Announced` episode flag keeping the `WaitForMore`/`Complete` and `Join`/`Part` accounting balanced when a fresh push lands mid-episode.

## Testing

- Debug `tetris_manager.test`: **0/300** failures (was 6/300 on master).
- TSan `tetris_manager.test` (`setarch -R`, no suppressions needed for it): **0/50** warning runs (was 50/50).
- `make test`: all 194 unit binaries pass.
- `python3 tools/lang_test.py -d tests/lang_tests`: 156 passed / 2 xfail / 1 abort — the abort is `lists_of/lists_of_opt_lt_lteq.orly` exit 134 (`terminate called without an active exception`), i.e. the exact #386 signature on one of the exact two tests #386 named. It is pre-existing, not from this diff: orlyc's `RunTestsOnIndy` intentionally leaks the server and `_exit()`s, so `Stop()`/`StopAllPlayers()` (and the `Stopping` flag) never execute in the lang_test path — this diff is inert there. Reopening #386 with the evidence.
- The waits are deliberately fiber-context-agnostic (plain-thread teardown yields via `std::this_thread::yield()`), which removes blockers 1/2 in `docs/teardown-design.md` for the #440 `TServer::Shutdown()` effort.

Known pre-existing limitation, unchanged: `Pause()` still waits while `PausePlayer()` holds `FiberMutex` (same deadlock shape as 2, different trigger), and stopping a currently-paused player would wait forever in `UnpausedSync.Sync()`. Neither is reachable from the shutdown or test paths touched here; noted for a future pass.
