### PR TITLE
server: orderly TServer::Shutdown() on ctrl-c (#440 slice A)

### DIFF
--- a/base/scheduler.cc
+++ b/base/scheduler.cc
@@ -44,6 +44,10 @@ TScheduler::TPolicy::TPolicy(size_t min_worker_count, size_t max_worker_count, c
 }
 
 void TScheduler::TPolicy::RunUntilCtrlC(TMainJob &&main_job) const {
+  RunUntilCtrlC(std::move(main_job), std::function<void ()>());
+}
+
+void TScheduler::TPolicy::RunUntilCtrlC(TMainJob &&main_job, const std::function<void ()> &on_signal) const {
   try {
     TMasker masker(*TSet(TSet::Full));
     THandlerInstaller handler(
@@ -54,6 +58,9 @@ void TScheduler::TPolicy::RunUntilCtrlC(TMainJob &&main_job) const {
     );
     TScheduler scheduler(*this, pthread_self(), &main_job);
     sigsuspend(&*TSet(TSet::Exclude, { SIGINT }));
+    if (on_signal) {
+      on_signal();
+    }
   } catch (const exception &ex) {
     syslog(LOG_ERR, "run_until_c; standard exception; %s", ex.what());
   } catch (...) {
@@ -106,11 +113,21 @@ bool TScheduler::Shutdown(const milliseconds &timeout) {
   unique_lock<mutex> lock(Mutex);
   if (WorkerCount) {
     Policy = TPolicy::Shutdown;
+    /* Interrupting is best-effort: a worker wedged in an uninterruptible
+       state (e.g. blocked on a lock whose holder died un-unwound, see #440)
+       would otherwise spin this loop forever.  Bound it; the stragglers are
+       detached threads and die with the process. */
+    size_t interrupt_rounds = 0;
+    static const size_t max_interrupt_rounds = 100;
     do {
       PolicyChangedOrJobPushed.notify_all();
-      if (WorkerListChanged.wait_for(lock, timeout) == cv_status::timeout) {
+      if (WorkerListChanged.wait_for(lock, std::max(timeout, milliseconds(100))) == cv_status::timeout) {
         TWorker::Interrupt(this);
         is_clean = false;
+        if (++interrupt_rounds >= max_interrupt_rounds) {
+          syslog(LOG_WARNING, "scheduler %p; giving up on %ld wedged worker(s) after %ld interrupts", static_cast<void *>(this), WorkerCount, interrupt_rounds);
+          break;
+        }
       }
     } while (WorkerCount);
   }

--- a/base/scheduler.h
+++ b/base/scheduler.h
@@ -107,6 +107,12 @@ namespace Base {
          and return.  It's common to call this function from main(). */
       void RunUntilCtrlC(TMainJob &&main_job) const;
 
+      /* As above, but runs 'on_signal' after ctrl-c lands and before the
+         scheduler is torn down -- the hook for orderly server shutdown
+         (#440).  The callback runs on the thread that called us, which is
+         not a fiber. */
+      void RunUntilCtrlC(TMainJob &&main_job, const std::function<void ()> &on_signal) const;
+
       /* The policy of no workers. */
       static const TPolicy Shutdown;
 

--- a/docs/teardown-design.md
+++ b/docs/teardown-design.md
@@ -1,0 +1,48 @@
+# TServer teardown design note (#440, roadmap keystone)
+
+## Why nothing destroys a TServer today
+
+- orlyi: `RunUntilCtrlC` blocks in `sigsuspend`; SIGINT stops the scheduler
+  and the process exits with fiber runners dying mid-syscall ("FATAL ERROR:
+  Fiber Runner caught exception ... Interrupted system call"). `~TServer`
+  never runs.
+- orlyc: documented leak-and-`_exit` policy in `RunTestsOnIndy`.
+- `~TServer` exists (WsRunner stop, TetrisManager delete, DurableManager
+  Clear/reset, GlobalRepo/RepoManager reset, frame free) but is dead code.
+
+## Proven blockers (empirical, from #436 work)
+
+1. `~TDurableManager` runs `TSingleSem::Pop()` which asserts
+   `TRunner::LocalRunner` — requires fiber context; member destructors run
+   on whatever thread drops the last reference (non-fiber).
+2. The orlyc comment: `~TServer` must run on a non-fiber thread to free the
+   fiber frame it allocated (`Frame` via `LocalFramePool`), yet teardown
+   paths take fiber locks (`StopAllPlayers`) asserting fiber context.
+3. Un-flushed state: stopping without flushing loses whatever the mergers
+   had not written (durability window = merge cadence, #440).
+
+## Plan
+
+1. **Inventory** every fiber-context-requiring teardown path:
+   `TSingleSem`, `TCompletionTrigger`, `StopAllPlayers`, tetris player
+   teardown, durable manager clear, repo manager reset. Also inventory all
+   threads TServer owns (WsThread, Slow/Fast runner vecs, BGFastRunner via
+   scheduler, WS server threads, durable/merge threads).
+2. **`TServer::Shutdown()`** — explicit, called before destruction:
+   - stop accepting (close listeners, Ws.reset())
+   - quiesce writers, flush mem layers + durable layers (closes #440)
+   - run fiber-needing teardown ON a fiber (TJumpRunnable onto a fast
+     runner), incl. tetris stop + durable manager clear
+   - shut down + join all runner threads (order: ws, fast, slow, bg)
+   - after Shutdown(), ~TServer only touches non-fiber state
+3. **Wire orlyi**: SIGINT → Shutdown → destroy → clean exit. Replace
+   orlyc's leak-and-_exit with the same (keeps _exit as fallback).
+4. **Test**: extend tests/restart_test.sh — graceful stop must make data
+   durable with NO flush-window sleep; add ASan smoke of construct+destroy.
+
+## Sequencing (PR-sized)
+
+- PR A: inventory + Shutdown() skeleton stopping/joining threads only
+  (no flush), orlyi wiring, restart test keeps sleep.
+- PR B: flush-on-shutdown (drop the sleeps in restart_test.sh) → #440.
+- PR C: make ~TServer safe after Shutdown; orlyc drops _exit; ASan smoke.

--- a/orly/indy/disk/util/disk_engine.h
+++ b/orly/indy/disk/util/disk_engine.h
@@ -33,6 +33,11 @@ namespace Orly {
           NO_COPY(TDiskEngine);
           public:
 
+          /* The controller, so the server can stop its polling loop (#440). */
+          TDiskController *GetController() const {
+            return DiskController.get();
+          }
+
           TDiskEngine(Base::TScheduler *scheduler,
                       Fiber::TRunner::TRunnerCons &runner_cons,
                       Base::TThreadLocalGlobalPoolManager<Indy::Fiber::TFrame, size_t, Indy::Fiber::TRunner *> *frame_pool_manager,

--- a/orly/indy/disk/util/volume_manager.cc
+++ b/orly/indy/disk/util/volume_manager.cc
@@ -163,7 +163,7 @@ void TDiskController::QueueRunner(std::vector<TPersistentDevice *> device_vec, b
     memset(io_ev, 0, max_aio_num * sizeof(struct io_event));
     size_t num_laps_without_work = 0UL;
     const size_t laps_before_sleep = 5UL;
-    for (;;) {
+    while (likely(KeepRunning.load(std::memory_order_relaxed))) {
       ++num_laps_without_work;
       if (num_laps_without_work > laps_before_sleep) {
         this_thread::sleep_for(10000ns);

--- a/orly/indy/disk/util/volume_manager.h
+++ b/orly/indy/disk/util/volume_manager.h
@@ -311,6 +311,11 @@ namespace Orly {
           NO_COPY(TDiskController);
           public:
 
+            /* Ask QueueRunner() to exit its polling loop (#440). */
+            void ShutDown() {
+              KeepRunning.store(false, std::memory_order_relaxed);
+            }
+
           typedef InvCon::UnorderedList::TCollection<TDiskController, TPersistentDevice> TDeviceCollection;
 
           class TEvent
@@ -484,7 +489,10 @@ namespace Orly {
             return &DeviceCollection;
           }
 
-          void QueueRunner(std::vector<TPersistentDevice *> device_vec, bool no_realtime, size_t core);
+          /* Cleared by ShutDown(); QueueRunner()'s loop condition. */
+            std::atomic<bool> KeepRunning{true};
+
+            void QueueRunner(std::vector<TPersistentDevice *> device_vec, bool no_realtime, size_t core);
 
           void Report(std::stringstream &ss, double elapsed_time) const;
 

--- a/orly/server/orlyi.cc
+++ b/orly/server/orlyi.cc
@@ -108,6 +108,15 @@ int main(int argc, char *argv[]) {
     }
   }
   std::shared_ptr<TServer> server = nullptr;
-  TScheduler::TPolicy(cmd.MinWorkerCount, cmd.MaxWorkerCount, milliseconds(cmd.IdleWorkerTimeout), false).RunUntilCtrlC(bind(LaunchServer, _1, cref(cmd), ref(server)));
+  TScheduler::TPolicy(cmd.MinWorkerCount, cmd.MaxWorkerCount, milliseconds(cmd.IdleWorkerTimeout), false).RunUntilCtrlC(
+      bind(LaunchServer, _1, cref(cmd), ref(server)),
+      /* Orderly shutdown on ctrl-c (#440): stop serving, tear down the
+         fiber-entangled managers on a fiber, stop and join the server's
+         threads.  Destruction stays deferred (docs/teardown-design.md). */
+      [&server] {
+        if (server) {
+          server->Shutdown();
+        }
+      });
   return EXIT_SUCCESS;
 }

--- a/orly/server/server.cc
+++ b/orly/server/server.cc
@@ -1319,7 +1319,75 @@ void TServer::Init() {
   InitCond.notify_all();
 }
 
+void TServer::Shutdown() {
+  if (ShutdownCalled) {
+    return;
+  }
+  ShutdownCalled = true;
+  assert(!Fiber::TRunner::LocalRunner);
+  syslog(LOG_INFO, "TServer::Shutdown() begin");
+  /* Stop the websockets server first: no new work arrives. */
+  Ws.reset();
+  /* Tear down the fiber-entangled managers on a fiber, while every runner
+     is still alive: ~TDurableManager blocks on TSingleSem (fiber-only) for
+     its writer/merger fibers, and ~TRepoTetrisManager's StopAllPlayers
+     takes fiber locks. */
+  Indy::Fiber::TJumpRunnable teardown_jumper([this] {
+    delete TetrisManager;
+    TetrisManager = nullptr;
+    DurableManager->Clear();
+    DurableManager.reset();
+    /* GlobalRepo/RepoManager stay alive (leaked, as they always were):
+       cached durable sessions still pin their POV repos, so ~L0::TManager's
+       PreDtor asserts PtrCount == 0.  Draining those pins is the next
+       teardown slice (docs/teardown-design.md, PR C). */
+  });
+  teardown_jumper(FramePoolManager.get(), FastRunnerVec[0].get());
+  /* Stop the engine-level services that would otherwise wedge the
+     scheduler's teardown: the background runners this server hosts on
+     scheduler jobs (replication, layer cleaners, mergers, slave wait) and
+     the disk controller's polling loop. */
+  WaitForSlaveRunner.ShutDown();
+  RunReplicationQueueRunner.ShutDown();
+  RunReplicationWorkRunner.ShutDown();
+  RunReplicateTransactionRunner.ShutDown();
+  RepoLayerCleanerRunner.ShutDown();
+  for (auto &runner : MergeMemRunnerVec) {
+    runner->ShutDown();
+  }
+  for (auto &runner : MergeDiskRunnerVec) {
+    runner->ShutDown();
+  }
+  if (DiskEngine) {
+    DiskEngine->GetController()->ShutDown();
+  }
+  /* Now nothing needs the runners; stop and join them. */
+  WsRunner.ShutDown();
+  WsThread.join();
+  DurableLayerCleanerRunner.ShutDown();
+  BGFastRunner.ShutDown();
+  for (auto &runner : FastRunnerVec) {
+    runner->ShutDown();
+  }
+  for (auto &t : FastRunnerThreadVec) {
+    t->join();
+  }
+  for (auto &runner : SlowRunnerVec) {
+    runner->ShutDown();
+  }
+  for (auto &t : SlowRunnerThreadVec) {
+    t->join();
+  }
+  syslog(LOG_INFO, "TServer::Shutdown() complete");
+}
+
 TServer::~TServer() {
+  if (ShutdownCalled) {
+    /* Shutdown() already stopped the threads and destroyed the managers;
+       only the init frame is left. */
+    Fiber::TFrame::LocalFramePool->Free(Frame);
+    return;
+  }
   WsRunner.ShutDown();
   WsThread.join();
   delete TetrisManager;

--- a/orly/server/server.h
+++ b/orly/server/server.h
@@ -389,6 +389,14 @@ namespace Orly {
          run tests on indy instead of the legacy SPA engine (#262). Installs,
          opens a throwaway session, and runs the suite on a fiber (durable/
          transaction work asserts it runs in a fiber context). */
+      /* Orderly stop (#440): stops serving, tears down the fiber-entangled
+         managers ON a fiber (their destructors block on fiber semaphores and
+         must run while the runners are still alive), then stops and joins
+         every thread this server owns.  After this the server must not be
+         used; destruction itself remains deferred (docs/teardown-design.md).
+         Idempotent.  Must be called from a non-fiber thread. */
+      void Shutdown();
+
       bool RunPackageTests(const std::vector<std::string> &package_name, uint64_t version, bool verbose);
 
       private:
@@ -765,6 +773,10 @@ namespace Orly {
       std::shared_ptr<Orly::Indy::Disk::TIndyUtilReporter> UtilReporter;
 
       std::shared_ptr<std::function<void (const Base::TFd &)>> WaitForSlaveActionCb;
+
+      /* Set once Shutdown() has run; makes it idempotent and tells the
+         destructor the managers are already gone. */
+      bool ShutdownCalled = false;
 
       bool InitFinished;
       std::condition_variable InitCond;


### PR DESCRIPTION
First slice of the teardown roadmap (#440; design and sequencing in the included `docs/teardown-design.md`).

Teardown today is "kill the process and hope the mergers flushed": SIGINT tears down the scheduler under a live server, fiber runners die with FATAL-ERROR spray, and `~TServer` is unreachable dead code (its managers' destructors need fiber context — unwinding asserts or terminates, as #436 demonstrated live).

**What this adds:**
- `TServer::Shutdown()`, run by orlyi after ctrl-c via a new `RunUntilCtrlC` `on_signal` hook (non-fiber main thread, after the signal, before scheduler teardown). It stops the WS server, tears down the tetris manager and durable manager **on a fiber** via `TJumpRunnable` (their destructors block on fiber semaphores and take fiber locks, and must run while every runner is still alive), stops the engine-level services that otherwise wedge scheduler teardown (replication runners, layer cleaners, mem/disk mergers, slave-wait, and the disk controller's polling loop — previously an exitless `for(;;)`, now flag-checked), then stops and joins every thread the server owns.
- A bounded `TScheduler::Shutdown` interrupt loop (was infinite): a worker wedged on a lock whose fiber holder died un-unwound would spin it forever; after 100 rounds it logs the stragglers and proceeds — they're detached and die with the process. Found live: two workers deadlocked on the replication epoll mutex during shutdown, which is engine work for a later slice.

**Deliberately deferred** (documented in the design note): `GlobalRepo`/`RepoManager` stay leaked as they always were — cached durable sessions still pin their POV repos, so `~L0::TManager`'s `PreDtor` asserts `PtrCount == 0` (verified live). Draining those pins is slice C; flush-on-shutdown (the actual #440 close) is slice B and now has a clean place to live.

**Verified:** disk-backed instance SIGINT now exits cleanly in ~13s with zero fiber FATAL errors and zero asserts (before: never exits, or only via the FATAL spray); data intact across the graceful cycle; `tests/restart_test.sh` passes end-to-end; `base/scheduler.test` and `jump_runnable.test` pass. Includes field-testing of #441's `StopAllPlayers` fix, which this path exercises on every shutdown.