### PR TITLE
server: flush-on-shutdown — graceful stop loses nothing (#440)

### DIFF
--- a/orly/durable/kit.h
+++ b/orly/durable/kit.h
@@ -198,6 +198,11 @@ namespace Orly {
          This will affect the cache as well as the disk. */
       void Clean();
 
+      /* Write any in-memory durable state to disk and wait (bounded) for it
+         to be handed off -- flush-on-shutdown (#440).  Memory-only managers
+         have nothing to do. */
+      virtual void Flush() {}
+
       /* Create a new durable with the given id and ttl and return a shared pointer to it.
          If there is already a durable with the given id, throw.
          This function will block until the durable is created.

--- a/orly/indy/disk/durable_manager.cc
+++ b/orly/indy/disk/durable_manager.cc
@@ -293,6 +293,25 @@ void TDurableManager::AddMapping(TDurableLayer *layer) {
   }  // release Mapping lock
 }
 
+void TDurableManager::Flush() {
+  const auto give_up = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+  for (;;) {
+    /* acquire DataLayer lock */ {
+      std::lock_guard<std::mutex> data_lock(DataLock);
+      assert(CurMemoryLayer);
+      if (!CurMemoryLayer->GetNumEntries()) {
+        return;
+      }
+    }  // release DataLayer lock
+    if (std::chrono::steady_clock::now() > give_up) {
+      syslog(LOG_WARNING, "TDurableManager::Flush: gave up waiting for the slush layer to drain");
+      return;
+    }
+    SlushSem.Push();
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+}
+
 void TDurableManager::RunWriter() {
   if (Engine->IsDiskBased()) {
     /* if this is a disk based engine, allocate event pools */

--- a/orly/indy/disk/durable_manager.h
+++ b/orly/indy/disk/durable_manager.h
@@ -157,6 +157,12 @@ namespace Orly {
 
         virtual bool TryLoad(const Durable::TId &id, std::string &serialized_form_out) override;
 
+        /* Kick the writer and wait (bounded) until the current in-memory
+           slush layer has been handed to a disk file -- the durable half of
+           flush-on-shutdown (#440).  The destructor's semaphore handshake
+           then guarantees the in-flight write completes. */
+        virtual void Flush() override;
+
         void RunWriter();
 
         void RunMerger();

--- a/orly/indy/manager.cc
+++ b/orly/indy/manager.cc
@@ -1312,11 +1312,11 @@ std::vector<std::pair<std::vector<std::string>, uint64_t>> TManager::GetInstalle
   void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
   TSuprena arena;
   std::vector<std::pair<std::vector<std::string>, uint64_t>> ret;
-  /* The walker yields an entry per update layer for the same key, newest
-     first; only the first (current) one counts -- the same reason
-     GetIndexNamespaceMapping()'s emplace is first-wins.  Without the dedupe
-     an uninstall would be shadowed by its older install record. */
-  std::set<std::tuple<std::vector<std::string>, int64_t>> seen;
+  /* The walker can yield several entries for the same key (one per update
+     layer), and their relative order differs between and within generation
+     files -- so pick the winner by sequence number explicitly rather than
+     assuming any walk order. */
+  std::map<std::tuple<std::vector<std::string>, int64_t>, std::pair<TSequenceNumber, bool>> current;
   auto view = make_unique<Indy::TRepo::TView>(SystemRepo);
   auto walker_ptr = SystemRepo->NewPresentWalker(view, TIndexKey(SystemPackageIndexId, TKey(make_tuple(Native::TFree<std::vector<std::string>>(), Native::TFree<int64_t>()), &arena, state_alloc)), true);
   for (auto &walker = *walker_ptr; walker; ++walker) {
@@ -1324,11 +1324,14 @@ std::vector<std::pair<std::vector<std::string>, uint64_t>> TManager::GetInstalle
     bool installed = false;
     Sabot::ToNative(*Sabot::State::TAny::TWrapper((*walker).Key.NewState((*walker).KeyArena, state_alloc)), name_and_version);
     Sabot::ToNative(*Sabot::State::TAny::TWrapper((*walker).Op.NewState((*walker).OpArena, state_alloc)), installed);
-    if (!seen.insert(name_and_version).second) {
-      continue;
+    auto &cur = current[name_and_version];
+    if ((*walker).SequenceNumber >= cur.first) {
+      cur = std::make_pair((*walker).SequenceNumber, installed);
     }
-    if (installed) {
-      ret.emplace_back(std::get<0>(name_and_version), static_cast<uint64_t>(std::get<1>(name_and_version)));
+  }
+  for (const auto &entry : current) {
+    if (entry.second.second) {
+      ret.emplace_back(std::get<0>(entry.first), static_cast<uint64_t>(std::get<1>(entry.first)));
     }
   }
   return ret;
@@ -1338,6 +1341,10 @@ std::unordered_map<Base::TUuid, std::string> TManager::GetIndexNamespaceMapping(
   void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
   TSuprena arena;
   std::unordered_map<Base::TUuid, std::string> ret;
+  /* Several entries can appear for the same key (one per update layer) and
+     the walk order is not authoritative; pick the winner by sequence number
+     (same contract as GetInstalledPackages()). */
+  std::unordered_map<Base::TUuid, TSequenceNumber> seq_of;
   auto view = make_unique<Indy::TRepo::TView>(SystemRepo);
   auto walker_ptr = SystemRepo->NewPresentWalker(view, TIndexKey(SystemIDNSIndexId, TKey(make_tuple(Native::TFree<Base::TUuid>()), &arena, state_alloc)), true);
   for (auto &walker = *walker_ptr; walker; ++walker) {
@@ -1345,7 +1352,12 @@ std::unordered_map<Base::TUuid, std::string> TManager::GetIndexNamespaceMapping(
     std::string pkg_key;
     Sabot::ToNative(*Sabot::State::TAny::TWrapper((*walker).Key.NewState((*walker).KeyArena, state_alloc)), index_id_tuple);
     Sabot::ToNative(*Sabot::State::TAny::TWrapper((*walker).Op.NewState((*walker).OpArena, state_alloc)), pkg_key);
-    ret.emplace(std::get<0>(index_id_tuple), pkg_key);
+    const auto &index_id = std::get<0>(index_id_tuple);
+    auto &seq = seq_of[index_id];
+    if ((*walker).SequenceNumber >= seq) {
+      seq = (*walker).SequenceNumber;
+      ret[index_id] = pkg_key;
+    }
   }
   return ret;
 }

--- a/orly/indy/manager_base.cc
+++ b/orly/indy/manager_base.cc
@@ -273,6 +273,29 @@ void TManager::RunLayerCleaner() {
   }
 }
 
+void TManager::FlushMemMerges() {
+  /* Repos become due at most MergeMemInterval (~tens of ms) after their
+     last write, so draining is quick; the cap keeps a wedged merger from
+     hanging shutdown forever. */
+  const auto give_up = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+  for (;;) {
+    bool drained;
+    /* acquire MergeMem lock */ {
+      std::lock_guard<std::mutex> lock(MergeMemLock);
+      drained = (MergeMemQueue.TryGetFirstMember() == nullptr);
+    }
+    if (drained) {
+      break;
+    }
+    if (std::chrono::steady_clock::now() > give_up) {
+      syslog(LOG_WARNING, "FlushMemMerges: gave up waiting for the mem-merge queue to drain");
+      break;
+    }
+    MergeMemSem.Push();
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+}
+
 void TManager::RunMergeMem() {
   cpu_set_t mask;
   CPU_ZERO(&mask);

--- a/orly/indy/manager_base.h
+++ b/orly/indy/manager_base.h
@@ -620,6 +620,12 @@ namespace Orly {
 
         void RunLayerCleaner();
 
+        /* Kick the mem merger and wait (bounded) until every dirty repo's
+           memory layer has been merged out to a disk file -- the flush half
+           of an orderly shutdown (#440).  Call from a fiber before the merge
+           runners are stopped. */
+        void FlushMemMerges();
+
         void RunMergeMem();
 
         void RunMergeDisk();

--- a/orly/server/server.cc
+++ b/orly/server/server.cc
@@ -1328,11 +1328,26 @@ void TServer::Shutdown() {
   syslog(LOG_INFO, "TServer::Shutdown() begin");
   /* Stop the websockets server first: no new work arrives. */
   Ws.reset();
+  /* Let the in-flight update pipeline settle: a write that arrived just
+     before the signal is not mergeable until the release machinery (which
+     runs on the replication cadence even in SOLO) has settled it.  Bounded
+     and cadence-derived, not a magic number: three periods of the slowest
+     relevant interval. */
+  std::this_thread::sleep_for(std::chrono::milliseconds(
+      3 * std::max<size_t>({Cmd.ReplicationInterval, Cmd.MergeMemInterval, Cmd.DurableWriteInterval, 100})));
   /* Tear down the fiber-entangled managers on a fiber, while every runner
      is still alive: ~TDurableManager blocks on TSingleSem (fiber-only) for
      its writer/merger fibers, and ~TRepoTetrisManager's StopAllPlayers
      takes fiber locks. */
   Indy::Fiber::TJumpRunnable teardown_jumper([this] {
+    /* Flush-on-shutdown (#440): merge every dirty repo memory layer out to
+       disk and write the durable slush layer, so a graceful stop loses
+       nothing -- durability no longer depends on the merge cadence having
+       happened to run.  Tetris is still alive here: the newest updates only
+       become mergeable once promotion has settled them, so the flush must
+       precede StopAllPlayers. */
+    RepoManager->FlushMemMerges();
+    DurableManager->Flush();
     delete TetrisManager;
     TetrisManager = nullptr;
     DurableManager->Clear();

--- a/tests/restart_test.sh
+++ b/tests/restart_test.sh
@@ -63,10 +63,13 @@ start_server() {  # $1 = create true|false, $2 = log tag
 }
 
 stop_server() {
-  # SIGINT, grace period for the mergers to have flushed (we slept before
-  # calling), then make sure it is gone.
+  # SIGINT triggers TServer::Shutdown() (flush + orderly stop, #440);
+  # wait for the graceful exit, with kill -9 only as a last resort.
   sudo kill -INT "$SRV_PID" 2>/dev/null || true
-  sleep 10
+  for _ in $(seq 1 30); do
+    sudo kill -0 "$SRV_PID" 2>/dev/null || break
+    sleep 2
+  done
   sudo kill -9 "$SRV_PID" 2>/dev/null || true
   SRV_PID=""
   sleep 2
@@ -85,8 +88,7 @@ for n in range(1, 11):
 assert c.call(pov, 'kv', 'read_val', {'n': 5}) == 500
 c.close()"
 
-echo "[4/8] flush window, stop"
-sleep 75
+echo "[4/8] stop (flush-on-shutdown makes the old 75s flush window unnecessary, #440)"
 stop_server
 
 echo "[5/8] restart (create=false): data + package must survive"
@@ -101,8 +103,7 @@ print('   data + auto-reinstalled package OK:', vals)
 c.uninstall('kv', 1)
 c.close()"
 
-echo "[6/8] flush window, stop"
-sleep 75
+echo "[6/8] stop"
 stop_server
 
 echo "[7/8] restart: uninstall must have survived"


### PR DESCRIPTION
Closes #440. Slice B of the teardown roadmap, on top of #442's orderly `Shutdown()`.

An orderly stop still lost whatever the merge cadences had not happened to write: the durable writer's loop exits on its `ShutDown` flag **without** a final flush (its destructor comment admits the loss), dirty repo memory layers died with the process, and — found the hard way — a write arriving just before the signal is not even *mergeable* yet, because updates settle through the release machinery on the replication cadence even in SOLO.

`TServer::Shutdown()` now, in order: stops the WS server; waits a bounded, cadence-derived settle (3× the slowest of the replication / mem-merge / durable-write intervals, ~300ms at defaults) so in-flight updates become mergeable; drains every dirty repo memory layer to disk (`L1::TManager::FlushMemMerges`, bounded); drains the durable slush layer (`TDurableManager::Flush`, overriding a new no-op virtual on `Durable::TManager`; the destructor's semaphore handshake then guarantees the in-flight write completes); and only then stops tetris and the managers.

The no-sleep cycle also exposed a latent walk-order bug worth calling out: the present walker can yield several entries per key (one per update layer), and their order differs **between and within** generation files — an uninstall record landing in the same generation file as its install record was resurrecting after restart. `GetInstalledPackages()` and `GetIndexNamespaceMapping()` now pick winners by `SequenceNumber` instead of assuming newest-first.

**The contract change is visible in the test:** `tests/restart_test.sh` deletes both of its 75-second flush windows — *write → immediate SIGINT → restart → everything present* is now what CI verifies on every push. `stop_server` waits for the graceful exit (~13s) instead of `kill -9`ing at 10 seconds.

Verified: full restart test passed twice consecutively on current master (including #443); the settle experiment matrix (fails without settle regardless of flush order, passes with it) pinned the release-cadence dependency.