### PR TITLE
ws: give each server instance a unique compile tmp dir

### DIFF
--- a/orly/server/ws.cc
+++ b/orly/server/ws.cc
@@ -73,6 +73,19 @@ using tcp = net::ip::tcp;
    Each connection runs on its own asio strand, so per-connection handlers
    serialize across the io_context's thread pool. The Conns set is guarded
    by Mutex; the strands cover everything else. */
+/* The compile scratch dir must be unique per server instance: a fixed
+   machine-global path breaks concurrent runs (two checkouts, or make test
+   racing a live orlyi) and cross-user runs (a root-invoked orlyi leaves a
+   root-owned dir that aborts every later non-root ws.test at teardown),
+   #444. */
+static std::string MakeCompileTmpDir() {
+  std::string path = Util::MakePath({ P_tmpdir }, { "orly_ws_compile.XXXXXX" });
+  if (!mkdtemp(path.data())) {
+    throw std::system_error(errno, std::generic_category(), "mkdtemp for ws compile dir");
+  }
+  return path;
+}
+
 class TWsImpl final
     : public TWs {
   public:
@@ -82,7 +95,7 @@ class TWsImpl final
       TSessionManager *session_mngr, size_t thread_count,
       in_port_t port_number)
       : SessionManager(session_mngr),
-        TmpDirMaker(MakePath({ P_tmpdir, "orly_ws_compile" }, {})),
+        TmpDirMaker(MakeCompileTmpDir()),
         IoCtx(thread_count ? static_cast<int>(thread_count) : 1),
         Acceptor(IoCtx) {
     assert(session_mngr);


### PR DESCRIPTION
Closes #444.

The WS compile scratch dir was the fixed machine-global `/tmp/orly_ws_compile`, so concurrent runs (two checkouts, or `make test` racing a live orlyi) deleted it out from under each other at teardown, and a root-invoked orlyi (e.g. the restart harness) left a root-owned dir that aborted every later non-root `ws.test` — `Operation not permitted` thrown from `TTmpDirMaker`'s destructor, which is an abort since it throws during unwind.

Now each server instance gets its own `mkdtemp(/tmp/orly_ws_compile.XXXXXX)` dir: collisions impossible by construction, teardown removal untouched, and a stale root-owned leftover (crash-only; normal exit still cleans up) can never collide with a fresh instance's name.

One gotcha documented in a comment: `Util::MakePath` with an empty `parts` list appends a trailing slash, which makes `mkdtemp` fail with `EINVAL` — the template has to go in `parts`.

Verified: `ws.test` passes solo **and two instances running concurrently** (the exact collision the issue reports), with no leftover dirs.