### PR TITLE
server: teardown slice C -- full manager destruction (#440)

### DIFF
--- a/asan.jhm
+++ b/asan.jhm
@@ -1,0 +1,46 @@
+{
+  "test": {
+    "build_with_default_targets": true,
+    "excluded": [
+      "third_party",
+      ".git"
+    ]
+  },
+  "cmd": {
+    "+g++": [
+      "-DDEBUG",
+      "-g",
+      "-O1",
+      "-fsanitize=address",
+      "-fno-omit-frame-pointer",
+      "-U_FORTIFY_SOURCE"
+    ],
+    "+gcc": [
+      "-DDEBUG",
+      "-g",
+      "-O1",
+      "-fsanitize=address",
+      "-fno-omit-frame-pointer",
+      "-U_FORTIFY_SOURCE"
+    ],
+    "flex": {
+      "+g++": [
+        "-g",
+        "-DDEBUG",
+        "-fsanitize=address"
+      ]
+    },
+    "bison": {
+      "+g++": [
+        "-g",
+        "-DDEBUG",
+        "-fsanitize=address"
+      ]
+    },
+    "ld": {
+      "+flags": [
+        "-fsanitize=address"
+      ]
+    }
+  }
+}

--- a/base/event_semaphore.h
+++ b/base/event_semaphore.h
@@ -55,4 +55,23 @@ namespace Base {
 
   };  // TEventSemaphore
 
+  /* RAII: pushes the semaphore once on scope exit, including exceptional
+     exit.  Lets a service loop signal 'I have returned' to a joiner no
+     matter how the loop unwinds (#440). */
+  class TPushOnExit {
+    NO_COPY(TPushOnExit);
+    public:
+
+    explicit TPushOnExit(TEventSemaphore &sem) : Sem(sem) {}
+
+    ~TPushOnExit() {
+      Sem.Push();
+    }
+
+    private:
+
+    TEventSemaphore &Sem;
+
+  };  // TPushOnExit
+
 }  // Base

--- a/base/scheduler.cc
+++ b/base/scheduler.cc
@@ -111,6 +111,13 @@ bool TScheduler::Shutdown(const milliseconds &timeout) {
   ShutDown();
   bool is_clean = true;
   unique_lock<mutex> lock(Mutex);
+  if (!JobQueue.empty()) {
+    /* Schedule() queues past the worker cap but never launches another
+       worker, so a long-lived job scheduled after the cap saturates is
+       silently starved forever.  Make that visible at teardown instead of
+       leaving the next caller to rediscover it (#440). */
+    syslog(LOG_WARNING, "scheduler %p; %ld job(s) were scheduled but never ran (worker cap too low?)", static_cast<void *>(this), JobQueue.size());
+  }
   if (WorkerCount) {
     Policy = TPolicy::Shutdown;
     /* Interrupting is best-effort: a worker wedged in an uninterruptible

--- a/base/scheduler.cc
+++ b/base/scheduler.cc
@@ -115,7 +115,8 @@ bool TScheduler::Shutdown(const milliseconds &timeout) {
     /* Schedule() queues past the worker cap but never launches another
        worker, so a long-lived job scheduled after the cap saturates is
        silently starved forever.  Make that visible at teardown instead of
-       leaving the next caller to rediscover it (#440). */
+       leaving the next caller to rediscover it (#440); actually cancelling
+       queued-but-never-started jobs is TODO(#462). */
     syslog(LOG_WARNING, "scheduler %p; %ld job(s) were scheduled but never ran (worker cap too low?)", static_cast<void *>(this), JobQueue.size());
   }
   if (WorkerCount) {

--- a/base/timer_fd.cc
+++ b/base/timer_fd.cc
@@ -40,3 +40,8 @@ uint64_t TTimerFd::Pop() {
   IfLt0(read(Fd, &count, sizeof(count)));
   return count;
 }
+
+void TTimerFd::FireNow() {
+  itimerspec fire_now{{0, 0}, {0, 1}};
+  IfLt0(timerfd_settime(Fd, 0, &fire_now, nullptr));
+}

--- a/base/timer_fd.h
+++ b/base/timer_fd.h
@@ -41,6 +41,12 @@ namespace Base {
 
     uint64_t Pop();
 
+    /* Force the next Pop() to return immediately by re-arming the timer as
+       a one-shot that fires at once.  This replaces the periodic schedule --
+       the timer will not tick again -- so it is only for waking a loop that
+       is about to exit (#440). */
+    void FireNow();
+
     private:
 
     TFd Fd;

--- a/docs/teardown-design.md
+++ b/docs/teardown-design.md
@@ -1,48 +1,100 @@
 # TServer teardown design note (#440, roadmap keystone)
 
-## Why nothing destroys a TServer today
+Originally a pre-implementation design note; now the record of what landed,
+the constraints that shaped it, and what deliberately remains. All three
+slices are in (A: `de4a38c8` / PR #442, B: `250294ba` / PR #447, C: PR #459).
 
-- orlyi: `RunUntilCtrlC` blocks in `sigsuspend`; SIGINT stops the scheduler
-  and the process exits with fiber runners dying mid-syscall ("FATAL ERROR:
-  Fiber Runner caught exception ... Interrupted system call"). `~TServer`
-  never runs.
-- orlyc: documented leak-and-`_exit` policy in `RunTestsOnIndy`.
-- `~TServer` exists (WsRunner stop, TetrisManager delete, DurableManager
-  Clear/reset, GlobalRepo/RepoManager reset, frame free) but is dead code.
+## Where teardown stands
 
-## Proven blockers (empirical, from #436 work)
+- orlyi: SIGINT → `TServer::Shutdown()` → destroy → clean exit (slice A).
+  A graceful stop makes all data durable with no flush-window sleep
+  (slice B; `tests/restart_test.sh` gates this — its remaining `sleep`s are
+  startup/exit polling, not flush windows).
+- orlyc: constructs, runs, and fully destroys the server on every test run
+  (slice C) — the old leak-and-`_exit` policy is gone, so every orlyc
+  invocation doubles as a construct/run/destroy smoke of the whole server.
+  `_exit` survives only as the fallback when teardown itself throws
+  (a deterministic non-zero exit beats a hang).
+- `Shutdown()` destroys everything: service loops joined, dirty mem layers
+  flushed, tetris deleted, DurableManager cleared and reset,
+  GlobalRepo/RepoManager reset. After it, `~TServer` touches only
+  non-fiber state.
+- An `asan.jhm` config exists for AddressSanitizer builds, intended for a
+  CI smoke of the teardown paths (use-after-free, not leak accounting —
+  see "deliberate leaks" below).  The smoke itself is blocked on the fiber
+  engine: Ubuntu's default `_FORTIFY_SOURCE` (active at the sanitizer
+  build's `-O1`) aborts on the fibers' cross-stack longjmps
+  (`-U_FORTIFY_SOURCE` in the config sidesteps that), and a truly clean
+  run needs `__sanitizer_start_switch_fiber`/`finish_switch_fiber`
+  annotations in orly/indy/fiber.
+
+## Constraints (empirical — the reasons the code looks the way it does)
+
+The original three, from the #436 work:
 
 1. `~TDurableManager` runs `TSingleSem::Pop()` which asserts
-   `TRunner::LocalRunner` — requires fiber context; member destructors run
-   on whatever thread drops the last reference (non-fiber).
-2. The orlyc comment: `~TServer` must run on a non-fiber thread to free the
-   fiber frame it allocated (`Frame` via `LocalFramePool`), yet teardown
-   paths take fiber locks (`StopAllPlayers`) asserting fiber context.
-3. Un-flushed state: stopping without flushing loses whatever the mergers
-   had not written (durability window = merge cadence, #440).
+   `TRunner::LocalRunner` — fiber-entangled teardown must run ON a fiber.
+   Hence the `TJumpRunnable teardown_jumper` in `Shutdown()`.
+2. `~TServer` must run on a non-fiber thread to free the fiber frame it
+   allocated, yet teardown paths take fiber locks (`StopAllPlayers`).
+   Hence: fiber-needing work happens in `Shutdown()`'s jumper, and the
+   post-Shutdown destructor is non-fiber-safe by construction.
+3. Stopping without flushing loses whatever the mergers had not written
+   (durability window = merge cadence). Hence flush-on-shutdown (slice B),
+   done inline by `FlushMemMerges` so it cannot depend on merge scheduling.
 
-## Plan
+Discovered during slice C (each cost a real bug):
 
-1. **Inventory** every fiber-context-requiring teardown path:
-   `TSingleSem`, `TCompletionTrigger`, `StopAllPlayers`, tetris player
-   teardown, durable manager clear, repo manager reset. Also inventory all
-   threads TServer owns (WsThread, Slow/Fast runner vecs, BGFastRunner via
-   scheduler, WS server threads, durable/merge threads).
-2. **`TServer::Shutdown()`** — explicit, called before destruction:
-   - stop accepting (close listeners, Ws.reset())
-   - quiesce writers, flush mem layers + durable layers (closes #440)
-   - run fiber-needing teardown ON a fiber (TJumpRunnable onto a fast
-     runner), incl. tetris stop + durable manager clear
-   - shut down + join all runner threads (order: ws, fast, slow, bg)
-   - after Shutdown(), ~TServer only touches non-fiber state
-3. **Wire orlyi**: SIGINT → Shutdown → destroy → clean exit. Replace
-   orlyc's leak-and-_exit with the same (keeps _exit as fallback).
-4. **Test**: extend tests/restart_test.sh — graceful stop must make data
-   durable with NO flush-window sleep; add ASan smoke of construct+destroy.
+4. **A stop is only a flag plus a wake.** Signaling a service loop proves
+   nothing about when it exits; destroying a manager while a loop is
+   mid-body is a use-after-free. Every loop therefore counts itself in on
+   entry and pushes an exited-latch on the way out (exception-safe,
+   `Base::TPushOnExit`), and `Shutdown()` joins them all before the
+   teardown jumper runs. Order matters twice over: the settle window must
+   come BEFORE the stops (a stopped release loop can no longer drain its
+   queue), and the merge runners must be stopped and joined BEFORE
+   `FlushMemMerges` (so the flush is the queue's only drainer and a
+   mid-step re-enqueue cannot be lost).
+5. **Dirty repos pin themselves open.** A written repo holds a
+   `MakeDirty()` self-ptr until its updates are released (tetris
+   promotion) or its mem layer merges out. Paused-and-written repos —
+   every compile-time test pov — are never promoted, so the pin never
+   drops; `~TManager` now calls `ReleaseDirtySelfPins()` first, and the
+   close cascade force-releases parent-repo ptrs. Never seen before
+   slice C because `PreDtor` was dead code until teardown became real.
+6. **The scheduler silently starves jobs past the worker cap.**
+   `TScheduler::Schedule` queues but never launches another worker once
+   the cap is reached, and long-lived service jobs never return their
+   worker. An under-provisioned cap therefore silently never runs the
+   last N jobs (orlyc's old 8-worker policy never ran ~6 of them).
+   `TScheduler::Shutdown` now logs any jobs that were scheduled but never
+   ran; orlyc provisions 32.
 
-## Sequencing (PR-sized)
+## Deliberate leaks (why the ASan smoke disables leak detection)
 
-- PR A: inventory + Shutdown() skeleton stopping/joining threads only
-  (no flush), orlyi wiring, restart test keeps sleep.
-- PR B: flush-on-shutdown (drop the sleeps in restart_test.sh) → #440.
-- PR C: make ~TServer safe after Shutdown; orlyc drops _exit; ASan smoke.
+Teardown frees every real resource but intentionally leaks a few pool
+slabs: thread-local frame/event pools created on scheduler-worker threads
+cannot be reclaimed without thread-exit hooks, so their MANAGERS are
+released, not destroyed (`FramePoolManager.release()`,
+`DiskEventPoolManager.release()`). Similarly, `Clear()`/`PreDtor` log and
+LEAK an object that still has live ptrs rather than free it out from under
+them (release builds; debug asserts). The ASan smoke exists to catch
+use-after-free and heap corruption in the teardown paths, so it runs with
+`detect_leaks=0`; turning LSan on would require suppressions for exactly
+these documented leaks and would gate on noise, not signal.
+
+## Known follow-ons (tracked; also noted at the code sites)
+
+- **#460 — drain live client connections before `Clear()`**: orlyi under
+  load can reach `Clear()` while a connection still holds its session ptr;
+  today that is a logged leak (and a debug assert), not a drain. The real
+  fix is closing established connections and joining their serving fibers
+  before the teardown jumper.
+- **#461 — master-mode replication**: a replicate loop wedged in a remote
+  `future->Sync()` holds `JoinReplicationServices()` until the RPC
+  resolves; interrupting in-flight RPCs is future work.
+- **#462 — never-scheduled fibers**: a fiber that was latched but never
+  granted a worker cannot be joined (the started/exited handshake skips
+  it) and would touch freed state if it ever ran mid-teardown. The
+  scheduler's starved-jobs log makes this visible; a real fix needs job
+  cancellation.

--- a/orly/durable/kit.cc
+++ b/orly/durable/kit.cc
@@ -56,6 +56,17 @@ TManager::~TManager() {
 }
 
 void TManager::Clear() {
+  /* Cached-but-closed objects (sessions, povs) still hold live pointers --
+     a pov keeps its repo ptr, for one -- until TTL expiry or cache pressure
+     evicts them.  Destroy them first so the openable sweep below sees only
+     genuinely open objects, and so the repo manager can verify every repo
+     ptr is gone at its own teardown (#440). */
+  while (!ClosedObjs.empty()) {
+    auto iter = ClosedObjs.begin();
+    TObj *cached_obj = iter->second;
+    ClosedObjs.erase(iter);
+    DestroyObj(cached_obj);
+  }
   for (const auto &item: OpenableObjs) {
     /* If this assertion fails, it means there is at least one ptr still alive someplace. */
     assert(item.second->PtrCount == 0);

--- a/orly/durable/kit.cc
+++ b/orly/durable/kit.cc
@@ -30,14 +30,8 @@ void TManager::Clean() {
   /* extra */ {
     lock_guard<mutex> lock(Mutex);
     auto now = TDeadline::clock::now();
-    while (!ClosedObjs.empty()) {
-      auto iter = ClosedObjs.begin();
-      if (iter->first.first > now) {
-        break;
-      }
-      TObj *cached_obj = iter->second;
-      ClosedObjs.erase(iter);
-      DestroyObj(cached_obj);
+    while (!ClosedObjs.empty() && ClosedObjs.begin()->first.first <= now) {
+      EvictOldestClosed();
     }
     CleanDisk(now, &sem);
   }
@@ -56,23 +50,41 @@ TManager::~TManager() {
 }
 
 void TManager::Clear() {
+  /* No lock: the caller must have stopped and joined every concurrent user
+     of these maps first -- in particular the housekeeper, whose Clean()
+     mutates them under the Mutex (TServer::Shutdown waits for CleanHouse to
+     return before running us, #440). */
   /* Cached-but-closed objects (sessions, povs) still hold live pointers --
      a pov keeps its repo ptr, for one -- until TTL expiry or cache pressure
      evicts them.  Destroy them first so the openable sweep below sees only
      genuinely open objects, and so the repo manager can verify every repo
      ptr is gone at its own teardown (#440). */
   while (!ClosedObjs.empty()) {
-    auto iter = ClosedObjs.begin();
-    TObj *cached_obj = iter->second;
-    ClosedObjs.erase(iter);
-    DestroyObj(cached_obj);
+    EvictOldestClosed();
   }
   for (const auto &item: OpenableObjs) {
-    /* If this assertion fails, it means there is at least one ptr still alive someplace. */
-    assert(item.second->PtrCount == 0);
+    /* An object still open here is a teardown-ordering bug: the caller must
+       drain everything holding durable ptrs (live sessions, connections)
+       before clearing.  Name the leaker, then (in release builds) leak it
+       rather than free an object a live ptr still references. */
+    if (item.second->PtrCount != 0) {
+      char buf[TId::MinBufSize];
+      item.first.Format(buf);
+      syslog(LOG_ERR, "TManager::Clear: durable {%s} still has [%d] live ptr(s); leaking it", buf, int(item.second->PtrCount));
+      assert(item.second->PtrCount == 0);
+      continue;
+    }
     delete item.second;
   }
   OpenableObjs.clear();
+}
+
+void TManager::EvictOldestClosed() {
+  auto iter = ClosedObjs.begin();
+  assert(iter != ClosedObjs.end());
+  TObj *cached_obj = iter->second;
+  ClosedObjs.erase(iter);
+  DestroyObj(cached_obj);
 }
 
 void TManager::DestroyObj(TObj *obj) noexcept {
@@ -93,10 +105,7 @@ bool TManager::TryCacheObj(TObj *obj) noexcept {
       /* Discard objects from the cache until there's room for the new object.
          Start with the object with the soonest deadline and work forward. */
       while (ClosedObjs.size() >= MaxCacheSize) {
-        auto iter = ClosedObjs.begin();
-        TObj *cached_obj = iter->second;
-        ClosedObjs.erase(iter);
-        DestroyObj(cached_obj);
+        EvictOldestClosed();
       }
       /* Insert this object into the cache in order of its deadline. */
       ClosedObjs.insert(make_pair(make_pair(*(obj->GetDeadline()), obj->GetId()), obj));

--- a/orly/durable/kit.cc
+++ b/orly/durable/kit.cc
@@ -65,8 +65,9 @@ void TManager::Clear() {
   for (const auto &item: OpenableObjs) {
     /* An object still open here is a teardown-ordering bug: the caller must
        drain everything holding durable ptrs (live sessions, connections)
-       before clearing.  Name the leaker, then (in release builds) leak it
-       rather than free an object a live ptr still references. */
+       before clearing -- connection draining is TODO(#460).  Name the
+       leaker, then (in release builds) leak it rather than free an object a
+       live ptr still references. */
     if (item.second->PtrCount != 0) {
       char buf[TId::MinBufSize];
       item.first.Format(buf);

--- a/orly/durable/kit.h
+++ b/orly/durable/kit.h
@@ -234,6 +234,18 @@ namespace Orly {
 
       virtual void RunLayerCleaner() = 0;
 
+      /* Make RunLayerCleaner return: without this the cleaner fiber sits in
+         a blocking read on its timer fd forever, pinning its runner thread
+         and (at shutdown) racing the fd's destruction (#440).  The default
+         covers managers whose cleaner doesn't block. */
+      virtual void StopLayerCleaner() {}
+
+      /* Block until a stopped cleaner has actually returned: a stop is only
+         a flag plus a wake, and the manager must not be destroyed while the
+         cleaner fiber is still inside RunLayerCleaner (#440).  The default
+         covers managers whose cleaner never runs. */
+      virtual void JoinLayerCleaner() {}
+
       protected:
 
       /* The cache size is the maximum number of closed objects we will keep in memory. */
@@ -277,6 +289,11 @@ namespace Orly {
          NOTE 1: The object pointer passed to this function WILL BE BAD by the time this function returns.
          NOTE 2: This function assumes that the mutex has already been obtained. */
       void DestroyObj(TObj *obj) noexcept;
+
+      /* Pop the closed object with the soonest deadline out of the cache
+         and destroy it.  The cache must be non-empty.  Assumes the mutex
+         (where the caller requires it) has already been obtained. */
+      void EvictOldestClosed();
 
       /* If we're caching, insert the given object into the set of closed objects.
          Discard enough old objects to make room.

--- a/orly/indy/disk/durable_manager.cc
+++ b/orly/indy/disk/durable_manager.cc
@@ -17,6 +17,7 @@
    limitations under the License. */
 
 #include <orly/indy/disk/durable_manager.h>
+
 #include <optional>
 
 #include <base/booster.h>
@@ -125,6 +126,8 @@ TDurableManager::TDurableManager(TScheduler *scheduler,
       MappingCollection(this),
       RemovalCollection(this),
       LayerCleanerTimer(layer_cleaning_interval),
+      LayerCleanerStopping(false),
+      LayerCleanerStarted(false),
       Notify(notify) {
   /* acquire Mapping lock */ {
     std::lock_guard<std::mutex> mapping_lock(MappingLock);
@@ -194,6 +197,8 @@ void TDurableManager::CleanDisk(const Durable::TDeadline &/*now*/, Durable::TSem
 }
 
 void TDurableManager::RunLayerCleaner() {
+  LayerCleanerStarted = true;
+  Base::TPushOnExit exit_latch(LayerCleanerExited);
   if (Engine->IsDiskBased()) {
     /* if this is a disk based engine, allocate event pools */
     assert(!Disk::Util::TDiskController::TEvent::LocalEventPool);
@@ -202,6 +207,10 @@ void TDurableManager::RunLayerCleaner() {
   TDurableLayer *durable_layer = nullptr;
   for (;;) {
     LayerCleanerTimer.Pop();
+    if (LayerCleanerStopping) {
+      syslog(LOG_INFO, "TDurableManager::RunLayerCleaner shutting down (#440)");
+      return;
+    }
     for (;;) {
       /* Acquire Removal lock */ {
         std::lock_guard<std::mutex> removal_lock(RemovalLock);
@@ -217,6 +226,19 @@ void TDurableManager::RunLayerCleaner() {
         break;
       }
     }
+  }
+}
+
+void TDurableManager::StopLayerCleaner() {
+  LayerCleanerStopping = true;
+  LayerCleanerTimer.FireNow();
+}
+
+void TDurableManager::JoinLayerCleaner() {
+  /* A cleaner whose fiber never got to run can't be waited for (and never
+     touches us); one that did run pushes Exited on its way out. */
+  if (LayerCleanerStarted) {
+    LayerCleanerExited.Pop();
   }
 }
 

--- a/orly/indy/disk/durable_manager.h
+++ b/orly/indy/disk/durable_manager.h
@@ -154,6 +154,14 @@ namespace Orly {
 
         virtual void RunLayerCleaner() override;
 
+        /* See Durable::TManager: raise the stop flag and fire the cleaner's
+           timer so its blocking Pop() wakes and the loop returns (#440). */
+        virtual void StopLayerCleaner() override;
+
+        /* See Durable::TManager: block until the cleaner loop has actually
+           returned (if it ever started). */
+        virtual void JoinLayerCleaner() override;
+
         virtual void Save(const Durable::TId &id, const Durable::TDeadline &deadline, const TTtl &ttl, const std::string &serialized_form, Durable::TSem *sem) override;
 
         virtual bool TryLoad(const Durable::TId &id, std::string &serialized_form_out) override;
@@ -784,6 +792,11 @@ namespace Orly {
 
         mutable TRemovalCollection::TImpl RemovalCollection;
         Base::TTimerFd LayerCleanerTimer;
+        std::atomic<bool> LayerCleanerStopping;
+        /* RunLayerCleaner() marks Started on entry and pushes Exited when it
+           returns; JoinLayerCleaner() waits on that handshake (#440). */
+        std::atomic<bool> LayerCleanerStarted;
+        Base::TEventSemaphore LayerCleanerExited;
 
         std::mutex RemovalLock;
 

--- a/orly/indy/manager.cc
+++ b/orly/indy/manager.cc
@@ -162,6 +162,10 @@ TManager::TManager(Disk::Util::TEngine *engine,
 }
 
 TManager::~TManager() {
+  /* Paused-and-written repos (test povs) hold MakeDirty() self-pins that
+     nothing will ever release; drop them so the sweeps below see only
+     genuinely referenced repos (#440). */
+  ReleaseDirtySelfPins();
   CloseAllUnreferencedObjects();
   SystemRepo.Reset();
   PreDtor();

--- a/orly/indy/manager.cc
+++ b/orly/indy/manager.cc
@@ -94,6 +94,8 @@ TManager::TManager(Disk::Util::TEngine *engine,
       StateChangeCb(state_change_cb),
       ReplicationRead(false),
       ReplicationWork(false),
+      ReplicationServicesStopping(false),
+      ReplicationServicesStarted(0),
       ReplicationNextTime(chrono::steady_clock::now()),
       ReplicationDelay(replication_delay),
       UpdateReplicationNotificationCb(update_replication_notification_cb),
@@ -178,6 +180,8 @@ L0::TManager::TPtr<TRepo> TManager::NewFastRepo(const TUuid &repo_id,
 }
 
 void TManager::RunReplicationQueue() {
+  ++ReplicationServicesStarted;
+  Base::TPushOnExit exit_latch(ReplicationServicesExited);
   try {
     epoll_event event;
     int timeout = -1;
@@ -195,6 +199,10 @@ void TManager::RunReplicationQueue() {
           IfLt0(ret);
           break;
         }
+      }
+      if (ReplicationServicesStopping) {
+        syslog(LOG_INFO, "TManager::RunReplicationQueue shutting down (#440)");
+        return;
       }
       ReplicationQueueSem.Pop();
       for (;;) {
@@ -238,6 +246,8 @@ void TManager::RunReplicationQueue() {
 }
 
 void TManager::RunReplicationWork() {
+  ++ReplicationServicesStarted;
+  Base::TPushOnExit exit_latch(ReplicationServicesExited);
   try {
     epoll_event event;
     int timeout = -1;
@@ -255,6 +265,10 @@ void TManager::RunReplicationWork() {
           IfLt0(ret);
           break;
         }
+      }
+      if (ReplicationServicesStopping) {
+        syslog(LOG_INFO, "TManager::RunReplicationWork shutting down (#440)");
+        return;
       }
       ReplicationWorkSem.Pop();
       for (;;) {
@@ -285,6 +299,8 @@ void TManager::RunReplicationWork() {
 }
 
 void TManager::RunReplicateTransaction() {
+  ++ReplicationServicesStarted;
+  Base::TPushOnExit exit_latch(ReplicationServicesExited);
   epoll_event event;
   int timeout = -1;
   void *state_alloc = alloca(Sabot::State::GetMaxStateSize());
@@ -303,6 +319,10 @@ void TManager::RunReplicateTransaction() {
           IfLt0(ret);
           break;
         }
+      }
+      if (ReplicationServicesStopping) {
+        syslog(LOG_INFO, "TManager::RunReplicateTransaction shutting down (#440)");
+        return;
       }
       SleepUntil(ReplicationNextTime);
       ReplicationNextTime = chrono::steady_clock::now() + ReplicationDelay;
@@ -487,6 +507,25 @@ void TManager::RunReplicateTransaction() {
     }
   }
   DEBUG_LOG("RunReplicateTransaction() Exiting");
+}
+
+void TManager::StopReplicationServices() {
+  ReplicationServicesStopping = true;
+  /* Each push makes the loop's epoll_wait return; the loop then sees the
+     flag (before consuming the semaphore) and returns. */
+  ReplicationQueueSem.Push();
+  ReplicationWorkSem.Push();
+  ReplicationSem.Push();
+}
+
+void TManager::JoinReplicationServices() {
+  /* Reap exactly as many exits as loops that actually entered; a loop
+     whose fiber never got to run can't be waited for (and never touches
+     us).  Every entered loop pushes Exited on its way out, including the
+     exception paths. */
+  for (size_t n = ReplicationServicesStarted; n > 0; --n) {
+    ReplicationServicesExited.Pop();
+  }
 }
 
 TManager::TMaster::TMaster(TManager *manager, const TFd &fd)

--- a/orly/indy/manager.h
+++ b/orly/indy/manager.h
@@ -135,8 +135,8 @@ namespace Orly {
          returned: a stop is only a flag plus a wake, and this manager must
          not be destroyed while a loop is still inside its body (#440).
          NOTE: a master-mode loop wedged in a remote Sync() holds this join
-         until the RPC resolves; interrupting in-flight RPCs is future
-         teardown work. */
+         until the RPC resolves; interrupting in-flight RPCs is
+         TODO(#461). */
       void JoinReplicationServices();
 
       inline void SetDurableManager(const std::shared_ptr<Durable::TManager> &durable_manager) {

--- a/orly/indy/manager.h
+++ b/orly/indy/manager.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <mutex>
 #include <optional>
 #include <thread>
@@ -123,6 +124,20 @@ namespace Orly {
       virtual void RunReplicationWork() override;
 
       virtual void RunReplicateTransaction() override;
+
+      /* Make the three replication service loops return: raise the stop
+         flag, then push each loop's semaphore so its epoll_wait wakes.
+         Without this the loops block their runner threads forever and any
+         later manager teardown races their epoll fds (#440). */
+      void StopReplicationServices();
+
+      /* Block until every replication loop that actually started has
+         returned: a stop is only a flag plus a wake, and this manager must
+         not be destroyed while a loop is still inside its body (#440).
+         NOTE: a master-mode loop wedged in a remote Sync() holds this join
+         until the RPC resolves; interrupting in-flight RPCs is future
+         teardown work. */
+      void JoinReplicationServices();
 
       inline void SetDurableManager(const std::shared_ptr<Durable::TManager> &durable_manager) {
         DurableManager = durable_manager;
@@ -515,6 +530,12 @@ namespace Orly {
       std::mutex ReplicationEpollLock;
       epoll_event ReplicationEvent;
       Base::TEventSemaphore ReplicationSem;
+      std::atomic<bool> ReplicationServicesStopping;
+      /* Each replication loop counts itself in on entry and pushes Exited
+         on the way out (however it unwinds); JoinReplicationServices()
+         reaps exactly that many exits (#440). */
+      std::atomic<size_t> ReplicationServicesStarted;
+      Base::TEventSemaphore ReplicationServicesExited;
       std::chrono::steady_clock::time_point ReplicationNextTime;
 
       std::chrono::milliseconds ReplicationDelay;

--- a/orly/indy/manager_base.cc
+++ b/orly/indy/manager_base.cc
@@ -206,8 +206,12 @@ TManager::TManager(Disk::Util::TEngine *engine,
       AllowTailing(allow_tailing),
       RemovalCollection(this),
       LayerCleanerTimer(layer_cleaning_interval),
+      LayerCleanerStopping(false),
+      LayerCleanerStarted(false),
       MergeMemQueue(this),
+      MergeMemLoopsStarted(0),
       MergeDiskQueue(this),
+      MergeDiskLoopsStarted(0),
       MergeMemDelay(merge_mem_delay),
       MergeDiskDelay(merge_disk_delay),
       BlockSlotsAvailablePerMerger(block_slots_available_per_merger),
@@ -251,9 +255,12 @@ bool TManager::PreDtor() {
     if (item.second->PtrCount != 0) {
       std::ostringstream strm;
       strm << item.first;
-      syslog(LOG_ERR, "TManager::PreDtor: repo [%s] still has [%d] live ptr(s)", strm.str().c_str(), int(item.second->PtrCount));
+      syslog(LOG_ERR, "TManager::PreDtor: repo [%s] still has [%d] live ptr(s); leaking it", strm.str().c_str(), int(item.second->PtrCount));
+      assert(item.second->PtrCount == 0);
+      /* NDEBUG: leak the repo rather than free it out from under the live
+         ptr. */
+      continue;
     }
-    assert(item.second->PtrCount == 0);
     delete item.second;
   }
   return false;
@@ -269,6 +276,8 @@ void TManager::SetTetrisManager(Orly::Server::TTetrisManager *tetris_manager) {
 }
 
 void TManager::RunLayerCleaner() {
+  LayerCleanerStarted = true;
+  Base::TPushOnExit exit_latch(LayerCleanerExited);
   if (Engine->IsDiskBased()) {
     /* if this is a disk based engine, allocate event pools */
     assert(!Disk::Util::TDiskController::TEvent::LocalEventPool);
@@ -276,30 +285,74 @@ void TManager::RunLayerCleaner() {
   }
   for (;;) {
     LayerCleanerTimer.Pop();
+    if (LayerCleanerStopping) {
+      syslog(LOG_INFO, "TManager::RunLayerCleaner shutting down (#440)");
+      return;
+    }
     RemoveLayersFromQueue();
   }
 }
 
+void TManager::StopLayerCleaner() {
+  LayerCleanerStopping = true;
+  LayerCleanerTimer.FireNow();
+}
+
+void TManager::JoinLayerCleaner() {
+  /* A cleaner whose fiber never got to run can't be waited for (and never
+     touches us); one that did run pushes Exited on its way out. */
+  if (LayerCleanerStarted) {
+    LayerCleanerExited.Pop();
+  }
+}
+
+void TManager::StopMergeRunners() {
+  ShuttingDown = true;
+  /* Wake and reap the merge loops one at a time: the sems are binary
+     (TSingleSem), so a blind Push(n) would collapse into one wake.  A loop
+     that is mid-Step sees the flag on its next while-check and exits
+     without consuming the push; the leftover flag then wakes the next
+     waiter, so each iteration always reaps exactly one exit.  Loops whose
+     fiber never started never counted themselves and are not waited for. */
+  for (size_t n = MergeMemLoopsStarted; n > 0; --n) {
+    MergeMemSem.Push();
+    MergeMemExited.Pop();
+  }
+  for (size_t n = MergeDiskLoopsStarted; n > 0; --n) {
+    MergeDiskSem.Push();
+    MergeDiskExited.Pop();
+  }
+}
+
 void TManager::FlushMemMerges() {
-  /* Repos become due at most MergeMemInterval (~tens of ms) after their
-     last write, so draining is quick; the cap keeps a wedged merger from
-     hanging shutdown forever. */
-  const auto give_up = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+  /* Drain the queue inline, on this fiber, instead of waking the merge-mem
+     runner and polling: the merge runners have already been stopped and
+     joined (StopMergeRunners), so we are the only drainer -- a live runner
+     mid-merge could otherwise re-enqueue a still-dirty repo after we saw
+     the queue empty and returned (#440).  Ignore merge deadlines --
+     everything dirty flushes now.  A repo whose merge leaves it dirty
+     re-enqueues itself (CheckRemoveDirty), so keep going until the queue
+     is empty; writes have stopped by the time this runs, so it converges.
+     Bounded all the same: if something upstream is still dirtying repos, a
+     logged partial flush beats spinning shutdown forever. */
+  const auto give_up = steady_clock::now() + std::chrono::seconds(30);
   for (;;) {
-    bool drained;
+    if (steady_clock::now() > give_up) {
+      syslog(LOG_WARNING, "TManager::FlushMemMerges: mem-merge queue still non-empty after 30s; giving up with unflushed repos");
+      break;
+    }
+    TRepo *repo = nullptr;
     /* acquire MergeMem lock */ {
       std::lock_guard<std::mutex> lock(MergeMemLock);
-      drained = (MergeMemQueue.TryGetFirstMember() == nullptr);
-    }
-    if (drained) {
+      repo = MergeMemQueue.TryGetFirstMember();
+      if (repo) {
+        repo->MergeMemMembership.Remove();
+      }
+    }  // release MergeMem lock
+    if (!repo) {
       break;
     }
-    if (std::chrono::steady_clock::now() > give_up) {
-      syslog(LOG_WARNING, "FlushMemMerges: gave up waiting for the mem-merge queue to drain");
-      break;
-    }
-    MergeMemSem.Push();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    repo->StepMergeMem();
   }
 }
 
@@ -311,6 +364,8 @@ void TManager::RunMergeMem() {
     CPU_SET(core, &mask);
   }
   IfLt0(sched_setaffinity(syscall(SYS_gettid), sizeof(cpu_set_t), &mask));
+  ++MergeMemLoopsStarted;
+  Base::TPushOnExit exit_latch(MergeMemExited);
   if (Engine->IsDiskBased()) {
     /* if this is a disk based engine, allocate event pools */
     assert(!Disk::Util::TDiskController::TEvent::LocalEventPool);
@@ -386,6 +441,8 @@ void TManager::RunMergeDisk() {
     CPU_SET(core, &mask);
   }
   IfLt0(sched_setaffinity(syscall(SYS_gettid), sizeof(cpu_set_t), &mask));
+  ++MergeDiskLoopsStarted;
+  Base::TPushOnExit exit_latch(MergeDiskExited);
   if (Engine->IsDiskBased()) {
     /* if this is a disk based engine, allocate event pools */
     assert(!Disk::Util::TDiskController::TEvent::LocalEventPool);

--- a/orly/indy/manager_base.cc
+++ b/orly/indy/manager_base.cc
@@ -245,7 +245,14 @@ bool TManager::PreDtor() {
   MergeDiskQueue.RemoveEachMember();
   MergeMemQueue.RemoveEachMember();
   for (const auto &item: OpenableObjs) {
-    /* If this assertion fails, it means there is at least one ptr still alive someplace. */
+    /* A nonzero count here means at least one TPtr is still alive someplace;
+       name the leaker before the assert so teardown bugs are diagnosable
+       from the log (#440). */
+    if (item.second->PtrCount != 0) {
+      std::ostringstream strm;
+      strm << item.first;
+      syslog(LOG_ERR, "TManager::PreDtor: repo [%s] still has [%d] live ptr(s)", strm.str().c_str(), int(item.second->PtrCount));
+    }
     assert(item.second->PtrCount == 0);
     delete item.second;
   }

--- a/orly/indy/manager_base.cc
+++ b/orly/indy/manager_base.cc
@@ -228,6 +228,28 @@ TManager::~TManager() {
   ShuttingDown = true;
 }
 
+void TManager::ReleaseDirtySelfPins() {
+  /* Releasing a pin can cascade: a repo whose count hits zero closes,
+     force-releases its parent ptr (possibly closing the parent too), and
+     caching it can evict other closed repos -- all of which mutate
+     OpenableObjs/ClosedObjs.  So rescan from the top after every release
+     instead of iterating; repo counts at teardown are small. */
+  for (;;) {
+    TRepo *dirty_repo = nullptr;
+    for (const auto &item: OpenableObjs) {
+      TRepo *repo = dynamic_cast<TRepo *>(item.second);
+      if (repo && repo->DirtyPtr) {
+        dirty_repo = repo;
+        break;
+      }
+    }
+    if (!dirty_repo) {
+      break;
+    }
+    dirty_repo->RemoveFromDirty();
+  }
+}
+
 void TManager::CloseAllUnreferencedObjects() {
   MergeDiskQueue.RemoveEachMember();
   MergeMemQueue.RemoveEachMember();

--- a/orly/indy/manager_base.h
+++ b/orly/indy/manager_base.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cassert>
 #include <chrono>
 #include <optional>
@@ -620,10 +621,27 @@ namespace Orly {
 
         void RunLayerCleaner();
 
-        /* Kick the mem merger and wait (bounded) until every dirty repo's
-           memory layer has been merged out to a disk file -- the flush half
-           of an orderly shutdown (#440).  Call from a fiber before the merge
-           runners are stopped. */
+        /* Make RunLayerCleaner return: raise the stop flag and fire its
+           timer so the blocking Pop() wakes.  Without this the cleaner
+           fiber sits in a read on the timer fd forever, pinning its runner
+           thread and (at shutdown) racing the fd's destruction (#440). */
+        void StopLayerCleaner();
+
+        /* Block until a stopped cleaner has actually returned (if it ever
+           started): a stop is only a flag plus a wake, and the manager must
+           not be destroyed while the cleaner is still inside its loop
+           (#440). */
+        void JoinLayerCleaner();
+
+        /* Stop the RunMergeMem/RunMergeDisk loops and wait for every one
+           that started to actually return (#440).  Must run on a fiber:
+           the wake sems are fiber primitives.  Call before FlushMemMerges
+           so the flush is the only drainer of the merge queues. */
+        void StopMergeRunners();
+
+        /* Merge every dirty repo's memory layer out to a disk file -- the
+           flush half of an orderly shutdown (#440).  Call from a fiber,
+           after StopMergeRunners(). */
         void FlushMemMerges();
 
         void RunMergeMem();
@@ -788,23 +806,34 @@ namespace Orly {
 
         void RemoveLayersFromQueue();
 
-        bool ShuttingDown;
+        std::atomic<bool> ShuttingDown;
 
         bool AllowTailing;
 
         mutable TRemovalCollection::TImpl RemovalCollection;
         std::mutex RemovalLock;
         Base::TTimerFd LayerCleanerTimer;
+        std::atomic<bool> LayerCleanerStopping;
+        /* RunLayerCleaner() marks Started on entry and pushes Exited when it
+           returns; JoinLayerCleaner() waits on that handshake (#440). */
+        std::atomic<bool> LayerCleanerStarted;
+        Base::TEventSemaphore LayerCleanerExited;
 
         mutable TRepoQueue::TImpl MergeMemQueue;
         std::mutex MergeMemLock;
         std::mutex MergeMemEpollLock;
         Fiber::TSingleSem MergeMemSem;
+        /* Each merge loop counts itself in on entry and pushes Exited on the
+           way out; StopMergeRunners() reaps exactly that many exits (#440). */
+        std::atomic<size_t> MergeMemLoopsStarted;
+        Base::TEventSemaphore MergeMemExited;
 
         mutable TRepoQueue::TImpl MergeDiskQueue;
         Fiber::TFiberLock MergeDiskLock;
         Fiber::TFiberLock MergeDiskEpollLock;
         Fiber::TSingleSem MergeDiskSem;
+        std::atomic<size_t> MergeDiskLoopsStarted;
+        Base::TEventSemaphore MergeDiskExited;
 
         std::chrono::milliseconds MergeMemDelay;
         std::chrono::milliseconds MergeDiskDelay;

--- a/orly/indy/manager_base.h
+++ b/orly/indy/manager_base.h
@@ -772,6 +772,17 @@ namespace Orly {
 
         virtual ~TManager();
 
+        /* Teardown step (#440): drop every repo's MakeDirty() self-pin.  A
+           dirty repo pins itself open until its updates are released or its
+           mem layer merges out, but a paused-and-written repo (compile-time
+           test povs, paused players) is never promoted, so its pin would
+           never drop and PreDtor would see a live ptr on every one.  By the
+           time this runs everything durable has been flushed
+           (FlushMemMerges) and a fast repo's data is volatile by design, so
+           releasing the pins loses nothing.  Call before
+           CloseAllUnreferencedObjects(). */
+        void ReleaseDirtySelfPins();
+
         void CloseAllUnreferencedObjects();
 
         bool PreDtor();

--- a/orly/orlyc.cc
+++ b/orly/orlyc.cc
@@ -127,9 +127,19 @@ static bool RunTestsOnIndy(const Package::TVersionedName &output, const TCompile
      on scheduler-worker threads cannot be reclaimed without thread-exit
      hooks, and the managers' destructors (correctly) refuse to die while
      pools exist. */
-  Base::TScheduler::TPolicy(2, 8, std::chrono::milliseconds(1000)).RunUntilCtrlC(
+  /* The worker cap must cover every long-lived job the server schedules
+     (runner hosts for replication/mergers/cleaners, discard runners, tetris,
+     accept loops, ...): TScheduler::Schedule queues past the cap but never
+     launches another worker, so an 8-worker scheduler silently never ran the
+     last ~6 jobs -- and a loop that never runs can neither do its part of
+     the update pipeline nor confirm its exit to Shutdown()'s joins (#440).
+     32 covers the ~16 jobs with headroom; the scheduler now logs any jobs
+     still queued at teardown, so an under-provisioned cap is visible
+     instead of a silent hang. */
+  Base::TScheduler::TPolicy(2, 32, std::chrono::milliseconds(1000)).RunUntilCtrlC(
       [&](Base::TScheduler *scheduler) {
         int exit_code = EXIT_FAILURE;
+        Orly::Server::TServer *server = nullptr;
         try {
           TIndyTestServerCmd server_cmd;
           server_cmd.MemorySim = true;
@@ -173,21 +183,38 @@ static bool RunTestsOnIndy(const Package::TVersionedName &output, const TCompile
              fast/slow core vectors. */
           server_cmd.ResolveCoreVecDefaults();
 
-          auto *server = new Orly::Server::TServer(scheduler, server_cmd);
+          server = new Orly::Server::TServer(scheduler, server_cmd);
           /* Installing the package, opening a session, and running the tests all
              create durable objects / transactions, which must execute inside a
              fiber (TCompletionTrigger::Wait asserts on LocalFrame). RunPackageTests
              does all of that on a fast runner and hands back the result. */
           bool ok = server->RunPackageTests(output.Name.Name, output.Version, cmd.VerboseTests);
           exit_code = ok ? EXIT_SUCCESS : EXIT_FAILURE;
-          server->Shutdown();
-          delete server;
         } catch (const std::exception &ex) {
           std::cerr << "error: running tests on indy: " << ex.what() << std::endl;
           exit_code = EXIT_FAILURE;
         } catch (...) {
           std::cerr << "error: running tests on indy: unknown error" << std::endl;
           exit_code = EXIT_FAILURE;
+        }
+        /* Shutdown on every path, success or throw: the server's service
+           loops park scheduler workers in blocking syscalls, and the
+           scheduler only quiesces (synthesizing the ctrl-c RunUntilCtrlC
+           waits for) once every worker is idle.  Skipping Shutdown() after
+           an exception would therefore hang the process instead of exiting
+           FAILURE (#440). */
+        if (server) {
+          try {
+            server->Shutdown();
+            delete server;
+          } catch (const std::exception &ex) {
+            std::cerr << "error: tearing down test server: " << ex.what() << std::endl;
+            std::cout.flush();
+            std::cerr.flush();
+            /* Teardown is wedged or broken; a deterministic non-zero exit
+               beats a hang. */
+            _exit(EXIT_FAILURE);
+          }
         }
         if (cmd.MachineForm) {
           std::cout << "MM_NOTICE: Tests done" << std::endl;

--- a/orly/orlyc.cc
+++ b/orly/orlyc.cc
@@ -113,18 +113,20 @@ class TIndyTestServerCmd final : public Orly::Server::TServer::TCmd {
 };
 
 static bool RunTestsOnIndy(const Package::TVersionedName &output, const TCompilerConfig &cmd) {
+  int result_code = EXIT_FAILURE;
   /* The server's fiber machinery (transactions, the engine) must run inside a
      scheduler/fiber context -- the same context RunUntilCtrlC gives its main
-     job (orlyi constructs its TServer there too). We do the work in that job
-     and then _exit with the result.
+     job (orlyi constructs its TServer there too). We do the work in that job.
 
-     We deliberately do NOT destroy the server. ~TServer would have to run on
-     this (non-fiber) thread to free the fiber frame it allocated here, yet it
-     also takes a fiber lock (StopAllPlayers) that asserts a fiber context --
-     a contradiction. orlyi sidesteps this the same way: it never destroys its
-     server; RunUntilCtrlC blocks until a signal and the process just exits.
-     This is a short-lived compiler invocation, so leaking and _exit()ing is
-     the clean, deterministic path (it also skips the crash-prone teardown). */
+     Teardown is now a first-class operation (#440): Shutdown() flushes and
+     stops everything in order, the destructor is safe afterward, and the job
+     returning quiesces the scheduler (which synthesizes the ctrl-c that
+     RunUntilCtrlC waits for).  Every orlyc test run therefore doubles as a
+     construct/run/destroy smoke of the whole server.  The two thread-local
+     pool MANAGERS are intentionally released, not destroyed: pools created
+     on scheduler-worker threads cannot be reclaimed without thread-exit
+     hooks, and the managers' destructors (correctly) refuse to die while
+     pools exist. */
   Base::TScheduler::TPolicy(2, 8, std::chrono::milliseconds(1000)).RunUntilCtrlC(
       [&](Base::TScheduler *scheduler) {
         int exit_code = EXIT_FAILURE;
@@ -171,7 +173,6 @@ static bool RunTestsOnIndy(const Package::TVersionedName &output, const TCompile
              fast/slow core vectors. */
           server_cmd.ResolveCoreVecDefaults();
 
-          /* Intentionally leaked (see above). */
           auto *server = new Orly::Server::TServer(scheduler, server_cmd);
           /* Installing the package, opening a session, and running the tests all
              create durable objects / transactions, which must execute inside a
@@ -179,6 +180,8 @@ static bool RunTestsOnIndy(const Package::TVersionedName &output, const TCompile
              does all of that on a fast runner and hands back the result. */
           bool ok = server->RunPackageTests(output.Name.Name, output.Version, cmd.VerboseTests);
           exit_code = ok ? EXIT_SUCCESS : EXIT_FAILURE;
+          server->Shutdown();
+          delete server;
         } catch (const std::exception &ex) {
           std::cerr << "error: running tests on indy: " << ex.what() << std::endl;
           exit_code = EXIT_FAILURE;
@@ -191,11 +194,13 @@ static bool RunTestsOnIndy(const Package::TVersionedName &output, const TCompile
         }
         std::cout.flush();
         std::cerr.flush();
-        _exit(exit_code);
+        /* See the pool-manager note above. */
+        Orly::Indy::Disk::Util::TDiskController::TEvent::DiskEventPoolManager.release();
+        result_code = exit_code;
+        /* Returning quiesces the scheduler; RunUntilCtrlC then returns. */
       });
 
-  /* Unreachable: the job _exit()s. Present so the function has a return path. */
-  return false;
+  return result_code == EXIT_SUCCESS;
 }
 
 int CompileCode(const TCompilerConfig &cmd) {

--- a/orly/orlyc.cc
+++ b/orly/orlyc.cc
@@ -216,9 +216,10 @@ static bool RunTestsOnIndy(const Package::TVersionedName &output, const TCompile
             _exit(EXIT_FAILURE);
           }
         }
-        if (cmd.MachineForm) {
-          std::cout << "MM_NOTICE: Tests done" << std::endl;
-        }
+        /* No "MM_NOTICE: Tests done" here: CompileCode() prints it after we
+           return (it was only printed here back when this job _exit()'d and
+           CompileCode's copy was unreachable); a second copy would add a
+           section to the machine-form output lang_test baselines compare. */
         std::cout.flush();
         std::cerr.flush();
         /* See the pool-manager note above. */

--- a/orly/server/server.cc
+++ b/orly/server/server.cc
@@ -21,6 +21,7 @@
 #include <cstring>
 #include <optional>
 #include <poll.h>
+#include <sys/timerfd.h>
 #include <sys/syscall.h>
 
 #include <base/as_str.h>
@@ -1284,6 +1285,15 @@ void TServer::Shutdown() {
   syslog(LOG_INFO, "TServer::Shutdown() begin");
   /* Stop the websockets server first: no new work arrives. */
   Ws.reset();
+  /* Wake and stop the standalone service loops so the scheduler can drain
+     (#440): the client accept loop (blocked in accept), the reporter's
+     accept loop, and the housekeeper (blocked on its timer). */
+  shutdown(MainSocket, SHUT_RDWR);
+  if (Reporter) {
+    Reporter->Stop();
+  }
+  itimerspec fire_now{{0, 0}, {0, 1}};
+  timerfd_settime(HousecleaningTimer.GetFd(), 0, &fire_now, nullptr);
   /* Let the in-flight update pipeline settle: a write that arrived just
      before the signal is not mergeable until the release machinery (which
      runs on the replication cadence even in SOLO) has settled it.  Bounded
@@ -1308,10 +1318,8 @@ void TServer::Shutdown() {
     TetrisManager = nullptr;
     DurableManager->Clear();
     DurableManager.reset();
-    /* GlobalRepo/RepoManager stay alive (leaked, as they always were):
-       cached durable sessions still pin their POV repos, so ~L0::TManager's
-       PreDtor asserts PtrCount == 0.  Draining those pins is the next
-       teardown slice (docs/teardown-design.md, PR C). */
+    GlobalRepo.Reset();
+    RepoManager.reset();
   });
   teardown_jumper(FramePoolManager.get(), FastRunnerVec[0].get());
   /* Stop the engine-level services that would otherwise wedge the
@@ -1355,8 +1363,15 @@ void TServer::Shutdown() {
 TServer::~TServer() {
   if (ShutdownCalled) {
     /* Shutdown() already stopped the threads and destroyed the managers;
-       only the init frame is left. */
+       free the init frame, then intentionally release (not destroy) the
+       frame-pool manager: pools created on scheduler-worker threads (accept
+       loops, ws jumps) cannot be reclaimed without thread-exit hooks, and
+       the manager's destructor correctly refuses to die while they exist.
+       A few slabs leak; every real resource is gone (#440). */
     Fiber::TFrame::LocalFramePool->Free(Frame);
+    delete Fiber::TFrame::LocalFramePool;
+    Fiber::TFrame::LocalFramePool = nullptr;
+    FramePoolManager.release();
     return;
   }
   WsRunner.ShutDown();
@@ -1688,6 +1703,10 @@ void TServer::AcceptClientConnections() {
       new TServeClientRunnable(this, SlowRunnerVec[prev_assignment_count % SlowRunnerVec.size()].get(), move(client_socket), client_address);
       //Scheduler->Schedule(bind(&TServer::ServeClient, this, move(client_socket), client_address));
     } catch (const std::system_error &err) {
+      if (ShutdownCalled) {
+        syslog(LOG_INFO, "TServer::AcceptClientConnections shutting down (#440)");
+        return;
+      }
       if (WasInterrupted(err)) {
         syslog(LOG_INFO, "TServer::AcceptClientConnections shutting down on system_error [%s]", err.what());
         throw;
@@ -1695,6 +1714,10 @@ void TServer::AcceptClientConnections() {
         syslog(LOG_ERR, "TServer::AcceptClientConnections caught exception [%s], continue accept loop", err.what());
       }
     } catch (const std::exception &ex) {
+      if (ShutdownCalled) {
+        syslog(LOG_INFO, "TServer::AcceptClientConnections shutting down (#440)");
+        return;
+      }
       syslog(LOG_ERR, "TServer::AcceptClientConnections caught exception [%s], continue accept loop", ex.what());
     }
   }
@@ -1711,6 +1734,10 @@ void TServer::CleanHouse() {
   for (;;) {
     //DEBUG_LOG("housecleaner: waiting");
     HousecleaningTimer.Pop();
+    if (ShutdownCalled) {
+      syslog(LOG_INFO, "TServer::CleanHouse shutting down (#440)");
+      return;
+    }
     //DEBUG_LOG("housecleaner: cleaning");
     DurableManager->Clean();
     //DEBUG_LOG("housecleaner: done cleaning");
@@ -2536,8 +2563,21 @@ TIndyReporter::TIndyReporter(const TServer *server, TScheduler *scheduler, int p
 
 void TIndyReporter::AcceptClientConnections() {
   for (;;) {
-    Scheduler->Schedule(bind(&TIndyReporter::ServeClient, this, TFd(accept(Socket, nullptr, nullptr))));
+    int fd = accept(Socket, nullptr, nullptr);
+    if (fd < 0) {
+      if (Stopping) {
+        syslog(LOG_INFO, "TIndyReporter::AcceptClientConnections shutting down");
+        return;
+      }
+      ::Util::ThrowSystemError(errno);
+    }
+    Scheduler->Schedule(bind(&TIndyReporter::ServeClient, this, TFd(fd)));
   }
+}
+
+void TIndyReporter::Stop() {
+  Stopping = true;
+  shutdown(Socket, SHUT_RDWR);
 }
 
 void TIndyReporter::ServeClient(TFd &fd) {

--- a/orly/server/server.cc
+++ b/orly/server/server.cc
@@ -21,7 +21,6 @@
 #include <cstring>
 #include <optional>
 #include <poll.h>
-#include <sys/timerfd.h>
 #include <sys/syscall.h>
 
 #include <base/as_str.h>
@@ -1285,27 +1284,59 @@ void TServer::Shutdown() {
   syslog(LOG_INFO, "TServer::Shutdown() begin");
   /* Stop the websockets server first: no new work arrives. */
   Ws.reset();
-  /* Wake and stop the standalone service loops so the scheduler can drain
-     (#440): the client accept loop (blocked in accept), the reporter's
-     accept loop, and the housekeeper (blocked on its timer). */
+  /* Cut off the work sources next: wake the accept loops (blocked in
+     accept) so no new clients, slaves, or report requests arrive while we
+     drain (#440). */
   shutdown(MainSocket, SHUT_RDWR);
+  /* under SlaveSocketLock: WaitForSlave() publishes SlaveSocket under the
+     same lock, so we either shut down the fd it is (or is about to be)
+     accepting on, or it sees ShutdownCalled before blocking (#440). */ {
+    std::lock_guard<std::mutex> lock(SlaveSocketLock);
+    shutdown(SlaveSocket, SHUT_RDWR);
+  }
   if (Reporter) {
     Reporter->Stop();
   }
-  itimerspec fire_now{{0, 0}, {0, 1}};
-  timerfd_settime(HousecleaningTimer.GetFd(), 0, &fire_now, nullptr);
-  /* Let the in-flight update pipeline settle: a write that arrived just
-     before the signal is not mergeable until the release machinery (which
-     runs on the replication cadence even in SOLO) has settled it.  Bounded
-     and cadence-derived, not a magic number: three periods of the slowest
+  /* Let the in-flight update pipeline settle while ALL of the cadence
+     machinery (replication release, mergers, tetris) is still running: a
+     write that arrived just before the signal is not mergeable until the
+     release machinery (which runs on the replication cadence even in SOLO)
+     has settled it.  This must precede the stop calls below -- a stopped
+     replication loop can no longer drain its queue.  Bounded and
+     cadence-derived, not a magic number: three periods of the slowest
      relevant interval. */
   std::this_thread::sleep_for(std::chrono::milliseconds(
       3 * std::max<size_t>({Cmd.ReplicationInterval, Cmd.MergeMemInterval, Cmd.DurableWriteInterval, 100})));
+  /* Now stop the standalone service loops -- the housekeeper (blocked on
+     its timer), the two layer cleaners (ditto), and the three replication
+     loops (blocked in epoll_wait) -- and WAIT for each to actually return:
+     a stop is only a flag plus a wake, and the manager teardown below
+     would otherwise free the very fds/collections a still-parked loop
+     references (#440).  The joins reap only loops that actually entered;
+     a fiber that was scheduled but never granted a worker is not waited
+     for and remains the one residual hazard here (see the worker-cap note
+     in orlyc.cc). */
+  HousecleaningTimer.FireNow();
+  RepoManager->StopReplicationServices();
+  RepoManager->StopLayerCleaner();
+  DurableManager->StopLayerCleaner();
+  RepoManager->JoinReplicationServices();
+  RepoManager->JoinLayerCleaner();
+  DurableManager->JoinLayerCleaner();
+  if (HousekeeperStarted) {
+    HousekeeperExited.Pop();
+  }
   /* Tear down the fiber-entangled managers on a fiber, while every runner
      is still alive: ~TDurableManager blocks on TSingleSem (fiber-only) for
      its writer/merger fibers, and ~TRepoTetrisManager's StopAllPlayers
      takes fiber locks. */
   Indy::Fiber::TJumpRunnable teardown_jumper([this] {
+    /* Stop the merge loops first (their wake sems are fiber primitives, so
+       this must run on a fiber): the flush below must be the only drainer
+       of the merge queue, or a live merger mid-step could re-enqueue a
+       still-dirty repo after the flush saw an empty queue and returned,
+       and that repo would never reach disk (#440). */
+    RepoManager->StopMergeRunners();
     /* Flush-on-shutdown (#440): merge every dirty repo memory layer out to
        disk and write the durable slush layer, so a graceful stop loses
        nothing -- durability no longer depends on the merge cadence having
@@ -1731,6 +1762,8 @@ void TServer::BeginImport() {
 
 void TServer::CleanHouse() {
   cout << "TServer::CleanHouse()" << endl;
+  HousekeeperStarted = true;
+  Base::TPushOnExit exit_latch(HousekeeperExited);
   for (;;) {
     //DEBUG_LOG("housecleaner: waiting");
     HousecleaningTimer.Pop();
@@ -2531,16 +2564,30 @@ void TServer::WaitForSlave() {
   }
   DEBUG_LOG("TServer::WaitForSlave() entering");
   try {
-    TFd fd(socket(AF_INET, SOCK_STREAM, IPPROTO_TCP));
+    TFd listener(socket(AF_INET, SOCK_STREAM, IPPROTO_TCP));
     int flag = true;
-    IfLt0(setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag)));
-    Bind(fd, TAddress(TAddress::IPv4Any, Cmd.SlavePortNumber));
-    IfLt0(listen(fd, 4));
+    IfLt0(setsockopt(listener, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag)));
+    Bind(listener, TAddress(TAddress::IPv4Any, Cmd.SlavePortNumber));
+    IfLt0(listen(listener, 4));
+    /* Publish the listener under the lock Shutdown() takes before its
+       shutdown(2): either Shutdown() sees the fd we are about to accept
+       on, or we see ShutdownCalled and bail before blocking (#440). */ {
+      std::lock_guard<std::mutex> lock(SlaveSocketLock);
+      if (ShutdownCalled) {
+        syslog(LOG_INFO, "TServer::WaitForSlave shutting down (#440)");
+        return;
+      }
+      SlaveSocket = std::move(listener);
+    }
     syslog(LOG_INFO, "waiting for slave to connect");
-    TFd slave_fd(accept(fd, nullptr, nullptr));
+    TFd slave_fd(accept(SlaveSocket, nullptr, nullptr));
     syslog(LOG_INFO, "slave has connected");
     (*WaitForSlaveActionCb)(slave_fd);
   } catch (const exception &ex) {
+    if (ShutdownCalled) {
+      syslog(LOG_INFO, "TServer::WaitForSlave shutting down (#440)");
+      return;
+    }
     syslog(LOG_ERR, "failed to wait for slave: %s", ex.what());
     throw;
   }

--- a/orly/server/server.cc
+++ b/orly/server/server.cc
@@ -575,7 +575,14 @@ TServer::TCmd::TCmd()
       << "[" << (100 * static_cast<double>(br_slow_memory_sim) / bytes_alloted) << "%] br_slow_memory_sim = [" << br_slow_memory_sim << "]" << endl
       << "[" << (100 * static_cast<double>(br_fiber_frame_stacks) / bytes_alloted) << "%] br_fiber_frame_stacks = [" << br_fiber_frame_stacks << "]" << endl
       << "[" << (100 * static_cast<double>(br_disk_events) / bytes_alloted) << "%] br_disk_events = [" << br_disk_events << "]" << endl;
-    std::cout << ss.str();
+    /* Syslog, not stdout: orlyc embeds this server, and orlyc's stdout is
+       the machine-form compiler protocol that lang_test baselines compare
+       against -- this dump names the host's RAM, so it must never land
+       there (#440). */
+    std::string line;
+    while (std::getline(ss, line)) {
+      syslog(LOG_INFO, "%s", line.c_str());
+    }
   }
 }
 
@@ -684,19 +691,21 @@ void TServer::TCmd::ResolveCoreVecDefaults() {
   if (!user_ctl.empty()) {DiskControllerCoreVec = user_ctl;}
 
   /* Log the resolved core assignment (issue #240): makes the effective config
-     visible and distinguishes user overrides from hardware defaults. */
+     visible and distinguishes user overrides from hardware defaults.  Syslog,
+     not stdout -- orlyc's stdout is the compiler protocol (#440). */
   auto join_cores = [](const std::vector<size_t> &v) {
     std::stringstream s;
     for (size_t i = 0; i < v.size(); ++i) { s << (i ? "," : "") << v[i]; }
     return s.str();
   };
-  std::cout << "resolved core assignment:"
-            << " fast=[" << join_cores(FastCoreVec) << "]"
-            << " slow=[" << join_cores(SlowCoreVec) << "]"
-            << " mem_merge=[" << join_cores(MemMergeCoreVec) << "]"
-            << " disk_merge=[" << join_cores(DiskMergeCoreVec) << "]"
-            << " disk_controller=[" << join_cores(DiskControllerCoreVec) << "]"
-            << std::endl;
+  std::stringstream resolved;
+  resolved << "resolved core assignment:"
+           << " fast=[" << join_cores(FastCoreVec) << "]"
+           << " slow=[" << join_cores(SlowCoreVec) << "]"
+           << " mem_merge=[" << join_cores(MemMergeCoreVec) << "]"
+           << " disk_merge=[" << join_cores(DiskMergeCoreVec) << "]"
+           << " disk_controller=[" << join_cores(DiskControllerCoreVec) << "]";
+  syslog(LOG_INFO, "%s", resolved.str().c_str());
 }
 
 TServer::TServer(TScheduler *scheduler, const TCmd &cmd)
@@ -976,7 +985,7 @@ void TServer::Init() {
     }
     assert(engine_ptr);
 
-    std::cout << "Cmd.DiscardOnCreate = " << (Cmd.DiscardOnCreate ? "true" : "false") << std::endl;
+    syslog(LOG_INFO, "Cmd.DiscardOnCreate = %s", Cmd.DiscardOnCreate ? "true" : "false");
     size_t block_slots_available_per_merger = (((Cmd.BlockCacheSizeMB * 1024) / Disk::Util::PhysicalBlockSize) * 0.8) / Cmd.NumDiskMergeThreads;
     auto for_each_scheduler_cb = [this](const std::function<bool (Fiber::TRunner *)> &cb) {
       for (auto &runner_ptr : FastRunnerVec) {
@@ -1315,7 +1324,7 @@ void TServer::Shutdown() {
      references (#440).  The joins reap only loops that actually entered;
      a fiber that was scheduled but never granted a worker is not waited
      for and remains the one residual hazard here (see the worker-cap note
-     in orlyc.cc). */
+     in orlyc.cc; job cancellation is TODO(#462)). */
   HousecleaningTimer.FireNow();
   RepoManager->StopReplicationServices();
   RepoManager->StopLayerCleaner();
@@ -1761,7 +1770,7 @@ void TServer::BeginImport() {
 }
 
 void TServer::CleanHouse() {
-  cout << "TServer::CleanHouse()" << endl;
+  syslog(LOG_INFO, "TServer::CleanHouse() begin");
   HousekeeperStarted = true;
   Base::TPushOnExit exit_latch(HousekeeperExited);
   for (;;) {

--- a/orly/server/server.h
+++ b/orly/server/server.h
@@ -112,6 +112,10 @@ namespace Orly {
       NO_COPY(TIndyReporter);
       public:
 
+      /* Stops the accept loop (#440): flags it and wakes the blocked
+         accept() with a socket shutdown. */
+      void Stop();
+
       TIndyReporter(const TServer *server, Base::TScheduler *scheduler, int port_number);
 
       private:
@@ -123,6 +127,9 @@ namespace Orly {
       void AddReport(std::stringstream &ss) const;
 
       const TServer *Server;
+
+      /* Set by Stop(); checked by AcceptClientConnections(). */
+      std::atomic<bool> Stopping{false};
 
       Base::TFd Socket;
 

--- a/orly/server/server.h
+++ b/orly/server/server.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cassert>
 #include <memory>
 #include <mutex>
@@ -26,6 +27,7 @@
 
 #include <base/class_traits.h>
 #include <base/debug_log.h>
+#include <base/event_semaphore.h>
 #include <base/fd.h>
 #include <base/log.h>
 #include <base/scheduler.h>
@@ -747,8 +749,26 @@ namespace Orly {
       /* The timer waited for by CleanHouse(). */
       Base::TTimerFd HousecleaningTimer;
 
+      /* CleanHouse() marks Started on entry and pushes Exited when it
+         returns, so Shutdown() can wait for the housekeeper to actually be
+         out of DurableManager->Clean() before tearing the manager down
+         (#440). */
+      std::atomic<bool> HousekeeperStarted{false};
+      Base::TEventSemaphore HousekeeperExited;
+
       /* The socket on which AcceptClientConnections() listens. */
       Base::TFd MainSocket;
+
+      /* The socket on which WaitForSlave() listens.  A member (rather than
+         a local of WaitForSlave) so Shutdown() can shut it down to wake the
+         blocked accept (#440). */
+      Base::TFd SlaveSocket;
+
+      /* Serializes WaitForSlave()'s publication of SlaveSocket against
+         Shutdown()'s wake-up shutdown(2) of it: TFd is not atomic, and
+         without the handshake Shutdown() could shut down a stale fd (or
+         -1) and leave the accept parked forever (#440). */
+      std::mutex SlaveSocketLock;
 
       /* Covers ConnectionBySessionId. */
       std::mutex ConnectionMutex;
@@ -763,8 +783,10 @@ namespace Orly {
       std::shared_ptr<std::function<void (const Base::TFd &)>> WaitForSlaveActionCb;
 
       /* Set once Shutdown() has run; makes it idempotent and tells the
-         destructor the managers are already gone. */
-      bool ShutdownCalled = false;
+         destructor the managers are already gone.  Atomic: the service
+         loops (accept, housekeeper, slave wait) read it from their own
+         threads. */
+      std::atomic<bool> ShutdownCalled{false};
 
       bool InitFinished;
       std::condition_variable InitCond;

--- a/tools/lang_test.py
+++ b/tools/lang_test.py
@@ -145,12 +145,18 @@ def LoadXFail(directory):
   with f:
     for raw_line in f:
       line = raw_line.strip()
-      if not line or line.startswith('# '):
+      # Any line starting with '#' is a comment (a bare '#' spacer line used
+      # to parse as a phantom entry); real entries are paths, which never
+      # start with '#'.
+      if not line or line.startswith('#'):
         continue
       parts = line.split()
       rel_path = parts[0]
       issues = [p for p in parts[1:] if p.startswith('#')]
-      key = os.path.normpath(os.path.join(directory, rel_path))
+      # Absolute keys: in file mode the .xfail walk-up runs on abspaths while
+      # the harness's collected filepaths stay as given, so relative keys
+      # would never match and every xfail would report as unexpected.
+      key = os.path.abspath(os.path.join(directory, rel_path))
       entries[key] = issues
   return entries
 
@@ -216,10 +222,10 @@ def Main():
   xfail_map = BuildXFailMap(args.filepaths, args.directories)
 
   def IsXFail(filepath):
-    return os.path.normpath(filepath) in xfail_map
+    return os.path.abspath(filepath) in xfail_map
 
   def XFailIssues(filepath):
-    return xfail_map.get(os.path.normpath(filepath), [])
+    return xfail_map.get(os.path.abspath(filepath), [])
 
   changed_files = []
   passed_files = []


### PR DESCRIPTION
Third slice of the orderly-teardown work (docs/teardown-design.md): `TServer::Shutdown()` now tears down the repo and durable managers completely instead of leaking them, and every orlyc test run doubles as a construct/run/destroy smoke of the whole server.

## What's in here

**Teardown mechanics (19c3df66):** stop flags + wakes for every standalone service loop (replication x3, both layer cleaners, housekeeper, accept loops), inline shutdown flush of dirty mem layers (`FlushMemMerges`), durable `Clear()` destroying cached-closed sessions/povs so their repo pins drop, and full `GlobalRepo`/`RepoManager` destruction. orlyc no longer leaks-and-`_exit()`s.

**Join-before-destroy (30a7e632):** a stop is only a flag plus a wake, so every loop now confirms its exit (started-counter + exited-latch handshake, exception-safe) and `Shutdown()` joins them all before the teardown fiber destroys the managers. Merge runners get a real stop and are joined before the flush so it is the queue's only drainer. The settle window moved ahead of the stops (a stopped release loop can't drain its queue). Also: `SlaveSocket` publication race fixed, orlyc shuts down on the exception path instead of hanging, `FlushMemMerges` regained its 30s give-up bound, the scheduler logs jobs that were scheduled but never ran, and `PreDtor`/`Clear` name any leaking object before asserting.

**Dirty self-pin release (550365c9):** a written repo pins itself open via `MakeDirty()` until its updates are released; paused test povs are never promoted, so the pin never dropped and `PreDtor` aborted ~32 of 96 general lang tests once teardown became real. `~TManager` now drops the self-pins first and lets the close cascade release parent ptrs.

## Testing

- Full lang suite serially: 161 passed, 2 tracked xfails (#74, #75). (`variants_mutual.orly` flaked once in the long run, passed 4/4 reruns — pre-existing timing sensitivity, worth watching.)
- Unit suites for touched code: event_semaphore, scheduler, durable/kit, durable_manager — all green.
- TSan gate unchanged (durable_manager.test already in it).

## Known follow-ons (documented in-code)

- Draining live client connections before `Clear()` (orlyi under load): `Clear` currently logs + leaks a still-open durable rather than freeing it out from under a live ptr.
- A master-mode replicate loop wedged in a remote `Sync()` holds the shutdown join until the RPC resolves; interrupting in-flight RPCs is future work.
- A fiber scheduled but never granted a worker can't be joined; the scheduler now logs this at teardown instead of silently starving.