### PR TITLE
Teardown ASan smoke: two real fixes and the CI gate (#440 follow-on)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,14 @@
 #                            Playwright test driving two tabs trading on one
 #                            market (run-e2e.sh)
 #
+# A seventh job, `asan-smoke`, builds orlyc under AddressSanitizer and runs a
+# handful of lang tests through it. Every orlyc run constructs, runs, and
+# fully destroys the server (#440 teardown), so this smokes the teardown
+# paths -- join-before-destroy, flush, manager destruction -- for
+# use-after-free at the memory level. Leak detection is OFF by design:
+# teardown deliberately leaks a few pool slabs (docs/teardown-design.md,
+# "Deliberate leaks"). Like `tsan`, it skips pull_request events.
+#
 # A sixth job, `tsan`, builds the concurrency tests under ThreadSanitizer to
 # validate the lock-free / commutative-merge claim at the memory level (data-
 # race freedom). It is GATING (issue #184): the curated set is clean, so the
@@ -644,3 +652,71 @@ jobs:
           name: tsan-logs
           path: tsan-logs/
           if-no-files-found: warn
+
+  asan-smoke:
+    name: AddressSanitizer smoke
+    # Smokes the #440 teardown paths: every orlyc run constructs, runs, and
+    # fully destroys the server, so a handful of lang tests under ASan police
+    # Shutdown()/~TServer for use-after-free and heap corruption. Sanitizer
+    # builds are slow, so (like `tsan`) this skips pull_request events and
+    # runs on push-to-master, the nightly schedule, and manual dispatch.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install system dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        with:
+          packages: build-essential gcc g++ uuid-dev libgmp-dev libaio-dev libsnappy-dev libreadline-dev libboost-system-dev zlib1g-dev bison flex valgrind ccache
+          version: 1.2
+
+      - name: Set up ccache
+        # Same masquerade as the other jobs: jhm/orlyc invoke g++/gcc by bare
+        # name via execvp, so symlink them ahead of /usr/bin to route compiles
+        # through ccache.
+        run: |
+          for c in gcc g++ cc c++; do
+            sudo ln -sf "$(command -v ccache)" "/usr/local/bin/$c"
+          done
+          {
+            echo "CCACHE_DIR=$HOME/.ccache"
+            echo "CCACHE_MAXSIZE=3G"
+            echo "CCACHE_COMPRESS=1"
+          } >> "$GITHUB_ENV"
+
+      - name: Cache ccache
+        # Cache on every trigger (like `tsan`): this job's value is the ASan
+        # report, not cache-correctness, and a cold sanitizer build is
+        # expensive.
+        uses: actions/cache@v5
+        with:
+          path: ~/.ccache
+          key: orly-ccache-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
+          restore-keys: |
+            orly-ccache-${{ runner.os }}-${{ github.job }}-
+            orly-ccache-${{ runner.os }}-
+
+      - name: Bootstrap jhm
+        run: make bootstrap
+
+      - name: Build orlyc under ASan
+        run: PATH="$PWD/tools:$PATH" tools/jhm -c asan orly/orlyc
+
+      - name: Run teardown smoke under ASan
+        # Three lang tests through the ASan orlyc: two with with-block writes
+        # (they exercise the dirty-self-pin release and the full manager
+        # destruction) and one pure. An ASan error makes orlyc exit non-zero,
+        # lang_test reports it as an unexpected failure, and its exit code
+        # fails the job. detect_leaks=0 is deliberate: teardown intentionally
+        # leaks a few pool slabs (docs/teardown-design.md, "Deliberate
+        # leaks"); this smoke gates on use-after-free, not leak accounting.
+        run: |
+          ASAN_OPTIONS=detect_leaks=0 \
+          ORLYC="$PWD/../out_orly/asan/orly/orlyc" \
+          PATH="$PWD/tools:$PATH" \
+          python3 tools/lang_test.py \
+            tests/lang_tests/general/assertions.orly \
+            tests/lang_tests/general/exists.orly \
+            tests/lang_tests/general/arithmetic.orly

--- a/base/mem_aligned_ptr.h
+++ b/base/mem_aligned_ptr.h
@@ -17,6 +17,7 @@
    limitations under the License. */
 #pragma once
 
+#include <cstdlib>
 #include <cstring>
 
 #include <memory>
@@ -25,18 +26,33 @@
 #include <base/util/error.h>
 
 namespace Base {
+
+  /* posix_memalign memory must be released with free(); a plain
+     std::unique_ptr's default deleter (operator delete) is an
+     alloc/dealloc mismatch.  Latent for years because these buffers were
+     process-lifetime -- #440's real teardown gave them destructors and
+     AddressSanitizer flagged every one. */
+  struct TFreeDeleter {
+    void operator()(void *ptr) const noexcept {
+      std::free(ptr);
+    }
+  };  // TFreeDeleter
+
   template <typename T>
-  std::unique_ptr<T> MemAlignedAlloc(std::size_t align_to, std::size_t size) {
+  using TMemAlignedPtr = std::unique_ptr<T, TFreeDeleter>;
+
+  template <typename T>
+  TMemAlignedPtr<T> MemAlignedAlloc(std::size_t align_to, std::size_t size) {
     static_assert(std::is_trivial<T>::value, "T must be a trivial type");
-    typename std::unique_ptr<T>::pointer mem;
+    T *mem;
     Util::IfNe0( posix_memalign(
           reinterpret_cast<void**>(&mem), align_to, size) );
 
-    return std::unique_ptr<T>{mem};
+    return TMemAlignedPtr<T>{mem};
   } // MemAlignedAlloc
 
   template <typename T>
-  std::unique_ptr<T> MemAlignedAllocZeroInitialized(std::size_t align_to, std::size_t size) {
+  TMemAlignedPtr<T> MemAlignedAllocZeroInitialized(std::size_t align_to, std::size_t size) {
     auto ptr = MemAlignedAlloc<T>(align_to, size);
     memset(ptr.get(), 0, size);
 

--- a/docs/teardown-design.md
+++ b/docs/teardown-design.md
@@ -19,14 +19,17 @@ slices are in (A: `de4a38c8` / PR #442, B: `250294ba` / PR #447, C: PR #459).
   flushed, tetris deleted, DurableManager cleared and reset,
   GlobalRepo/RepoManager reset. After it, `~TServer` touches only
   non-fiber state.
-- An `asan.jhm` config exists for AddressSanitizer builds, intended for a
-  CI smoke of the teardown paths (use-after-free, not leak accounting —
-  see "deliberate leaks" below).  The smoke itself is blocked on the fiber
-  engine: Ubuntu's default `_FORTIFY_SOURCE` (active at the sanitizer
-  build's `-O1`) aborts on the fibers' cross-stack longjmps
-  (`-U_FORTIFY_SOURCE` in the config sidesteps that), and a truly clean
-  run needs `__sanitizer_start_switch_fiber`/`finish_switch_fiber`
-  annotations in orly/indy/fiber.
+- CI: the `asan-smoke` job builds orlyc with `asan.jhm` and runs lang
+  tests through it, policing the teardown paths at the memory level
+  (use-after-free, not leak accounting — see "deliberate leaks" below).
+  `-U_FORTIFY_SOURCE` in the config is load-bearing: Ubuntu's default
+  fortify (active at the sanitizer build's `-O1`) aborts on the fibers'
+  cross-stack longjmps.  Unlike TSan (#194), no fiber-switch annotations
+  proved necessary for a clean run.  The smoke's very first run caught
+  two real teardown bugs: a `TCmd` use-after-scope in orlyc's
+  Shutdown-on-every-path flow, and `Base::MemAlignedAlloc`'s
+  posix_memalign/operator-delete alloc-dealloc mismatch on every aligned
+  disk buffer.
 
 ## Constraints (empirical — the reasons the code looks the way it does)
 

--- a/orly/indy/disk/block_hit_counter.h
+++ b/orly/indy/disk/block_hit_counter.h
@@ -79,9 +79,9 @@ namespace Orly {
 
         const size_t NumBlocks;
 
-        std::unique_ptr<uint8_t> WorksetBuf;
+        Base::TMemAlignedPtr<uint8_t> WorksetBuf;
 
-        std::unique_ptr<uint8_t> FlushBuf;
+        Base::TMemAlignedPtr<uint8_t> FlushBuf;
 
         mutable std::mutex CountLock;
 

--- a/orly/indy/disk/buf_block.h
+++ b/orly/indy/disk/buf_block.h
@@ -141,7 +141,7 @@ namespace Orly {
 
           const size_t BlockSize;
 
-          std::unique_ptr<TBlock> Blob;
+          Base::TMemAlignedPtr<TBlock> Blob;
 
           TBlock *FirstBlock;
 

--- a/orly/indy/disk/util/cache.h
+++ b/orly/indy/disk/util/cache.h
@@ -891,7 +891,7 @@ namespace Orly {
 
           std::unique_ptr<TLRU[]> LRUArray;
 
-          std::unique_ptr<char> PageData;
+          Base::TMemAlignedPtr<char> PageData;
 
           std::function<bool (const TSlot &, TSlot *&, size_t &, size_t &)> TryRemoveSlotFunc;
 

--- a/orly/indy/disk/util/volume_manager.cc
+++ b/orly/indy/disk/util/volume_manager.cc
@@ -27,6 +27,7 @@
 #include <sys/syscall.h>
 
 #include <base/booster.h>
+#include <base/mem_aligned_ptr.h>
 #include <base/sigma_calc.h>
 #include <base/zero.h>
 #include <orly/indy/disk/util/corruption_detector.h>
@@ -983,10 +984,10 @@ namespace Orly {
 
           Base::TScheduler *Scheduler;
 
-          std::unique_ptr<size_t> BlockMapBuf;
+          Base::TMemAlignedPtr<size_t> BlockMapBuf;
           std::mutex BlockMapLock;
           size_t CachedStart;
-          std::unique_ptr<size_t> DiscardMapBuf;
+          Base::TMemAlignedPtr<size_t> DiscardMapBuf;
           std::mutex DiscardMapLock;
 
           size_t BlocksUsed;

--- a/orly/indy/disk/util/volume_manager.h
+++ b/orly/indy/disk/util/volume_manager.h
@@ -676,7 +676,7 @@ namespace Orly {
           bool ReadImpl(const Base::TCodeLocation &code_location /* DEBUG */, TBufKind buf_kind, uint8_t util_src, void *buf, const TOffset offset,
                         long long nbytes, DiskPriority priority, bool abort_on_error);
 
-          std::unique_ptr<char> Data;
+          Base::TMemAlignedPtr<char> Data;
 
         };  // TMemoryDevice
 

--- a/orly/orlyc.cc
+++ b/orly/orlyc.cc
@@ -140,8 +140,12 @@ static bool RunTestsOnIndy(const Package::TVersionedName &output, const TCompile
       [&](Base::TScheduler *scheduler) {
         int exit_code = EXIT_FAILURE;
         Orly::Server::TServer *server = nullptr;
+        /* Declared OUTSIDE the try: TServer keeps a REFERENCE to its TCmd,
+           and Shutdown()/delete below (correctly outside the try, #440) read
+           it -- a try-scoped cmd would be a stack-use-after-scope there.
+           Found by the ASan teardown smoke on its first run. */
+        TIndyTestServerCmd server_cmd;
         try {
-          TIndyTestServerCmd server_cmd;
           server_cmd.MemorySim = true;
           server_cmd.Create = true;
           server_cmd.StartingState = "SOLO";


### PR DESCRIPTION
The AddressSanitizer teardown smoke drafted during #459 turned out not to need fiber-switch annotations after all — `-U_FORTIFY_SOURCE` in `asan.jhm` (already on master) is enough to keep glibc's fortified longjmp happy across the fibers' stack switches. Its first two runs each caught a real bug, which felt like sufficient proof of value to ship it.

## Fixes (found by the smoke)

1. **`TCmd` use-after-scope in orlyc** (introduced in #459's Shutdown-on-every-path change): `server_cmd` was try-scoped while `Shutdown()`/`delete` run after the try — and `TServer` holds its `TCmd` by reference, so the settle-sleep's `Cmd` reads hit a dead stack object (worked only because the frame hadn't been overwritten). Declaration hoisted to the job scope.

2. **`Base::MemAlignedAlloc` alloc/dealloc mismatch** (2014-era, latent): `posix_memalign` memory returned as a plain `std::unique_ptr`, whose default deleter is `operator delete`. Every aligned disk buffer — page cache, mem-sim volume, block/discard maps, buf blocks, hit counters — had this; it was invisible until real teardown started freeing them. The helper now returns a `free()`-deleting `TMemAlignedPtr<T>`; the six member declarations adopt it.

## CI

New `asan-smoke` job: builds orlyc with `jhm -c asan`, runs three lang tests through it (two with-block tests exercising the dirty-self-pin release and full manager destruction, one pure), gates on `lang_test.py`'s exit code. Mirrors the `tsan` job's policy (skips pull_request; runs on push-to-master, nightly, dispatch) and ccache setup. `detect_leaks=0` by design — teardown deliberately leaks a few pool slabs (docs/teardown-design.md, 'Deliberate leaks'); the gate is use-after-free, not leak accounting.

docs/teardown-design.md's formerly-blocked ASan note is updated to match reality, which also completes the last open item from the design note's original PR-C scope.

## Testing

- ASan smoke locally: 3/3 pass, clean sanitizer output, empty baseline `Change` list.
- `volume_manager.test`, `durable_manager.test` green on debug after the allocator retype; lang tests (incl. baseline-bearing) unchanged.
- Workflow YAML validated; todo-lint clean.