### PR TITLE
synth: generalize TUnaryType::TGet / TBinaryType::TGet to std::function

### DIFF
--- a/orly/synth/binary_type.cc
+++ b/orly/synth/binary_type.cc
@@ -24,7 +24,9 @@ using namespace Orly;
 using namespace Orly::Synth;
 
 TBinaryType::TBinaryType(TType *lhs, TType *rhs, TGet get)
-    : Get(get), Lhs(Base::AssertTrue(lhs)), Rhs(Base::AssertTrue(rhs)) {}
+    : Get(std::move(get)), Lhs(Base::AssertTrue(lhs)), Rhs(Base::AssertTrue(rhs)) {
+  assert(Get);
+}
 
 TBinaryType::~TBinaryType() {
   delete Lhs;

--- a/orly/synth/binary_type.h
+++ b/orly/synth/binary_type.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <functional>
+
 #include <orly/synth/type.h>
 
 namespace Orly {
@@ -31,7 +33,7 @@ namespace Orly {
       NO_COPY(TBinaryType);
       public:
 
-      typedef Type::TType (*TGet)(const Type::TType &, const Type::TType &);
+      using TGet = std::function<Type::TType (const Type::TType &, const Type::TType &)>;
 
       TBinaryType(TType *lhs, TType *rhs, TGet get);
 

--- a/orly/synth/new_type.cc
+++ b/orly/synth/new_type.cc
@@ -64,7 +64,11 @@ TType *Orly::Synth::NewType(const Package::Syntax::TType *root) {
       const Package::Syntax::TType *addr_type;
       that->GetOptMutableTypeAt()->Accept(TOptMutableAtVisitor(addr_type));
       if (addr_type) {
-        OnBinary(addr_type, that->GetType(), Type::TMutable::Get);
+        /* TMutable::Get is an overload set, so name the two-argument one
+           explicitly for the std::function-typed callback. */
+        OnBinary(addr_type, that->GetType(), [](const Type::TType &addr, const Type::TType &val) {
+          return Type::TMutable::Get(addr, val);
+        });
       } else {
         OnUnary(that->GetType(), [](const Type::TType &that) {
           return Type::TMutable::Get(Type::TAddr::Get({}), that);

--- a/orly/synth/unary_type.cc
+++ b/orly/synth/unary_type.cc
@@ -26,7 +26,9 @@ using namespace Orly;
 using namespace Orly::Synth;
 
 TUnaryType::TUnaryType(TType *type, TGet get)
-    : Type(Base::AssertTrue(type)), Get(get) {}
+    : Type(Base::AssertTrue(type)), Get(std::move(get)) {
+  assert(Get);
+}
 
 TUnaryType::~TUnaryType() {
   delete Type;

--- a/orly/synth/unary_type.h
+++ b/orly/synth/unary_type.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <functional>
+
 #include <orly/synth/type.h>
 
 namespace Orly {
@@ -32,7 +34,7 @@ namespace Orly {
       NO_COPY(TUnaryType);
       public:
 
-      typedef Type::TType (*TGet)(const Type::TType &);
+      using TGet = std::function<Type::TType (const Type::TType &)>;
 
       TUnaryType(TType *type, TGet get);
 


### PR DESCRIPTION
## What

Generalizes the synth type-builder callbacks `TUnaryType::TGet` and `TBinaryType::TGet` from raw function pointers to `std::function`, so builders can capture state — notably the pos-range a diagnostic needs (the #314 mutable-in-mutable error is the first consumer).

- `orly/synth/unary_type.h` / `binary_type.h`: `typedef Type::TType (*TGet)(...)` becomes `using TGet = std::function<Type::TType (...)>`.
- Constructors move the callback and assert it is non-empty (the raw pointer was equally assumed non-null via unchecked calls).
- `new_type.cc`: `Type::TMutable::Get` is an overload set, which `std::function` cannot disambiguate the way a typed function-pointer target could; the two-argument overload is now named via a small lambda. Every other `Type::T*::Get` reference is a single function and converts as before.

No behavior change; `TAtomicType::TGet` (nullary) has no capture-needing consumer and stays a function pointer.

## Why

Session 2 prerequisite from the #434 roadmap: #314's clean mutable-in-mutable error (and the rest of the diagnostics/codegen work behind it) needs the type-builder callback to carry the source position of the type expression it lowers. Lands alone per the kickoff brief.

## Gate

- `make debug`, `make test` (196 tests) — green
- Full `lang_test` suite on this exact tree: **157 passed / 2 xfail, 0 unexpected, 0 changes** (the corpus is 159 files on current master, one more than the roadmap's "156 passed" note)
