### PR TITLE
indy: real repo-reload deadline (#324); unwind partial extent allocation (#331); ttl-preserving durable open (#366)

### DIFF
--- a/orly/durable/kit.h
+++ b/orly/durable/kit.h
@@ -230,6 +230,17 @@ namespace Orly {
       template <typename TSomeObj>
       TPtr<TSomeObj> Open(const TId &id);
 
+      /* Read the durable with the given id via 'visit' without disturbing its ttl countdown
+         (#366).  Open() always resets a resident-but-closed durable's pending deadline (and,
+         once released, re-arms a fresh one), which is exactly right for a caller that means to
+         keep using the durable -- but wrong for a caller that only wants to peek at it, e.g.
+         resolving a parent pov's shared-parents list while creating a child pov.  If the
+         durable is already resident (open or closed-and-cached), 'visit' runs directly against
+         it under the manager lock, leaving any pending deadline untouched.  Otherwise there is
+         no pending lease to disturb, so this falls back to a normal Open(). */
+      template <typename TSomeObj, typename TVisitor>
+      auto OpenAndVisit(const TId &id, const TVisitor &visit) -> decltype(visit(std::declval<const TSomeObj &>()));
+
       void Clear();
 
       virtual void RunLayerCleaner() = 0;
@@ -649,6 +660,26 @@ namespace Orly {
         OpenableObjs.erase(iter);
         throw;
       }
+    }
+
+    template <typename TSomeObj, typename TVisitor>
+    auto TManager::OpenAndVisit(const TId &id, const TVisitor &visit) -> decltype(visit(std::declval<const TSomeObj &>())) {
+      /* extra */ {
+        std::lock_guard<std::mutex> lock(Mutex);
+        auto iter = OpenableObjs.find(id);
+        if (iter != OpenableObjs.end() && iter->second) {
+          /* Already resident (open or closed-and-cached): visit it in place under the lock,
+             without touching PtrCount/Deadline, so a mere read never disturbs its lease. */
+          auto *some_obj = dynamic_cast<TSomeObj *>(iter->second);
+          if (!some_obj) {
+            THROW_ERROR(TWrongType) << "expected \"" << typeid(TSomeObj).name() << "\", got \"" << typeid(*iter->second).name() << '"';
+          }
+          return visit(*some_obj);
+        }
+      }  // release lock
+      /* Not resident, so there is no pending lease to preserve; a normal (lease-affecting)
+         load-from-disk is exactly right here. */
+      return visit(*Open<TSomeObj>(id));
     }
 
   }  // Durable

--- a/orly/indy/disk/util/volume_manager.cc
+++ b/orly/indy/disk/util/volume_manager.cc
@@ -2954,6 +2954,7 @@ void TVolumeManager::AllocateLogicalExtents(TExtentSet &logical_extent_set, size
   assert(logical_extent_set.empty());
   const size_t required_consecutive_extent = ceil(static_cast<double>(extent_size) / ExtentAllocationBlockSize);
   size_t consective_found = 0UL;
+  std::vector<size_t> blocks_allocated_this_call;
   for (size_t num_find = 0UL; num_find < num_extent; ++num_find) {
     bool found = false;
     for (size_t i = 0UL; i < AllocatedExtentBlocks.size(); ++i) {
@@ -2964,6 +2965,7 @@ void TVolumeManager::AllocateLogicalExtents(TExtentSet &logical_extent_set, size
           for (size_t j = (i - required_consecutive_extent + 1UL); j <= i; ++j) {
             AllocatedExtentBlocks[j] = true;
             LogicalExtentStartToVolumeMap.emplace(j * ExtentAllocationBlockSize, volume);
+            blocks_allocated_this_call.push_back(j);
           }
           logical_extent_set.insert(TLogicalExtent{extent_start, extent_size});
           found = true;
@@ -2974,7 +2976,13 @@ void TVolumeManager::AllocateLogicalExtents(TExtentSet &logical_extent_set, size
       }
     }
     if (!found) {
-      /* TODO(#331): unwind any extents we just allocated. */
+      /* Unwind every block this call allocated before failing, so a mid-request failure
+         doesn't leak logical extent space (#331). */
+      for (size_t j : blocks_allocated_this_call) {
+        AllocatedExtentBlocks[j] = false;
+        LogicalExtentStartToVolumeMap.erase(j * ExtentAllocationBlockSize);
+      }
+      logical_extent_set.clear();
       throw std::runtime_error("Cannot allocate enough consecutive extent space.");
     }
   }

--- a/orly/indy/manager.cc
+++ b/orly/indy/manager.cc
@@ -1295,7 +1295,10 @@ L0::TManager::TRepo *TManager::ConstructRepo(const TUuid &repo_id,
 
 L0::TManager::TRepo *TManager::ReconstructRepo(const TUuid &repo_id) {
   if (repo_id != SystemRepoId) { /* construct a regular repo */
-    auto deadline = TDeadline::max(); /* TODO(#324): we should figure out the right deadline here */
+    /* The repo's original ttl isn't persisted across on-disk reload (#173), so give it the
+       same bounded default lifetime used elsewhere for shared povs (session.cc) rather than
+       TDeadline::max(), which pinned every reloaded repo in memory forever. */
+    auto deadline = TDeadline::clock::now() + std::chrono::seconds(1000);
     return TSafeRepo::ReConstructFromDisk(this, repo_id, deadline);
   }
   assert(!SystemRepo);

--- a/orly/indy/repo.cc
+++ b/orly/indy/repo.cc
@@ -1414,7 +1414,11 @@ TSafeRepo *TSafeRepo::ReConstructFromDisk(L0::TManager *manager,
     manager->GetEngine()->RemoveFile(repo_id, gen_id, trigger);
   }
   trigger.Wait();
-  TSafeRepo *safe_repo = new TSafeRepo(manager, repo_id, TTtl(deadline.time_since_epoch().count()), parent_repo, lowest, highest, next_update, TStatus::Normal);
+  /* 'deadline' is an absolute time point; convert it to the relative ttl TSafeRepo expects
+     rather than reinterpreting its raw epoch tick count as a ttl (which produced an
+     effectively-infinite ttl for any real deadline). */
+  TTtl repo_ttl = std::chrono::duration_cast<TTtl>(deadline - TDeadline::clock::now());
+  TSafeRepo *safe_repo = new TSafeRepo(manager, repo_id, repo_ttl, parent_repo, lowest, highest, next_update, TStatus::Normal);
   return safe_repo;
 }
 

--- a/orly/server/server.cc
+++ b/orly/server/server.cc
@@ -1128,7 +1128,6 @@ void TServer::Init() {
       reinstall_jumper(FramePoolManager.get(), &BGFastRunner);
     }
 
-    /* TODO(#366) : durable manager does not support create=false */
     DurableManager = make_shared<Orly::Indy::Disk::TDurableManager>(Scheduler,
                                                                     RunnerCons,
                                                                     FramePoolManager.get(),

--- a/orly/server/session.cc
+++ b/orly/server/session.cc
@@ -779,8 +779,7 @@ TUuid TSession::NewPov(
   auto durable_manager = server->GetDurableManager();
   TPov::TSharedParents shared_parents;
   if (parent_pov_id) {
-    // TODO(#366): add the ability to open a durable w/o changing ttl
-    shared_parents = durable_manager->Open<TPov>(*parent_pov_id)->GetSharedParents();
+    shared_parents = durable_manager->OpenAndVisit<TPov>(*parent_pov_id, [](const TPov &parent) { return parent.GetSharedParents(); });
     shared_parents.push_back(*parent_pov_id);
   }
   auto pov = durable_manager->New<TPov>(TUuid::Twister, time_to_live, GetId(), audience, policy, shared_parents);


### PR DESCRIPTION
## Summary

Three quick-win indy fixes from the #434 backlog:

- **#324** — `TManager::ReconstructRepo` used `TDeadline::max()` as a regular repo's reload deadline. That deadline then flowed into `TSafeRepo::ReConstructFromDisk`, which reinterpreted it as a ttl by casting its raw epoch tick count directly (instead of converting relative to now) -- so *any* deadline produced an effectively-infinite ttl, not just `max()`. Fixed both: the conversion now derives the ttl from `deadline - now()`, and the reload path gives regular repos a bounded default lifetime instead of pinning them in memory forever.
- **#331** — `AllocateLogicalExtents` leaked logical extent space when a multi-extent allocation failed partway through: blocks marked allocated by earlier iterations of the same call were never freed. Now unwound before throwing.
- **#366** — the `durable manager does not support create=false` TODO was stale: `TDurableManager`'s constructor already handles `!create` and `tests/restart_test.sh` (CI-gated) exercises a real restart with `--create=false`. Removed the stale comment. The real gap was resolving a parent pov's shared parents via `Open<TPov>()`, which unconditionally resets/re-arms the parent's ttl countdown as a side effect of merely reading it. Added `Durable::TManager::OpenAndVisit()`, which reads an already-resident durable in place under the manager lock without touching `PtrCount`/`Deadline`, falling back to a normal `Open()` only when the durable must be loaded from disk (where there's no pending lease to disturb).

## Test plan

- [x] CI: `make debug + make test`
- [x] CI: `lang_test.py`
- [x] CI: `restart durability (tests/restart_test.sh)` — exercises the `#366` create=false path directly
- [x] CI: `todo-lint`