### PR TITLE
ci: turn #463 hangs into cores (orlyc under timeout --signal=ABRT)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,9 +303,23 @@ jobs:
           sudo chmod 1777 /tmp/cores
           sudo sysctl -w kernel.core_pattern=/tmp/cores/core.%e.%p
 
+      # The #463 class has a hang presentation too (an orlyc that never exits;
+      # lang_test waits on it until the job timeout, yielding no evidence).
+      # Run every orlyc under `timeout --signal=ABRT`: the whole suite takes
+      # ~8 minutes, so any single orlyc alive at 15 is hung, and SIGABRT dumps
+      # a core the symbolize step below turns into a backtrace of the deadlock.
+      - name: Wrap orlyc in a hang-to-core timeout (#463)
+        run: |
+          sudo tee /usr/local/bin/orlyc-hang-to-core >/dev/null <<EOF
+          #!/bin/sh
+          exec timeout --signal=ABRT --kill-after=30 900 "$GITHUB_WORKSPACE/../out_orly/debug/orly/orlyc" "\$@"
+          EOF
+          sudo chmod +x /usr/local/bin/orlyc-hang-to-core
+
       - name: python3 tools/lang_test.py
         run: |
           ulimit -c unlimited
+          ORLYC=/usr/local/bin/orlyc-hang-to-core \
           python3 tools/lang_test.py -d orly/data tests/lang_tests
 
       # Symbolize in-job rather than uploading multi-hundred-MB cores: the debug orlyc has

--- a/.github/workflows/flake-hunt.yml
+++ b/.github/workflows/flake-hunt.yml
@@ -86,9 +86,22 @@ jobs:
           sudo chmod 1777 /tmp/cores
           sudo sysctl -w kernel.core_pattern=/tmp/cores/core.%e.%p
 
+      # The #463 class has a hang presentation too (dispatch 1, shot 3: five
+      # clean passes, then one orlyc never exited and the job died at its
+      # timeout with no evidence). SIGABRT after a generous per-process
+      # ceiling turns any hang into a core the symbolize step can read.
+      - name: Wrap orlyc in a hang-to-core timeout (#463)
+        run: |
+          sudo tee /usr/local/bin/orlyc-hang-to-core >/dev/null <<EOF
+          #!/bin/sh
+          exec timeout --signal=ABRT --kill-after=30 900 "$GITHUB_WORKSPACE/../out_orly/debug/orly/orlyc" "\$@"
+          EOF
+          sudo chmod +x /usr/local/bin/orlyc-hang-to-core
+
       - name: Hunt (repeated full lang_test passes)
         run: |
           ulimit -c unlimited
+          export ORLYC=/usr/local/bin/orlyc-hang-to-core
           passes='${{ inputs.passes }}'
           workers='${{ inputs.workers }}'
           for i in $(seq 1 "$passes"); do


### PR DESCRIPTION
Follow-up to the PR #481 instrumentation, prompted by today's evidence on #463.

The flake class has two presentations. The crash form was caught today with a full backtrace (see the issue). The hang form has now occurred twice — PR #478's 10-hour job, and flake-hunt dispatch 1 shot 3 (five clean passes, then one orlyc never exited; the job died at its 90-minute timeout and the only trace was an orphaned-process cleanup line). A hang currently yields zero evidence.

lang_test.py honors an ORLYC override, so both lang jobs (the ci lang-tests job and every flake-hunt shot) now run orlyc through a 3-line wrapper: timeout --signal=ABRT --kill-after=30 900. The whole suite takes ~8 minutes, so a single orlyc alive at 15 is hung by any measure. SIGABRT core-dumps into the already-armed /tmp/cores, lang_test sees exit 124 and reports the failure, and the existing gdb step symbolizes the deadlock's threads.

Net effect: the next hang costs 15 minutes and produces the blocked-thread backtrace the fix work (see the teardown-race diagnosis on #463) will want, instead of costing a job timeout and producing a cleanup line.

Part of #463.