### PR TITLE
fix: replace hardcoded run_time sentinel with current time

### DIFF
--- a/orly/server/session.cc
+++ b/orly/server/session.cc
@@ -224,7 +224,7 @@ TMethodResult TSession::Try(TServer *server, const TUuid &pov_id, const vector<s
       if(indy_context.GetOptRandomSeed().IsKnown()) {
         random_seed = indy_context.GetOptRandomSeed().GetVal();
       }
-      Base::Chrono::TTimePnt run_time = Base::Chrono::CreateTimePnt(2013, 10, 23, 17, 47, 14, 0, 0);
+      Base::Chrono::TTimePnt run_time = Base::Chrono::Now();
       if(indy_context.GetOptNow().IsKnown()) {
         run_time = indy_context.GetOptNow().GetVal();
       }
@@ -414,7 +414,7 @@ TMethodResult TSession::TryBatch(TServer *server, const TUuid &pov_id, const vec
       if(indy_context.GetOptRandomSeed().IsKnown()) {
         random_seed = indy_context.GetOptRandomSeed().GetVal();
       }
-      Base::Chrono::TTimePnt run_time = Base::Chrono::CreateTimePnt(2013, 10, 23, 17, 47, 14, 0, 0);
+      Base::Chrono::TTimePnt run_time = Base::Chrono::Now();
       if(indy_context.GetOptNow().IsKnown()) {
         run_time = indy_context.GetOptNow().GetVal();
       }
@@ -664,7 +664,7 @@ void TSession::RunFuncCommit(TServer *server,
   if (indy_context.GetOptRandomSeed().IsKnown()) {
     random_seed = indy_context.GetOptRandomSeed().GetVal();
   }
-  Base::Chrono::TTimePnt run_time = Base::Chrono::CreateTimePnt(2013, 10, 23, 17, 47, 14, 0, 0);
+  Base::Chrono::TTimePnt run_time = Base::Chrono::Now();
   if (indy_context.GetOptNow().IsKnown()) {
     run_time = indy_context.GetOptNow().GetVal();
   }


### PR DESCRIPTION
## What this PR does
Replaces the hardcoded `run_time` sentinel (2013-10-23) in session meta records with the current time.

## Changes
- Replaced `Base::Chrono::CreateTimePnt(2013, ...)` with `Base::Chrono::Now()`
- Updated all three locations (lines 227, 417, 667)
- Prevents misleading 2013-10-23 timestamp in meta records

## Related Issue
Closes #494

## Testing
- Verified that `run_time` now uses current time when `GetOptNow()` is unknown

Ready for review.