### PR TITLE
chore: changelog fragments — kill the [Unreleased] merge conflicts

### DIFF
--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,10 @@
+# Changelog fragments
+
+Every PR that would touch `CHANGELOG.md`'s `[Unreleased]` section instead adds
+one uniquely named file here: `<issue-or-pr>-<slug>.md`, containing exactly the
+bullet entry (starting with `- **`) it would have prepended. Unique filenames
+cannot merge-conflict, which is the whole point.
+
+`tools/fold_changelog.py` folds all fragments into `CHANGELOG.md`'s
+`[Unreleased]` section (newest first by file mtime) and deletes them; it runs
+periodically, typically when merges land.

--- a/tools/fold_changelog.py
+++ b/tools/fold_changelog.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Fold changelog.d/ fragments into CHANGELOG.md's [Unreleased] section."""
+import os
+import sys
+
+FRAG_DIR = 'changelog.d'
+MARKER = '## [Unreleased]\n\n### Fixed\n'
+
+def main():
+    frags = [
+        os.path.join(FRAG_DIR, name)
+        for name in os.listdir(FRAG_DIR)
+        if name.endswith('.md') and name != 'README.md'
+    ]
+    if not frags:
+        print('no fragments to fold')
+        return 0
+    frags.sort(key=lambda p: os.path.getmtime(p), reverse=True)
+    entries = []
+    for path in frags:
+        with open(path) as f:
+            text = f.read().strip()
+        if not text.startswith('- **'):
+            sys.exit(f'{path}: fragment must start with a "- **" bullet')
+        entries.append(text + '\n')
+    with open('CHANGELOG.md') as f:
+        changelog = f.read()
+    if MARKER not in changelog:
+        sys.exit('CHANGELOG.md: cannot find the [Unreleased] ### Fixed marker')
+    changelog = changelog.replace(MARKER, MARKER + ''.join(entries), 1)
+    with open('CHANGELOG.md', 'w') as f:
+        f.write(changelog)
+    for path in frags:
+        os.remove(path)
+    print(f'folded {len(frags)} fragment(s)')
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Every PR prepends its entry to the same `CHANGELOG.md` line, so any two in-flight PRs conflict **by construction** — and GitHub ignores gitattributes merge drivers, so the `merge=union` rule only helps CLI-side merges.

Standard fix, standard shape: **changelog fragments**. A PR adds one uniquely named file under `changelog.d/` (`<issue>-<slug>.md`) containing exactly the bullet it would have prepended; unique filenames cannot conflict. `tools/fold_changelog.py` folds fragments into `[Unreleased]` (and deletes them) when merges land, preserving the long-form entries verbatim. `changelog.d/README.md` documents the convention.

The four currently in-flight PRs keep their direct CHANGELOG edits (touching them would re-trigger their CI); everything after adopts fragments.